### PR TITLE
Add Auto-close on inbound/outbound update_fee delay

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2014,7 +2014,8 @@ impl<Signer: Sign> Channel<Signer> {
 		                                          &self.channel_transaction_parameters,
 		                                          funding_redeemscript.clone(), self.channel_value_satoshis,
 		                                          obscure_factor,
-		                                          holder_commitment_tx, best_block);
+		                                          holder_commitment_tx, best_block,
+							  self.config.spikes_force_close_rate);
 
 		channel_monitor.provide_latest_counterparty_commitment_tx(counterparty_initial_commitment_txid, Vec::new(), self.cur_counterparty_commitment_transaction_number, self.counterparty_cur_commitment_point.unwrap(), logger);
 
@@ -2091,7 +2092,8 @@ impl<Signer: Sign> Channel<Signer> {
 		                                          &self.channel_transaction_parameters,
 		                                          funding_redeemscript.clone(), self.channel_value_satoshis,
 		                                          obscure_factor,
-		                                          holder_commitment_tx, best_block);
+		                                          holder_commitment_tx, best_block,
+							  self.config.spikes_force_close_rate);
 
 		channel_monitor.provide_latest_counterparty_commitment_tx(counterparty_initial_bitcoin_tx.txid, Vec::new(), self.cur_counterparty_commitment_transaction_number, self.counterparty_cur_commitment_point.unwrap(), logger);
 

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -246,6 +246,13 @@ pub struct ChannelConfig {
 	/// [`Normal`]: crate::chain::chaininterface::ConfirmationTarget::Normal
 	/// [`Background`]: crate::chain::chaininterface::ConfirmationTarget::Background
 	pub force_close_avoidance_max_fee_satoshis: u64,
+	/// When we detect a fee spikes and receive a block, we force-close immediately channel
+	/// with pending non-dust inbound HTLCs, of which the preimage is known.
+	///
+	/// To disable the force-close on fee spikes mechanism, select 0 as a rate.
+	///
+	/// Default value: 30%
+	pub spikes_force_close_rate: u32,
 }
 
 impl Default for ChannelConfig {
@@ -259,6 +266,7 @@ impl Default for ChannelConfig {
 			commit_upfront_shutdown_pubkey: true,
 			max_dust_htlc_exposure_msat: 5_000_000,
 			force_close_avoidance_max_fee_satoshis: 1000,
+			spikes_force_close_rate: 1300,
 		}
 	}
 }
@@ -269,6 +277,7 @@ impl_writeable_tlv_based!(ChannelConfig, {
 	(2, cltv_expiry_delta, required),
 	(3, force_close_avoidance_max_fee_satoshis, (default_value, 1000)),
 	(4, announced_channel, required),
+	(5, spikes_force_close_rate, (default_value, 1300)),
 	(6, commit_upfront_shutdown_pubkey, required),
 	(8, forwarding_fee_base_msat, required),
 });


### PR DESCRIPTION
Auto-close timer, if the channel is outbound, we sent a `update_fee`, and we didn't
receive a RAA from counterparty committing this state after `AUTOCLOSE_TIMEOUT` periods,
this channel must be force-closed.
If the channel is inbound, it has been observed the channel feerate should increase,
and we didn't receive a RAA from counterparty committing an `update_fee` after
`AUTOCLOSE_TIMEOUT` periods, this channel must be force-closed.

Close #993 

- [ ] test coverage
- [ ] distrust inbound `update_fee`, verify it's going up
- [x]  if feerates are going downwards, do not trigger timers
- [ ] verify other implems timers to fine-tune `AUTOCLOSE_TIMEOUT` value