### PR TITLE
Fix announcements of our own gossip

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -493,9 +493,10 @@ mod tests {
 
 		macro_rules! check_persisted_data {
 			($node: expr, $filepath: expr, $expected_bytes: expr) => {
-				match $node.write(&mut $expected_bytes) {
-					Ok(()) => {
-						loop {
+				loop {
+					$expected_bytes.clear();
+					match $node.write(&mut $expected_bytes) {
+						Ok(()) => {
 							match std::fs::read($filepath) {
 								Ok(bytes) => {
 									if bytes == $expected_bytes {
@@ -506,9 +507,9 @@ mod tests {
 								},
 								Err(_) => continue
 							}
-						}
-					},
-					Err(e) => panic!("Unexpected error: {}", e)
+						},
+						Err(e) => panic!("Unexpected error: {}", e)
+					}
 				}
 			}
 		}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -481,8 +481,13 @@ pub(super) struct Channel<Signer: Sign> {
 	holding_cell_update_fee: Option<u32>,
 	next_holder_htlc_id: u64,
 	next_counterparty_htlc_id: u64,
-	update_time_counter: u32,
 	feerate_per_kw: u32,
+
+	/// The timestamp set on our latest `channel_update` message for this channel. It is updated
+	/// when the channel is updated in ways which may impact the `channel_update` message or when a
+	/// new block is received, ensuring it's always at least moderately close to the current real
+	/// time.
+	update_time_counter: u32,
 
 	#[cfg(debug_assertions)]
 	/// Max to_local and to_remote outputs in a locally-generated commitment transaction

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4167,6 +4167,7 @@ impl<Signer: Sign> Channel<Signer> {
 	}
 
 	pub fn set_channel_update_status(&mut self, status: ChannelUpdateStatus) {
+		self.update_time_counter += 1;
 		self.channel_update_status = status;
 	}
 

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -715,6 +715,10 @@ pub enum ErrorAction {
 	/// The peer did something harmless that we weren't able to meaningfully process.
 	/// If the error is logged, log it at the given level.
 	IgnoreAndLog(logger::Level),
+	/// The peer provided us with a gossip message which we'd already seen. In most cases this
+	/// should be ignored, but it may result in the message being forwarded if it is a duplicate of
+	/// our own channel announcements.
+	IgnoreDuplicateGossip,
 	/// The peer did something incorrect. Tell them.
 	SendErrorMessage {
 		/// The message to send.

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -1351,8 +1351,10 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 					},
 					MessageSendEvent::BroadcastChannelAnnouncement { msg, update_msg } => {
 						log_debug!(self.logger, "Handling BroadcastChannelAnnouncement event in peer_handler for short channel id {}", msg.contents.short_channel_id);
-						if self.message_handler.route_handler.handle_channel_announcement(&msg).is_ok() && self.message_handler.route_handler.handle_channel_update(&update_msg).is_ok() {
+						if self.message_handler.route_handler.handle_channel_announcement(&msg).is_ok() {
 							self.forward_broadcast_msg(peers, &wire::Message::ChannelAnnouncement(msg), None);
+						}
+						if self.message_handler.route_handler.handle_channel_update(&update_msg).is_ok() {
 							self.forward_broadcast_msg(peers, &wire::Message::ChannelUpdate(update_msg), None);
 						}
 					},

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -847,8 +847,10 @@ impl NetworkGraph {
 			None => Err(LightningError{err: "No existing channels for node_announcement".to_owned(), action: ErrorAction::IgnoreError}),
 			Some(node) => {
 				if let Some(node_info) = node.announcement_info.as_ref() {
-					if node_info.last_update  >= msg.timestamp {
+					if node_info.last_update  > msg.timestamp {
 						return Err(LightningError{err: "Update older than last processed update".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)});
+					} else if node_info.last_update  == msg.timestamp {
+						return Err(LightningError{err: "Update had the same timestamp as last processed update".to_owned(), action: ErrorAction::IgnoreDuplicateGossip});
 					}
 				}
 
@@ -977,7 +979,7 @@ impl NetworkGraph {
 					Self::remove_channel_in_nodes(&mut nodes, &entry.get(), msg.short_channel_id);
 					*entry.get_mut() = chan_info;
 				} else {
-					return Err(LightningError{err: "Already have knowledge of channel".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)})
+					return Err(LightningError{err: "Already have knowledge of channel".to_owned(), action: ErrorAction::IgnoreDuplicateGossip});
 				}
 			},
 			BtreeEntry::Vacant(entry) => {
@@ -1082,8 +1084,10 @@ impl NetworkGraph {
 				macro_rules! maybe_update_channel_info {
 					( $target: expr, $src_node: expr) => {
 						if let Some(existing_chan_info) = $target.as_ref() {
-							if existing_chan_info.last_update >= msg.timestamp {
+							if existing_chan_info.last_update > msg.timestamp {
 								return Err(LightningError{err: "Update older than last processed update".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)});
+							} else if existing_chan_info.last_update == msg.timestamp {
+								return Err(LightningError{err: "Update had same timestamp as last processed update".to_owned(), action: ErrorAction::IgnoreDuplicateGossip});
 							}
 							chan_was_enabled = existing_chan_info.enabled;
 						} else {
@@ -1720,7 +1724,7 @@ mod tests {
 
 		match net_graph_msg_handler.handle_channel_update(&valid_channel_update) {
 			Ok(_) => panic!(),
-			Err(e) => assert_eq!(e.err, "Update older than last processed update")
+			Err(e) => assert_eq!(e.err, "Update had same timestamp as last processed update")
 		};
 		unsigned_channel_update.timestamp += 500;
 

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -847,6 +847,9 @@ impl NetworkGraph {
 			None => Err(LightningError{err: "No existing channels for node_announcement".to_owned(), action: ErrorAction::IgnoreError}),
 			Some(node) => {
 				if let Some(node_info) = node.announcement_info.as_ref() {
+					// The timestamp field is somewhat of a misnomer - the BOLTs use it to order
+					// updates to ensure you always have the latest one, only vaguely suggesting
+					// that it be at least the current time.
 					if node_info.last_update  > msg.timestamp {
 						return Err(LightningError{err: "Update older than last processed update".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)});
 					} else if node_info.last_update  == msg.timestamp {
@@ -1084,6 +1087,12 @@ impl NetworkGraph {
 				macro_rules! maybe_update_channel_info {
 					( $target: expr, $src_node: expr) => {
 						if let Some(existing_chan_info) = $target.as_ref() {
+							// The timestamp field is somewhat of a misnomer - the BOLTs use it to
+							// order updates to ensure you always have the latest one, only
+							// suggesting  that it be at least the current time. For
+							// channel_updates specifically, the BOLTs discuss the possibility of
+							// pruning based on the timestamp field being more than two weeks old,
+							// but only in the non-normative section.
 							if existing_chan_info.last_update > msg.timestamp {
 								return Err(LightningError{err: "Update older than last processed update".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)});
 							} else if existing_chan_info.last_update == msg.timestamp {


### PR DESCRIPTION
This fixes three separate issues that, together, make announcements of our own `channel_update` messages incredibly unreliable.