### PR TITLE
(0.0.103 Bindings) Support `logger::Record` in C by String-ing the fmt::Arguments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,14 @@ jobs:
           cargo test --verbose --color always  -p lightning
           cargo test --verbose --color always  -p lightning-invoice
           cargo build --verbose  --color always -p lightning-persister
+          cargo build --verbose  --color always -p lightning-background-processor
+      - name: Test C Bindings Modifications on Rust ${{ matrix.toolchain }}
+        if: "! matrix.build-net-tokio"
+        run: |
+          RUSTFLAGS="--cfg=c_bindings" cargo test --verbose --color always  -p lightning
+          RUSTFLAGS="--cfg=c_bindings" cargo test --verbose --color always  -p lightning-invoice
+          RUSTFLAGS="--cfg=c_bindings" cargo build --verbose  --color always -p lightning-persister
+          RUSTFLAGS="--cfg=c_bindings" cargo build --verbose  --color always -p lightning-background-processor
       - name: Test Block Sync Clients on Rust ${{ matrix.toolchain }} with features
         if: "matrix.build-net-tokio && !matrix.coverage"
         run: |

--- a/lightning/src/util/logger.rs
+++ b/lightning/src/util/logger.rs
@@ -84,32 +84,45 @@ impl Level {
 
 /// A Record, unit of logging output with Metadata to enable filtering
 /// Module_path, file, line to inform on log's source
-/// (C-not exported) - we convert to a const char* instead
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct Record<'a> {
 	/// The verbosity level of the message.
 	pub level: Level,
+	#[cfg(not(c_bindings))]
 	/// The message body.
 	pub args: fmt::Arguments<'a>,
+	#[cfg(c_bindings)]
+	/// The message body.
+	pub args: String,
 	/// The module path of the message.
-	pub module_path: &'a str,
+	pub module_path: &'static str,
 	/// The source file containing the message.
-	pub file: &'a str,
+	pub file: &'static str,
 	/// The line containing the message.
 	pub line: u32,
+
+	#[cfg(c_bindings)]
+	/// We don't actually use the lifetime parameter in C bindings (as there is no good way to
+	/// communicate a lifetime to a C, or worse, Java user).
+	_phantom: core::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> Record<'a> {
 	/// Returns a new Record.
 	/// (C-not exported) as fmt can't be used in C
 	#[inline]
-	pub fn new(level: Level, args: fmt::Arguments<'a>, module_path: &'a str, file: &'a str, line: u32) -> Record<'a> {
+	pub fn new(level: Level, args: fmt::Arguments<'a>, module_path: &'static str, file: &'static str, line: u32) -> Record<'a> {
 		Record {
 			level,
+			#[cfg(not(c_bindings))]
 			args,
+			#[cfg(c_bindings)]
+			args: format!("{}", args),
 			module_path,
 			file,
-			line
+			line,
+			#[cfg(c_bindings)]
+			_phantom: core::marker::PhantomData,
 		}
 	}
 }


### PR DESCRIPTION
This adds a new (non-feature) cfg argument `c_bindings` which will
be set when building C bindings. With this, we can (slightly) tweak
behavior and API based on whether we are being built for Rust or C
users.

Ideally we'd never need this, but as long as we can keep the API
consistent-enough to avoid material code drift, this gives us a
cheap way of doing the "right" thing for both C and Rust when the
two are in tension.

We also move lightning-background-processor to support the same
MSRV as the main lightning crate, instead of only
lightning-net-tokio's MSRV.

This is a backport of 016eb96fc7170bdbab238292d3cc9338c2a66eb9