### PR TITLE
Score successful payment paths

### DIFF
--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -4665,6 +4665,7 @@ mod tests {
 		}
 
 		fn payment_path_failed(&mut self, _path: &[&RouteHop], _short_channel_id: u64) {}
+		fn payment_path_successful(&mut self, _path: &[&RouteHop]) {}
 	}
 
 	struct BadNodeScorer {
@@ -4682,6 +4683,7 @@ mod tests {
 		}
 
 		fn payment_path_failed(&mut self, _path: &[&RouteHop], _short_channel_id: u64) {}
+		fn payment_path_successful(&mut self, _path: &[&RouteHop]) {}
 	}
 
 	#[test]

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -95,6 +95,9 @@ pub trait Score $(: $supertrait)* {
 
 	/// Handles updating channel penalties after failing to route through a channel.
 	fn payment_path_failed(&mut self, path: &[&RouteHop], short_channel_id: u64);
+
+	/// Handles updating channel penalties after successfully routing along a path.
+	fn payment_path_successful(&mut self, path: &[&RouteHop]);
 }
 
 impl<S: Score, T: DerefMut<Target=S> $(+ $supertrait)*> Score for T {
@@ -104,6 +107,10 @@ impl<S: Score, T: DerefMut<Target=S> $(+ $supertrait)*> Score for T {
 
 	fn payment_path_failed(&mut self, path: &[&RouteHop], short_channel_id: u64) {
 		self.deref_mut().payment_path_failed(path, short_channel_id)
+	}
+
+	fn payment_path_successful(&mut self, path: &[&RouteHop]) {
+		self.deref_mut().payment_path_successful(path)
 	}
 }
 } }
@@ -377,6 +384,8 @@ impl<T: Time> Score for ScorerUsingTime<T> {
 			.and_modify(|failure| failure.add_penalty(failure_penalty_msat, half_life))
 			.or_insert_with(|| ChannelFailure::new(failure_penalty_msat));
 	}
+
+	fn payment_path_successful(&mut self, _path: &[&RouteHop]) {}
 }
 
 impl<T: Time> Writeable for ScorerUsingTime<T> {


### PR DESCRIPTION
Expand the `Score` trait with a `payment_path_successful` function for scoring successful payment paths. Called by `InvoicePayer`'s `EventHandler` implementation when processing `PaymentPathSuccessful` events. May be used by `Score` implementations to revert any channel penalties that were applied by calls to `payment_path_failed`.

In `Scorer`, if a payment failed to route through a channel, a penalty is applied to the channel in the future when finding a route. This penalty decays over time. Immediately decay the penalty by one half life when a payment is successfully routed through the channel.