### PR TITLE
Fix payment retry races and inform users when a payment fails

### DIFF
--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -152,6 +152,10 @@ where
 	) -> Result<(), PaymentSendFailure> {
 		self.retry_payment(route, payment_id)
 	}
+
+	fn abandon_payment(&self, payment_id: PaymentId) {
+		self.abandon_payment(payment_id)
+	}
 }
 
 #[cfg(test)]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2393,8 +2393,8 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						}))
 					},
 					PendingOutboundPayment::Fulfilled { .. } => {
-						return Err(PaymentSendFailure::ParameterError(APIError::RouteError {
-							err: "Payment already completed"
+						return Err(PaymentSendFailure::ParameterError(APIError::APIMisuseError {
+							err: "Payment already completed".to_owned()
 						}));
 					},
 					PendingOutboundPayment::Abandoned { .. } => {

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -336,10 +336,11 @@ pub fn create_chan_between_nodes_with_value<'a, 'b, 'c, 'd>(node_a: &'a Node<'b,
 }
 
 #[macro_export]
+/// Gets an RAA and CS which were sent in response to a commitment update
 macro_rules! get_revoke_commit_msgs {
 	($node: expr, $node_id: expr) => {
 		{
-			use util::events::MessageSendEvent;
+			use $crate::util::events::MessageSendEvent;
 			let events = $node.node.get_and_clear_pending_msg_events();
 			assert_eq!(events.len(), 2);
 			(match events[0] {
@@ -400,8 +401,8 @@ macro_rules! get_event {
 	}
 }
 
-#[cfg(test)]
 #[macro_export]
+/// Gets an UpdateHTLCs MessageSendEvent
 macro_rules! get_htlc_update_msgs {
 	($node: expr, $node_id: expr) => {
 		{
@@ -933,6 +934,9 @@ impl SendEvent {
 	}
 }
 
+#[macro_export]
+/// Performs the "commitment signed dance" - the series of message exchanges which occur after a
+/// commitment update.
 macro_rules! commitment_signed_dance {
 	($node_a: expr, $node_b: expr, $commitment_signed: expr, $fail_backwards: expr, true /* skip last step */) => {
 		{
@@ -999,7 +1003,7 @@ macro_rules! commitment_signed_dance {
 		{
 			commitment_signed_dance!($node_a, $node_b, $commitment_signed, $fail_backwards, true);
 			if $fail_backwards {
-				expect_pending_htlcs_forwardable!($node_a);
+				$crate::expect_pending_htlcs_forwardable!($node_a);
 				check_added_monitors!($node_a, 1);
 
 				let channel_state = $node_a.node.channel_state.lock().unwrap();
@@ -1057,6 +1061,8 @@ macro_rules! get_route_and_payment_hash {
 	}}
 }
 
+#[macro_export]
+/// Clears (and ignores) a PendingHTLCsForwardable event
 macro_rules! expect_pending_htlcs_forwardable_ignore {
 	($node: expr) => {{
 		let events = $node.node.get_and_clear_pending_events();
@@ -1068,9 +1074,11 @@ macro_rules! expect_pending_htlcs_forwardable_ignore {
 	}}
 }
 
+#[macro_export]
+/// Handles a PendingHTLCsForwardable event
 macro_rules! expect_pending_htlcs_forwardable {
 	($node: expr) => {{
-		expect_pending_htlcs_forwardable_ignore!($node);
+		$crate::expect_pending_htlcs_forwardable_ignore!($node);
 		$node.node.process_pending_htlc_forwards();
 
 		// Ensure process_pending_htlc_forwards is idempotent.
@@ -1199,60 +1207,95 @@ macro_rules! expect_payment_forwarded {
 	}
 }
 
+pub struct PaymentFailedConditions<'a> {
+	pub(crate) expected_htlc_error_data: Option<(u16, &'a [u8])>,
+	pub(crate) expected_blamed_scid: Option<u64>,
+	pub(crate) expected_blamed_chan_closed: Option<bool>,
+}
+
+impl<'a> PaymentFailedConditions<'a> {
+	pub fn new() -> Self {
+		Self {
+			expected_htlc_error_data: None,
+			expected_blamed_scid: None,
+			expected_blamed_chan_closed: None,
+		}
+	}
+	pub fn blamed_scid(mut self, scid: u64) -> Self {
+		self.expected_blamed_scid = Some(scid);
+		self
+	}
+	pub fn blamed_chan_closed(mut self, closed: bool) -> Self {
+		self.expected_blamed_chan_closed = Some(closed);
+		self
+	}
+	pub fn expected_htlc_error_data(mut self, code: u16, data: &'a [u8]) -> Self {
+		self.expected_htlc_error_data = Some((code, data));
+		self
+	}
+}
+
 #[cfg(test)]
 macro_rules! expect_payment_failed_with_update {
 	($node: expr, $expected_payment_hash: expr, $rejected_by_dest: expr, $scid: expr, $chan_closed: expr) => {
-		let events = $node.node.get_and_clear_pending_events();
-		assert_eq!(events.len(), 1);
-		match events[0] {
-			Event::PaymentPathFailed { ref payment_hash, rejected_by_dest, ref network_update, ref error_code, ref error_data, ref path, ref retry, .. } => {
-				assert_eq!(*payment_hash, $expected_payment_hash, "unexpected payment_hash");
-				assert_eq!(rejected_by_dest, $rejected_by_dest, "unexpected rejected_by_dest value");
-				assert!(retry.is_some(), "expected retry.is_some()");
-				assert_eq!(retry.as_ref().unwrap().final_value_msat, path.last().unwrap().fee_msat, "Retry amount should match last hop in path");
-				assert_eq!(retry.as_ref().unwrap().payee.pubkey, path.last().unwrap().pubkey, "Retry payee node_id should match last hop in path");
-				assert!(error_code.is_some(), "expected error_code.is_some() = true");
-				assert!(error_data.is_some(), "expected error_data.is_some() = true");
-				match network_update {
-					&Some(NetworkUpdate::ChannelUpdateMessage { ref msg }) if !$chan_closed => {
-						assert_eq!(msg.contents.short_channel_id, $scid);
-						assert_eq!(msg.contents.flags & 2, 0);
-					},
-					&Some(NetworkUpdate::ChannelClosed { short_channel_id, is_permanent }) if $chan_closed => {
-						assert_eq!(short_channel_id, $scid);
-						assert!(is_permanent);
-					},
-					Some(_) => panic!("Unexpected update type"),
-					None => panic!("Expected update"),
-				}
-			},
-			_ => panic!("Unexpected event"),
-		}
+		expect_payment_failed_conditions!($node, $expected_payment_hash, $rejected_by_dest,
+			$crate::ln::functional_test_utils::PaymentFailedConditions::new().blamed_scid($scid).blamed_chan_closed($chan_closed));
 	}
 }
 
 #[cfg(test)]
 macro_rules! expect_payment_failed {
 	($node: expr, $expected_payment_hash: expr, $rejected_by_dest: expr $(, $expected_error_code: expr, $expected_error_data: expr)*) => {
+		let mut conditions = $crate::ln::functional_test_utils::PaymentFailedConditions::new();
+		$(
+			conditions = conditions.expected_htlc_error_data($expected_error_code, &$expected_error_data);
+		)*
+		expect_payment_failed_conditions!($node, $expected_payment_hash, $rejected_by_dest, conditions);
+	};
+}
+
+#[cfg(test)]
+macro_rules! expect_payment_failed_conditions {
+	($node: expr, $expected_payment_hash: expr, $rejected_by_dest: expr, $conditions: expr) => {
 		let events = $node.node.get_and_clear_pending_events();
 		assert_eq!(events.len(), 1);
 		match events[0] {
-			Event::PaymentPathFailed { ref payment_hash, rejected_by_dest, network_update: _, ref error_code, ref error_data, ref path, ref retry, .. } => {
+			Event::PaymentPathFailed { ref payment_hash, rejected_by_dest, ref error_code, ref error_data, ref path, ref retry, ref network_update, .. } => {
 				assert_eq!(*payment_hash, $expected_payment_hash, "unexpected payment_hash");
 				assert_eq!(rejected_by_dest, $rejected_by_dest, "unexpected rejected_by_dest value");
 				assert!(retry.is_some(), "expected retry.is_some()");
 				assert_eq!(retry.as_ref().unwrap().final_value_msat, path.last().unwrap().fee_msat, "Retry amount should match last hop in path");
 				assert_eq!(retry.as_ref().unwrap().payee.pubkey, path.last().unwrap().pubkey, "Retry payee node_id should match last hop in path");
+
 				assert!(error_code.is_some(), "expected error_code.is_some() = true");
 				assert!(error_data.is_some(), "expected error_data.is_some() = true");
-				$(
-					assert_eq!(error_code.unwrap(), $expected_error_code, "unexpected error code");
-					assert_eq!(&error_data.as_ref().unwrap()[..], $expected_error_data, "unexpected error data");
-				)*
+				if let Some((code, data)) = $conditions.expected_htlc_error_data {
+					assert_eq!(error_code.unwrap(), code, "unexpected error code");
+					assert_eq!(&error_data.as_ref().unwrap()[..], data, "unexpected error data");
+				}
+
+				if let Some(chan_closed) = $conditions.expected_blamed_chan_closed {
+					match network_update {
+						&Some($crate::routing::network_graph::NetworkUpdate::ChannelUpdateMessage { ref msg }) if !chan_closed => {
+							if let Some(scid) = $conditions.expected_blamed_scid {
+								assert_eq!(msg.contents.short_channel_id, scid);
+							}
+							assert_eq!(msg.contents.flags & 2, 0);
+						},
+						&Some($crate::routing::network_graph::NetworkUpdate::ChannelClosed { short_channel_id, is_permanent }) if chan_closed => {
+							if let Some(scid) = $conditions.expected_blamed_scid {
+								assert_eq!(short_channel_id, scid);
+							}
+							assert!(is_permanent);
+						},
+						Some(_) => panic!("Unexpected update type"),
+						None => panic!("Expected update"),
+					}
+				}
 			},
 			_ => panic!("Unexpected event"),
-		}
-	}
+		};
+	};
 }
 
 pub fn send_along_route_with_secret<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, route: Route, expected_paths: &[&[&Node<'a, 'b, 'c>]], recv_value: u64, our_payment_hash: PaymentHash, our_payment_secret: PaymentSecret) -> PaymentId {

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -23,7 +23,7 @@ use ln::channelmanager::{ChannelManager, ChannelManagerReadArgs, PaymentId, RAAC
 use ln::channel::{Channel, ChannelError};
 use ln::{chan_utils, onion_utils};
 use ln::chan_utils::{HTLC_SUCCESS_TX_WEIGHT, HTLC_TIMEOUT_TX_WEIGHT, HTLCOutputInCommitment};
-use routing::network_graph::{NetworkUpdate, RoutingFees};
+use routing::network_graph::RoutingFees;
 use routing::router::{Payee, Route, RouteHop, RouteHint, RouteHintHop, RouteParameters, find_route, get_route};
 use ln::features::{ChannelFeatures, InitFeatures, InvoiceFeatures, NodeFeatures};
 use ln::msgs;

--- a/lightning/src/ln/monitor_tests.rs
+++ b/lightning/src/ln/monitor_tests.rs
@@ -16,7 +16,6 @@ use ln::channelmanager::BREAKDOWN_TIMEOUT;
 use ln::features::InitFeatures;
 use ln::msgs::ChannelMessageHandler;
 use util::events::{Event, MessageSendEvent, MessageSendEventsProvider, ClosureReason};
-use routing::network_graph::NetworkUpdate;
 
 use bitcoin::blockdata::script::Builder;
 use bitcoin::blockdata::opcodes;

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -67,7 +67,7 @@ fn retry_single_path_payment() {
 	check_added_monitors!(nodes[1], 1);
 	nodes[0].node.handle_update_fail_htlc(&nodes[1].node.get_our_node_id(), &htlc_updates.update_fail_htlcs[0]);
 	commitment_signed_dance!(nodes[0], nodes[1], htlc_updates.commitment_signed, false);
-	expect_payment_failed!(nodes[0], payment_hash, false);
+	expect_payment_failed_conditions!(nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
 
 	// Rebalance the channel so the retry succeeds.
 	send_payment(&nodes[2], &vec!(&nodes[1])[..], 3_000_000);
@@ -170,7 +170,7 @@ fn mpp_retry() {
 	check_added_monitors!(nodes[2], 1);
 	nodes[0].node.handle_update_fail_htlc(&nodes[2].node.get_our_node_id(), &htlc_updates.update_fail_htlcs[0]);
 	commitment_signed_dance!(nodes[0], nodes[2], htlc_updates.commitment_signed, false);
-	expect_payment_failed!(nodes[0], payment_hash, false);
+	expect_payment_failed_conditions!(nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
 
 	// Rebalance the channel so the second half of the payment can succeed.
 	send_payment(&nodes[3], &vec!(&nodes[2])[..], 1_500_000);
@@ -437,7 +437,7 @@ fn do_retry_with_no_persist(confirm_before_reload: bool) {
 		confirm_transaction(&nodes[0], &as_htlc_timeout_txn[0]);
 	}
 	nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap().clear();
-	expect_payment_failed!(nodes[0], payment_hash, false);
+	expect_payment_failed_conditions!(nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
 
 	// Finally, retry the payment (which was reloaded from the ChannelMonitor when nodes[0] was
 	// reloaded) via a route over the new channel, which work without issue and eventually be

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -15,7 +15,6 @@ use chain::{Confirm, Watch};
 use ln::channelmanager::{ChannelManager, ChannelManagerReadArgs};
 use ln::features::InitFeatures;
 use ln::msgs::ChannelMessageHandler;
-use routing::network_graph::NetworkUpdate;
 use util::enforcing_trait_impls::EnforcingSigner;
 use util::events::{Event, MessageSendEvent, MessageSendEventsProvider, ClosureReason};
 use util::test_utils;

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -13,7 +13,6 @@ use chain::keysinterface::KeysInterface;
 use chain::transaction::OutPoint;
 use ln::channelmanager::PaymentSendFailure;
 use routing::router::{Payee, get_route};
-use routing::network_graph::NetworkUpdate;
 use ln::features::{InitFeatures, InvoiceFeatures};
 use ln::msgs;
 use ln::msgs::{ChannelMessageHandler, ErrorAction};


### PR DESCRIPTION
As described in #1164, our payment retry logic is race-y and may retry payments after we should have exhausted our retry count. Worse, when using our `InvoicePayer`, there is no clear way for a user to detect at all when a payment is fully and irrevocably failed. This PR addresses both with a new event - `PaymentFailed` which is generated only after all HTLCs for a payment are failed and the payment has timed out or the user marks it as no longer retryable.