### PR TITLE
Remove OnionV2 parsing support

### DIFF
--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -475,10 +475,9 @@ macro_rules! impl_array {
 	);
 }
 
-//TODO: performance issue with [u8; size] with impl_array!()
 impl_array!(3); // for rgb
 impl_array!(4); // for IPv4
-impl_array!(10); // for OnionV2
+impl_array!(12); // for OnionV2
 impl_array!(16); // for IPv6
 impl_array!(32); // for channel id & hmac
 impl_array!(PUBLIC_KEY_SIZE); // for PublicKey


### PR DESCRIPTION
OnionV2s don't (really) work on Tor anymore anyway, and the field
is set for removal in the BOLTs [1]. Sadly because of the way
addresses are parsed we have to continue to understand that type 3
addresses are 12 bytes long. Thus, for simplicity we keep the
`OnionV2` enum variant around and just make it an opaque 12 bytes,
with the documentation updated to note the deprecation.

[1] https://github.com/lightning/bolts/pull/940