### PR TITLE
Add a method to prune stale channels from NetworkGraph

### DIFF
--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 bitcoin = "0.27"
-lightning = { version = "0.0.103", path = "../lightning", features = ["allow_wallclock_use"] }
+lightning = { version = "0.0.103", path = "../lightning", features = ["std"] }
 lightning-persister = { version = "0.0.103", path = "../lightning-persister" }
 
 [dev-dependencies]

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -11,7 +11,6 @@ Still missing tons of error-handling. See GitHub issues for suggested projects i
 """
 
 [features]
-allow_wallclock_use = []
 fuzztarget = ["bitcoin/fuzztarget", "regex"]
 # Internal test utilities exposed to other repo crates
 _test_utils = ["hex", "regex", "bitcoin/bitcoinconsensus"]
@@ -53,6 +52,3 @@ secp256k1 = { version = "0.20.2", default-features = false, features = ["alloc"]
 version = "0.27"
 default-features = false
 features = ["bitcoinconsensus", "secp-recovery"]
-
-[package.metadata.docs.rs]
-features = ["allow_wallclock_use"] # When https://github.com/rust-lang/rust/issues/43781 complies with our MSVR, we can add nice banners in the docs for the methods behind this feature-gate.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -67,9 +67,10 @@ use io::{Cursor, Read};
 use sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
-#[cfg(any(test, feature = "allow_wallclock_use"))]
-use std::time::Instant;
 use core::ops::Deref;
+
+#[cfg(any(test, feature = "std"))]
+use std::time::Instant;
 
 // We hold various information about HTLC relay in the HTLC objects in Channel itself:
 //
@@ -5110,8 +5111,9 @@ where
 	/// indicating whether persistence is necessary. Only one listener on
 	/// `await_persistable_update` or `await_persistable_update_timeout` is guaranteed to be woken
 	/// up.
-	/// Note that the feature `allow_wallclock_use` must be enabled to use this function.
-	#[cfg(any(test, feature = "allow_wallclock_use"))]
+	///
+	/// Note that this method is not available with the `no-std` feature.
+	#[cfg(any(test, feature = "std"))]
 	pub fn await_persistable_update_timeout(&self, max_wait: Duration) -> bool {
 		self.persistence_notifier.wait_timeout(max_wait)
 	}
@@ -5406,7 +5408,7 @@ impl PersistenceNotifier {
 		}
 	}
 
-	#[cfg(any(test, feature = "allow_wallclock_use"))]
+	#[cfg(any(test, feature = "std"))]
 	fn wait_timeout(&self, max_wait: Duration) -> bool {
 		let current_time = Instant::now();
 		loop {

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -249,6 +249,12 @@ where C::Target: chain::Access, L::Target: Logger
 		self.chain_access = chain_access;
 	}
 
+	/// Gets a reference to the underlying [`NetworkGraph`] which was provided in
+	/// [`NetGraphMsgHandler::new`].
+	pub fn network_graph(&self) -> &G {
+		&self.network_graph
+	}
+
 	/// Returns true when a full routing table sync should be performed with a peer.
 	fn should_request_full_sync(&self, _node_id: &PublicKey) -> bool {
 		//TODO: Determine whether to request a full sync based on the network map.
@@ -1074,6 +1080,8 @@ impl NetworkGraph {
 	/// updates every two weeks, the non-normative section of BOLT 7 currently suggests that
 	/// pruning occur for updates which are at least two weeks old, which we implement here.
 	///
+	/// Note that for users of the `lightning-background-processor` crate this method may be
+	/// automatically called regularly for you.
 	///
 	/// This method is only available with the `std` feature. See
 	/// [`NetworkGraph::remove_stale_channels_with_time`] for `no-std` use.


### PR DESCRIPTION
We define "stale" as "haven't heard an updated channel_update in
two weeks", as described in BOLT 7.

We also filter out stale channels at write-time for `std` users, as
we can look up the current time.