### PR TITLE
Add utility for retrieving an LDK payment preimage

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5026,8 +5026,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	/// payment secret fetched via this method or [`create_inbound_payment`], and which is at least
 	/// the `min_value_msat` provided here, if one is provided.
 	///
-	/// The [`PaymentHash`] (and corresponding [`PaymentPreimage`]) must be globally unique. This
-	/// method may return an Err if another payment with the same payment_hash is still pending.
+	/// The [`PaymentHash`] (and corresponding [`PaymentPreimage`]) should be globally unique, though
+	/// note that LDK will not stop you from registering duplicate payment hashes for inbound
+	/// payments.
 	///
 	/// `min_value_msat` should be set if the invoice being generated contains a value. Any payment
 	/// received for the returned [`PaymentHash`] will be required to be at least `min_value_msat`

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -113,7 +113,7 @@ mod inbound_payment {
 
 	impl ExpandedKey {
 		pub(super) fn new(key_material: &KeyMaterial) -> ExpandedKey {
-			hkdf_extract_expand(&vec![0], &key_material)
+			hkdf_extract_expand(b"LDK Inbound Payment Key Expansion", &key_material)
 		}
 	}
 


### PR DESCRIPTION
#1177 introduced a way to register inbound payments with LDK that does not require storing any information about said payments.

However, it was missing a utility for users to be able to retrieve the payment preimage when it was originally supplied by LDK, so we add that here.

Based on #1215 

Closes #1213