### PR TITLE
Adapt lightning-invoice to no_std

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,11 @@ jobs:
           # check if there is a conflict between no-std and the default std feature
           cargo test --verbose --color always --features no-std
           cd ..
+          cd lightning-invoice
+          cargo test --verbose --color always --no-default-features --features no-std
+          # check if there is a conflict between no-std and the default std feature
+          cargo test --verbose --color always --features no-std
+          cd ..
       - name: Test on no-std builds Rust ${{ matrix.toolchain }} and full code-linking for coverage generation
         if: "matrix.build-no-std && matrix.coverage"
         run: |

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -8,13 +8,20 @@ license = "MIT OR Apache-2.0"
 keywords = [ "lightning", "bitcoin", "invoice", "BOLT11" ]
 readme = "README.md"
 
+[features]
+default = ["std"]
+no-std = ["hashbrown", "lightning/no-std", "core2/alloc"]
+std = ["bitcoin_hashes/std", "num-traits/std", "lightning/std"]
+
 [dependencies]
 bech32 = "0.8"
-lightning = { version = "0.0.104", path = "../lightning" }
-secp256k1 = { version = "0.20", features = ["recovery"] }
-num-traits = "0.2.8"
-bitcoin_hashes = "0.10"
+lightning = { version = "0.0.104", path = "../lightning", default-features = false }
+secp256k1 = { version = "0.20", default-features = false, features = ["recovery", "alloc"] }
+num-traits = { version = "0.2.8", default-features = false }
+bitcoin_hashes = { version = "0.10", default-features = false }
+hashbrown = { version = "0.11", optional = true }
+core2 = { version = "0.3.0", default-features = false, optional = true }
 
 [dev-dependencies]
+lightning = { version = "0.0.104", path = "../lightning", default-features = false, features = ["_test_utils"] }
 hex = "0.3"
-lightning = { version = "0.0.104", path = "../lightning", features = ["_test_utils"] }

--- a/lightning-invoice/src/de.rs
+++ b/lightning-invoice/src/de.rs
@@ -1,15 +1,17 @@
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt;
-use std::fmt::{Display, Formatter};
-use std::num::ParseIntError;
-use std::str;
-use std::str::FromStr;
+use core::fmt;
+use core::fmt::{Display, Formatter};
+use core::num::ParseIntError;
+use core::str;
+use core::str::FromStr;
 
 use bech32;
 use bech32::{u5, FromBase32};
 
 use bitcoin_hashes::Hash;
 use bitcoin_hashes::sha256;
+use crate::prelude::*;
 use lightning::ln::PaymentSecret;
 use lightning::routing::network_graph::RoutingFees;
 use lightning::routing::router::{RouteHint, RouteHintHop};
@@ -28,7 +30,7 @@ use self::hrp_sm::parse_hrp;
 
 /// State machine to parse the hrp
 mod hrp_sm {
-	use std::ops::Range;
+	use core::ops::Range;
 
 	#[derive(PartialEq, Eq, Debug)]
 	enum States {
@@ -723,8 +725,10 @@ impl Display for ParseOrSemanticError {
 	}
 }
 
+#[cfg(feature = "std")]
 impl error::Error for ParseError {}
 
+#[cfg(feature = "std")]
 impl error::Error for ParseOrSemanticError {}
 
 macro_rules! from_error {

--- a/lightning-invoice/src/ser.rs
+++ b/lightning-invoice/src/ser.rs
@@ -1,6 +1,7 @@
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use core::fmt;
+use core::fmt::{Display, Formatter};
 use bech32::{ToBase32, u5, WriteBase32, Base32Len};
+use crate::prelude::*;
 
 use super::{Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiry, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
 	PrivateRoute, Description, RawTaggedField, Currency, RawHrp, SiPrefix, constants, SignedRawInvoice, RawDataPart};
@@ -64,7 +65,7 @@ impl<'a, W: WriteBase32> BytesToBase32<'a, W> {
 
 	pub fn finalize(mut self) ->  Result<(), W::Err> {
 		self.inner_finalize()?;
-		std::mem::forget(self);
+		core::mem::forget(self);
 		Ok(())
 	}
 

--- a/lightning-invoice/src/sync.rs
+++ b/lightning-invoice/src/sync.rs
@@ -1,0 +1,37 @@
+use core::cell::{RefCell, RefMut};
+use core::ops::{Deref, DerefMut};
+
+pub type LockResult<Guard> = Result<Guard, ()>;
+
+pub struct Mutex<T: ?Sized> {
+	inner: RefCell<T>
+}
+
+#[must_use = "if unused the Mutex will immediately unlock"]
+pub struct MutexGuard<'a, T: ?Sized + 'a> {
+	lock: RefMut<'a, T>,
+}
+
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
+		&self.lock.deref()
+	}
+}
+
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
+	fn deref_mut(&mut self) -> &mut T {
+		self.lock.deref_mut()
+	}
+}
+
+impl<T> Mutex<T> {
+	pub fn new(inner: T) -> Mutex<T> {
+		Mutex { inner: RefCell::new(inner) }
+	}
+
+	pub fn lock<'a>(&'a self) -> LockResult<MutexGuard<'a, T>> {
+		Ok(MutexGuard { lock: self.inner.borrow_mut() })
+	}
+}

--- a/lightning-invoice/tests/ser_de.rs
+++ b/lightning-invoice/tests/ser_de.rs
@@ -15,7 +15,7 @@ use lightning_invoice::*;
 use secp256k1::PublicKey;
 use secp256k1::recovery::{RecoverableSignature, RecoveryId};
 use std::collections::HashSet;
-use std::time::{Duration, UNIX_EPOCH};
+use std::time::Duration;
 use std::str::FromStr;
 
 fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
@@ -23,7 +23,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 		(
 			"lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq9qrsgq357wnc5r2ueh7ck6q93dj32dlqnls087fxdwk8qakdyafkq3yap9us6v52vjjsrvywa6rt52cm9r9zqt8r2t7mlcwspyetp5h2tztugp9lfyql".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
 						"0001020304050607080900010203040506070809000102030405060708090102"
@@ -44,7 +44,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0rl77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(250_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"
@@ -66,7 +66,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(250_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"
@@ -88,7 +88,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqs9qrsgq7ea976txfraylvgzuxs8kgcw23ezlrszfnh8r6qtfpr6cxga50aj6txm9rxrydzd06dfeawfk6swupvz4erwnyutnjq7x39ymw6j38gp7ynn44".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(2_000_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
@@ -109,7 +109,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lntb20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un989qrsgqdj545axuxtnfemtpwkc45hx9d2ft7x04mt8q7y6t0k2dge9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8".to_owned(),
 			InvoiceBuilder::new(Currency::BitcoinTestnet)
 				.amount_milli_satoshis(2_000_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
@@ -131,7 +131,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85fr9yq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqpqqqqq9qqqvpeuqafqxu92d8lr6fvg0r5gv0heeeqgcrqlnm6jhphu9y00rrhy4grqszsvpcgpy9qqqqqqgqqqqq7qqzq9qrsgqdfjcdk6w3ak5pca9hwfwfh63zrrz06wwfya0ydlzpgzxkn5xagsqz7x9j4jwe7yj7vaf2k9lqsdk45kts2fd0fkr28am0u4w95tt2nsq76cqw0".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(2_000_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
@@ -170,7 +170,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfppj3a24vwu6r8ejrss3axul8rxldph2q7z99qrsgqz6qsgww34xlatfj6e3sngrwfy3ytkt29d2qttr8qz2mnedfqysuqypgqex4haa2h8fx3wnypranf3pdwyluftwe680jjcfp438u82xqphf75ym".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(2_000_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
@@ -192,7 +192,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfppqw508d6qejxtdg4y5r3zarvary0c5xw7k9qrsgqt29a0wturnys2hhxpner2e3plp6jyj8qx7548zr2z7ptgjjc7hljm98xhjym0dg52sdrvqamxdezkmqg4gdrvwwnf0kv2jdfnl4xatsqmrnsse".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(2_000_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
@@ -216,7 +216,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfp4qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q9qrsgq9vlvyj8cqvq6ggvpwd53jncp9nwc47xlrsnenq2zp70fq83qlgesn4u3uyf4tesfkkwwfg3qs54qe426hp3tz7z6sweqdjg05axsrjqp9yrrwc".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(2_000_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
@@ -240,7 +240,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc9678785340p1pwmna7lpp5gc3xfm08u9qy06djf8dfflhugl6p7lgza6dsjxq454gxhj9t7a0sd8dgfkx7cmtwd68yetpd5s9xar0wfjn5gpc8qhrsdfq24f5ggrxdaezqsnvda3kkum5wfjkzmfqf3jkgem9wgsyuctwdus9xgrcyqcjcgpzgfskx6eqf9hzqnteypzxz7fzypfhg6trddjhygrcyqezcgpzfysywmm5ypxxjemgw3hxjmn8yptk7untd9hxwg3q2d6xjcmtv4ezq7pqxgsxzmnyyqcjqmt0wfjjq6t5v4khxsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsxqyjw5qcqp2rzjq0gxwkzc8w6323m55m4jyxcjwmy7stt9hwkwe2qxmy8zpsgg7jcuwz87fcqqeuqqqyqqqqlgqqqqn3qq9q9qrsgqrvgkpnmps664wgkp43l22qsgdw4ve24aca4nymnxddlnp8vh9v2sdxlu5ywdxefsfvm0fq3sesf08uf6q9a2ke0hc9j6z6wlxg5z5kqpu2v9wz".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(967878534)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1572468703))
+				.duration_since_epoch(Duration::from_secs(1572468703))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
 					"462264ede7e14047e9b249da94fefc47f41f7d02ee9b091815a5506bc8abf75f"
@@ -272,7 +272,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqqqqqqqqqqqqsgq2a25dxl5hrntdtn6zvydt7d66hyzsyhqs4wdynavys42xgl6sgx9c4g7me86a27t07mdtfry458rtjr0v92cnmswpsjscgt2vcse3sgpz3uapa".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(2_500_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"
@@ -293,7 +293,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"LNBC25M1PVJLUEZPP5QQQSYQCYQ5RQWZQFQQQSYQCYQ5RQWZQFQQQSYQCYQ5RQWZQFQYPQDQ5VDHKVEN9V5SXYETPDEESSP5ZYG3ZYG3ZYG3ZYG3ZYG3ZYG3ZYG3ZYG3ZYG3ZYG3ZYG3ZYG3ZYGS9Q5SQQQQQQQQQQQQQQQQSGQ2A25DXL5HRNTDTN6ZVYDT7D66HYZSYHQS4WDYNAVYS42XGL6SGX9C4G7ME86A27T07MDTFRY458RTJR0V92CNMSWPSJSCGT2VCSE3SGPZ3UAPA".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(2_500_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"
@@ -314,7 +314,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 			"lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqqqqqqqqqqqqsgq2qrqqqfppnqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqppnqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpp4qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhpnqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhp4qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqspnqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsp4qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnp5qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnpkqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz599y53s3ujmcfjp5xrdap68qxymkqphwsexhmhr8wdz5usdzkzrse33chw6dlp3jhuhge9ley7j2ayx36kawe7kmgg8sv5ugdyusdcqzn8z9x".to_owned(),
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(2_500_000_000)
-				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
+				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
 				.payment_hash(sha256::Hash::from_hex(
 					"0001020304050607080900010203040506070809000102030405060708090102"

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -22,7 +22,7 @@ use ln::msgs;
 use ln::msgs::{ChannelMessageHandler,RoutingMessageHandler};
 use util::enforcing_trait_impls::EnforcingSigner;
 use util::test_utils;
-use util::test_utils::TestChainMonitor;
+use util::test_utils::{panicking, TestChainMonitor};
 use util::events::{Event, MessageSendEvent, MessageSendEventsProvider, PaymentPurpose};
 use util::errors::APIError;
 use util::config::UserConfig;
@@ -40,7 +40,7 @@ use bitcoin::secp256k1::key::PublicKey;
 use io;
 use prelude::*;
 use core::cell::RefCell;
-use std::rc::Rc;
+use alloc::rc::Rc;
 use sync::{Arc, Mutex};
 use core::mem;
 
@@ -231,7 +231,7 @@ impl<'a, 'b, 'c> Node<'a, 'b, 'c> {
 
 impl<'a, 'b, 'c> Drop for Node<'a, 'b, 'c> {
 	fn drop(&mut self) {
-		if !::std::thread::panicking() {
+		if !panicking() {
 			// Check that we processed all pending events
 			assert!(self.node.get_and_clear_pending_msg_events().is_empty());
 			assert!(self.node.get_and_clear_pending_events().is_empty());


### PR DESCRIPTION
Allow lightning-invoice to be used in a `no_std` environment.

The most interesting part is switching `PositiveTimestamp` to wrap `Duration` since the epoch, rather than `SystemTime`.

Also, re-exports some boilerplate `no_std` stubs from the lightning crate.
