### PR TITLE
update repo name to use lightningdevkit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
           profile: minimal
       - name: Fetch full tree and rebase on upstream
         run: |
-          git remote add upstream https://github.com/rust-bitcoin/rust-lightning
+          git remote add upstream https://github.com/lightningdevkit/rust-lightning
           git fetch upstream
           export GIT_COMMITTER_EMAIL="rl-ci@example.com"
           export GIT_COMMITTER_NAME="RL CI"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ Communication about Rust-Lightning happens primarily on #ldk-dev on the
 Discussion about code base improvements happens in GitHub issues and on pull
 requests.
 
-Major projects are tracked [here](https://github.com/rust-bitcoin/rust-lightning/projects).
-Major milestones are tracked [here](https://github.com/rust-bitcoin/rust-lightning/milestones?direction=asc&sort=title&state=open).
+Major projects are tracked [here](https://github.com/lightningdevkit/rust-lightning/projects).
+Major milestones are tracked [here](https://github.com/lightningdevkit/rust-lightning/milestones?direction=asc&sort=title&state=open).
 
 Getting Started
 ---------------
@@ -33,7 +33,7 @@ This doesn't mean don't be ambitious with the breadth and depth of your contribu
 understand the project culture before investing an asymmetric number of hours on
 development compared to your merged work.
 
-Browsing through the [meeting minutes](https://github.com/rust-bitcoin/rust-lightning/wiki/Meetings)
+Browsing through the [meeting minutes](https://github.com/lightningdevkit/rust-lightning/wiki/Meetings)
 is a good first step. You will learn who is working on what, how releases are drafted, what are the
 pending tasks to deliver, where you can contribute review bandwidth, etc.
 

--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -3,7 +3,7 @@ name = "lightning-background-processor"
 version = "0.0.104"
 authors = ["Valentine Wallace <vwallace@protonmail.com>"]
 license = "MIT OR Apache-2.0"
-repository = "http://github.com/rust-bitcoin/rust-lightning"
+repository = "http://github.com/lightningdevkit/rust-lightning"
 description = """
 Utilities to perform required background tasks for Rust Lightning.
 """

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -3,7 +3,7 @@ name = "lightning-block-sync"
 version = "0.0.104"
 authors = ["Jeffrey Czyz", "Matt Corallo"]
 license = "MIT OR Apache-2.0"
-repository = "http://github.com/rust-bitcoin/rust-lightning"
+repository = "http://github.com/lightningdevkit/rust-lightning"
 description = """
 Utilities to fetch the chain data from a block source and feed them into Rust Lightning.
 """

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -3,7 +3,7 @@ name = "lightning-net-tokio"
 version = "0.0.104"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/rust-bitcoin/rust-lightning/"
+repository = "https://github.com/lightningdevkit/rust-lightning/"
 description = """
 Implementation of the rust-lightning network stack using Tokio.
 For Rust-Lightning clients which wish to make direct connections to Lightning P2P nodes, this is a simple alternative to implementing the required network stack, especially for those already using Tokio.

--- a/lightning-persister/Cargo.toml
+++ b/lightning-persister/Cargo.toml
@@ -3,7 +3,7 @@ name = "lightning-persister"
 version = "0.0.104"
 authors = ["Valentine Wallace", "Matt Corallo"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/rust-bitcoin/rust-lightning/"
+repository = "https://github.com/lightningdevkit/rust-lightning/"
 description = """
 Utilities to manage Rust-Lightning channel data persistence and retrieval.
 """

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -3,7 +3,7 @@ name = "lightning"
 version = "0.0.104"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/rust-bitcoin/rust-lightning/"
+repository = "https://github.com/lightningdevkit/rust-lightning/"
 description = """
 A Bitcoin Lightning library in Rust.
 Does most of the hard work, without implying a specific runtime, requiring clients implement basic network logic, chain interactions and disk storage.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -6372,7 +6372,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 					log_error!(args.logger, " The chain::Watch API *requires* that monitors are persisted durably before returning,");
 					log_error!(args.logger, " client applications must ensure that ChannelMonitor data is always available and the latest to avoid funds loss!");
 					log_error!(args.logger, " Without the latest ChannelMonitor we cannot continue without risking funds.");
-					log_error!(args.logger, " Please ensure the chain::Watch API requirements are met and file a bug report at https://github.com/rust-bitcoin/rust-lightning");
+					log_error!(args.logger, " Please ensure the chain::Watch API requirements are met and file a bug report at https://github.com/lightningdevkit/rust-lightning");
 					return Err(DecodeError::InvalidValue);
 				} else if channel.get_cur_holder_commitment_transaction_number() > monitor.get_cur_holder_commitment_number() ||
 						channel.get_revoked_counterparty_commitment_transaction_number() > monitor.get_min_seen_secret() ||
@@ -6403,7 +6403,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 				log_error!(args.logger, " The chain::Watch API *requires* that monitors are persisted durably before returning,");
 				log_error!(args.logger, " client applications must ensure that ChannelMonitor data is always available and the latest to avoid funds loss!");
 				log_error!(args.logger, " Without the ChannelMonitor we cannot continue without risking funds.");
-				log_error!(args.logger, " Please ensure the chain::Watch API requirements are met and file a bug report at https://github.com/rust-bitcoin/rust-lightning");
+				log_error!(args.logger, " Please ensure the chain::Watch API requirements are met and file a bug report at https://github.com/lightningdevkit/rust-lightning");
 				return Err(DecodeError::InvalidValue);
 			}
 		}


### PR DESCRIPTION
Updating references to the repo to have updated github org name of `lightningdevkit`