### PR TITLE
[0.0.104 Bindings] Support building `cfg=c_bindings` with `no-std`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,11 +109,14 @@ jobs:
         run: RUSTFLAGS="-C link-dead-code" cargo test --verbose --color always
       - name: Test on no-std bullds Rust ${{ matrix.toolchain }}
         if: "matrix.build-no-std && !matrix.coverage"
+        shell: bash # Default on Winblows is powershell
         run: |
           cd lightning
           cargo test --verbose --color always --no-default-features --features no-std
           # check if there is a conflict between no-std and the default std feature
           cargo test --verbose --color always --features no-std
+          # check if there is a conflict between no-std and the c_bindings cfg
+          RUSTFLAGS="--cfg=c_bindings" cargo test --verbose --color always --no-default-features --features=no-std
           cd ..
       - name: Test on no-std builds Rust ${{ matrix.toolchain }} and full code-linking for coverage generation
         if: "matrix.build-no-std && matrix.coverage"

--- a/lightning/src/util/logger.rs
+++ b/lightning/src/util/logger.rs
@@ -17,6 +17,9 @@
 use core::cmp;
 use core::fmt;
 
+#[cfg(c_bindings)]
+use prelude::*; // Needed for String
+
 static LOG_LEVEL_NAMES: [&'static str; 6] = ["GOSSIP", "TRACE", "DEBUG", "INFO", "WARN", "ERROR"];
 
 /// An enum representing the available verbosity levels of the logger.


### PR DESCRIPTION
This is just #1226 backported to the 0.0.104-bindings branch, so that I can work on JS bindings against the 0.0.104 bindings.