### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" 
+    directory: "/" 
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo" 
+    directory: "/lightning-background-processor" 
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo" 
+    directory: "/lightning-block-sync" 
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo" 
+    directory: "/lightning-invoice" 
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo" 
+    directory: "/lightning-net-tokio"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo" 
+    directory: "/lightning-persister"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo" 
+    directory: "/lightning"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions" 
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
With the rise in supply chain attacks, it helps to get the dependency updates.

Even if the project decides not to update the dependency it helps to be informed. 

The dependabot settings have to be enabled in the security settings of the repository. 