### PR TITLE
Fix compiler warning during building/testing.

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -117,7 +117,7 @@ pub const DEFAULT_MIN_FINAL_CLTV_EXPIRY: u64 = 18;
 fn __system_time_size_check() {
 	// Use 2 * sizeof(u64) as expected size since the expected underlying implementation is storing
 	// a `Duration` since `SystemTime::UNIX_EPOCH`.
-	unsafe { core::mem::transmute_copy::<SystemTime, [u8; 16]>(&SystemTime::UNIX_EPOCH); }
+	unsafe { let _ = core::mem::transmute_copy::<SystemTime, [u8; 16]>(&SystemTime::UNIX_EPOCH); }
 }
 
 


### PR DESCRIPTION
This PR fixes the following warnings I got when running `cargo build`/`cargo test`:

```
warning: unused return value of `transmute_copy` that must be used
   --> lightning-invoice/src/lib.rs:120:11
    |
120 |     unsafe { core::mem::transmute_copy::<SystemTime, [u8; 16]>(&SystemTime::UNIX_EPOCH); }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default

...

warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
  --> /Users/ero/workspace/rust-lightning/lightning/src/lib.rs:23:9
   |
23 | #![deny(broken_intra_doc_links)]
   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default

...

warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
 --> /Users/ero/workspace/rust-lightning/lightning-background-processor/src/lib.rs:5:9
  |
5 | #![deny(broken_intra_doc_links)]
  |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
  |
  = note: `#[warn(renamed_and_removed_lints)]` on by default

...

warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
 --> /Users/ero/workspace/rust-lightning/lightning-invoice/src/lib.rs:6:9
  |
6 | #![deny(broken_intra_doc_links)]
  |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
  |
  = note: `#[warn(renamed_and_removed_lints)]` on by default

...

warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
 --> /Users/ero/workspace/rust-lightning/lightning-persister/src/lib.rs:3:9
  |
3 | #![deny(broken_intra_doc_links)]
  |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
  |
  = note: `#[warn(renamed_and_removed_lints)]` on by default

...

warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
  --> /Users/ero/workspace/rust-lightning/lightning-net-tokio/src/lib.rs:69:9
   |
69 | #![deny(broken_intra_doc_links)]
   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default

...

warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
  --> /Users/ero/workspace/rust-lightning/lightning-block-sync/src/lib.rs:16:9
   |
16 | #![deny(broken_intra_doc_links)]
   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default
```
