### PR TITLE
Rename `Payee` to `PaymentParameters`

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -308,7 +308,7 @@ fn send_payment(source: &ChanMan, dest: &ChanMan, dest_chan_id: u64, amt: u64, p
 			fee_msat: amt,
 			cltv_expiry_delta: 200,
 		}]],
-		payee: None,
+		payment_params: None,
 	}, payment_hash, &Some(payment_secret)) {
 		check_payment_err(err);
 		false
@@ -334,7 +334,7 @@ fn send_hop_payment(source: &ChanMan, middle: &ChanMan, middle_chan_id: u64, des
 			fee_msat: amt,
 			cltv_expiry_delta: 200,
 		}]],
-		payee: None,
+		payment_params: None,
 	}, payment_hash, &Some(payment_secret)) {
 		check_payment_err(err);
 		false

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -38,7 +38,7 @@ use lightning::ln::peer_handler::{MessageHandler,PeerManager,SocketDescriptor,Ig
 use lightning::ln::msgs::DecodeError;
 use lightning::ln::script::ShutdownScript;
 use lightning::routing::network_graph::{NetGraphMsgHandler, NetworkGraph};
-use lightning::routing::router::{find_route, Payee, RouteParameters};
+use lightning::routing::router::{find_route, PaymentParameters, RouteParameters};
 use lightning::routing::scoring::Scorer;
 use lightning::util::config::UserConfig;
 use lightning::util::errors::APIError;
@@ -446,9 +446,9 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 			},
 			4 => {
 				let final_value_msat = slice_to_be24(get_slice!(3)) as u64;
-				let payee = Payee::from_node_id(get_pubkey!());
+				let payment_params = PaymentParameters::from_node_id(get_pubkey!());
 				let params = RouteParameters {
-					payee,
+					payment_params,
 					final_value_msat,
 					final_cltv_expiry_delta: 42,
 				};
@@ -469,9 +469,9 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 			},
 			15 => {
 				let final_value_msat = slice_to_be24(get_slice!(3)) as u64;
-				let payee = Payee::from_node_id(get_pubkey!());
+				let payment_params = PaymentParameters::from_node_id(get_pubkey!());
 				let params = RouteParameters {
-					payee,
+					payment_params,
 					final_value_msat,
 					final_cltv_expiry_delta: 42,
 				};

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -16,7 +16,7 @@ use lightning::chain::transaction::OutPoint;
 use lightning::ln::channelmanager::{ChannelDetails, ChannelCounterparty};
 use lightning::ln::features::InitFeatures;
 use lightning::ln::msgs;
-use lightning::routing::router::{find_route, Payee, RouteHint, RouteHintHop, RouteParameters};
+use lightning::routing::router::{find_route, PaymentParameters, RouteHint, RouteHintHop, RouteParameters};
 use lightning::routing::scoring::Scorer;
 use lightning::util::logger::Logger;
 use lightning::util::ser::Readable;
@@ -251,12 +251,12 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 				}
 				let scorer = Scorer::with_fixed_penalty(0);
 				for target in node_pks.iter() {
-					let params = RouteParameters {
-						payee: Payee::from_node_id(*target).with_route_hints(last_hops.clone()),
+					let route_params = RouteParameters {
+						payment_params: PaymentParameters::from_node_id(*target).with_route_hints(last_hops.clone()),
 						final_value_msat: slice_to_be64(get_slice!(8)),
 						final_cltv_expiry_delta: slice_to_be32(get_slice!(4)),
 					};
-					let _ = find_route(&our_pubkey, &params, &net_graph,
+					let _ = find_route(&our_pubkey, &route_params, &net_graph,
 						first_hops.map(|c| c.iter().collect::<Vec<_>>()).as_ref().map(|a| a.as_slice()),
 						Arc::clone(&logger), &scorer);
 				}

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -198,7 +198,7 @@ mod test {
 	use lightning::ln::functional_test_utils::*;
 	use lightning::ln::features::InitFeatures;
 	use lightning::ln::msgs::ChannelMessageHandler;
-	use lightning::routing::router::{Payee, RouteParameters, find_route};
+	use lightning::routing::router::{PaymentParameters, RouteParameters, find_route};
 	use lightning::util::events::MessageSendEventsProvider;
 	use lightning::util::test_utils;
 	use utils::create_invoice_from_channelmanager_and_duration_since_epoch;
@@ -217,11 +217,11 @@ mod test {
 		assert_eq!(invoice.min_final_cltv_expiry(), MIN_FINAL_CLTV_EXPIRY as u64);
 		assert_eq!(invoice.description(), InvoiceDescription::Direct(&Description("test".to_string())));
 
-		let payee = Payee::from_node_id(invoice.recover_payee_pub_key())
+		let payment_params = PaymentParameters::from_node_id(invoice.recover_payee_pub_key())
 			.with_features(invoice.features().unwrap().clone())
 			.with_route_hints(invoice.route_hints());
-		let params = RouteParameters {
-			payee,
+		let route_params = RouteParameters {
+			payment_params,
 			final_value_msat: invoice.amount_milli_satoshis().unwrap(),
 			final_cltv_expiry_delta: invoice.min_final_cltv_expiry() as u32,
 		};
@@ -230,7 +230,7 @@ mod test {
 		let logger = test_utils::TestLogger::new();
 		let scorer = test_utils::TestScorer::with_fixed_penalty(0);
 		let route = find_route(
-			&nodes[0].node.get_our_node_id(), &params, network_graph,
+			&nodes[0].node.get_our_node_id(), &route_params, network_graph,
 			Some(&first_hops.iter().collect::<Vec<_>>()), &logger, &scorer,
 		).unwrap();
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -5992,7 +5992,7 @@ mod tests {
 				first_hop_htlc_msat: 548,
 				payment_id: PaymentId([42; 32]),
 				payment_secret: None,
-				payee: None,
+				payment_params: None,
 			}
 		});
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -45,7 +45,7 @@ use chain::transaction::{OutPoint, TransactionData};
 use ln::{PaymentHash, PaymentPreimage, PaymentSecret};
 use ln::channel::{Channel, ChannelError, ChannelUpdateStatus, UpdateFulfillCommitFetch};
 use ln::features::{InitFeatures, NodeFeatures};
-use routing::router::{Payee, Route, RouteHop, RoutePath, RouteParameters};
+use routing::router::{PaymentParameters, Route, RouteHop, RoutePath, RouteParameters};
 use ln::msgs;
 use ln::msgs::NetAddress;
 use ln::onion_utils;
@@ -491,7 +491,7 @@ pub(crate) enum HTLCSource {
 		first_hop_htlc_msat: u64,
 		payment_id: PaymentId,
 		payment_secret: Option<PaymentSecret>,
-		payee: Option<Payee>,
+		payment_params: Option<PaymentParameters>,
 	},
 }
 #[allow(clippy::derive_hash_xor_eq)] // Our Hash is faithful to the data, we just don't have SecretKey::hash
@@ -502,14 +502,14 @@ impl core::hash::Hash for HTLCSource {
 				0u8.hash(hasher);
 				prev_hop_data.hash(hasher);
 			},
-			HTLCSource::OutboundRoute { path, session_priv, payment_id, payment_secret, first_hop_htlc_msat, payee } => {
+			HTLCSource::OutboundRoute { path, session_priv, payment_id, payment_secret, first_hop_htlc_msat, payment_params } => {
 				1u8.hash(hasher);
 				path.hash(hasher);
 				session_priv[..].hash(hasher);
 				payment_id.hash(hasher);
 				payment_secret.hash(hasher);
 				first_hop_htlc_msat.hash(hasher);
-				payee.hash(hasher);
+				payment_params.hash(hasher);
 			},
 		}
 	}
@@ -523,7 +523,7 @@ impl HTLCSource {
 			first_hop_htlc_msat: 0,
 			payment_id: PaymentId([2; 32]),
 			payment_secret: None,
-			payee: None,
+			payment_params: None,
 		}
 	}
 }
@@ -2428,7 +2428,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	}
 
 	// Only public for testing, this should otherwise never be called direcly
-	pub(crate) fn send_payment_along_path(&self, path: &Vec<RouteHop>, payee: &Option<Payee>, payment_hash: &PaymentHash, payment_secret: &Option<PaymentSecret>, total_value: u64, cur_height: u32, payment_id: PaymentId, keysend_preimage: &Option<PaymentPreimage>) -> Result<(), APIError> {
+	pub(crate) fn send_payment_along_path(&self, path: &Vec<RouteHop>, payment_params: &Option<PaymentParameters>, payment_hash: &PaymentHash, payment_secret: &Option<PaymentSecret>, total_value: u64, cur_height: u32, payment_id: PaymentId, keysend_preimage: &Option<PaymentPreimage>) -> Result<(), APIError> {
 		log_trace!(self.logger, "Attempting to send payment for path with next hop {}", path.first().unwrap().short_channel_id);
 		let prng_seed = self.keys_manager.get_secure_random_bytes();
 		let session_priv_bytes = self.keys_manager.get_secure_random_bytes();
@@ -2493,7 +2493,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							first_hop_htlc_msat: htlc_msat,
 							payment_id,
 							payment_secret: payment_secret.clone(),
-							payee: payee.clone(),
+							payment_params: payment_params.clone(),
 						}, onion_packet, &self.logger),
 					channel_state, chan)
 				} {
@@ -2622,7 +2622,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let cur_height = self.best_block.read().unwrap().height() + 1;
 		let mut results = Vec::new();
 		for path in route.paths.iter() {
-			results.push(self.send_payment_along_path(&path, &route.payee, &payment_hash, payment_secret, total_value, cur_height, payment_id, &keysend_preimage));
+			results.push(self.send_payment_along_path(&path, &route.payment_params, &payment_hash, payment_secret, total_value, cur_height, payment_id, &keysend_preimage));
 		}
 		let mut has_ok = false;
 		let mut has_err = false;
@@ -2646,9 +2646,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				results,
 				payment_id,
 				failed_paths_retry: if pending_amt_unsent != 0 {
-					if let Some(payee) = &route.payee {
+					if let Some(payment_params) = &route.payment_params {
 						Some(RouteParameters {
-							payee: payee.clone(),
+							payment_params: payment_params.clone(),
 							final_value_msat: pending_amt_unsent,
 							final_cltv_expiry_delta: max_unsent_cltv_delta,
 						})
@@ -3585,16 +3585,16 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					self.fail_htlc_backwards_internal(channel_state,
 						htlc_src, &payment_hash, HTLCFailReason::Reason { failure_code, data: onion_failure_data});
 				},
-				HTLCSource::OutboundRoute { session_priv, payment_id, path, payee, .. } => {
+				HTLCSource::OutboundRoute { session_priv, payment_id, path, payment_params, .. } => {
 					let mut session_priv_bytes = [0; 32];
 					session_priv_bytes.copy_from_slice(&session_priv[..]);
 					let mut outbounds = self.pending_outbound_payments.lock().unwrap();
 					if let hash_map::Entry::Occupied(mut payment) = outbounds.entry(payment_id) {
 						if payment.get_mut().remove(&session_priv_bytes, Some(&path)) && !payment.get().is_fulfilled() {
-							let retry = if let Some(payee_data) = payee {
+							let retry = if let Some(payment_params_data) = payment_params {
 								let path_last_hop = path.last().expect("Outbound payments must have had a valid path");
 								Some(RouteParameters {
-									payee: payee_data,
+									payment_params: payment_params_data,
 									final_value_msat: path_last_hop.fee_msat,
 									final_cltv_expiry_delta: path_last_hop.cltv_expiry_delta,
 								})
@@ -3646,7 +3646,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		// from block_connected which may run during initialization prior to the chain_monitor
 		// being fully configured. See the docs for `ChannelManagerReadArgs` for more.
 		match source {
-			HTLCSource::OutboundRoute { ref path, session_priv, payment_id, ref payee, .. } => {
+			HTLCSource::OutboundRoute { ref path, session_priv, payment_id, ref payment_params, .. } => {
 				let mut session_priv_bytes = [0; 32];
 				session_priv_bytes.copy_from_slice(&session_priv[..]);
 				let mut outbounds = self.pending_outbound_payments.lock().unwrap();
@@ -3676,10 +3676,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					return;
 				}
 				mem::drop(channel_state_lock);
-				let retry = if let Some(payee_data) = payee {
+				let retry = if let Some(payment_params_data) = payment_params {
 					let path_last_hop = path.last().expect("Outbound payments must have had a valid path");
 					Some(RouteParameters {
-						payee: payee_data.clone(),
+						payment_params: payment_params_data.clone(),
 						final_value_msat: path_last_hop.fee_msat,
 						final_cltv_expiry_delta: path_last_hop.cltv_expiry_delta,
 					})
@@ -5985,14 +5985,14 @@ impl Readable for HTLCSource {
 				let mut path = Some(Vec::new());
 				let mut payment_id = None;
 				let mut payment_secret = None;
-				let mut payee = None;
+				let mut payment_params = None;
 				read_tlv_fields!(reader, {
 					(0, session_priv, required),
 					(1, payment_id, option),
 					(2, first_hop_htlc_msat, required),
 					(3, payment_secret, option),
 					(4, path, vec_type),
-					(5, payee, option),
+					(5, payment_params, option),
 				});
 				if payment_id.is_none() {
 					// For backwards compat, if there was no payment_id written, use the session_priv bytes
@@ -6005,7 +6005,7 @@ impl Readable for HTLCSource {
 					path: path.unwrap(),
 					payment_id: payment_id.unwrap(),
 					payment_secret,
-					payee,
+					payment_params,
 				})
 			}
 			1 => Ok(HTLCSource::PreviousHopData(Readable::read(reader)?)),
@@ -6017,7 +6017,7 @@ impl Readable for HTLCSource {
 impl Writeable for HTLCSource {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::io::Error> {
 		match self {
-			HTLCSource::OutboundRoute { ref session_priv, ref first_hop_htlc_msat, ref path, payment_id, payment_secret, payee } => {
+			HTLCSource::OutboundRoute { ref session_priv, ref first_hop_htlc_msat, ref path, payment_id, payment_secret, payment_params } => {
 				0u8.write(writer)?;
 				let payment_id_opt = Some(payment_id);
 				write_tlv_fields!(writer, {
@@ -6026,7 +6026,7 @@ impl Writeable for HTLCSource {
 					(2, first_hop_htlc_msat, required),
 					(3, payment_secret, option),
 					(4, path, vec_type),
-					(5, payee, option),
+					(5, payment_params, option),
 				 });
 			}
 			HTLCSource::PreviousHopData(ref field) => {
@@ -6639,7 +6639,7 @@ mod tests {
 	use ln::functional_test_utils::*;
 	use ln::msgs;
 	use ln::msgs::ChannelMessageHandler;
-	use routing::router::{Payee, RouteParameters, find_route};
+	use routing::router::{PaymentParameters, RouteParameters, find_route};
 	use util::errors::APIError;
 	use util::events::{Event, MessageSendEvent, MessageSendEventsProvider};
 	use util::test_utils;
@@ -6786,7 +6786,7 @@ mod tests {
 		// Use the utility function send_payment_along_path to send the payment with MPP data which
 		// indicates there are more HTLCs coming.
 		let cur_height = CHAN_CONFIRM_DEPTH + 1; // route_payment calls send_payment, which adds 1 to the current height. So we do the same here to match.
-		nodes[0].node.send_payment_along_path(&route.paths[0], &route.payee, &our_payment_hash, &Some(payment_secret), 200_000, cur_height, payment_id, &None).unwrap();
+		nodes[0].node.send_payment_along_path(&route.paths[0], &route.payment_params, &our_payment_hash, &Some(payment_secret), 200_000, cur_height, payment_id, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 		let mut events = nodes[0].node.get_and_clear_pending_msg_events();
 		assert_eq!(events.len(), 1);
@@ -6816,7 +6816,7 @@ mod tests {
 		expect_payment_failed!(nodes[0], our_payment_hash, true);
 
 		// Send the second half of the original MPP payment.
-		nodes[0].node.send_payment_along_path(&route.paths[0], &route.payee, &our_payment_hash, &Some(payment_secret), 200_000, cur_height, payment_id, &None).unwrap();
+		nodes[0].node.send_payment_along_path(&route.paths[0], &route.payment_params, &our_payment_hash, &Some(payment_secret), 200_000, cur_height, payment_id, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 		let mut events = nodes[0].node.get_and_clear_pending_msg_events();
 		assert_eq!(events.len(), 1);
@@ -6902,13 +6902,13 @@ mod tests {
 		let (payment_preimage, payment_hash, _) = route_payment(&nodes[0], &expected_route, 100_000);
 
 		// Next, attempt a keysend payment and make sure it fails.
-		let params = RouteParameters {
-			payee: Payee::for_keysend(expected_route.last().unwrap().node.get_our_node_id()),
+		let route_params = RouteParameters {
+			payment_params: PaymentParameters::for_keysend(expected_route.last().unwrap().node.get_our_node_id()),
 			final_value_msat: 100_000,
 			final_cltv_expiry_delta: TEST_FINAL_CLTV,
 		};
 		let route = find_route(
-			&nodes[0].node.get_our_node_id(), &params, nodes[0].network_graph, None,
+			&nodes[0].node.get_our_node_id(), &route_params, nodes[0].network_graph, None,
 			nodes[0].logger, &scorer
 		).unwrap();
 		nodes[0].node.send_spontaneous_payment(&route, Some(payment_preimage)).unwrap();
@@ -6939,7 +6939,7 @@ mod tests {
 		// To start (2), send a keysend payment but don't claim it.
 		let payment_preimage = PaymentPreimage([42; 32]);
 		let route = find_route(
-			&nodes[0].node.get_our_node_id(), &params, nodes[0].network_graph, None,
+			&nodes[0].node.get_our_node_id(), &route_params, nodes[0].network_graph, None,
 			nodes[0].logger, &scorer
 		).unwrap();
 		let (payment_hash, _) = nodes[0].node.send_spontaneous_payment(&route, Some(payment_preimage)).unwrap();
@@ -6993,8 +6993,8 @@ mod tests {
 		nodes[1].node.peer_connected(&payer_pubkey, &msgs::Init { features: InitFeatures::known() });
 
 		let _chan = create_chan_between_nodes(&nodes[0], &nodes[1], InitFeatures::known(), InitFeatures::known());
-		let params = RouteParameters {
-			payee: Payee::for_keysend(payee_pubkey),
+		let route_params = RouteParameters {
+			payment_params: PaymentParameters::for_keysend(payee_pubkey),
 			final_value_msat: 10000,
 			final_cltv_expiry_delta: 40,
 		};
@@ -7002,7 +7002,7 @@ mod tests {
 		let first_hops = nodes[0].node.list_usable_channels();
 		let scorer = test_utils::TestScorer::with_fixed_penalty(0);
 		let route = find_route(
-			&payer_pubkey, &params, network_graph, Some(&first_hops.iter().collect::<Vec<_>>()),
+			&payer_pubkey, &route_params, network_graph, Some(&first_hops.iter().collect::<Vec<_>>()),
 			nodes[0].logger, &scorer
 		).unwrap();
 
@@ -7036,8 +7036,8 @@ mod tests {
 		nodes[1].node.peer_connected(&payer_pubkey, &msgs::Init { features: InitFeatures::known() });
 
 		let _chan = create_chan_between_nodes(&nodes[0], &nodes[1], InitFeatures::known(), InitFeatures::known());
-		let params = RouteParameters {
-			payee: Payee::for_keysend(payee_pubkey),
+		let route_params = RouteParameters {
+			payment_params: PaymentParameters::for_keysend(payee_pubkey),
 			final_value_msat: 10000,
 			final_cltv_expiry_delta: 40,
 		};
@@ -7045,7 +7045,7 @@ mod tests {
 		let first_hops = nodes[0].node.list_usable_channels();
 		let scorer = test_utils::TestScorer::with_fixed_penalty(0);
 		let route = find_route(
-			&payer_pubkey, &params, network_graph, Some(&first_hops.iter().collect::<Vec<_>>()),
+			&payer_pubkey, &route_params, network_graph, Some(&first_hops.iter().collect::<Vec<_>>()),
 			nodes[0].logger, &scorer
 		).unwrap();
 
@@ -7136,7 +7136,7 @@ pub mod bench {
 	use ln::functional_test_utils::*;
 	use ln::msgs::{ChannelMessageHandler, Init};
 	use routing::network_graph::NetworkGraph;
-	use routing::router::{Payee, get_route};
+	use routing::router::{PaymentParameters, get_route};
 	use routing::scoring::Scorer;
 	use util::test_utils;
 	use util::config::UserConfig;
@@ -7245,10 +7245,10 @@ pub mod bench {
 		macro_rules! send_payment {
 			($node_a: expr, $node_b: expr) => {
 				let usable_channels = $node_a.list_usable_channels();
-				let payee = Payee::from_node_id($node_b.get_our_node_id())
+				let payment_params = PaymentParameters::from_node_id($node_b.get_our_node_id())
 					.with_features(InvoiceFeatures::known());
 				let scorer = Scorer::with_fixed_penalty(0);
-				let route = get_route(&$node_a.get_our_node_id(), &payee, &dummy_graph,
+				let route = get_route(&$node_a.get_our_node_id(), &payment_params, &dummy_graph,
 					Some(&usable_channels.iter().map(|r| r).collect::<Vec<_>>()), 10_000, TEST_FINAL_CLTV, &logger_a, &scorer).unwrap();
 
 				let mut payment_preimage = PaymentPreimage([0; 32]);

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -500,10 +500,10 @@ impl InvoiceFeatures {
 	/// Getting a route for a keysend payment to a private node requires providing the payee's
 	/// features (since they were not announced in a node announcement). However, keysend payments
 	/// don't have an invoice to pull the payee's features from, so this method is provided for use in
-	/// [`Payee::for_keysend`], thus omitting the need for payers to manually construct an
+	/// [`PaymentParameters::for_keysend`], thus omitting the need for payers to manually construct an
 	/// `InvoiceFeatures` for [`find_route`].
 	///
-	/// [`Payee::for_keysend`]: crate::routing::router::Payee::for_keysend
+	/// [`PaymentParameters::for_keysend`]: crate::routing::router::PaymentParameters::for_keysend
 	/// [`find_route`]: crate::routing::router::find_route
 	pub(crate) fn for_keysend() -> InvoiceFeatures {
 		InvoiceFeatures::empty().set_variable_length_onion_optional()

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -555,7 +555,7 @@ mod tests {
 						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 			]],
-			payee: None,
+			payment_params: None,
 		};
 
 		let session_priv = SecretKey::from_slice(&hex::decode("4141414141414141414141414141414141414141414141414141414141414141").unwrap()[..]).unwrap();

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -18,7 +18,7 @@ use ln::channelmanager::{BREAKDOWN_TIMEOUT, ChannelManager, ChannelManagerReadAr
 use ln::features::{InitFeatures, InvoiceFeatures};
 use ln::msgs;
 use ln::msgs::ChannelMessageHandler;
-use routing::router::{Payee, get_route};
+use routing::router::{PaymentParameters, get_route};
 use util::events::{ClosureReason, Event, MessageSendEvent, MessageSendEventsProvider};
 use util::test_utils;
 use util::errors::APIError;
@@ -721,11 +721,11 @@ fn get_ldk_payment_preimage() {
 	let expiry_secs = 60 * 60;
 	let (payment_hash, payment_secret) = nodes[1].node.create_inbound_payment(Some(amt_msat), expiry_secs).unwrap();
 
-	let payee = Payee::from_node_id(nodes[1].node.get_our_node_id())
+	let payment_params = PaymentParameters::from_node_id(nodes[1].node.get_our_node_id())
 		.with_features(InvoiceFeatures::known());
 	let scorer = test_utils::TestScorer::with_fixed_penalty(0);
 	let route = get_route(
-		&nodes[0].node.get_our_node_id(), &payee, &nodes[0].network_graph,
+		&nodes[0].node.get_our_node_id(), &payment_params, &nodes[0].network_graph,
 		Some(&nodes[0].node.list_usable_channels().iter().collect::<Vec<_>>()),
 		amt_msat, TEST_FINAL_CLTV, nodes[0].logger, &scorer).unwrap();
 	let _payment_id = nodes[0].node.send_payment(&route, payment_hash, &Some(payment_secret)).unwrap();

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -12,7 +12,7 @@
 use chain::keysinterface::KeysInterface;
 use chain::transaction::OutPoint;
 use ln::channelmanager::PaymentSendFailure;
-use routing::router::{Payee, get_route};
+use routing::router::{PaymentParameters, get_route};
 use ln::features::{InitFeatures, InvoiceFeatures};
 use ln::msgs;
 use ln::msgs::{ChannelMessageHandler, ErrorAction};
@@ -91,10 +91,10 @@ fn updates_shutdown_wait() {
 
 	let (_, payment_hash, payment_secret) = get_payment_preimage_hash!(nodes[0]);
 
-	let payee_1 = Payee::from_node_id(nodes[1].node.get_our_node_id()).with_features(InvoiceFeatures::known());
-	let route_1 = get_route(&nodes[0].node.get_our_node_id(), &payee_1, nodes[0].network_graph, None, 100000, TEST_FINAL_CLTV, &logger, &scorer).unwrap();
-	let payee_2 = Payee::from_node_id(nodes[0].node.get_our_node_id()).with_features(InvoiceFeatures::known());
-	let route_2 = get_route(&nodes[1].node.get_our_node_id(), &payee_2, nodes[1].network_graph, None, 100000, TEST_FINAL_CLTV, &logger, &scorer).unwrap();
+	let payment_params_1 = PaymentParameters::from_node_id(nodes[1].node.get_our_node_id()).with_features(InvoiceFeatures::known());
+	let route_1 = get_route(&nodes[0].node.get_our_node_id(), &payment_params_1, nodes[0].network_graph, None, 100000, TEST_FINAL_CLTV, &logger, &scorer).unwrap();
+	let payment_params_2 = PaymentParameters::from_node_id(nodes[0].node.get_our_node_id()).with_features(InvoiceFeatures::known());
+	let route_2 = get_route(&nodes[1].node.get_our_node_id(), &payment_params_2, nodes[1].network_graph, None, 100000, TEST_FINAL_CLTV, &logger, &scorer).unwrap();
 	unwrap_send_err!(nodes[0].node.send_payment(&route_1, payment_hash, &Some(payment_secret)), true, APIError::ChannelUnavailable {..}, {});
 	unwrap_send_err!(nodes[1].node.send_payment(&route_2, payment_hash, &Some(payment_secret)), true, APIError::ChannelUnavailable {..}, {});
 


### PR DESCRIPTION
This PR is a follow-up to #1234. 

As suggested there, it currently renames `Payee` to `PaymentParameters` and `Payee.pubkey` to `PaymentParameters.payee_pubkey`.

Should, for the sake of consistency, `Payee.features` maybe also get renamed to `PaymentParameters.payee_features`?