### PR TITLE
Add option accept or reject channel requests

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4723,6 +4723,15 @@ impl<Signer: Sign> Channel<Signer> {
 		}
 	}
 
+	/// Enables the possibility for tests to extract a [`msgs::AcceptChannel`] message for an
+	/// inbound channel without accepting it.
+	///
+	/// [`msgs::AcceptChannel`]: crate::ln::msgs::AcceptChannel
+	#[cfg(test)]
+	pub fn get_accept_channel_message(&self) -> msgs::AcceptChannel {
+		self.generate_accept_channel_message()
+	}
+
 	/// If an Err is returned, it is a ChannelError::Close (for get_outbound_funding_created)
 	fn get_outbound_funding_created_signature<L: Deref>(&mut self, logger: &L) -> Result<Signature, ChannelError> where L::Target: Logger {
 		let counterparty_keys = self.build_remote_transaction_keys()?;

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -305,6 +305,20 @@ pub struct UserConfig {
 	/// If this is set to false, we do not accept inbound requests to open a new channel.
 	/// Default value: true.
 	pub accept_inbound_channels: bool,
+	/// If this is set to true, the user needs to manually accept inbound requests to open a new
+	/// channel.
+	///
+	/// When set to true, [`Event::OpenChannelRequest`] will be triggered once a request to open a
+	/// new inbound channel is received through a [`msgs::OpenChannel`] message. In that case, a
+	/// [`msgs::AcceptChannel`] message will not be sent back to the counterparty node unless the
+	/// user explicitly chooses to accept the request.
+	///
+	/// Default value: false.
+	///
+	/// [`Event::OpenChannelRequest`]: crate::util::events::Event::OpenChannelRequest
+	/// [`msgs::OpenChannel`]: crate::ln::msgs::OpenChannel
+	/// [`msgs::AcceptChannel`]: crate::ln::msgs::AcceptChannel
+	pub manually_accept_inbound_channels: bool,
 }
 
 impl Default for UserConfig {
@@ -315,6 +329,7 @@ impl Default for UserConfig {
 			channel_options: ChannelConfig::default(),
 			accept_forwards_to_priv_channels: false,
 			accept_inbound_channels: true,
+			manually_accept_inbound_channels: false,
 		}
 	}
 }


### PR DESCRIPTION
Adds support for manually accepting or rejecting a request to open a channel. Issue #1242
