### PR TITLE
Remove stale reference to incomplete BOLT compliance

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4731,9 +4731,6 @@ impl<Signer: Sign> Channel<Signer> {
 	/// Will only fail if we're not in a state where channel_announcement may be sent (including
 	/// closing).
 	///
-	/// Note that the "channel must be funded" requirement is stricter than BOLT 7 requires - see
-	/// https://github.com/lightningnetwork/lightning-rfc/issues/468
-	///
 	/// This will only return ChannelError::Ignore upon failure.
 	fn get_channel_announcement(&self, node_id: PublicKey, chain_hash: BlockHash) -> Result<msgs::UnsignedChannelAnnouncement, ChannelError> {
 		if !self.config.announced_channel {


### PR DESCRIPTION
The referenced issue was closed some time ago with a PR to amend
the BOLTs to be more restrictive, which we are in compliance with.

As pointed out by Val at https://github.com/lightningdevkit/rust-lightning/pull/1179#discussion_r792963206