### PR TITLE
Log penalty info in route-success line

### DIFF
--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -1252,6 +1252,7 @@ mod tests {
 					}],
 				],
 				payment_params: None,
+				path_penalties: Vec::with_capacity(2),
 			}
 		}
 
@@ -1544,6 +1545,7 @@ mod tests {
 				}],
 			],
 			payment_params: Some(PaymentParameters::from_node_id(nodes[1].node.get_our_node_id())),
+			path_penalties: Vec::with_capacity(2),
 		};
 		let router = ManualRouter(RefCell::new(VecDeque::new()));
 		router.expect_find_route(Ok(route.clone()));
@@ -1588,6 +1590,7 @@ mod tests {
 				}],
 			],
 			payment_params: Some(PaymentParameters::from_node_id(nodes[1].node.get_our_node_id())),
+			path_penalties: Vec::with_capacity(1),
 		};
 		let router = ManualRouter(RefCell::new(VecDeque::new()));
 		router.expect_find_route(Ok(route.clone()));
@@ -1669,6 +1672,7 @@ mod tests {
 				}]
 			],
 			payment_params: Some(PaymentParameters::from_node_id(nodes[2].node.get_our_node_id())),
+			path_penalties: Vec::with_capacity(2)
 		};
 		let router = ManualRouter(RefCell::new(VecDeque::new()));
 		router.expect_find_route(Ok(route.clone()));

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -1081,7 +1081,7 @@ fn fake_network_test() {
 	});
 	hops[1].fee_msat = chan_4.1.contents.fee_base_msat as u64 + chan_4.1.contents.fee_proportional_millionths as u64 * hops[2].fee_msat as u64 / 1000000;
 	hops[0].fee_msat = chan_3.0.contents.fee_base_msat as u64 + chan_3.0.contents.fee_proportional_millionths as u64 * hops[1].fee_msat as u64 / 1000000;
-	let payment_preimage_1 = send_along_route(&nodes[1], Route { paths: vec![hops], payment_params: None }, &vec!(&nodes[2], &nodes[3], &nodes[1])[..], 1000000).0;
+	let payment_preimage_1 = send_along_route(&nodes[1], Route { paths: vec![hops], payment_params: None, path_penalties: Vec::with_capacity(1) }, &vec!(&nodes[2], &nodes[3], &nodes[1])[..], 1000000).0;
 
 	let mut hops = Vec::with_capacity(3);
 	hops.push(RouteHop {
@@ -1110,7 +1110,7 @@ fn fake_network_test() {
 	});
 	hops[1].fee_msat = chan_2.1.contents.fee_base_msat as u64 + chan_2.1.contents.fee_proportional_millionths as u64 * hops[2].fee_msat as u64 / 1000000;
 	hops[0].fee_msat = chan_3.1.contents.fee_base_msat as u64 + chan_3.1.contents.fee_proportional_millionths as u64 * hops[1].fee_msat as u64 / 1000000;
-	let payment_hash_2 = send_along_route(&nodes[1], Route { paths: vec![hops], payment_params: None }, &vec!(&nodes[3], &nodes[2], &nodes[1])[..], 1000000).1;
+	let payment_hash_2 = send_along_route(&nodes[1], Route { paths: vec![hops], payment_params: None, path_penalties: Vec::with_capacity(1) }, &vec!(&nodes[3], &nodes[2], &nodes[1])[..], 1000000).1;
 
 	// Claim the rebalances...
 	fail_payment(&nodes[1], &vec!(&nodes[3], &nodes[2], &nodes[1])[..], payment_hash_2);

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -556,6 +556,7 @@ mod tests {
 					},
 			]],
 			payment_params: None,
+			path_penalties: Vec::with_capacity(1),
 		};
 
 		let session_priv = SecretKey::from_slice(&hex::decode("4141414141414141414141414141414141414141414141414141414141414141").unwrap()[..]).unwrap();

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -72,7 +72,7 @@ pub(crate) struct DebugRoute<'a>(pub &'a Route);
 impl<'a> core::fmt::Display for DebugRoute<'a> {
 	fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
 		for (idx, p) in self.0.paths.iter().enumerate() {
-			writeln!(f, "path {}:", idx)?;
+			writeln!(f, "path {} (penalty: {}):", idx, self.0.path_penalties[idx])?;
 			for h in p.iter() {
 				writeln!(f, " node_id: {}, short_channel_id: {}, fee_msat: {}, cltv_expiry_delta: {}", log_pubkey!(h.pubkey), h.short_channel_id, h.fee_msat, h.cltv_expiry_delta)?;
 			}


### PR DESCRIPTION
This PR is an attempt at #1233.

My goal is to be able to leverage on the existing `log_route!` macro to print the penalties for each path found within a route, which meant making the penalty data available somehow in the `Route` struct.

I think this contribution can be improved by adding test coverage, but am struggling to figure out where to add them. Suggestions welcome!

I'm new to Rust + contributing to open-source, so please feel free to leave feedback! I am also happy to change the implementation if adding a field to Route is not something we want to pursue. 

Thanks!

## Demo
This is the old output for routes (ran via `routing::router::tests::simple_route_test`):

```
INFO   [lightning::routing::router : lightning/src/routing/router.rs, 1538] Got route to 03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b: path 0:
 node_id: 02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337, short_channel_id: 2, fee_msat: 100, cltv_expiry_delta: 65
 node_id: 03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b, short_channel_id: 4, fee_msat: 100, cltv_expiry_delta: 42
```

New (diff in ****):

```
INFO   [lightning::routing::router : lightning/src/routing/router.rs, 1538] Got route to 03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b: path 0 **(penalty: 0)**:
 node_id: 02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337, short_channel_id: 2, fee_msat: 100, cltv_expiry_delta: 65
 node_id: 03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b, short_channel_id: 4, fee_msat: 100, cltv_expiry_delta: 42
```