### PR TITLE
Generate docs with features for docs.rs 

### DIFF
--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -9,6 +9,10 @@ Utilities to perform required background tasks for Rust Lightning.
 """
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 bitcoin = "0.27"
 lightning = { version = "0.0.104", path = "../lightning", features = ["std"] }

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -6,6 +6,8 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #[macro_use] extern crate lightning;
 
 use lightning::chain;

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -9,6 +9,10 @@ Utilities to fetch the chain data from a block source and feed them into Rust Li
 """
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 rest-client = [ "serde", "serde_json", "chunked_transfer" ]
 rpc-client = [ "serde", "serde_json", "chunked_transfer" ]

--- a/lightning-block-sync/src/convert.rs
+++ b/lightning-block-sync/src/convert.rs
@@ -182,7 +182,7 @@ impl TryInto<Txid> for JsonResponse {
 }
 
 /// Converts a JSON value into a transaction. WATCH OUT! this cannot be used for zero-input transactions
-/// (e.g. createrawtransaction). See https://github.com/rust-bitcoin/rust-bitcoincore-rpc/issues/197
+/// (e.g. createrawtransaction). See <https://github.com/rust-bitcoin/rust-bitcoincore-rpc/issues/197>
 impl TryInto<Transaction> for JsonResponse {
 	type Error = std::io::Error;
 	fn try_into(self) -> std::io::Result<Transaction> {

--- a/lightning-block-sync/src/lib.rs
+++ b/lightning-block-sync/src/lib.rs
@@ -17,6 +17,8 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #[cfg(any(feature = "rest-client", feature = "rpc-client"))]
 pub mod http;
 

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT OR Apache-2.0"
 keywords = [ "lightning", "bitcoin", "invoice", "BOLT11" ]
 readme = "README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["std"]
 no-std = ["hashbrown", "lightning/no-std", "core2/alloc"]

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -5,6 +5,8 @@
 #![deny(unused_mut)]
 #![deny(broken_intra_doc_links)]
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -10,6 +10,10 @@ For Rust-Lightning clients which wish to make direct connections to Lightning P2
 """
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 bitcoin = "0.27"
 lightning = { version = "0.0.104", path = "../lightning" }

--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -69,6 +69,8 @@
 #![deny(broken_intra_doc_links)]
 #![deny(missing_docs)]
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 use bitcoin::secp256k1::key::PublicKey;
 
 use tokio::net::TcpStream;

--- a/lightning-persister/Cargo.toml
+++ b/lightning-persister/Cargo.toml
@@ -8,6 +8,10 @@ description = """
 Utilities to manage Rust-Lightning channel data persistence and retrieval.
 """
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 _bench_unstable = ["lightning/_bench_unstable"]
 

--- a/lightning-persister/src/lib.rs
+++ b/lightning-persister/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(broken_intra_doc_links)]
 #![deny(missing_docs)]
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![cfg_attr(all(test, feature = "_bench_unstable"), feature(test))]
 #[cfg(all(test, feature = "_bench_unstable"))] extern crate test;
 

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -10,6 +10,10 @@ Does most of the hard work, without implying a specific runtime, requiring clien
 Still missing tons of error-handling. See GitHub issues for suggested projects if you want to contribute. Don't have to bother telling you not to use this for anything serious, because you'd have to build a client around it to even try.
 """
 
+[package.metadata.docs.rs]
+features = ["std"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 # Internal test utilities exposed to other repo crates
 _test_utils = ["hex", "regex", "bitcoin/bitcoinconsensus"]

--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -28,6 +28,8 @@
 #![allow(bare_trait_objects)]
 #![allow(ellipsis_inclusive_range_patterns)]
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 #![cfg_attr(all(any(test, feature = "_test_utils"), feature = "_bench_unstable"), feature(test))]

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -246,7 +246,6 @@ type ConfiguredTime = time::Eternity;
 /// [`Score`] implementation.
 ///
 /// (C-not exported) generally all users should use the [`Scorer`] type alias.
-#[doc(hidden)]
 pub struct ScorerUsingTime<T: Time> {
 	params: ScoringParameters,
 	// TODO: Remove entries of closed channels.
@@ -493,7 +492,6 @@ pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, ConfiguredTi
 /// Probabilistic [`Score`] implementation.
 ///
 /// (C-not exported) generally all users should use the [`ProbabilisticScorer`] type alias.
-#[doc(hidden)]
 pub struct ProbabilisticScorerUsingTime<G: Deref<Target = NetworkGraph>, T: Time> {
 	params: ProbabilisticScoringParameters,
 	network_graph: G,

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -235,7 +235,7 @@ pub enum Event {
 	/// Note that this does *not* indicate that all paths for an MPP payment have failed, see
 	/// [`Event::PaymentFailed`] and [`all_paths_failed`].
 	///
-	/// [`all_paths_failed`]: Self::all_paths_failed
+	/// [`all_paths_failed`]: Self::PaymentPathFailed::all_paths_failed
 	PaymentPathFailed {
 		/// The id returned by [`ChannelManager::send_payment`] and used with
 		/// [`ChannelManager::retry_payment`] and [`ChannelManager::abandon_payment`].


### PR DESCRIPTION
Enable generating docs using `--all-features` or `--features="std"` where applicable. Additionally, use `doc_auto_cfg` to tag items requiring a feature.

https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg

This requires building with `nightly`, which is what is used by docs.rs.

https://docs.rs/about/builds

To test locally, use:

`RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc ...`