### PR TITLE
Immutable BlockSource interface

### DIFF
--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -20,6 +20,7 @@ rpc-client = [ "serde", "serde_json", "chunked_transfer" ]
 [dependencies]
 bitcoin = "0.27"
 lightning = { version = "0.0.106", path = "../lightning" }
+futures = { version = "0.3" }
 tokio = { version = "1.0", features = [ "io-util", "net", "time" ], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/lightning-block-sync/src/init.rs
+++ b/lightning-block-sync/src/init.rs
@@ -16,7 +16,7 @@ use lightning::chain;
 /// start when there are no chain listeners to sync yet.
 ///
 /// [`SpvClient`]: crate::SpvClient
-pub async fn validate_best_block_header<B: BlockSource>(block_source: &mut B) ->
+pub async fn validate_best_block_header<B: BlockSource>(block_source: &B) ->
 BlockSourceResult<ValidatedBlockHeader> {
 	let (best_block_hash, best_block_height) = block_source.get_best_block().await?;
 	block_source
@@ -67,7 +67,7 @@ BlockSourceResult<ValidatedBlockHeader> {
 /// 	C: chain::Filter,
 /// 	P: chainmonitor::Persist<S>,
 /// >(
-/// 	block_source: &mut B,
+/// 	block_source: &B,
 /// 	chain_monitor: &ChainMonitor<S, &C, &T, &F, &L, &P>,
 /// 	config: UserConfig,
 /// 	keys_manager: &K,
@@ -122,7 +122,7 @@ BlockSourceResult<ValidatedBlockHeader> {
 /// [`ChannelManager`]: lightning::ln::channelmanager::ChannelManager
 /// [`ChannelMonitor`]: lightning::chain::channelmonitor::ChannelMonitor
 pub async fn synchronize_listeners<'a, B: BlockSource, C: Cache, L: chain::Listen + ?Sized>(
-	block_source: &mut B,
+	block_source: &B,
 	network: Network,
 	header_cache: &mut C,
 	mut chain_listeners: Vec<(BlockHash, &'a L)>,

--- a/lightning-block-sync/src/lib.rs
+++ b/lightning-block-sync/src/lib.rs
@@ -61,11 +61,11 @@ pub trait BlockSource : Sync + Send {
 	///
 	/// Implementations that cannot find headers based on the hash should return a `Transient` error
 	/// when `height_hint` is `None`.
-	fn get_header<'a>(&'a mut self, header_hash: &'a BlockHash, height_hint: Option<u32>) -> AsyncBlockSourceResult<'a, BlockHeaderData>;
+	fn get_header<'a>(&'a self, header_hash: &'a BlockHash, height_hint: Option<u32>) -> AsyncBlockSourceResult<'a, BlockHeaderData>;
 
 	/// Returns the block for a given hash. A headers-only block source should return a `Transient`
 	/// error.
-	fn get_block<'a>(&'a mut self, header_hash: &'a BlockHash) -> AsyncBlockSourceResult<'a, Block>;
+	fn get_block<'a>(&'a self, header_hash: &'a BlockHash) -> AsyncBlockSourceResult<'a, Block>;
 
 	/// Returns the hash of the best block and, optionally, its height.
 	///
@@ -73,7 +73,7 @@ pub trait BlockSource : Sync + Send {
 	/// to allow for a more efficient lookup.
 	///
 	/// [`get_header`]: Self::get_header
-	fn get_best_block<'a>(&'a mut self) -> AsyncBlockSourceResult<(BlockHash, Option<u32>)>;
+	fn get_best_block<'a>(&'a self) -> AsyncBlockSourceResult<(BlockHash, Option<u32>)>;
 }
 
 /// Result type for `BlockSource` requests.

--- a/lightning-block-sync/src/test_utils.rs
+++ b/lightning-block-sync/src/test_utils.rs
@@ -113,7 +113,7 @@ impl Blockchain {
 }
 
 impl BlockSource for Blockchain {
-	fn get_header<'a>(&'a mut self, header_hash: &'a BlockHash, _height_hint: Option<u32>) -> AsyncBlockSourceResult<'a, BlockHeaderData> {
+	fn get_header<'a>(&'a self, header_hash: &'a BlockHash, _height_hint: Option<u32>) -> AsyncBlockSourceResult<'a, BlockHeaderData> {
 		Box::pin(async move {
 			if self.without_headers {
 				return Err(BlockSourceError::persistent("header not found"));
@@ -133,7 +133,7 @@ impl BlockSource for Blockchain {
 		})
 	}
 
-	fn get_block<'a>(&'a mut self, header_hash: &'a BlockHash) -> AsyncBlockSourceResult<'a, Block> {
+	fn get_block<'a>(&'a self, header_hash: &'a BlockHash) -> AsyncBlockSourceResult<'a, Block> {
 		Box::pin(async move {
 			for (height, block) in self.blocks.iter().enumerate() {
 				if block.header.block_hash() == *header_hash {
@@ -150,7 +150,7 @@ impl BlockSource for Blockchain {
 		})
 	}
 
-	fn get_best_block<'a>(&'a mut self) -> AsyncBlockSourceResult<'a, (BlockHash, Option<u32>)> {
+	fn get_best_block<'a>(&'a self) -> AsyncBlockSourceResult<'a, (BlockHash, Option<u32>)> {
 		Box::pin(async move {
 			match self.blocks.last() {
 				None => Err(BlockSourceError::transient("empty chain")),


### PR DESCRIPTION
Querying a `BlockSource` is a logically immutable operation. Use non-`mut` references in its interface to reflect this, which allows for users to hold multiple references if desired.