### PR TITLE
Bump MSRV to 1.41.1.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,8 @@ jobs:
         platform: [ ubuntu-latest ]
         toolchain: [ stable,
                      beta,
-                     # 1.36.0 is MSRV for Rust-Lightning, lightning-invoice, and lightning-persister
-                     1.36.0,
-                     # 1.41.0 is Debian stable
-                     1.41.0,
+                     # 1.41.1 is MSRV for Rust-Lightning, lightning-invoice, and lightning-persister
+                     1.41.1,
                      # 1.45.2 is MSRV for lightning-net-tokio, lightning-block-sync, and coverage generation
                      1.45.2,
                      # 1.47.0 will be the MSRV for no-std builds using hashbrown once core2 is updated
@@ -41,11 +39,9 @@ jobs:
           - toolchain: beta
             build-net-tokio: true
             build-no-std: true
-          - toolchain: 1.36.0
+          - toolchain: 1.41.1
             build-no-std: false
             test-log-variants: true
-          - toolchain: 1.41.0
-            build-no-std: false
           - toolchain: 1.45.2
             build-net-old-tokio: true
             build-net-tokio: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ be covered by functional tests.
 When refactoring, structure your PR to make it easy to review and don't
 hestitate to split it into multiple small, focused PRs.
 
-The Minimal Supported Rust Version is 1.36.0 (enforced by our GitHub Actions).
+The Minimal Supported Rust Version is 1.41.1 (enforced by our GitHub Actions).
 
 Commits should cover both the issue fixed and the solution's rationale.
 These [guidelines](https://chris.beams.io/posts/git-commit/) should be kept in mind.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ be covered by functional tests.
 When refactoring, structure your PR to make it easy to review and don't
 hestitate to split it into multiple small, focused PRs.
 
-The Minimal Supported Rust Version is 1.41.1 (enforced by our GitHub Actions).
+The Minimum Supported Rust Version is 1.41.1 (enforced by our GitHub Actions).
 
 Commits should cover both the issue fixed and the solution's rationale.
 These [guidelines](https://chris.beams.io/posts/git-commit/) should be kept in mind.


### PR DESCRIPTION
1.41.1 is currently the Firefox ESR MSRV, which means its also the
version several Linux distros ship. Further, rust-bitcoin is likely
to make a similar change soon, see
https://github.com/rust-bitcoin/rust-bitcoin/issues/510.

Lets wait until 106 for this.