### PR TITLE
Restrict tokio to 1.14 as a dev-dependency

### DIFF
--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -22,4 +22,4 @@ serde_json = { version = "1.0", optional = true }
 chunked_transfer = { version = "1.4", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.0", features = [ "macros", "rt" ] }
+tokio = { version = "~1.14", features = [ "macros", "rt" ] }

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -16,4 +16,4 @@ lightning = { version = "0.0.104", path = "../lightning" }
 tokio = { version = "1.0", features = [ "io-util", "macros", "rt", "sync", "net", "time" ] }
 
 [dev-dependencies]
-tokio = { version = "1.0", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
+tokio = { version = "~1.14", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }


### PR DESCRIPTION
This maintains our MSRV for simple `cargo test` runs, but doesn't
restrict users to any specific 1.X tokio version.