### PR TITLE
Fix what `bolt2_open_channel_sending_node_checks_part1` tests

### DIFF
--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -6001,7 +6001,7 @@ fn bolt2_open_channel_sending_node_checks_part1() { //This test needs to be on i
 	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	//Force duplicate channel ids
 	for node in nodes.iter() {
-		*node.keys_manager.override_channel_id_priv.lock().unwrap() = Some([0; 32]);
+		*node.keys_manager.override_random_bytes.lock().unwrap() = Some([0; 32]);
 	}
 
 	// BOLT #2 spec: Sending node must ensure temporary_channel_id is unique from any other channel ID with the same peer.

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -6010,9 +6010,10 @@ fn bolt2_open_channel_sending_node_checks_part1() { //This test needs to be on i
 	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), channel_value_satoshis, push_msat, 42, None).unwrap();
 	let node0_to_1_send_open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
 	nodes[1].node.handle_open_channel(&nodes[0].node.get_our_node_id(), InitFeatures::known(), &node0_to_1_send_open_channel);
+	get_event_msg!(nodes[1], MessageSendEvent::SendAcceptChannel, nodes[0].node.get_our_node_id());
 
 	//Create a second channel with a channel_id collision
-	assert!(nodes[0].node.create_channel(nodes[0].node.get_our_node_id(), channel_value_satoshis, push_msat, 42, None).is_err());
+	assert!(nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), channel_value_satoshis, push_msat, 42, None).is_err());
 }
 
 #[test]

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -320,7 +320,7 @@ fn test_onion_failure() {
 	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[Some(config), Some(config), Some(node_2_cfg)]);
 	let mut nodes = create_network(3, &node_cfgs, &node_chanmgrs);
 	for node in nodes.iter() {
-		*node.keys_manager.override_session_priv.lock().unwrap() = Some([3; 32]);
+		*node.keys_manager.override_random_bytes.lock().unwrap() = Some([3; 32]);
 	}
 	let channels = [create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known()), create_announced_chan_between_nodes(&nodes, 1, 2, InitFeatures::known(), InitFeatures::known())];
 	let (route, payment_hash, _, payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[2], 40000);
@@ -693,7 +693,7 @@ fn test_phantom_invalid_onion_payload() {
 
 	// We'll use the session priv later when constructing an invalid onion packet.
 	let session_priv = [3; 32];
-	*nodes[0].keys_manager.override_session_priv.lock().unwrap() = Some(session_priv);
+	*nodes[0].keys_manager.override_random_bytes.lock().unwrap() = Some(session_priv);
 	nodes[0].node.send_payment(&route, payment_hash.clone(), &Some(payment_secret)).unwrap();
 	check_added_monitors!(nodes[0], 1);
 	let update_0 = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());


### PR DESCRIPTION
This is split out from #1311.

There are currently two issues with
`bolt2_open_channel_sending_node_checks_part1` which counteract
each other and hide that the test isn't testing what it should be.

First of all, the final `create_channel` call actually fails
because we try to open a channel with ourselves, instead of
panicing as the test is supposed to check for.

However, when we fix the create_channel call to panic, when we
drop `nodes[1]` after `create_channel` panics, we fail the
no-pending-messages test as it as an expeted `accept_channel` in
its outbound buffer. This causes a double-panic.

Previously, these two offset each other - instead of panicing in
`create_channel` we'd panic in the Node drop checks.

This fixes both by fetching the `accept_channel` before we go into
the panic'ing `create_channel` call (who's arguments were
		corrected).