### PR TITLE
Implement custom debug for PathBuildingHop

### DIFF
--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -423,7 +423,7 @@ impl<'a> CandidateRouteHop<'a> {
 /// so that we can choose cheaper paths (as per Dijkstra's algorithm).
 /// Fee values should be updated only in the context of the whole path, see update_value_and_recompute_fees.
 /// These fee values are useful to choose hops as we traverse the graph "payee-to-payer".
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct PathBuildingHop<'a> {
 	// Note that this should be dropped in favor of loading it from CandidateRouteHop, but doing so
 	// is a larger refactor and will require careful performance analysis.
@@ -461,6 +461,22 @@ struct PathBuildingHop<'a> {
 	// value_contribution_msat, which requires tracking it here. See comments below where it is
 	// used for more info.
 	value_contribution_msat: u64,
+}
+
+impl<'a> core::fmt::Debug for PathBuildingHop<'a> {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+		f.debug_struct("PathBuildingHop")
+			.field("node_id", &self.node_id)
+			.field("short_channel_id", &self.candidate.short_channel_id())
+			.field("total_fee_msat", &self.total_fee_msat)
+			.field("next_hops_fee_msat", &self.next_hops_fee_msat)
+			.field("hop_use_fee_msat", &self.hop_use_fee_msat)
+			.field("total_fee_msat - (next_hops_fee_msat + hop_use_fee_msat)", &(&self.total_fee_msat - (&self.next_hops_fee_msat + &self.hop_use_fee_msat)))
+			.field("path_penalty_msat", &self.path_penalty_msat)
+			.field("path_htlc_minimum_msat", &self.path_htlc_minimum_msat)
+			.field("cltv_expiry_delta", &self.candidate.cltv_expiry_delta())
+			.finish()
+	}
 }
 
 // Instantiated with a list of hops with correct data in them collected during path finding,
@@ -1299,8 +1315,8 @@ where L::Target: Logger {
 				ordered_hops.last_mut().unwrap().0.fee_msat = value_contribution_msat;
 				ordered_hops.last_mut().unwrap().0.hop_use_fee_msat = 0;
 
-				log_trace!(logger, "Found a path back to us from the target with {} hops contributing up to {} msat: {:?}",
-					ordered_hops.len(), value_contribution_msat, ordered_hops);
+				log_trace!(logger, "Found a path back to us from the target with {} hops contributing up to {} msat: \n {:#?}",
+					ordered_hops.len(), value_contribution_msat, ordered_hops.iter().map(|h| &(h.0)).collect::<Vec<&PathBuildingHop>>());
 
 				let mut payment_path = PaymentPath {hops: ordered_hops};
 


### PR DESCRIPTION
Re-opened of #1300 
This PR is an attempt at #1233.

The goal here is to clean up the existing output for `PathBuildingHop`, and surface only the [properties we care about](https://github.com/lightningdevkit/rust-lightning/issues/1233#issuecomment-1037281691).

## Demo
This is the new output for PathBuildingHop (ran via `routing::router::tests::simple_route_test`):

```
Found a path back to us from the target with 2 hops contributing up to 100 msat: 
[(PathBuildingHop: node_id: NodeId(02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337), short_channel_id: 2, fee_msat: 100, path_penalty_msat: 0, path_htlc_minimum_msat: 4294967295, cltv_expiry_delta: 83, [8]), (PathBuildingHop: node_id: NodeId(03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b), short_channel_id: 4, fee_msat: 100, path_penalty_msat: 0, path_htlc_minimum_msat: 0, cltv_expiry_delta: 65, [32])]
```

## Some Questions
I am somewhat dissatisfied with the current implementation because the print-out just doesn't seem very ergonomic. Ideally, we'll be able to have the print-out be something closer to what [we have for logging routes](https://github.com/lightningdevkit/rust-lightning/blob/main/lightning/src/routing/router.rs#L1519). Where instead of printing out the `Vec`, we'll be able to show:

```
Found a path back to us from the target with 2 hops contributing up to 100 msat: 
  node_id: 02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337, short_channel_id: 2, fee_msat: 100, path_penalty_msat: 0, path_htlc_minimum_msat: 4294967295, cltv_expiry_delta: 8
  node_id: 03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b, short_channel_id: 4, fee_msat: 100, path_penalty_msat: 0, path_htlc_minimum_msat: 0, cltv_expiry_delta: 65
```

There is an opportunity for improvement here by adding a macro to `macro_logger` that does a clean Display of `PaymentPath`, but that will mean having to exposing fields in `PathBuildingHop` and `PaymentPath` to be public, which I am not sure we want.

Any thoughts on this will be appreciated!