### PR TITLE
Ignore .tmp files when loading ChannelMonitors in persister

### DIFF
--- a/lightning-persister/src/lib.rs
+++ b/lightning-persister/src/lib.rs
@@ -122,6 +122,12 @@ impl FilesystemPersister {
 					"Invalid ChannelMonitor file name",
 				));
 			}
+			if filename.unwrap().ends_with(".tmp") {
+				// If we were in the middle of committing an new update and crashed, it should be
+				// safe to ignore the update - we should never have returned to the caller and
+				// irrevocably committed to the new state in any way.
+				continue;
+			}
 
 			let txid = Txid::from_hex(filename.unwrap().split_at(64).0);
 			if txid.is_err() {


### PR DESCRIPTION
If we are in the middle of persisting an update to a
`ChannelMonitor` when we shutdown (or crash), we'll start up with
a .tmp file lying around. We should ignore it, as failure to
return from the update call should have prevented the
`ChannelManager` from taking any irrevocable action based on the
update.

We're somewhat protected from any filesystem inconsistency behavior
as the `ChannelManager` will refuse to load if we're outright
missing `ChannelMonitor`s.

Fixes #1330.