### PR TITLE
[0.0.105] (Bindings Only) Concretize LockableScore as MultiThreadedLockableScore

### DIFF
--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -662,7 +662,7 @@ pub struct ChannelInfo {
 impl ChannelInfo {
 	/// Returns a [`DirectedChannelInfo`] for the channel directed to the given `target` from a
 	/// returned `source`, or `None` if `target` is not one of the channel's counterparties.
-	pub fn as_directed_to(&self, target: &NodeId) -> Option<(DirectedChannelInfo, &NodeId)> {
+	pub(crate) fn as_directed_to(&self, target: &NodeId) -> Option<(DirectedChannelInfo, &NodeId)> {
 		let (direction, source) = {
 			if target == &self.node_one {
 				(self.two_to_one.as_ref(), &self.node_two)

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -232,12 +232,10 @@ impl Score for FixedPenaltyScorer {
 	since = "0.0.105",
 	note = "ProbabilisticScorer should be used instead of Scorer.",
 )]
-pub type Scorer = ScorerUsingTime::<ConfiguredTime>;
-
 #[cfg(not(feature = "no-std"))]
-type ConfiguredTime = std::time::Instant;
+pub type Scorer = ScorerUsingTime::<std::time::Instant>;
 #[cfg(feature = "no-std")]
-type ConfiguredTime = time::Eternity;
+pub type Scorer = ScorerUsingTime::<time::Eternity>;
 
 // Note that ideally we'd hide ScorerUsingTime from public view by sealing it as well, but rustdoc
 // doesn't handle this well - instead exposing a `Scorer` which has no trait implementation(s) or
@@ -487,7 +485,10 @@ impl<T: Time> Readable for ChannelFailure<T> {
 /// behavior.
 ///
 /// [1]: https://arxiv.org/abs/2107.05322
-pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, ConfiguredTime>;
+#[cfg(not(feature = "no-std"))]
+pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, std::time::Instant>;
+#[cfg(feature = "no-std")]
+pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, time::Eternity>;
 
 /// Probabilistic [`Score`] implementation.
 ///


### PR DESCRIPTION
We don't really care about more than this in bindings - calling
into a custom `Score` is likely too slow to be practical anyway,
so this is also a performance improvement.

Works around https://github.com/rust-lang/rust/issues/90448

This is a forward port of the same commit as applied to 0.0.104 and 0.0.103, now on a new branch - `0.0.105-bindings`, which I'll update to 0.0.105 before we land this (after 105 is tagged).