### PR TITLE
Implement the SCIDAlias Channel Type and provide SCID Privacy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,9 +236,7 @@ jobs:
   check_commits:
     runs-on: ubuntu-latest
     env:
-      # rustc 1.53 regressed and panics when building our (perfectly fine) docs.
-      # See https://github.com/rust-lang/rust/issues/84738
-      TOOLCHAIN: 1.52.1
+      TOOLCHAIN: 1.57.0
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -215,6 +215,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 									forwarding_info: None,
 								},
 								funding_txo: Some(OutPoint { txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(), index: 0 }),
+								channel_type: None,
 								short_channel_id: Some(scid),
 								inbound_scid_alias: None,
 								channel_value_satoshis: slice_to_be64(get_slice!(8)),

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4232,6 +4232,11 @@ impl<Signer: Sign> Channel<Signer> {
 		self.user_id
 	}
 
+	/// Gets the channel's type
+	pub fn get_channel_type(&self) -> &ChannelTypeFeatures {
+		&self.channel_type
+	}
+
 	/// Guaranteed to be Some after both FundingLocked messages have been exchanged (and, thus,
 	/// is_usable() returns true).
 	/// Allowed in any state (including after shutdown)

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2420,7 +2420,13 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							// Note that the behavior here should be identical to the above block - we
 							// should NOT reveal the existence or non-existence of a private channel if
 							// we don't allow forwards outbound over them.
-							break Some(("Don't have available channel for forwarding as requested.", 0x4000 | 10, None));
+							break Some(("Refusing to forward to a private channel based on our config.", 0x4000 | 10, None));
+						}
+						if chan.get_channel_type().supports_scid_privacy() && *short_channel_id != chan.outbound_scid_alias() {
+							// `option_scid_alias` (referred to in LDK as `scid_privacy`) means
+							// "refuse to forward unless the SCID alias was used", so we pretend
+							// we don't have the channel here.
+							break Some(("Refusing to forward over real channel SCID as our counterparty requested.", 0x4000 | 10, None));
 						}
 
 						// Note that we could technically not return an error yet here and just hope

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1218,6 +1218,9 @@ pub struct ChannelDetails {
 	/// counterparty will recognize the alias provided here in place of the [`short_channel_id`]
 	/// when they see a payment to be routed to us.
 	///
+	/// Our counterparty may choose to rotate this value at any time, though will always recognize
+	/// previous values for inbound payment forwarding.
+	///
 	/// [`short_channel_id`]: Self::short_channel_id
 	pub inbound_scid_alias: Option<u64>,
 	/// The value, in satoshis, of this channel as appears in the funding output
@@ -1306,9 +1309,12 @@ pub struct ChannelDetails {
 }
 
 impl ChannelDetails {
-	/// Gets the SCID which should be used to identify this channel for inbound payments. This
-	/// should be used for providing invoice hints or in any other context where our counterparty
-	/// will forward a payment to us.
+	/// Gets the current SCID which should be used to identify this channel for inbound payments.
+	/// This should be used for providing invoice hints or in any other context where our
+	/// counterparty will forward a payment to us.
+	///
+	/// This is either the [`ChannelDetails::inbound_scid_alias`], if set, or the
+	/// [`ChannelDetails::short_channel_id`]. See those for more information.
 	pub fn get_inbound_payment_scid(&self) -> Option<u64> {
 		self.inbound_scid_alias.or(self.short_channel_id)
 	}

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -143,7 +143,7 @@ mod sealed {
 			// Byte 4
 			,
 			// Byte 5
-			ChannelType,
+			ChannelType | SCIDPrivacy,
 		],
 	});
 	define_context!(NodeContext {
@@ -175,7 +175,7 @@ mod sealed {
 			// Byte 4
 			,
 			// Byte 5
-			ChannelType,
+			ChannelType | SCIDPrivacy,
 			// Byte 6
 			Keysend,
 		],
@@ -214,6 +214,10 @@ mod sealed {
 			,
 			// Byte 3
 			,
+			// Byte 4
+			,
+			// Byte 5
+			SCIDPrivacy,
 		],
 		optional_features: [
 			// Byte 0
@@ -223,6 +227,10 @@ mod sealed {
 			// Byte 2
 			,
 			// Byte 3
+			,
+			// Byte 4
+			,
+			// Byte 5
 			,
 		],
 	});
@@ -388,6 +396,10 @@ mod sealed {
 	define_feature!(45, ChannelType, [InitContext, NodeContext],
 		"Feature flags for `option_channel_type`.", set_channel_type_optional,
 		set_channel_type_required, supports_channel_type, requires_channel_type);
+	define_feature!(47, SCIDPrivacy, [InitContext, NodeContext, ChannelTypeContext],
+		"Feature flags for only forwarding with SCID aliasing. Called `option_scid_alias` in the BOLTs",
+		set_scid_privacy_optional, set_scid_privacy_required, supports_scid_privacy, requires_scid_privacy);
+
 	define_feature!(55, Keysend, [NodeContext],
 		"Feature flags for keysend payments.", set_keysend_optional, set_keysend_required,
 		supports_keysend, requires_keysend);
@@ -826,6 +838,11 @@ mod tests {
 		assert!(InitFeatures::known().supports_shutdown_anysegwit());
 		assert!(NodeFeatures::known().supports_shutdown_anysegwit());
 
+		assert!(InitFeatures::known().supports_scid_privacy());
+		assert!(NodeFeatures::known().supports_scid_privacy());
+		assert!(!InitFeatures::known().requires_scid_privacy());
+		assert!(!NodeFeatures::known().requires_scid_privacy());
+
 		let mut init_features = InitFeatures::known();
 		assert!(init_features.initial_routing_sync());
 		init_features.clear_initial_routing_sync();
@@ -864,14 +881,14 @@ mod tests {
 			// - basic_mpp
 			// - opt_shutdown_anysegwit
 			// -
-			// - option_channel_type
+			// - option_channel_type | option_scid_alias
 			assert_eq!(node_features.flags.len(), 6);
 			assert_eq!(node_features.flags[0], 0b00000010);
 			assert_eq!(node_features.flags[1], 0b01010001);
 			assert_eq!(node_features.flags[2], 0b00000010);
 			assert_eq!(node_features.flags[3], 0b00001000);
 			assert_eq!(node_features.flags[4], 0b00000000);
-			assert_eq!(node_features.flags[5], 0b00100000);
+			assert_eq!(node_features.flags[5], 0b10100000);
 		}
 
 		// Check that cleared flags are kept blank when converting back:

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -14,7 +14,7 @@ use chain::{BestBlock, Confirm, Listen, Watch, keysinterface::KeysInterface};
 use chain::channelmonitor::ChannelMonitor;
 use chain::transaction::OutPoint;
 use ln::{PaymentPreimage, PaymentHash, PaymentSecret};
-use ln::channelmanager::{ChainParameters, ChannelManager, ChannelManagerReadArgs, RAACommitmentOrder, PaymentSendFailure, PaymentId};
+use ln::channelmanager::{ChainParameters, ChannelManager, ChannelManagerReadArgs, RAACommitmentOrder, PaymentSendFailure, PaymentId, MIN_CLTV_EXPIRY_DELTA};
 use routing::network_graph::{NetGraphMsgHandler, NetworkGraph};
 use routing::router::{PaymentParameters, Route, get_route};
 use ln::features::{InitFeatures, InvoiceFeatures};
@@ -1848,7 +1848,7 @@ pub fn test_default_channel_config() -> UserConfig {
 	let mut default_config = UserConfig::default();
 	// Set cltv_expiry_delta slightly lower to keep the final CLTV values inside one byte in our
 	// tests so that our script-length checks don't fail (see ACCEPTED_HTLC_SCRIPT_WEIGHT).
-	default_config.channel_options.cltv_expiry_delta = 6*6;
+	default_config.channel_options.cltv_expiry_delta = MIN_CLTV_EXPIRY_DELTA;
 	default_config.channel_options.announced_channel = true;
 	default_config.peer_channel_config_limits.force_announced_channel_preference = false;
 	// When most of our tests were written, the default HTLC minimum was fixed at 1000.

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -396,6 +396,26 @@ macro_rules! get_event_msg {
 	}
 }
 
+/// Get an error message from the pending events queue.
+#[macro_export]
+macro_rules! get_err_msg {
+	($node: expr, $node_id: expr) => {
+		{
+			let events = $node.node.get_and_clear_pending_msg_events();
+			assert_eq!(events.len(), 1);
+			match events[0] {
+				$crate::util::events::MessageSendEvent::HandleError {
+					action: $crate::ln::msgs::ErrorAction::SendErrorMessage { ref msg }, ref node_id
+				} => {
+					assert_eq!(*node_id, $node_id);
+					(*msg).clone()
+				},
+				_ => panic!("Unexpected event"),
+			}
+		}
+	}
+}
+
 /// Get a specific event from the pending events queue.
 #[macro_export]
 macro_rules! get_event {

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -993,4 +993,3 @@ fn test_phantom_failure_reject_payment() {
 		.expected_htlc_error_data(0x4000 | 15, &error_data);
 	expect_payment_failed_conditions!(nodes[0], payment_hash, true, fail_conditions);
 }
-

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -1667,6 +1667,7 @@ mod tests {
 				forwarding_info: None,
 			},
 			funding_txo: Some(OutPoint { txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(), index: 0 }),
+			channel_type: None,
 			short_channel_id,
 			inbound_scid_alias: None,
 			channel_value_satoshis: 0,
@@ -5363,6 +5364,7 @@ mod benches {
 			funding_txo: Some(OutPoint {
 				txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(), index: 0
 			}),
+			channel_type: None,
 			short_channel_id: Some(1),
 			inbound_scid_alias: None,
 			channel_value_satoshis: 10_000_000,

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -47,6 +47,28 @@ pub struct ChannelHandshakeConfig {
 	/// Default value: 1. If the value is less than 1, it is ignored and set to 1, as is required
 	/// by the protocol.
 	pub our_htlc_minimum_msat: u64,
+	/// If set, we attempt to negotiate the `scid_privacy` (referred to as `scid_alias` in the
+	/// BOLTs) option for outbound private channels. This provides better privacy by not including
+	/// our real on-chain channel UTXO in each invoice and requiring that our counterparty only
+	/// relay HTLCs to us using the channel's SCID alias.
+	///
+	/// If this option is set, channels may be created that will not be readable by LDK versions
+	/// prior to 0.0.106, causing [`ChannelManager`]'s read method to return a
+	/// [`DecodeError:InvalidValue`].
+	///
+	/// Note that setting this to true does *not* prevent us from opening channels with
+	/// counterparties that do not support the `scid_alias` option; we will simply fall back to a
+	/// private channel without that option.
+	///
+	/// Ignored if the channel is negotiated to be announced, see
+	/// [`ChannelConfig::announced_channel`] and
+	/// [`ChannelHandshakeLimits::force_announced_channel_preference`] for more.
+	///
+	/// Default value: false. This value is likely to change to true in the future.
+	///
+	/// [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
+	/// [`DecodeError:InvalidValue`]: crate::ln::msgs::DecodeError::InvalidValue
+	pub negotiate_scid_privacy: bool,
 }
 
 impl Default for ChannelHandshakeConfig {
@@ -55,6 +77,7 @@ impl Default for ChannelHandshakeConfig {
 			minimum_depth: 6,
 			our_to_self_delay: BREAKDOWN_TIMEOUT,
 			our_htlc_minimum_msat: 1,
+			negotiate_scid_privacy: false,
 		}
 	}
 }

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -433,6 +433,12 @@ pub enum Event {
 		/// The features that this channel will operate with. If you reject the channel, a
 		/// well-behaved counterparty may automatically re-attempt the channel with a new set of
 		/// feature flags.
+		///
+		/// Note that if [`ChannelTypeFeatures::supports_scid_privacy`] returns true on this type,
+		/// the resulting [`ChannelManager`] will not be readable by versions of LDK prior to
+		/// 0.0.106.
+		///
+		/// [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
 		channel_type: ChannelTypeFeatures,
 	},
 }

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -17,6 +17,7 @@
 use chain::keysinterface::SpendableOutputDescriptor;
 use ln::channelmanager::PaymentId;
 use ln::channel::FUNDING_CONF_DEADLINE_BLOCKS;
+use ln::features::ChannelTypeFeatures;
 use ln::msgs;
 use ln::msgs::DecodeError;
 use ln::{PaymentPreimage, PaymentHash, PaymentSecret};
@@ -429,6 +430,10 @@ pub enum Event {
 		funding_satoshis: u64,
 		/// Our starting balance in the channel if the request is accepted, in milli-satoshi.
 		push_msat: u64,
+		/// The features that this channel will operate with. If you reject the channel, a
+		/// well-behaved counterparty may automatically re-attempt the channel with a new set of
+		/// feature flags.
+		channel_type: ChannelTypeFeatures,
 	},
 }
 

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -174,6 +174,7 @@ pub trait Writeable {
 	}
 
 	/// Writes self out to a Vec<u8>
+	#[cfg(test)]
 	fn encode_with_len(&self) -> Vec<u8> {
 		let mut msg = VecWriter(Vec::new());
 		0u16.write(&mut msg).unwrap();


### PR DESCRIPTION
This is based on #1311 and implements the `SCIDAlias` channel type as well as ensures we don't leak "real" SCIDs via HTLC failures (as pointed out by Val at https://github.com/lightningdevkit/rust-lightning/pull/1311#discussion_r821118112)