### PR TITLE
ProbabilisticScorer optimizations

### DIFF
--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -533,7 +533,7 @@ pub struct ProbabilisticScoringParameters {
 	/// payments. This knowledge is decayed over time based on [`liquidity_offset_half_life`]. The
 	/// penalty is effectively limited to `2 * liquidity_penalty_multiplier_msat`.
 	///
-	/// Default value: 10,000 msat
+	/// Default value: 40,000 msat
 	///
 	/// [`liquidity_offset_half_life`]: Self::liquidity_offset_half_life
 	pub liquidity_penalty_multiplier_msat: u64,
@@ -603,7 +603,7 @@ impl Default for ProbabilisticScoringParameters {
 	fn default() -> Self {
 		Self {
 			base_penalty_msat: 500,
-			liquidity_penalty_multiplier_msat: 10_000,
+			liquidity_penalty_multiplier_msat: 40_000,
 			liquidity_offset_half_life: Duration::from_secs(3600),
 		}
 	}
@@ -2051,16 +2051,16 @@ mod tests {
 		let target = target_node_id();
 
 		let params = ProbabilisticScoringParameters {
-			base_penalty_msat: 0, ..Default::default()
+			base_penalty_msat: 0, liquidity_penalty_multiplier_msat: 1_000, ..Default::default()
 		};
 		let scorer = ProbabilisticScorer::new(params, &network_graph);
-		assert_eq!(scorer.channel_penalty_msat(42, 128, 1_024, &source, &target), 585);
+		assert_eq!(scorer.channel_penalty_msat(42, 128, 1_024, &source, &target), 58);
 
 		let params = ProbabilisticScoringParameters {
-			base_penalty_msat: 500, ..Default::default()
+			base_penalty_msat: 500, liquidity_penalty_multiplier_msat: 1_000, ..Default::default()
 		};
 		let scorer = ProbabilisticScorer::new(params, &network_graph);
-		assert_eq!(scorer.channel_penalty_msat(42, 128, 1_024, &source, &target), 1085);
+		assert_eq!(scorer.channel_penalty_msat(42, 128, 1_024, &source, &target), 558);
 	}
 
 	#[test]
@@ -2075,7 +2075,7 @@ mod tests {
 		let scorer = ProbabilisticScorer::new(params, &network_graph);
 		assert_eq!(
 			scorer.channel_penalty_msat(42, u64::max_value(), u64::max_value(), &source, &target),
-			20_000,
+			80_000,
 		);
 	}
 }

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -666,20 +666,21 @@ impl<L: Deref<Target = u64>, T: Time, U: Deref<Target = T>> DirectedChannelLiqui
 	/// Returns a penalty for routing the given HTLC `amount_msat` through the channel in this
 	/// direction.
 	fn penalty_msat(&self, amount_msat: u64, liquidity_penalty_multiplier_msat: u64) -> u64 {
+		let max_penalty_msat = liquidity_penalty_multiplier_msat.saturating_mul(2);
 		let max_liquidity_msat = self.max_liquidity_msat();
 		let min_liquidity_msat = core::cmp::min(self.min_liquidity_msat(), max_liquidity_msat);
 		if amount_msat > max_liquidity_msat {
-			u64::max_value()
+			max_penalty_msat
 		} else if amount_msat <= min_liquidity_msat {
 			0
 		} else {
 			let numerator = (max_liquidity_msat - amount_msat).saturating_add(1);
 			let denominator = (max_liquidity_msat - min_liquidity_msat).saturating_add(1);
-			approx::negative_log10_times_1024(numerator, denominator)
-				.saturating_mul(liquidity_penalty_multiplier_msat) / 1024
+			let penalty_msat = approx::negative_log10_times_1024(numerator, denominator)
+				.saturating_mul(liquidity_penalty_multiplier_msat) / 1024;
+			// Upper bound the penalty to ensure some channel is selected.
+			penalty_msat.min(max_penalty_msat)
 		}
-		// Upper bound the penalty to ensure some channel is selected.
-		.min(2 * liquidity_penalty_multiplier_msat)
 	}
 
 	/// Returns the lower bound of the channel liquidity balance in this direction.

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -197,10 +197,6 @@ pub struct FixedPenaltyScorer {
 	penalty_msat: u64,
 }
 
-impl_writeable_tlv_based!(FixedPenaltyScorer, {
-	(0, penalty_msat, required),
-});
-
 impl FixedPenaltyScorer {
 	/// Creates a new scorer using `penalty_msat`.
 	pub fn with_penalty(penalty_msat: u64) -> Self {
@@ -216,6 +212,22 @@ impl Score for FixedPenaltyScorer {
 	fn payment_path_failed(&mut self, _path: &[&RouteHop], _short_channel_id: u64) {}
 
 	fn payment_path_successful(&mut self, _path: &[&RouteHop]) {}
+}
+
+impl Writeable for FixedPenaltyScorer {
+	#[inline]
+	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+		write_tlv_fields!(w, {});
+		Ok(())
+	}
+}
+
+impl ReadableArgs<u64> for FixedPenaltyScorer {
+	#[inline]
+	fn read<R: Read>(r: &mut R, penalty_msat: u64) -> Result<Self, DecodeError> {
+		read_tlv_fields!(r, {});
+		Ok(Self { penalty_msat })
+	}
 }
 
 /// [`Score`] implementation that provides reasonable default behavior.


### PR DESCRIPTION
~~Without recent knowledge of channel liquidity balances, `ProbabilisticScorer` tends to give low penalties unless the payment amount is a large portion of a channel's capacity. Provide an option that gives a linear penalty increase as the success probability decreases, which may be useful in such scenarios.~~

~~Additionally, give a base penalty such that shorter paths are preferred over longer ones.~~

Make a few optimizations to `ProbabilisticScorer` including a per hop `base_penalty_msat`. Also, fix a integer overflow that will cause the log approximation to panic.

Closes #1372 