### PR TITLE
Include htlc min/max for ChannelDetails and ChannelCounterparty

### DIFF
--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -227,6 +227,8 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 								is_usable: true, is_public: true,
 								balance_msat: 0,
 								outbound_capacity_msat: 0,
+								inbound_htlc_minimum_msat: None,
+								inbound_htlc_maximum_msat: None,
 							});
 						}
 						Some(&first_hops_vec[..])

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -213,6 +213,8 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 									features: InitFeatures::known(),
 									unspendable_punishment_reserve: 0,
 									forwarding_info: None,
+									outbound_htlc_minimum_msat: None,
+									outbound_htlc_maximum_msat: None,
 								},
 								funding_txo: Some(OutPoint { txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(), index: 0 }),
 								channel_type: None,

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4347,6 +4347,11 @@ impl<Signer: Sign> Channel<Signer> {
 		self.counterparty_htlc_minimum_msat
 	}
 
+	/// Allowed in any state (including after shutdown), but will return none before TheirInitSent
+	pub fn get_counterparty_htlc_maximum_msat(&self) -> Option<u64> {
+		self.get_htlc_maximum_msat(self.counterparty_max_htlc_value_in_flight_msat)
+	}
+
 	fn get_htlc_maximum_msat(&self, party_max_htlc_value_in_flight_msat: u64) -> Option<u64> {
 		self.counterparty_selected_channel_reserve_satoshis.map(|counterparty_reserve| {
 			let holder_reserve = self.holder_selected_channel_reserve_satoshis;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -922,6 +922,12 @@ pub struct ChannelCounterparty {
 	/// Information on the fees and requirements that the counterparty requires when forwarding
 	/// payments to us through this channel.
 	pub forwarding_info: Option<CounterpartyForwardingInfo>,
+	/// The smallest value HTLC (in msat) the remote peer will accept, for this channel. This field
+	/// is only `None` before we have received either the `OpenChannel` or `AcceptChannel` message
+	/// from the remote peer, or for `ChannelCounterparty` objects serialized prior to LDK 0.0.107.
+	pub outbound_htlc_minimum_msat: Option<u64>,
+	/// The largest value HTLC (in msat) the remote peer currently will accept, for this channel.
+	pub outbound_htlc_maximum_msat: Option<u64>,
 }
 
 /// Details of a channel, as returned by ChannelManager::list_channels and ChannelManager::list_usable_channels
@@ -1675,6 +1681,14 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						features: InitFeatures::empty(),
 						unspendable_punishment_reserve: to_remote_reserve_satoshis,
 						forwarding_info: channel.counterparty_forwarding_info(),
+						// Ensures that we have actually received the `htlc_minimum_msat` value
+						// from the counterparty through the `OpenChannel` or `AcceptChannel`
+						// message (as they are always the first message from the counterparty).
+						// Else `Channel::get_counterparty_htlc_minimum_msat` could return the
+						// default `0` value set by `Channel::new_outbound`.
+						outbound_htlc_minimum_msat: if channel.have_received_message() {
+							Some(channel.get_counterparty_htlc_minimum_msat()) } else { None },
+						outbound_htlc_maximum_msat: channel.get_counterparty_htlc_maximum_msat(),
 					},
 					funding_txo: channel.get_funding_txo(),
 					// Note that accept_channel (or open_channel) is always the first message, so
@@ -5904,6 +5918,8 @@ impl_writeable_tlv_based!(ChannelCounterparty, {
 	(4, features, required),
 	(6, unspendable_punishment_reserve, required),
 	(8, forwarding_info, option),
+	(9, outbound_htlc_minimum_msat, option),
+	(11, outbound_htlc_maximum_msat, option),
 });
 
 impl_writeable_tlv_based!(ChannelDetails, {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1046,6 +1046,11 @@ pub struct ChannelDetails {
 	pub is_usable: bool,
 	/// True if this channel is (or will be) publicly-announced.
 	pub is_public: bool,
+	/// The smallest value HTLC (in msat) we will accept, for this channel. This field
+	/// is only `None` for `ChannelDetails` objects serialized prior to LDK 0.0.107
+	pub inbound_htlc_minimum_msat: Option<u64>,
+	/// The largest value HTLC (in msat) we currently will accept, for this channel.
+	pub inbound_htlc_maximum_msat: Option<u64>,
 }
 
 impl ChannelDetails {
@@ -1689,6 +1694,8 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					is_funding_locked: channel.is_usable(),
 					is_usable: channel.is_live(),
 					is_public: channel.should_announce(),
+					inbound_htlc_minimum_msat: Some(channel.get_holder_htlc_minimum_msat()),
+					inbound_htlc_maximum_msat: channel.get_holder_htlc_maximum_msat()
 				});
 			}
 		}
@@ -5918,6 +5925,8 @@ impl_writeable_tlv_based!(ChannelDetails, {
 	(28, is_funding_locked, required),
 	(30, is_usable, required),
 	(32, is_public, required),
+	(33, inbound_htlc_minimum_msat, option),
+	(35, inbound_htlc_maximum_msat, option),
 });
 
 impl_writeable_tlv_based!(PhantomRouteHints, {

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -1750,6 +1750,8 @@ mod tests {
 			force_close_spend_delay: None,
 			is_outbound: true, is_funding_locked: true,
 			is_usable: true, is_public: true,
+			inbound_htlc_minimum_msat: None,
+			inbound_htlc_maximum_msat: None,
 		}
 	}
 
@@ -5475,6 +5477,8 @@ mod benches {
 			is_funding_locked: true,
 			is_usable: true,
 			is_public: true,
+			inbound_htlc_minimum_msat: None,
+			inbound_htlc_maximum_msat: None,
 		}
 	}
 

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -1735,6 +1735,8 @@ mod tests {
 				node_id,
 				unspendable_punishment_reserve: 0,
 				forwarding_info: None,
+				outbound_htlc_minimum_msat: None,
+				outbound_htlc_maximum_msat: None,
 			},
 			funding_txo: Some(OutPoint { txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(), index: 0 }),
 			channel_type: None,
@@ -5458,6 +5460,8 @@ mod benches {
 				node_id,
 				unspendable_punishment_reserve: 0,
 				forwarding_info: None,
+				outbound_htlc_minimum_msat: None,
+				outbound_htlc_maximum_msat: None,
 			},
 			funding_txo: Some(OutPoint {
 				txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(), index: 0


### PR DESCRIPTION
Closes #1287.

Continues the implementation after PR #1297 was closed.

_Note:_
Please specifically check the serialization I've implemented, as I'm definitely not that confident that I'm doing it correctly.

Pushing the PR at this state to get some feedback of wether it looks ok. But I'll make sure to add these fields for the invoice creation in `lightning-invoice/src/utils.rs` as well as some tests later if this looks ok.