### PR TITLE
Pipe filesystem writes in `lightning-persister` through `BufWriter`

### DIFF
--- a/lightning-persister/src/lib.rs
+++ b/lightning-persister/src/lib.rs
@@ -28,7 +28,7 @@ use lightning::ln::channelmanager::ChannelManager;
 use lightning::util::logger::Logger;
 use lightning::util::ser::{ReadableArgs, Writeable};
 use std::fs;
-use std::io::{Cursor, Error};
+use std::io::{Cursor, Error, Write};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
@@ -49,7 +49,7 @@ pub struct FilesystemPersister {
 }
 
 impl<Signer: Sign> DiskWriteable for ChannelMonitor<Signer> {
-	fn write_to_file(&self, writer: &mut fs::File) -> Result<(), Error> {
+	fn write_to_file<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
 		self.write(writer)
 	}
 }
@@ -62,13 +62,13 @@ where
 	F::Target: FeeEstimator,
 	L::Target: Logger,
 {
-	fn write_to_file(&self, writer: &mut fs::File) -> Result<(), std::io::Error> {
+	fn write_to_file<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
 		self.write(writer)
 	}
 }
 
 impl DiskWriteable for NetworkGraph {
-	fn write_to_file(&self, writer: &mut fs::File) -> Result<(), std::io::Error> {
+	fn write_to_file<W: Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
 		self.write(writer)
 	}
 }


### PR DESCRIPTION
We generally make no effort to ensure all writes are buffered in
lower-level objects, so wrapping write calls in `BufWriter` may
substantially improve performance in some cases. This is especially
important now that we block the sample node exit until the
`NetworkGraph` has been written out, which includes many small-ish
writes.

With this change, shutdown of the sample node on a relatively
underpowered device went from 15-30 seconds of CPU time to a second
or two, plus IO sync time.