### PR TITLE
[0.0.106-bindings] Restrict ChannelInfo::as_directed_from visibility

### DIFF
--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -700,7 +700,7 @@ impl ChannelInfo {
 
 	/// Returns a [`DirectedChannelInfo`] for the channel directed from the given `source` to a
 	/// returned `target`, or `None` if `source` is not one of the channel's counterparties.
-	pub fn as_directed_from(&self, source: &NodeId) -> Option<(DirectedChannelInfo, &NodeId)> {
+	pub(crate) fn as_directed_from(&self, source: &NodeId) -> Option<(DirectedChannelInfo, &NodeId)> {
 		let (direction, target) = {
 			if source == &self.node_one {
 				(self.one_to_two.as_ref(), &self.node_two)

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -685,7 +685,7 @@ pub struct ChannelInfo {
 impl ChannelInfo {
 	/// Returns a [`DirectedChannelInfo`] for the channel directed to the given `target` from a
 	/// returned `source`, or `None` if `target` is not one of the channel's counterparties.
-	pub fn as_directed_to(&self, target: &NodeId) -> Option<(DirectedChannelInfo, &NodeId)> {
+	pub(crate) fn as_directed_to(&self, target: &NodeId) -> Option<(DirectedChannelInfo, &NodeId)> {
 		let (direction, source) = {
 			if target == &self.node_one {
 				(self.two_to_one.as_ref(), &self.node_two)

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -247,12 +247,10 @@ impl ReadableArgs<u64> for FixedPenaltyScorer {
 	since = "0.0.105",
 	note = "ProbabilisticScorer should be used instead of Scorer.",
 )]
-pub type Scorer = ScorerUsingTime::<ConfiguredTime>;
-
 #[cfg(not(feature = "no-std"))]
-type ConfiguredTime = std::time::Instant;
+pub type Scorer = ScorerUsingTime::<std::time::Instant>;
 #[cfg(feature = "no-std")]
-type ConfiguredTime = time::Eternity;
+pub type Scorer = ScorerUsingTime::<time::Eternity>;
 
 // Note that ideally we'd hide ScorerUsingTime from public view by sealing it as well, but rustdoc
 // doesn't handle this well - instead exposing a `Scorer` which has no trait implementation(s) or
@@ -503,7 +501,10 @@ impl<T: Time> Readable for ChannelFailure<T> {
 /// behavior.
 ///
 /// [1]: https://arxiv.org/abs/2107.05322
-pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, ConfiguredTime>;
+#[cfg(not(feature = "no-std"))]
+pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, std::time::Instant>;
+#[cfg(feature = "no-std")]
+pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, time::Eternity>;
 
 /// Probabilistic [`Score`] implementation.
 ///

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -230,6 +230,7 @@ impl ReadableArgs<u64> for FixedPenaltyScorer {
 	}
 }
 
+#[cfg(not(feature = "no-std"))]
 /// [`Score`] implementation that provides reasonable default behavior.
 ///
 /// Used to apply a fixed penalty to each channel, thus avoiding long paths when shorter paths with
@@ -247,9 +248,21 @@ impl ReadableArgs<u64> for FixedPenaltyScorer {
 	since = "0.0.105",
 	note = "ProbabilisticScorer should be used instead of Scorer.",
 )]
-#[cfg(not(feature = "no-std"))]
 pub type Scorer = ScorerUsingTime::<std::time::Instant>;
 #[cfg(feature = "no-std")]
+/// [`Score`] implementation that provides reasonable default behavior.
+///
+/// Used to apply a fixed penalty to each channel, thus avoiding long paths when shorter paths with
+/// slightly higher fees are available. Will further penalize channels that fail to relay payments.
+///
+/// See [module-level documentation] for usage and [`ScoringParameters`] for customization.
+///
+/// # Note
+///
+/// Mixing the `no-std` feature between serialization and deserialization results in undefined
+/// behavior.
+///
+/// [module-level documentation]: crate::routing::scoring
 pub type Scorer = ScorerUsingTime::<time::Eternity>;
 
 // Note that ideally we'd hide ScorerUsingTime from public view by sealing it as well, but rustdoc
@@ -479,6 +492,7 @@ impl<T: Time> Readable for ChannelFailure<T> {
 	}
 }
 
+#[cfg(not(feature = "no-std"))]
 /// [`Score`] implementation using channel success probability distributions.
 ///
 /// Based on *Optimally Reliable & Cheap Payment Flows on the Lightning Network* by Rene Pickhardt
@@ -501,9 +515,30 @@ impl<T: Time> Readable for ChannelFailure<T> {
 /// behavior.
 ///
 /// [1]: https://arxiv.org/abs/2107.05322
-#[cfg(not(feature = "no-std"))]
 pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, std::time::Instant>;
 #[cfg(feature = "no-std")]
+/// [`Score`] implementation using channel success probability distributions.
+///
+/// Based on *Optimally Reliable & Cheap Payment Flows on the Lightning Network* by Rene Pickhardt
+/// and Stefan Richter [[1]]. Given the uncertainty of channel liquidity balances, probability
+/// distributions are defined based on knowledge learned from successful and unsuccessful attempts.
+/// Then the negative `log10` of the success probability is used to determine the cost of routing a
+/// specific HTLC amount through a channel.
+///
+/// Knowledge about channel liquidity balances takes the form of upper and lower bounds on the
+/// possible liquidity. Certainty of the bounds is decreased over time using a decay function. See
+/// [`ProbabilisticScoringParameters`] for details.
+///
+/// Since the scorer aims to learn the current channel liquidity balances, it works best for nodes
+/// with high payment volume or that actively probe the [`NetworkGraph`]. Nodes with low payment
+/// volume are more likely to experience failed payment paths, which would need to be retried.
+///
+/// # Note
+///
+/// Mixing the `no-std` feature between serialization and deserialization results in undefined
+/// behavior.
+///
+/// [1]: https://arxiv.org/abs/2107.05322
 pub type ProbabilisticScorer<G> = ProbabilisticScorerUsingTime::<G, time::Eternity>;
 
 /// Probabilistic [`Score`] implementation.


### PR DESCRIPTION
Required changes for bindings generation. Same as #1400 but based on the right commit.