### PR TITLE
add `KVStorePersister` trait and blanket implementations of `Persist` and `Persister` for any type that implements `KVStorePersister`

### DIFF
--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -16,8 +16,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitcoin = "0.27"
 lightning = { version = "0.0.106", path = "../lightning", features = ["std"] }
-lightning-persister = { version = "0.0.106", path = "../lightning-persister" }
 
 [dev-dependencies]
 lightning = { version = "0.0.106", path = "../lightning", features = ["_test_utils"] }
 lightning-invoice = { version = "0.14.0", path = "../lightning-invoice" }
+lightning-persister = { version = "0.0.106", path = "../lightning-persister" }

--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -20,6 +20,7 @@ pub mod errors;
 pub mod ser;
 pub mod message_signing;
 pub mod invoice;
+pub mod persist;
 
 pub(crate) mod atomic_counter;
 pub(crate) mod byte_utils;

--- a/lightning/src/util/persist.rs
+++ b/lightning/src/util/persist.rs
@@ -1,0 +1,77 @@
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! This module contains a simple key-value store trait KVStorePersister that
+//! allows one to implement the persistence for [`ChannelManager`], [`NetworkGraph`],
+//! and [`ChannelMonitor`] all in one place.
+
+use core::ops::Deref;
+use bitcoin::hashes::hex::ToHex;
+use io::{self};
+
+use crate::{chain::{keysinterface::{Sign, KeysInterface}, self, transaction::{OutPoint}, chaininterface::{BroadcasterInterface, FeeEstimator}, chainmonitor::{Persist, MonitorUpdateId}, channelmonitor::{ChannelMonitor, ChannelMonitorUpdate}}, ln::channelmanager::ChannelManager, routing::network_graph::NetworkGraph};
+use super::{logger::Logger, ser::Writeable};
+
+/// Trait for a key-value store for persisting some writeable object at some key
+/// Implementing `KVStorePersister` provides auto-implementations for [`Persister`]
+/// and [`Persist`] traits.  It uses "manager", "network_graph",
+/// and "monitors/{funding_txo_id}_{funding_txo_index}" for keys.
+pub trait KVStorePersister {
+	/// Persist the given writeable using the provided key
+	fn persist<W: Writeable>(&self, key: &str, object: &W) -> io::Result<()>;
+}
+
+/// Trait that handles persisting a [`ChannelManager`] and [`NetworkGraph`] to disk.
+pub trait Persister<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
+	where M::Target: 'static + chain::Watch<Signer>,
+		T::Target: 'static + BroadcasterInterface,
+		K::Target: 'static + KeysInterface<Signer = Signer>,
+		F::Target: 'static + FeeEstimator,
+		L::Target: 'static + Logger,
+{
+	/// Persist the given ['ChannelManager'] to disk, returning an error if persistence failed.
+	fn persist_manager(&self, channel_manager: &ChannelManager<Signer, M, T, K, F, L>) -> Result<(), io::Error>;
+
+	/// Persist the given [`NetworkGraph`] to disk, returning an error if persistence failed.
+	fn persist_graph(&self, network_graph: &NetworkGraph) -> Result<(), io::Error>;
+}
+
+impl<A: KVStorePersister, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Persister<Signer, M, T, K, F, L> for A
+	where M::Target: 'static + chain::Watch<Signer>,
+		T::Target: 'static + BroadcasterInterface,
+		K::Target: 'static + KeysInterface<Signer = Signer>,
+		F::Target: 'static + FeeEstimator,
+		L::Target: 'static + Logger,
+{
+	/// Persist the given ['ChannelManager'] to disk, returning an error if persistence failed.
+	fn persist_manager(&self, channel_manager: &ChannelManager<Signer, M, T, K, F, L>) -> Result<(), io::Error> {
+		self.persist("manager", channel_manager)
+	}
+
+	/// Persist the given [`NetworkGraph`] to disk, returning an error if persistence failed.
+	fn persist_graph(&self, network_graph: &NetworkGraph) -> Result<(), io::Error> {
+		self.persist("network_graph", network_graph)
+	}
+}
+
+impl<ChannelSigner: Sign, K: KVStorePersister> Persist<ChannelSigner> for K {
+	// TODO: We really need a way for the persister to inform the user that its time to crash/shut
+	// down once these start returning failure.
+	// A PermanentFailure implies we need to shut down since we're force-closing channels without
+	// even broadcasting!
+
+	fn persist_new_channel(&self, funding_txo: OutPoint, monitor: &ChannelMonitor<ChannelSigner>, _update_id: MonitorUpdateId) -> Result<(), chain::ChannelMonitorUpdateErr> {
+		let key = format!("monitors/{}_{}", funding_txo.txid.to_hex(), funding_txo.index);
+		self.persist(&key, monitor)
+			.map_err(|_| chain::ChannelMonitorUpdateErr::PermanentFailure)
+	}
+
+	fn update_persisted_channel(&self, funding_txo: OutPoint, _update: &Option<ChannelMonitorUpdate>, monitor: &ChannelMonitor<ChannelSigner>, _update_id: MonitorUpdateId) -> Result<(), chain::ChannelMonitorUpdateErr> {
+		let key = format!("monitors/{}_{}", funding_txo.txid.to_hex(), funding_txo.index);
+		self.persist(&key, monitor)
+			.map_err(|_| chain::ChannelMonitorUpdateErr::PermanentFailure)
+	}
+}


### PR DESCRIPTION
- Introduces a  `KVStorePersister` trait for persisting `Writeable` objects with a certain `String` key.
- Adds blanket `Persist` and `Persister` implementations for any type that implements `KVStorePersister`
- implement `KVStorePersister` for `FilesystemPersister` using `util::write_to_file` to persist to filesystem.
- Moved `Persister` trait from lightning-background-processor to new `lightning::util::persister` module
- Use `String` to build paths in `FilesystemPersister` to avoid needing to go from `PathBuf` to `String` (to use as key in KVStorePersister).