### PR TITLE
Allow `&dyn BlockSource` in `lightning-block-sync`

### DIFF
--- a/lightning-block-sync/src/init.rs
+++ b/lightning-block-sync/src/init.rs
@@ -123,11 +123,11 @@ BlockSourceResult<ValidatedBlockHeader> where B::Target: BlockSource {
 /// [`SpvClient`]: crate::SpvClient
 /// [`ChannelManager`]: lightning::ln::channelmanager::ChannelManager
 /// [`ChannelMonitor`]: lightning::chain::channelmonitor::ChannelMonitor
-pub async fn synchronize_listeners<'a, B: Deref + Sized + Send + Sync, C: Cache, L: chain::Listen + ?Sized>(
+pub async fn synchronize_listeners<B: Deref + Sized + Send + Sync, C: Cache, L: chain::Listen + ?Sized>(
 	block_source: B,
 	network: Network,
 	header_cache: &mut C,
-	mut chain_listeners: Vec<(BlockHash, &'a L)>,
+	mut chain_listeners: Vec<(BlockHash, &L)>,
 ) -> BlockSourceResult<ValidatedBlockHeader> where B::Target: BlockSource {
 	let best_header = validate_best_block_header(&*block_source).await?;
 

--- a/lightning-block-sync/src/init.rs
+++ b/lightning-block-sync/src/init.rs
@@ -238,7 +238,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn sync_from_same_chain() {
-		let mut chain = Blockchain::default().with_height(4);
+		let chain = Blockchain::default().with_height(4);
 
 		let listener_1 = MockChainListener::new()
 			.expect_block_connected(*chain.at_height(2))
@@ -256,7 +256,7 @@ mod tests {
 			(chain.at_height(3).block_hash, &listener_3 as &dyn chain::Listen),
 		];
 		let mut cache = chain.header_cache(0..=4);
-		match synchronize_listeners(&mut chain, Network::Bitcoin, &mut cache, listeners).await {
+		match synchronize_listeners(&chain, Network::Bitcoin, &mut cache, listeners).await {
 			Ok(header) => assert_eq!(header, chain.tip()),
 			Err(e) => panic!("Unexpected error: {:?}", e),
 		}
@@ -264,7 +264,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn sync_from_different_chains() {
-		let mut main_chain = Blockchain::default().with_height(4);
+		let main_chain = Blockchain::default().with_height(4);
 		let fork_chain_1 = main_chain.fork_at_height(1);
 		let fork_chain_2 = main_chain.fork_at_height(2);
 		let fork_chain_3 = main_chain.fork_at_height(3);
@@ -293,7 +293,7 @@ mod tests {
 		let mut cache = fork_chain_1.header_cache(2..=4);
 		cache.extend(fork_chain_2.header_cache(3..=4));
 		cache.extend(fork_chain_3.header_cache(4..=4));
-		match synchronize_listeners(&mut main_chain, Network::Bitcoin, &mut cache, listeners).await {
+		match synchronize_listeners(&main_chain, Network::Bitcoin, &mut cache, listeners).await {
 			Ok(header) => assert_eq!(header, main_chain.tip()),
 			Err(e) => panic!("Unexpected error: {:?}", e),
 		}
@@ -301,7 +301,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn sync_from_overlapping_chains() {
-		let mut main_chain = Blockchain::default().with_height(4);
+		let main_chain = Blockchain::default().with_height(4);
 		let fork_chain_1 = main_chain.fork_at_height(1);
 		let fork_chain_2 = fork_chain_1.fork_at_height(2);
 		let fork_chain_3 = fork_chain_2.fork_at_height(3);
@@ -336,7 +336,7 @@ mod tests {
 		let mut cache = fork_chain_1.header_cache(2..=4);
 		cache.extend(fork_chain_2.header_cache(3..=4));
 		cache.extend(fork_chain_3.header_cache(4..=4));
-		match synchronize_listeners(&mut main_chain, Network::Bitcoin, &mut cache, listeners).await {
+		match synchronize_listeners(&main_chain, Network::Bitcoin, &mut cache, listeners).await {
 			Ok(header) => assert_eq!(header, main_chain.tip()),
 			Err(e) => panic!("Unexpected error: {:?}", e),
 		}
@@ -344,7 +344,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn cache_connected_and_keep_disconnected_blocks() {
-		let mut main_chain = Blockchain::default().with_height(2);
+		let main_chain = Blockchain::default().with_height(2);
 		let fork_chain = main_chain.fork_at_height(1);
 		let new_tip = main_chain.tip();
 		let old_tip = fork_chain.tip();
@@ -355,7 +355,7 @@ mod tests {
 
 		let listeners = vec![(old_tip.block_hash, &listener as &dyn chain::Listen)];
 		let mut cache = fork_chain.header_cache(2..=2);
-		match synchronize_listeners(&mut main_chain, Network::Bitcoin, &mut cache, listeners).await {
+		match synchronize_listeners(&main_chain, Network::Bitcoin, &mut cache, listeners).await {
 			Ok(_) => {
 				assert!(cache.contains_key(&new_tip.block_hash));
 				assert!(cache.contains_key(&old_tip.block_hash));

--- a/lightning-block-sync/src/poll.rs
+++ b/lightning-block-sync/src/poll.rs
@@ -170,12 +170,12 @@ mod sealed {
 ///
 /// Other `Poll` implementations should be built using `ChainPoller` as it provides the simplest way
 /// of validating chain data and checking consistency.
-pub struct ChainPoller<B: Deref<Target=T> + Sized, T: BlockSource> {
+pub struct ChainPoller<B: Deref<Target=T> + Sized + Send + Sync, T: BlockSource + ?Sized> {
 	block_source: B,
 	network: Network,
 }
 
-impl<B: Deref<Target=T> + Sized, T: BlockSource> ChainPoller<B, T> {
+impl<B: Deref<Target=T> + Sized + Send + Sync, T: BlockSource + ?Sized> ChainPoller<B, T> {
 	/// Creates a new poller for the given block source.
 	///
 	/// If the `network` parameter is mainnet, then the difficulty between blocks is checked for
@@ -185,7 +185,7 @@ impl<B: Deref<Target=T> + Sized, T: BlockSource> ChainPoller<B, T> {
 	}
 }
 
-impl<B: Deref<Target=T> + Sized + Send + Sync, T: BlockSource> Poll for ChainPoller<B, T> {
+impl<B: Deref<Target=T> + Sized + Send + Sync, T: BlockSource + ?Sized> Poll for ChainPoller<B, T> {
 	fn poll_chain_tip<'a>(&'a self, best_known_chain_tip: ValidatedBlockHeader) ->
 		AsyncBlockSourceResult<'a, ChainTip>
 	{


### PR DESCRIPTION
Update `lightning-block-sync`'s `init` and `poll` modules to support `&dyn BlockSource` such that the `BlockSource` can be determined at runtime.
