### PR TITLE
Allow indication to BackgroundProcessor that graph sync is pending

### DIFF
--- a/fuzz/src/process_network_graph.rs
+++ b/fuzz/src/process_network_graph.rs
@@ -1,11 +1,13 @@
-// Import that needs to be added manually
+// Imports that need to be added manually
+use lightning_rapid_gossip_sync::RapidGossipSync;
 use utils::test_logger;
 
 /// Actual fuzz test, method signature and name are fixed
 fn do_test(data: &[u8]) {
 	let block_hash = bitcoin::BlockHash::default();
 	let network_graph = lightning::routing::network_graph::NetworkGraph::new(block_hash);
-	lightning_rapid_gossip_sync::processing::update_network_graph(&network_graph, data);
+	let rapid_sync = RapidGossipSync::new(&network_graph);
+	let _ = rapid_sync.update_network_graph(data);
 }
 
 /// Method that needs to be added manually, {name}_test

--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -16,6 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitcoin = "0.28.1"
 lightning = { version = "0.0.106", path = "../lightning", features = ["std"] }
+lightning-rapid-gossip-sync = { version = "0.0.106", path = "../lightning-rapid-gossip-sync" }
 
 [dev-dependencies]
 lightning = { version = "0.0.106", path = "../lightning", features = ["_test_utils"] }


### PR DESCRIPTION
When running a graph sync, the network graph should not be modified from other sources until graph sync completes to avoid inconsistencies or developer/user confusion. Similarly, the network graph should not be prematurely pruned, as graph sync allows very large timestamp deltas in graph snapshot comparisons.

To that end, I add an argument to the BackgroundProcessor to indicate that network-graph-related processed should be avoided pending the graph sync completion, which can be signaled by calling a new method.

This PR depends on #1155. Thanks to @jkczyz for the logic and idiomaticness improvement suggestions!