### PR TITLE
Pull secp256k1 contexts from per-peer to per-PeerManager

### DIFF
--- a/fuzz/src/peer_crypt.rs
+++ b/fuzz/src/peer_crypt.rs
@@ -9,7 +9,7 @@
 
 use lightning::ln::peer_channel_encryptor::PeerChannelEncryptor;
 
-use bitcoin::secp256k1::{PublicKey,SecretKey};
+use bitcoin::secp256k1::{Secp256k1, PublicKey, SecretKey};
 
 use utils::test_logger;
 
@@ -35,6 +35,8 @@ pub fn do_test(data: &[u8]) {
 		}
 	}
 
+	let secp_ctx = Secp256k1::signing_only();
+
 	let our_network_key = match SecretKey::from_slice(get_slice!(32)) {
 		Ok(key) => key,
 		Err(_) => return,
@@ -50,16 +52,16 @@ pub fn do_test(data: &[u8]) {
 			Err(_) => return,
 		};
 		let mut crypter = PeerChannelEncryptor::new_outbound(their_pubkey, ephemeral_key);
-		crypter.get_act_one();
-		match crypter.process_act_two(get_slice!(50), &our_network_key) {
+		crypter.get_act_one(&secp_ctx);
+		match crypter.process_act_two(get_slice!(50), &our_network_key, &secp_ctx) {
 			Ok(_) => {},
 			Err(_) => return,
 		}
 		assert!(crypter.is_ready_for_encryption());
 		crypter
 	} else {
-		let mut crypter = PeerChannelEncryptor::new_inbound(&our_network_key);
-		match crypter.process_act_one_with_keys(get_slice!(50), &our_network_key, ephemeral_key) {
+		let mut crypter = PeerChannelEncryptor::new_inbound(&our_network_key, &secp_ctx);
+		match crypter.process_act_one_with_keys(get_slice!(50), &our_network_key, ephemeral_key, &secp_ctx) {
 			Ok(_) => {},
 			Err(_) => return,
 		}

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -15,7 +15,7 @@
 //! call into the provided message handlers (probably a ChannelManager and NetGraphmsgHandler) with messages
 //! they should handle, and encoding/sending response messages.
 
-use bitcoin::secp256k1::{SecretKey,PublicKey};
+use bitcoin::secp256k1::{self, Secp256k1, SecretKey, PublicKey};
 
 use ln::features::InitFeatures;
 use ln::msgs;
@@ -450,6 +450,7 @@ pub struct PeerManager<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: De
 	peer_counter: AtomicCounter,
 
 	logger: L,
+	secp_ctx: Secp256k1<secp256k1::SignOnly>
 }
 
 enum MessageHandlingError {
@@ -568,6 +569,10 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 		let mut ephemeral_key_midstate = Sha256::engine();
 		ephemeral_key_midstate.input(ephemeral_random_data);
 
+		let mut secp_ctx = Secp256k1::signing_only();
+		let ephemeral_hash = Sha256::from_engine(ephemeral_key_midstate.clone()).into_inner();
+		secp_ctx.seeded_randomize(&ephemeral_hash);
+
 		PeerManager {
 			message_handler,
 			peers: FairRwLock::new(HashMap::new()),
@@ -579,6 +584,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 			peer_counter: AtomicCounter::new(),
 			logger,
 			custom_message_handler,
+			secp_ctx,
 		}
 	}
 
@@ -623,7 +629,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 	/// [`socket_disconnected()`]: PeerManager::socket_disconnected
 	pub fn new_outbound_connection(&self, their_node_id: PublicKey, descriptor: Descriptor, remote_network_address: Option<NetAddress>) -> Result<Vec<u8>, PeerHandleError> {
 		let mut peer_encryptor = PeerChannelEncryptor::new_outbound(their_node_id.clone(), self.get_ephemeral_key());
-		let res = peer_encryptor.get_act_one().to_vec();
+		let res = peer_encryptor.get_act_one(&self.secp_ctx).to_vec();
 		let pending_read_buffer = [0; 50].to_vec(); // Noise act two is 50 bytes
 
 		let mut peers = self.peers.write().unwrap();
@@ -670,7 +676,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 	///
 	/// [`socket_disconnected()`]: PeerManager::socket_disconnected
 	pub fn new_inbound_connection(&self, descriptor: Descriptor, remote_network_address: Option<NetAddress>) -> Result<(), PeerHandleError> {
-		let peer_encryptor = PeerChannelEncryptor::new_inbound(&self.our_node_secret);
+		let peer_encryptor = PeerChannelEncryptor::new_inbound(&self.our_node_secret, &self.secp_ctx);
 		let pending_read_buffer = [0; 50].to_vec(); // Noise act one is 50 bytes
 
 		let mut peers = self.peers.write().unwrap();
@@ -935,14 +941,16 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 						let next_step = peer.channel_encryptor.get_noise_step();
 						match next_step {
 							NextNoiseStep::ActOne => {
-								let act_two = try_potential_handleerror!(peer,
-									peer.channel_encryptor.process_act_one_with_keys(&peer.pending_read_buffer[..], &self.our_node_secret, self.get_ephemeral_key())).to_vec();
+								let act_two = try_potential_handleerror!(peer, peer.channel_encryptor
+									.process_act_one_with_keys(&peer.pending_read_buffer[..],
+										&self.our_node_secret, self.get_ephemeral_key(), &self.secp_ctx)).to_vec();
 								peer.pending_outbound_buffer.push_back(act_two);
 								peer.pending_read_buffer = [0; 66].to_vec(); // act three is 66 bytes long
 							},
 							NextNoiseStep::ActTwo => {
 								let (act_three, their_node_id) = try_potential_handleerror!(peer,
-									peer.channel_encryptor.process_act_two(&peer.pending_read_buffer[..], &self.our_node_secret));
+									peer.channel_encryptor.process_act_two(&peer.pending_read_buffer[..],
+										&self.our_node_secret, &self.secp_ctx));
 								peer.pending_outbound_buffer.push_back(act_three.to_vec());
 								peer.pending_read_buffer = [0; 18].to_vec(); // Message length header is 18 bytes
 								peer.pending_read_is_header = true;


### PR DESCRIPTION
I was running some heap profiling on an LDK application and noticed we currently allocate a full secp context per peer, so figured I'd just remove it.

Instead of including a `Secp256k1` context per
`PeerChannelEncryptor`, which is relatively expensive memory-wise
and nontrivial CPU-wise to construct, we should keep one for all
peers and simply reuse it.

This is relatively trivial so we do so in this commit.

Since its trivial to do so, we also take this opportunity to
randomize the new PeerManager context.