### PR TITLE
Make `expect_payment_failed_conditions` a function

### DIFF
--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -9725,7 +9725,7 @@ fn do_test_dup_htlc_second_rejected(test_for_second_fail_panic: bool) {
 		nodes[0].node.handle_update_fail_htlc(&nodes[1].node.get_our_node_id(), &fail_updates_1.update_fail_htlcs[0]);
 		commitment_signed_dance!(nodes[0], nodes[1], fail_updates_1.commitment_signed, false);
 
-		expect_payment_failed_conditions!(nodes[0], our_payment_hash, true, PaymentFailedConditions::new().mpp_parts_remain());
+		expect_payment_failed_conditions(&nodes[0], our_payment_hash, true, PaymentFailedConditions::new().mpp_parts_remain());
 
 		claim_payment(&nodes[0], &[&nodes[1]], our_payment_preimage);
 	}
@@ -9830,7 +9830,7 @@ fn test_inconsistent_mpp_params() {
 	nodes[0].node.handle_update_fail_htlc(&nodes[2].node.get_our_node_id(), &fail_updates_2.update_fail_htlcs[0]);
 	commitment_signed_dance!(nodes[0], nodes[2], fail_updates_2.commitment_signed, false);
 
-	expect_payment_failed_conditions!(nodes[0], our_payment_hash, true, PaymentFailedConditions::new().mpp_parts_remain());
+	expect_payment_failed_conditions(&nodes[0], our_payment_hash, true, PaymentFailedConditions::new().mpp_parts_remain());
 
 	nodes[0].node.send_payment_along_path(&route.paths[1], &payment_params_opt, &our_payment_hash, &Some(our_payment_secret), 15_000_000, cur_height, payment_id, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -854,7 +854,7 @@ fn test_phantom_onion_hmac_failure() {
 		.blamed_scid(phantom_scid)
 		.blamed_chan_closed(true)
 		.expected_htlc_error_data(0x8000 | 0x4000 | 5, &sha256_of_onion);
-	expect_payment_failed_conditions!(nodes[0], payment_hash, false, fail_conditions);
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false, fail_conditions);
 }
 
 #[test]
@@ -927,7 +927,7 @@ fn test_phantom_invalid_onion_payload() {
 		.blamed_scid(phantom_scid)
 		.blamed_chan_closed(true)
 		.expected_htlc_error_data(0x4000 | 22, &error_data);
-	expect_payment_failed_conditions!(nodes[0], payment_hash, true, fail_conditions);
+	expect_payment_failed_conditions(&nodes[0], payment_hash, true, fail_conditions);
 }
 
 #[test]
@@ -983,7 +983,7 @@ fn test_phantom_final_incorrect_cltv_expiry() {
 	let mut fail_conditions = PaymentFailedConditions::new()
 		.blamed_scid(phantom_scid)
 		.expected_htlc_error_data(18, &error_data);
-	expect_payment_failed_conditions!(nodes[0], payment_hash, false, fail_conditions);
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false, fail_conditions);
 }
 
 #[test]
@@ -1028,7 +1028,7 @@ fn test_phantom_failure_too_low_cltv() {
 	let mut fail_conditions = PaymentFailedConditions::new()
 		.blamed_scid(phantom_scid)
 		.expected_htlc_error_data(17, &error_data);
-	expect_payment_failed_conditions!(nodes[0], payment_hash, false, fail_conditions);
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false, fail_conditions);
 }
 
 #[test]
@@ -1076,7 +1076,7 @@ fn test_phantom_failure_too_low_recv_amt() {
 	let mut fail_conditions = PaymentFailedConditions::new()
 		.blamed_scid(phantom_scid)
 		.expected_htlc_error_data(0x4000 | 15, &error_data);
-	expect_payment_failed_conditions!(nodes[0], payment_hash, true, fail_conditions);
+	expect_payment_failed_conditions(&nodes[0], payment_hash, true, fail_conditions);
 }
 
 #[test]
@@ -1123,7 +1123,7 @@ fn test_phantom_dust_exposure_failure() {
 		.blamed_scid(channel.0.contents.short_channel_id)
 		.blamed_chan_closed(false)
 		.expected_htlc_error_data(0x1000 | 7, &err_data);
-		expect_payment_failed_conditions!(nodes[0], payment_hash, false, fail_conditions);
+		expect_payment_failed_conditions(&nodes[0], payment_hash, false, fail_conditions);
 }
 
 #[test]
@@ -1174,5 +1174,5 @@ fn test_phantom_failure_reject_payment() {
 	let mut fail_conditions = PaymentFailedConditions::new()
 		.blamed_scid(phantom_scid)
 		.expected_htlc_error_data(0x4000 | 15, &error_data);
-	expect_payment_failed_conditions!(nodes[0], payment_hash, true, fail_conditions);
+	expect_payment_failed_conditions(&nodes[0], payment_hash, true, fail_conditions);
 }

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -70,7 +70,7 @@ fn retry_single_path_payment() {
 	check_added_monitors!(nodes[1], 1);
 	nodes[0].node.handle_update_fail_htlc(&nodes[1].node.get_our_node_id(), &htlc_updates.update_fail_htlcs[0]);
 	commitment_signed_dance!(nodes[0], nodes[1], htlc_updates.commitment_signed, false);
-	expect_payment_failed_conditions!(nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
 
 	// Rebalance the channel so the retry succeeds.
 	send_payment(&nodes[2], &vec!(&nodes[1])[..], 3_000_000);
@@ -173,7 +173,7 @@ fn mpp_retry() {
 	check_added_monitors!(nodes[2], 1);
 	nodes[0].node.handle_update_fail_htlc(&nodes[2].node.get_our_node_id(), &htlc_updates.update_fail_htlcs[0]);
 	commitment_signed_dance!(nodes[0], nodes[2], htlc_updates.commitment_signed, false);
-	expect_payment_failed_conditions!(nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
 
 	// Rebalance the channel so the second half of the payment can succeed.
 	send_payment(&nodes[3], &vec!(&nodes[2])[..], 1_500_000);
@@ -251,7 +251,7 @@ fn do_mpp_receive_timeout(send_partial_mpp: bool) {
 		check_added_monitors!(nodes[1], 1);
 		commitment_signed_dance!(nodes[0], nodes[1], htlc_fail_updates_1_0.commitment_signed, false);
 
-		expect_payment_failed_conditions!(nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain().expected_htlc_error_data(23, &[][..]));
+		expect_payment_failed_conditions(&nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain().expected_htlc_error_data(23, &[][..]));
 	} else {
 		// Pass half of the payment along the second path.
 		pass_along_path(&nodes[0], &[&nodes[2], &nodes[3]], 200_000, payment_hash, Some(payment_secret), events.remove(0), true, None);
@@ -521,7 +521,7 @@ fn do_retry_with_no_persist(confirm_before_reload: bool) {
 		confirm_transaction(&nodes[0], &first_htlc_timeout_tx);
 	}
 	nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap().clear();
-	expect_payment_failed_conditions!(nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false, PaymentFailedConditions::new().mpp_parts_remain());
 
 	// Finally, retry the payment (which was reloaded from the ChannelMonitor when nodes[0] was
 	// reloaded) via a route over the new channel, which work without issue and eventually be

--- a/lightning/src/ln/priv_short_conf_tests.rs
+++ b/lightning/src/ln/priv_short_conf_tests.rs
@@ -460,7 +460,7 @@ fn test_inbound_scid_privacy() {
 	nodes[0].node.handle_update_fail_htlc(&nodes[1].node.get_our_node_id(), &updates.update_fail_htlcs[0]);
 	commitment_signed_dance!(nodes[0], nodes[1], updates.commitment_signed, false);
 
-	expect_payment_failed_conditions!(nodes[0], payment_hash_2, false,
+	expect_payment_failed_conditions(&nodes[0], payment_hash_2, false,
 		PaymentFailedConditions::new().blamed_scid(last_hop[0].short_channel_id.unwrap())
 			.blamed_chan_closed(true).expected_htlc_error_data(0x4000|10, &[0; 0]));
 }
@@ -537,7 +537,7 @@ fn test_scid_alias_returned() {
 	err_data.extend_from_slice(&ChannelUpdate::TYPE.to_be_bytes());
 	err_data.extend_from_slice(&msg.encode());
 
-	expect_payment_failed_conditions!(nodes[0], payment_hash, false,
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false,
 		PaymentFailedConditions::new().blamed_scid(last_hop[0].inbound_scid_alias.unwrap())
 			.blamed_chan_closed(false).expected_htlc_error_data(0x1000|7, &err_data));
 
@@ -560,7 +560,7 @@ fn test_scid_alias_returned() {
 	err_data.extend_from_slice(&(msg.serialized_length() as u16 + 2).to_be_bytes());
 	err_data.extend_from_slice(&ChannelUpdate::TYPE.to_be_bytes());
 	err_data.extend_from_slice(&msg.encode());
-	expect_payment_failed_conditions!(nodes[0], payment_hash, false,
+	expect_payment_failed_conditions(&nodes[0], payment_hash, false,
 		PaymentFailedConditions::new().blamed_scid(last_hop[0].inbound_scid_alias.unwrap())
 			.blamed_chan_closed(false).expected_htlc_error_data(0x1000|12, &err_data));
 }


### PR DESCRIPTION
This reduces macro generated code in tests a good bit, and moves us
one step further away from using macros everywhere when we don't
need to.

Did this in an earlier version of #1495 but didn't need it, figured it was still worth upstreaming.