### PR TITLE
Disable LTO builds in tests (and bump deps to -O2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,20 @@ exclude = [
     "no-std-check",
 ]
 
-# Our tests do actual crypto and lots of work, the tradeoff for -O1 is well worth it.
-# Ideally we would only do this in profile.test, but profile.test only applies to
-# the test binary, not dependencies, which means most of the critical code still
-# gets compiled as -O0. See
+# Our tests do actual crypto and lots of work, the tradeoff for -O2 is well
+# worth it. Note that we only apply optimizations to dependencies, not workspace
+# crates themselves.
 # https://doc.rust-lang.org/cargo/reference/profiles.html#profile-selection
+[profile.dev.package."*"]
+opt-level = 2
+
+# It appears some minimal optimizations are required to inline many std methods
+# and reduce the otherwise-substantial time spent in std self-checks. We do so
+# here but ensure we keep LTO disabled as otherwise we're re-optimizing all our
+# dependencies every time we make any local changes.
 [profile.dev]
 opt-level = 1
-panic = "abort"
+lto = "off"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
    For some reason rustc, at some point, decided that our optimization
    of dependencies implies we want to also build with LTO. This causes
    our test builds to take substantially longer to compile, even with
    only a trivial change. By hard-disabling this (even keeping the
    optimization of the test and in-tree libraries enabled) the time
    required to build with only a trivial change to
    `functional_tests.rs` goes from 0m25.635s wall clock/1m14.220s CPU
    time to 0m17.841s wall clock/0m17.828s CPU time on my i7-13700K on
    rustc 1.63.
    
    While we're at it, we also bump dependencies to build with -O2
    because their build time is now substantially reduced cost.