### PR TITLE
Re-export `core2::io` or `std::io` depending on feature flags

### DIFF
--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -78,9 +78,11 @@ pub mod ln;
 pub mod routing;
 
 #[cfg(feature = "std")]
-use std::io;
+/// Re-export of either `core2::io` or `std::io`, depending on the `std` feature flag.
+pub use std::io;
 #[cfg(not(feature = "std"))]
-use core2::io;
+/// Re-export of either `core2::io` or `std::io`, depending on the `std` feature flag.
+pub use core2::io;
 
 #[cfg(not(feature = "std"))]
 mod io_extras {


### PR DESCRIPTION
This is useful in bindings as the `lightning::io` module is used in
the public interface, but also useful for users who want to refer
to the `io` as used in lightning irrespective of the feature flags.