### PR TITLE
Add 'repository' to lightning-invoice's Cargo.toml

### DIFF
--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/lightning-invoice/"
 license = "MIT OR Apache-2.0"
 keywords = [ "lightning", "bitcoin", "invoice", "BOLT11" ]
 readme = "README.md"
+repository = "https://github.com/lightningdevkit/rust-lightning/"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The repository doesn't show up anywhere on docs.rs or crates.io. Took me a couple minutes to find it.