### PR TITLE
Do not panic on early tx broadcasts in fuzzing

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4652,9 +4652,17 @@ impl<Signer: Sign> Channel<Signer> {
 		} else if non_shutdown_state == (ChannelState::FundingSent as u32 | ChannelState::OurChannelReady as u32) {
 			// We got a reorg but not enough to trigger a force close, just ignore.
 			false
-		} else if self.channel_state < ChannelState::ChannelFunded as u32 {
-			panic!("Started confirming a channel in a state pre-FundingSent?: {}", self.channel_state);
 		} else {
+			if self.channel_state < ChannelState::ChannelFunded as u32 {
+				// We should never see a funding transaction on-chain until we've received
+				// funding_signed (if we're an outbound channel), or seen funding_generated (if we're
+				// an inbound channel - before that we have no known funding TXID). The fuzzer,
+				// however, may do this and we shouldn't treat it as a bug.
+				#[cfg(not(fuzzing))]
+				panic!("Started confirming a channel in a state pre-FundingSent: {}.\n\
+					Do NOT broadcast a funding transaction manually - let LDK do it for you!",
+					self.channel_state);
+			}
 			// We got a reorg but not enough to trigger a force close, just ignore.
 			false
 		};


### PR DESCRIPTION
If the user broadcasts a funding transaction before the
counterparty provides a `funding_signed` we will panic in
`check_get_channel_ready`. This is expected - the user did
something which may lead to loss of funds, and we *really* need to
let them know.

However, the fuzzer can do this and we shouldn't treat it as a bug,
its a totally expected panic. Thus, we disable the panic in fuzz.

Thanks to Chaincode for providing fuzzing resources which managed
to hit this panic.