### PR TITLE
Fix `lightning-background-processor` release build

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -79,7 +79,7 @@ const PING_TIMER: u64 = 1;
 /// Prune the network graph of stale entries hourly.
 const NETWORK_PRUNE_TIMER: u64 = 60 * 60;
 
-#[cfg(all(not(test), debug_assertions))]
+#[cfg(not(test))]
 const SCORER_PERSIST_TIMER: u64 = 30;
 #[cfg(test)]
 const SCORER_PERSIST_TIMER: u64 = 1;


### PR DESCRIPTION
### Problem

```bash
cargo build --release

error[E0425]: cannot find value `SCORER_PERSIST_TIMER` in this scope
   --> lightning-background-processor/src/lib.rs:360:55
    |
360 |                 if last_scorer_persist_call.elapsed().as_secs() > SCORER_PERSIST_TIMER {
    |                                                                   ^^^^^^^^^^^^^^^^^^^^ not found in this scope

warning: ignoring -C extra-filename flag due to -o flag

For more information about this error, try `rustc --explain E0425`.
warning: `lightning-background-processor` (lib) generated 1 warning
error: could not compile `lightning-background-processor` due to previous error; 1 warning emitted
```

### Solution

Remove the `debug_assertions` compilation condition so that `SCORER_PERSIST_TIMER` will be compiled when building for release.