### PR TITLE
Rename UserConfig and LegacyChannelConfig fields

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -356,8 +356,8 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out) {
 				Arc::new(TestPersister { update_ret: Mutex::new(Ok(())) }), Arc::clone(&keys_manager)));
 
 			let mut config = UserConfig::default();
-			config.channel_options.forwarding_fee_proportional_millionths = 0;
-			config.own_channel_config.announced_channel = true;
+			config.channel_config.forwarding_fee_proportional_millionths = 0;
+			config.channel_handshake_config.announced_channel = true;
 			let network = Network::Bitcoin;
 			let params = ChainParameters {
 				network,
@@ -376,8 +376,8 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out) {
 				Arc::new(TestPersister { update_ret: Mutex::new(Ok(())) }), Arc::clone(& $keys_manager)));
 
 			let mut config = UserConfig::default();
-			config.channel_options.forwarding_fee_proportional_millionths = 0;
-			config.own_channel_config.announced_channel = true;
+			config.channel_config.forwarding_fee_proportional_millionths = 0;
+			config.channel_handshake_config.announced_channel = true;
 
 			let mut monitors = HashMap::new();
 			let mut old_monitors = $old_monitors.latest_monitors.lock().unwrap();

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -382,8 +382,8 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 
 	let keys_manager = Arc::new(KeyProvider { node_secret: our_network_key.clone(), inbound_payment_key: KeyMaterial(inbound_payment_key.try_into().unwrap()), counter: AtomicU64::new(0) });
 	let mut config = UserConfig::default();
-	config.channel_options.forwarding_fee_proportional_millionths =  slice_to_be32(get_slice!(4));
-	config.own_channel_config.announced_channel = get_slice!(1)[0] != 0;
+	config.channel_config.forwarding_fee_proportional_millionths =  slice_to_be32(get_slice!(4));
+	config.channel_handshake_config.announced_channel = get_slice!(1)[0] != 0;
 	let network = Network::Bitcoin;
 	let params = ChainParameters {
 		network,

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -659,7 +659,7 @@ mod test {
 		// `msgs::ChannelUpdate` is never handled for the node(s). As the `msgs::ChannelUpdate`
 		// is never handled, the `channel.counterparty.forwarding_info` is never assigned.
 		let mut private_chan_cfg = UserConfig::default();
-		private_chan_cfg.own_channel_config.announced_channel = false;
+		private_chan_cfg.channel_handshake_config.announced_channel = false;
 		let temporary_channel_id = nodes[2].node.create_channel(nodes[0].node.get_our_node_id(), 1_000_000, 500_000_000, 42, Some(private_chan_cfg)).unwrap();
 		let open_channel = get_event_msg!(nodes[2], MessageSendEvent::SendOpenChannel, nodes[0].node.get_our_node_id());
 		nodes[0].node.handle_open_channel(&nodes[2].node.get_our_node_id(), InitFeatures::known(), &open_channel);
@@ -1046,7 +1046,7 @@ mod test {
 		// `msgs::ChannelUpdate` is never handled for the node(s). As the `msgs::ChannelUpdate`
 		// is never handled, the `channel.counterparty.forwarding_info` is never assigned.
 		let mut private_chan_cfg = UserConfig::default();
-		private_chan_cfg.own_channel_config.announced_channel = false;
+		private_chan_cfg.channel_handshake_config.announced_channel = false;
 		let temporary_channel_id = nodes[1].node.create_channel(nodes[3].node.get_our_node_id(), 1_000_000, 500_000_000, 42, Some(private_chan_cfg)).unwrap();
 		let open_channel = get_event_msg!(nodes[1], MessageSendEvent::SendOpenChannel, nodes[3].node.get_our_node_id());
 		nodes[3].node.handle_open_channel(&nodes[1].node.get_our_node_id(), InitFeatures::known(), &open_channel);

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -2541,7 +2541,7 @@ fn test_temporary_error_during_shutdown() {
 	// Test that temporary failures when updating the monitor's shutdown script delay cooperative
 	// close.
 	let mut config = test_default_channel_config();
-	config.own_channel_config.commit_upfront_shutdown_pubkey = false;
+	config.channel_handshake_config.commit_upfront_shutdown_pubkey = false;
 
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
@@ -2596,7 +2596,7 @@ fn test_permanent_error_during_sending_shutdown() {
 	// Test that permanent failures when updating the monitor's shutdown script result in a force
 	// close when initiating a cooperative close.
 	let mut config = test_default_channel_config();
-	config.own_channel_config.commit_upfront_shutdown_pubkey = false;
+	config.channel_handshake_config.commit_upfront_shutdown_pubkey = false;
 
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
@@ -2617,7 +2617,7 @@ fn test_permanent_error_during_handling_shutdown() {
 	// Test that permanent failures when updating the monitor's shutdown script result in a force
 	// close when handling a cooperative close.
 	let mut config = test_default_channel_config();
-	config.own_channel_config.commit_upfront_shutdown_pubkey = false;
+	config.channel_handshake_config.commit_upfront_shutdown_pubkey = false;
 
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4346,7 +4346,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					if chan.get().get_counterparty_node_id() != *counterparty_node_id {
 						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.temporary_channel_id));
 					}
-					try_chan_entry!(self, chan.get_mut().accept_channel(&msg, &self.default_configuration.peer_channel_config_limits, &their_features), channel_state, chan);
+					try_chan_entry!(self, chan.get_mut().accept_channel(&msg, &self.default_configuration.channel_handshake_limits, &their_features), channel_state, chan);
 					(chan.get().get_value_satoshis(), chan.get().get_funding_redeemscript().to_v0_p2wsh(), chan.get().get_user_id())
 				},
 				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.temporary_channel_id))
@@ -7630,7 +7630,7 @@ pub mod bench {
 		let fee_estimator = test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) };
 
 		let mut config: UserConfig = Default::default();
-		config.own_channel_config.minimum_depth = 1;
+		config.channel_handshake_config.minimum_depth = 1;
 
 		let logger_a = test_utils::TestLogger::with_id("node a".to_owned());
 		let chain_monitor_a = ChainMonitor::new(None, &tx_broadcaster, &logger_a, &fee_estimator, &persister_a);

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -772,7 +772,7 @@ pub fn create_announced_chan_between_nodes_with_value<'a, 'b, 'c, 'd>(nodes: &'a
 
 pub fn create_unannounced_chan_between_nodes_with_value<'a, 'b, 'c, 'd>(nodes: &'a Vec<Node<'b, 'c, 'd>>, a: usize, b: usize, channel_value: u64, push_msat: u64, a_flags: InitFeatures, b_flags: InitFeatures) -> (msgs::ChannelReady, Transaction) {
 	let mut no_announce_cfg = test_default_channel_config();
-	no_announce_cfg.own_channel_config.announced_channel = false;
+	no_announce_cfg.channel_handshake_config.announced_channel = false;
 	nodes[a].node.create_channel(nodes[b].node.get_our_node_id(), channel_value, push_msat, 42, Some(no_announce_cfg)).unwrap();
 	let open_channel = get_event_msg!(nodes[a], MessageSendEvent::SendOpenChannel, nodes[b].node.get_our_node_id());
 	nodes[b].node.handle_open_channel(&nodes[a].node.get_our_node_id(), a_flags, &open_channel);
@@ -1691,7 +1691,7 @@ pub fn do_claim_payment_along_route<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, 
 					$node.node.handle_update_fulfill_htlc(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().0);
 					let fee = $node.node.channel_state.lock().unwrap()
 						.by_id.get(&next_msgs.as_ref().unwrap().0.channel_id).unwrap()
-						.config.mutable.forwarding_fee_base_msat;
+						.config.options.forwarding_fee_base_msat;
 					expect_payment_forwarded!($node, $next_node, $prev_node, Some(fee as u64), false, false);
 					expected_total_fee_msat += fee as u64;
 					check_added_monitors!($node, 1);
@@ -1967,15 +1967,15 @@ pub fn test_default_channel_config() -> UserConfig {
 	let mut default_config = UserConfig::default();
 	// Set cltv_expiry_delta slightly lower to keep the final CLTV values inside one byte in our
 	// tests so that our script-length checks don't fail (see ACCEPTED_HTLC_SCRIPT_WEIGHT).
-	default_config.channel_options.cltv_expiry_delta = MIN_CLTV_EXPIRY_DELTA;
-	default_config.own_channel_config.announced_channel = true;
-	default_config.peer_channel_config_limits.force_announced_channel_preference = false;
+	default_config.channel_config.cltv_expiry_delta = MIN_CLTV_EXPIRY_DELTA;
+	default_config.channel_handshake_config.announced_channel = true;
+	default_config.channel_handshake_limits.force_announced_channel_preference = false;
 	// When most of our tests were written, the default HTLC minimum was fixed at 1000.
 	// It now defaults to 1, so we simply set it to the expected value here.
-	default_config.own_channel_config.our_htlc_minimum_msat = 1000;
+	default_config.channel_handshake_config.our_htlc_minimum_msat = 1000;
 	// When most of our tests were written, we didn't have the notion of a `max_dust_htlc_exposure_msat`,
 	// It now defaults to 5_000_000 msat; to avoid interfering with tests we bump it to 50_000_000 msat.
-	default_config.channel_options.max_dust_htlc_exposure_msat = 50_000_000;
+	default_config.channel_config.max_dust_htlc_exposure_msat = 50_000_000;
 	default_config
 }
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -61,7 +61,7 @@ fn test_insane_channel_opens() {
 	// Stand up a network of 2 nodes
 	use ln::channel::TOTAL_BITCOIN_SUPPLY_SATOSHIS;
 	let mut cfg = UserConfig::default();
-	cfg.peer_channel_config_limits.max_funding_satoshis = TOTAL_BITCOIN_SUPPLY_SATOSHIS + 1;
+	cfg.channel_handshake_limits.max_funding_satoshis = TOTAL_BITCOIN_SUPPLY_SATOSHIS + 1;
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, Some(cfg)]);
@@ -1790,7 +1790,7 @@ fn test_channel_reserve_holding_cell_htlcs() {
 	// When this test was written, the default base fee floated based on the HTLC count.
 	// It is now fixed, so we simply set the fee to the expected value here.
 	let mut config = test_default_channel_config();
-	config.channel_options.forwarding_fee_base_msat = 239;
+	config.channel_config.forwarding_fee_base_msat = 239;
 	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[Some(config.clone()), Some(config.clone()), Some(config.clone())]);
 	let mut nodes = create_network(3, &node_cfgs, &node_chanmgrs);
 	let chan_1 = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 190000, 1001, InitFeatures::known(), InitFeatures::known());
@@ -2362,13 +2362,13 @@ fn channel_monitor_network_test() {
 fn test_justice_tx() {
 	// Test justice txn built on revoked HTLC-Success tx, against both sides
 	let mut alice_config = UserConfig::default();
-	alice_config.own_channel_config.announced_channel = true;
-	alice_config.peer_channel_config_limits.force_announced_channel_preference = false;
-	alice_config.own_channel_config.our_to_self_delay = 6 * 24 * 5;
+	alice_config.channel_handshake_config.announced_channel = true;
+	alice_config.channel_handshake_limits.force_announced_channel_preference = false;
+	alice_config.channel_handshake_config.our_to_self_delay = 6 * 24 * 5;
 	let mut bob_config = UserConfig::default();
-	bob_config.own_channel_config.announced_channel = true;
-	bob_config.peer_channel_config_limits.force_announced_channel_preference = false;
-	bob_config.own_channel_config.our_to_self_delay = 6 * 24 * 3;
+	bob_config.channel_handshake_config.announced_channel = true;
+	bob_config.channel_handshake_limits.force_announced_channel_preference = false;
+	bob_config.channel_handshake_config.our_to_self_delay = 6 * 24 * 3;
 	let user_cfgs = [Some(alice_config), Some(bob_config)];
 	let mut chanmon_cfgs = create_chanmon_cfgs(2);
 	chanmon_cfgs[0].keys_manager.disable_revocation_policy_check = true;
@@ -5275,7 +5275,7 @@ fn test_duplicate_payment_hash_one_failure_one_success() {
 	// When this test was written, the default base fee floated based on the HTLC count.
 	// It is now fixed, so we simply set the fee to the expected value here.
 	let mut config = test_default_channel_config();
-	config.channel_options.forwarding_fee_base_msat = 196;
+	config.channel_config.forwarding_fee_base_msat = 196;
 	let node_chanmgrs = create_node_chanmgrs(4, &node_cfgs,
 		&[Some(config.clone()), Some(config.clone()), Some(config.clone()), Some(config.clone())]);
 	let mut nodes = create_network(4, &node_cfgs, &node_chanmgrs);
@@ -5487,7 +5487,7 @@ fn do_test_fail_backwards_unrevoked_remote_announce(deliver_last_raa: bool, anno
 	// When this test was written, the default base fee floated based on the HTLC count.
 	// It is now fixed, so we simply set the fee to the expected value here.
 	let mut config = test_default_channel_config();
-	config.channel_options.forwarding_fee_base_msat = 196;
+	config.channel_config.forwarding_fee_base_msat = 196;
 	let node_chanmgrs = create_node_chanmgrs(6, &node_cfgs,
 		&[Some(config.clone()), Some(config.clone()), Some(config.clone()), Some(config.clone()), Some(config.clone()), Some(config.clone())]);
 	let nodes = create_network(6, &node_cfgs, &node_chanmgrs);
@@ -6369,7 +6369,7 @@ fn test_fail_holding_cell_htlc_upon_free_multihop() {
 	// When this test was written, the default base fee floated based on the HTLC count.
 	// It is now fixed, so we simply set the fee to the expected value here.
 	let mut config = test_default_channel_config();
-	config.channel_options.forwarding_fee_base_msat = 196;
+	config.channel_config.forwarding_fee_base_msat = 196;
 	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[Some(config.clone()), Some(config.clone()), Some(config.clone())]);
 	let mut nodes = create_network(3, &node_cfgs, &node_chanmgrs);
 	let chan_0_1 = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, InitFeatures::known(), InitFeatures::known());
@@ -7328,9 +7328,9 @@ fn test_user_configurable_csv_delay() {
 	// We test our channel constructors yield errors when we pass them absurd csv delay
 
 	let mut low_our_to_self_config = UserConfig::default();
-	low_our_to_self_config.own_channel_config.our_to_self_delay = 6;
+	low_our_to_self_config.channel_handshake_config.our_to_self_delay = 6;
 	let mut high_their_to_self_config = UserConfig::default();
-	high_their_to_self_config.peer_channel_config_limits.their_to_self_delay = 100;
+	high_their_to_self_config.channel_handshake_limits.their_to_self_delay = 100;
 	let user_cfgs = [Some(high_their_to_self_config.clone()), None];
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
@@ -8245,7 +8245,7 @@ fn test_override_channel_config() {
 
 	// Node0 initiates a channel to node1 using the override config.
 	let mut override_config = UserConfig::default();
-	override_config.own_channel_config.our_to_self_delay = 200;
+	override_config.channel_handshake_config.our_to_self_delay = 200;
 
 	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 16_000_000, 12_000_000, 42, Some(override_config)).unwrap();
 
@@ -8258,7 +8258,7 @@ fn test_override_channel_config() {
 #[test]
 fn test_override_0msat_htlc_minimum() {
 	let mut zero_config = UserConfig::default();
-	zero_config.own_channel_config.our_htlc_minimum_msat = 0;
+	zero_config.channel_handshake_config.our_htlc_minimum_msat = 0;
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, Some(zero_config.clone())]);
@@ -8282,17 +8282,17 @@ fn test_channel_update_has_correct_htlc_maximum_msat() {
 	// 2. MUST be set to less than or equal to the `max_htlc_value_in_flight_msat` received from the peer.
 
 	let mut config_30_percent = UserConfig::default();
-	config_30_percent.own_channel_config.announced_channel = true;
-	config_30_percent.own_channel_config.max_inbound_htlc_value_in_flight_percent_of_channel = 30;
+	config_30_percent.channel_handshake_config.announced_channel = true;
+	config_30_percent.channel_handshake_config.max_inbound_htlc_value_in_flight_percent_of_channel = 30;
 	let mut config_50_percent = UserConfig::default();
-	config_50_percent.own_channel_config.announced_channel = true;
-	config_50_percent.own_channel_config.max_inbound_htlc_value_in_flight_percent_of_channel = 50;
+	config_50_percent.channel_handshake_config.announced_channel = true;
+	config_50_percent.channel_handshake_config.max_inbound_htlc_value_in_flight_percent_of_channel = 50;
 	let mut config_95_percent = UserConfig::default();
-	config_95_percent.own_channel_config.announced_channel = true;
-	config_95_percent.own_channel_config.max_inbound_htlc_value_in_flight_percent_of_channel = 95;
+	config_95_percent.channel_handshake_config.announced_channel = true;
+	config_95_percent.channel_handshake_config.max_inbound_htlc_value_in_flight_percent_of_channel = 95;
 	let mut config_100_percent = UserConfig::default();
-	config_100_percent.own_channel_config.announced_channel = true;
-	config_100_percent.own_channel_config.max_inbound_htlc_value_in_flight_percent_of_channel = 100;
+	config_100_percent.channel_handshake_config.announced_channel = true;
+	config_100_percent.channel_handshake_config.max_inbound_htlc_value_in_flight_percent_of_channel = 100;
 
 	let chanmon_cfgs = create_chanmon_cfgs(4);
 	let node_cfgs = create_node_cfgs(4, &chanmon_cfgs);
@@ -10182,7 +10182,7 @@ fn do_test_max_dust_htlc_exposure(dust_outbound_balance: bool, exposure_breach_e
 
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let mut config = test_default_channel_config();
-	config.channel_options.max_dust_htlc_exposure_msat = 5_000_000; // default setting value
+	config.channel_config.max_dust_htlc_exposure_msat = 5_000_000; // default setting value
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[Some(config), None]);
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
@@ -10225,13 +10225,13 @@ fn do_test_max_dust_htlc_exposure(dust_outbound_balance: bool, exposure_breach_e
 		chan.get_dust_buffer_feerate(None) as u64
 	};
 	let dust_outbound_htlc_on_holder_tx_msat: u64 = (dust_buffer_feerate * htlc_timeout_tx_weight(opt_anchors) / 1000 + open_channel.dust_limit_satoshis - 1) * 1000;
-	let dust_outbound_htlc_on_holder_tx: u64 = config.channel_options.max_dust_htlc_exposure_msat / dust_outbound_htlc_on_holder_tx_msat;
+	let dust_outbound_htlc_on_holder_tx: u64 = config.channel_config.max_dust_htlc_exposure_msat / dust_outbound_htlc_on_holder_tx_msat;
 
 	let dust_inbound_htlc_on_holder_tx_msat: u64 = (dust_buffer_feerate * htlc_success_tx_weight(opt_anchors) / 1000 + open_channel.dust_limit_satoshis - 1) * 1000;
-	let dust_inbound_htlc_on_holder_tx: u64 = config.channel_options.max_dust_htlc_exposure_msat / dust_inbound_htlc_on_holder_tx_msat;
+	let dust_inbound_htlc_on_holder_tx: u64 = config.channel_config.max_dust_htlc_exposure_msat / dust_inbound_htlc_on_holder_tx_msat;
 
 	let dust_htlc_on_counterparty_tx: u64 = 25;
-	let dust_htlc_on_counterparty_tx_msat: u64 = config.channel_options.max_dust_htlc_exposure_msat / dust_htlc_on_counterparty_tx;
+	let dust_htlc_on_counterparty_tx_msat: u64 = config.channel_config.max_dust_htlc_exposure_msat / dust_htlc_on_counterparty_tx;
 
 	if on_holder_tx {
 		if dust_outbound_balance {
@@ -10275,9 +10275,9 @@ fn do_test_max_dust_htlc_exposure(dust_outbound_balance: bool, exposure_breach_e
 		if on_holder_tx {
 			let dust_outbound_overflow = dust_outbound_htlc_on_holder_tx_msat * (dust_outbound_htlc_on_holder_tx + 1);
 			let dust_inbound_overflow = dust_inbound_htlc_on_holder_tx_msat * dust_inbound_htlc_on_holder_tx + dust_outbound_htlc_on_holder_tx_msat;
-			unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash, &Some(payment_secret)), true, APIError::ChannelUnavailable { ref err }, assert_eq!(err, &format!("Cannot send value that would put our exposure to dust HTLCs at {} over the limit {} on holder commitment tx", if dust_outbound_balance { dust_outbound_overflow } else { dust_inbound_overflow }, config.channel_options.max_dust_htlc_exposure_msat)));
+			unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash, &Some(payment_secret)), true, APIError::ChannelUnavailable { ref err }, assert_eq!(err, &format!("Cannot send value that would put our exposure to dust HTLCs at {} over the limit {} on holder commitment tx", if dust_outbound_balance { dust_outbound_overflow } else { dust_inbound_overflow }, config.channel_config.max_dust_htlc_exposure_msat)));
 		} else {
-			unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash, &Some(payment_secret)), true, APIError::ChannelUnavailable { ref err }, assert_eq!(err, &format!("Cannot send value that would put our exposure to dust HTLCs at {} over the limit {} on counterparty commitment tx", dust_overflow, config.channel_options.max_dust_htlc_exposure_msat)));
+			unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash, &Some(payment_secret)), true, APIError::ChannelUnavailable { ref err }, assert_eq!(err, &format!("Cannot send value that would put our exposure to dust HTLCs at {} over the limit {} on counterparty commitment tx", dust_overflow, config.channel_config.max_dust_htlc_exposure_msat)));
 		}
 	} else if exposure_breach_event == ExposureEvent::AtHTLCReception {
 		let (route, payment_hash, _, payment_secret) = get_route_and_payment_hash!(nodes[1], nodes[0], if on_holder_tx { dust_inbound_htlc_on_holder_tx_msat } else { dust_htlc_on_counterparty_tx_msat });
@@ -10292,10 +10292,10 @@ fn do_test_max_dust_htlc_exposure(dust_outbound_balance: bool, exposure_breach_e
 			// Outbound dust balance: 6399 sats
 			let dust_inbound_overflow = dust_inbound_htlc_on_holder_tx_msat * (dust_inbound_htlc_on_holder_tx + 1);
 			let dust_outbound_overflow = dust_outbound_htlc_on_holder_tx_msat * dust_outbound_htlc_on_holder_tx + dust_inbound_htlc_on_holder_tx_msat;
-			nodes[0].logger.assert_log("lightning::ln::channel".to_string(), format!("Cannot accept value that would put our exposure to dust HTLCs at {} over the limit {} on holder commitment tx", if dust_outbound_balance { dust_outbound_overflow } else { dust_inbound_overflow }, config.channel_options.max_dust_htlc_exposure_msat), 1);
+			nodes[0].logger.assert_log("lightning::ln::channel".to_string(), format!("Cannot accept value that would put our exposure to dust HTLCs at {} over the limit {} on holder commitment tx", if dust_outbound_balance { dust_outbound_overflow } else { dust_inbound_overflow }, config.channel_config.max_dust_htlc_exposure_msat), 1);
 		} else {
 			// Outbound dust balance: 5200 sats
-			nodes[0].logger.assert_log("lightning::ln::channel".to_string(), format!("Cannot accept value that would put our exposure to dust HTLCs at {} over the limit {} on counterparty commitment tx", dust_overflow, config.channel_options.max_dust_htlc_exposure_msat), 1);
+			nodes[0].logger.assert_log("lightning::ln::channel".to_string(), format!("Cannot accept value that would put our exposure to dust HTLCs at {} over the limit {} on counterparty commitment tx", dust_overflow, config.channel_config.max_dust_htlc_exposure_msat), 1);
 		}
 	} else if exposure_breach_event == ExposureEvent::AtUpdateFeeOutbound {
 		let (route, payment_hash, _, payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[1], 2_500_000);

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -262,7 +262,7 @@ fn test_fee_failures() {
 	// When this test was written, the default base fee floated based on the HTLC count.
 	// It is now fixed, so we simply set the fee to the expected value here.
 	let mut config = test_default_channel_config();
-	config.channel_options.forwarding_fee_base_msat = 196;
+	config.channel_config.forwarding_fee_base_msat = 196;
 
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
@@ -307,14 +307,14 @@ fn test_onion_failure() {
 	// This exposed a previous bug because we were using the wrong value all the way down in
 	// Channel::get_counterparty_htlc_minimum_msat().
 	let mut node_2_cfg: UserConfig = Default::default();
-	node_2_cfg.own_channel_config.our_htlc_minimum_msat = 2000;
-	node_2_cfg.own_channel_config.announced_channel = true;
-	node_2_cfg.peer_channel_config_limits.force_announced_channel_preference = false;
+	node_2_cfg.channel_handshake_config.our_htlc_minimum_msat = 2000;
+	node_2_cfg.channel_handshake_config.announced_channel = true;
+	node_2_cfg.channel_handshake_limits.force_announced_channel_preference = false;
 
 	// When this test was written, the default base fee floated based on the HTLC count.
 	// It is now fixed, so we simply set the fee to the expected value here.
 	let mut config = test_default_channel_config();
-	config.channel_options.forwarding_fee_base_msat = 196;
+	config.channel_config.forwarding_fee_base_msat = 196;
 
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
@@ -600,7 +600,7 @@ fn test_default_to_onion_payload_tlv_format() {
 	// `features` for a node in the `network_graph` exists, or when the node isn't in the
 	// `network_graph`, and no other known `features` for the node exists.
 	let mut priv_channels_conf = UserConfig::default();
-	priv_channels_conf.own_channel_config.announced_channel = false;
+	priv_channels_conf.channel_handshake_config.announced_channel = false;
 	let chanmon_cfgs = create_chanmon_cfgs(5);
 	let node_cfgs = create_node_cfgs(5, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(5, &node_cfgs, &[None, None, None, None, Some(priv_channels_conf)]);
@@ -1084,8 +1084,8 @@ fn test_phantom_dust_exposure_failure() {
 	// Set the max dust exposure to the dust limit.
 	let max_dust_exposure = 546;
 	let mut receiver_config = UserConfig::default();
-	receiver_config.channel_options.max_dust_htlc_exposure_msat = max_dust_exposure;
-	receiver_config.own_channel_config.announced_channel = true;
+	receiver_config.channel_config.max_dust_htlc_exposure_msat = max_dust_exposure;
+	receiver_config.channel_handshake_config.announced_channel = true;
 
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -532,7 +532,7 @@ fn do_retry_with_no_persist(confirm_before_reload: bool) {
 	// and not the original fee. We also update node[1]'s relevant config as
 	// do_claim_payment_along_route expects us to never overpay.
 	nodes[1].node.channel_state.lock().unwrap().by_id.get_mut(&chan_id_2).unwrap()
-		.config.mutable.forwarding_fee_base_msat += 100_000;
+		.config.options.forwarding_fee_base_msat += 100_000;
 	new_route.paths[0][0].fee_msat += 100_000;
 
 	assert!(nodes[0].node.retry_payment(&new_route, payment_id_1).is_err()); // Shouldn't be allowed to retry a fulfilled payment

--- a/lightning/src/ln/priv_short_conf_tests.rs
+++ b/lightning/src/ln/priv_short_conf_tests.rs
@@ -170,13 +170,13 @@ fn do_test_1_conf_open(connect_style: ConnectStyle) {
 	// Previously, if the minium_depth config was set to 1, we'd never send a channel_ready. This
 	// tests that we properly send one in that case.
 	let mut alice_config = UserConfig::default();
-	alice_config.own_channel_config.minimum_depth = 1;
-	alice_config.own_channel_config.announced_channel = true;
-	alice_config.peer_channel_config_limits.force_announced_channel_preference = false;
+	alice_config.channel_handshake_config.minimum_depth = 1;
+	alice_config.channel_handshake_config.announced_channel = true;
+	alice_config.channel_handshake_limits.force_announced_channel_preference = false;
 	let mut bob_config = UserConfig::default();
-	bob_config.own_channel_config.minimum_depth = 1;
-	bob_config.own_channel_config.announced_channel = true;
-	bob_config.peer_channel_config_limits.force_announced_channel_preference = false;
+	bob_config.channel_handshake_config.minimum_depth = 1;
+	bob_config.channel_handshake_config.announced_channel = true;
+	bob_config.channel_handshake_limits.force_announced_channel_preference = false;
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[Some(alice_config), Some(bob_config)]);
@@ -308,8 +308,8 @@ fn test_scid_privacy_on_pub_channel() {
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 
 	let mut scid_privacy_cfg = test_default_channel_config();
-	scid_privacy_cfg.own_channel_config.announced_channel = true;
-	scid_privacy_cfg.own_channel_config.negotiate_scid_privacy = true;
+	scid_privacy_cfg.channel_handshake_config.announced_channel = true;
+	scid_privacy_cfg.channel_handshake_config.negotiate_scid_privacy = true;
 	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 100000, 10001, 42, Some(scid_privacy_cfg)).unwrap();
 	let mut open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
 
@@ -332,8 +332,8 @@ fn test_scid_privacy_negotiation() {
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 
 	let mut scid_privacy_cfg = test_default_channel_config();
-	scid_privacy_cfg.own_channel_config.announced_channel = false;
-	scid_privacy_cfg.own_channel_config.negotiate_scid_privacy = true;
+	scid_privacy_cfg.channel_handshake_config.announced_channel = false;
+	scid_privacy_cfg.channel_handshake_config.negotiate_scid_privacy = true;
 	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 100000, 10001, 42, Some(scid_privacy_cfg)).unwrap();
 
 	let init_open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
@@ -378,8 +378,8 @@ fn test_inbound_scid_privacy() {
 	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0, InitFeatures::known(), InitFeatures::known());
 
 	let mut no_announce_cfg = test_default_channel_config();
-	no_announce_cfg.own_channel_config.announced_channel = false;
-	no_announce_cfg.own_channel_config.negotiate_scid_privacy = true;
+	no_announce_cfg.channel_handshake_config.announced_channel = false;
+	no_announce_cfg.channel_handshake_config.negotiate_scid_privacy = true;
 	nodes[1].node.create_channel(nodes[2].node.get_our_node_id(), 100_000, 10_000, 42, Some(no_announce_cfg)).unwrap();
 	let mut open_channel = get_event_msg!(nodes[1], MessageSendEvent::SendOpenChannel, nodes[2].node.get_our_node_id());
 
@@ -521,7 +521,7 @@ fn test_scid_alias_returned() {
 		short_channel_id: last_hop[0].inbound_scid_alias.unwrap(),
 		timestamp: 21,
 		flags: 1,
-		cltv_expiry_delta: accept_forward_cfg.channel_options.cltv_expiry_delta,
+		cltv_expiry_delta: accept_forward_cfg.channel_config.cltv_expiry_delta,
 		htlc_minimum_msat: 1_000,
 		htlc_maximum_msat: OptionalField::Present(1_000_000), // Defaults to 10% of the channel value
 		fee_base_msat: last_hop[0].counterparty.forwarding_info.as_ref().unwrap().fee_base_msat,
@@ -665,7 +665,7 @@ fn test_0conf_channel_with_async_monitor() {
 
 	create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0, InitFeatures::known(), InitFeatures::known());
 
-	chan_config.own_channel_config.announced_channel = false;
+	chan_config.channel_handshake_config.announced_channel = false;
 	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 100000, 10001, 42, Some(chan_config)).unwrap();
 	let open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
 
@@ -811,7 +811,7 @@ fn test_0conf_close_no_early_chan_update() {
 	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 
 	// This is the default but we force it on anyway
-	chan_config.own_channel_config.announced_channel = true;
+	chan_config.channel_handshake_config.announced_channel = true;
 	open_zero_conf_channel(&nodes[0], &nodes[1], Some(chan_config));
 
 	// We can use the channel immediately, but won't generate a channel_update until we get confs
@@ -835,7 +835,7 @@ fn test_public_0conf_channel() {
 	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 
 	// This is the default but we force it on anyway
-	chan_config.own_channel_config.announced_channel = true;
+	chan_config.channel_handshake_config.announced_channel = true;
 	let tx = open_zero_conf_channel(&nodes[0], &nodes[1], Some(chan_config));
 
 	// We can use the channel immediately, but we can't announce it until we get 6+ confirmations
@@ -888,7 +888,7 @@ fn test_0conf_channel_reorg() {
 	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 
 	// This is the default but we force it on anyway
-	chan_config.own_channel_config.announced_channel = true;
+	chan_config.channel_handshake_config.announced_channel = true;
 	let tx = open_zero_conf_channel(&nodes[0], &nodes[1], Some(chan_config));
 
 	// We can use the channel immediately, but we can't announce it until we get 6+ confirmations
@@ -974,7 +974,7 @@ fn test_zero_conf_accept_reject() {
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
 
 	let events = nodes[1].node.get_and_clear_pending_events();
-	
+
 	match events[0] {
 		Event::OpenChannelRequest { temporary_channel_id, .. } => {
 			// Assert we fail to accept via the non-0conf method
@@ -1004,7 +1004,7 @@ fn test_zero_conf_accept_reject() {
 		&open_channel_msg);
 
 	let events = nodes[1].node.get_and_clear_pending_events();
-	
+
 	match events[0] {
 		Event::OpenChannelRequest { temporary_channel_id, .. } => {
 			// Assert we can accept via the 0conf method

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -409,9 +409,9 @@ fn test_upfront_shutdown_script() {
 	// enforce it at shutdown message
 
 	let mut config = UserConfig::default();
-	config.own_channel_config.announced_channel = true;
-	config.peer_channel_config_limits.force_announced_channel_preference = false;
-	config.own_channel_config.commit_upfront_shutdown_pubkey = false;
+	config.channel_handshake_config.announced_channel = true;
+	config.channel_handshake_limits.force_announced_channel_preference = false;
+	config.channel_handshake_config.commit_upfront_shutdown_pubkey = false;
 	let user_cfgs = [None, Some(config), None];
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
@@ -574,9 +574,9 @@ fn test_invalid_upfront_shutdown_script() {
 #[test]
 fn test_segwit_v0_shutdown_script() {
 	let mut config = UserConfig::default();
-	config.own_channel_config.announced_channel = true;
-	config.peer_channel_config_limits.force_announced_channel_preference = false;
-	config.own_channel_config.commit_upfront_shutdown_pubkey = false;
+	config.channel_handshake_config.announced_channel = true;
+	config.channel_handshake_limits.force_announced_channel_preference = false;
+	config.channel_handshake_config.commit_upfront_shutdown_pubkey = false;
 	let user_cfgs = [None, Some(config), None];
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
@@ -609,9 +609,9 @@ fn test_segwit_v0_shutdown_script() {
 #[test]
 fn test_anysegwit_shutdown_script() {
 	let mut config = UserConfig::default();
-	config.own_channel_config.announced_channel = true;
-	config.peer_channel_config_limits.force_announced_channel_preference = false;
-	config.own_channel_config.commit_upfront_shutdown_pubkey = false;
+	config.channel_handshake_config.announced_channel = true;
+	config.channel_handshake_limits.force_announced_channel_preference = false;
+	config.channel_handshake_config.commit_upfront_shutdown_pubkey = false;
 	let user_cfgs = [None, Some(config), None];
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
@@ -644,9 +644,9 @@ fn test_anysegwit_shutdown_script() {
 #[test]
 fn test_unsupported_anysegwit_shutdown_script() {
 	let mut config = UserConfig::default();
-	config.own_channel_config.announced_channel = true;
-	config.peer_channel_config_limits.force_announced_channel_preference = false;
-	config.own_channel_config.commit_upfront_shutdown_pubkey = false;
+	config.channel_handshake_config.announced_channel = true;
+	config.channel_handshake_limits.force_announced_channel_preference = false;
+	config.channel_handshake_config.commit_upfront_shutdown_pubkey = false;
 	let user_cfgs = [None, Some(config), None];
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 	let mut node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
@@ -686,9 +686,9 @@ fn test_unsupported_anysegwit_shutdown_script() {
 #[test]
 fn test_invalid_shutdown_script() {
 	let mut config = UserConfig::default();
-	config.own_channel_config.announced_channel = true;
-	config.peer_channel_config_limits.force_announced_channel_preference = false;
-	config.own_channel_config.commit_upfront_shutdown_pubkey = false;
+	config.channel_handshake_config.announced_channel = true;
+	config.channel_handshake_limits.force_announced_channel_preference = false;
+	config.channel_handshake_config.commit_upfront_shutdown_pubkey = false;
 	let user_cfgs = [None, Some(config), None];
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -350,7 +350,7 @@ impl Default for ChannelConfig {
 /// [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`] fields.
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct LegacyChannelConfig {
-	pub(crate) mutable: ChannelConfig,
+	pub(crate) options: ChannelConfig,
 	/// Deprecated but may still be read from. See [`ChannelHandshakeConfig::announced_channel`] to
 	/// set this when opening/accepting a channel.
 	pub(crate) announced_channel: bool,
@@ -363,7 +363,7 @@ pub(crate) struct LegacyChannelConfig {
 impl Default for LegacyChannelConfig {
 	fn default() -> Self {
 		Self {
-			mutable: ChannelConfig::default(),
+			options: ChannelConfig::default(),
 			announced_channel: false,
 			commit_upfront_shutdown_pubkey: true,
 		}
@@ -373,13 +373,13 @@ impl Default for LegacyChannelConfig {
 impl ::util::ser::Writeable for LegacyChannelConfig {
 	fn write<W: ::util::ser::Writer>(&self, writer: &mut W) -> Result<(), ::io::Error> {
 		write_tlv_fields!(writer, {
-			(0, self.mutable.forwarding_fee_proportional_millionths, required),
-			(1, self.mutable.max_dust_htlc_exposure_msat, (default_value, 5_000_000)),
-			(2, self.mutable.cltv_expiry_delta, required),
-			(3, self.mutable.force_close_avoidance_max_fee_satoshis, (default_value, 1000)),
+			(0, self.options.forwarding_fee_proportional_millionths, required),
+			(1, self.options.max_dust_htlc_exposure_msat, (default_value, 5_000_000)),
+			(2, self.options.cltv_expiry_delta, required),
+			(3, self.options.force_close_avoidance_max_fee_satoshis, (default_value, 1000)),
 			(4, self.announced_channel, required),
 			(6, self.commit_upfront_shutdown_pubkey, required),
-			(8, self.mutable.forwarding_fee_base_msat, required),
+			(8, self.options.forwarding_fee_base_msat, required),
 		});
 		Ok(())
 	}
@@ -404,7 +404,7 @@ impl ::util::ser::Readable for LegacyChannelConfig {
 			(8, forwarding_fee_base_msat, required),
 		});
 		Ok(Self {
-			mutable: ChannelConfig {
+			options: ChannelConfig {
 				forwarding_fee_proportional_millionths,
 				max_dust_htlc_exposure_msat,
 				cltv_expiry_delta,
@@ -423,12 +423,12 @@ impl ::util::ser::Readable for LegacyChannelConfig {
 /// (but currently with 0 relay fees!)
 #[derive(Copy, Clone, Debug)]
 pub struct UserConfig {
-	/// Channel config that we propose to our counterparty.
-	pub own_channel_config: ChannelHandshakeConfig,
-	/// Limits applied to our counterparty's proposed channel config settings.
-	pub peer_channel_config_limits: ChannelHandshakeLimits,
+	/// Channel handshake config that we propose to our counterparty.
+	pub channel_handshake_config: ChannelHandshakeConfig,
+	/// Limits applied to our counterparty's proposed channel handshake config settings.
+	pub channel_handshake_limits: ChannelHandshakeLimits,
 	/// Channel config which affects behavior during channel lifetime.
-	pub channel_options: ChannelConfig,
+	pub channel_config: ChannelConfig,
 	/// If this is set to false, we will reject any HTLCs which were to be forwarded over private
 	/// channels. This prevents us from taking on HTLC-forwarding risk when we intend to run as a
 	/// node which is not online reliably.
@@ -468,9 +468,9 @@ pub struct UserConfig {
 impl Default for UserConfig {
 	fn default() -> Self {
 		UserConfig {
-			own_channel_config: ChannelHandshakeConfig::default(),
-			peer_channel_config_limits: ChannelHandshakeLimits::default(),
-			channel_options: ChannelConfig::default(),
+			channel_handshake_config: ChannelHandshakeConfig::default(),
+			channel_handshake_limits: ChannelHandshakeLimits::default(),
+			channel_config: ChannelConfig::default(),
 			accept_forwards_to_priv_channels: false,
 			accept_inbound_channels: true,
 			manually_accept_inbound_channels: false,


### PR DESCRIPTION
The current names aren't very clear to what each field represents, this commit aims to improve that.

Follow-up from #1529.