### PR TITLE
Clarify description of get_node_secret() method

### DIFF
--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -397,7 +397,9 @@ pub trait KeysInterface {
 	/// A type which implements Sign which will be returned by get_channel_signer.
 	type Signer : Sign;
 
-	/// Get node secret key (aka node_id or network_key) based on the provided [`Recipient`].
+	/// Get node secret key based on the provided [`Recipient`].
+	///
+	/// The node_id/network_key is the public key that corresponds to this secret key.
 	///
 	/// This method must return the same value each time it is called with a given `Recipient`
 	/// parameter.


### PR DESCRIPTION
I was confused by the original description, so I'm proposing a small change. 
Probably for most, it was obvious that the secret key is not the node_id itself, but when I read this initially, I even thought that maybe the node_id/public key was being held in a SecretKey struct. 