### PR TITLE
Forward over substitute channels

### DIFF
--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -1413,12 +1413,12 @@ fn monitor_failed_no_reestablish_response() {
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let channel_id = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known()).2;
 	{
-		let node_0_per_peer_lock = nodes[0].node.per_peer_state.write().unwrap();
-		let mut node_0_peer_state_lock = node_0_per_peer_lock.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let node_1_per_peer_lock = nodes[1].node.per_peer_state.write().unwrap();
-		let mut node_1_peer_state_lock = node_1_per_peer_lock.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
-		get_channel_ref!(nodes[0], node_0_peer_state_lock, channel_id).announcement_sigs_state = AnnouncementSigsState::PeerReceived;
-		get_channel_ref!(nodes[1], node_1_peer_state_lock, channel_id).announcement_sigs_state = AnnouncementSigsState::PeerReceived;
+		let mut node_0_per_peer_lock;
+		let mut node_0_peer_state_lock;
+		let mut node_1_per_peer_lock;
+		let mut node_1_peer_state_lock;
+		get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, channel_id).announcement_sigs_state = AnnouncementSigsState::PeerReceived;
+		get_channel_ref!(nodes[1], nodes[0], node_1_per_peer_lock, node_1_peer_state_lock, channel_id).announcement_sigs_state = AnnouncementSigsState::PeerReceived;
 	}
 
 	// Route the payment and deliver the initial commitment_signed (with a monitor update failure

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -130,7 +130,9 @@ fn test_monitor_and_persister_update_fail() {
 	let updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
 	assert_eq!(updates.update_fulfill_htlcs.len(), 1);
 	nodes[0].node.handle_update_fulfill_htlc(&nodes[1].node.get_our_node_id(), &updates.update_fulfill_htlcs[0]);
-	if let Some(ref mut channel) = nodes[0].node.channel_state.lock().unwrap().by_id.get_mut(&chan.2) {
+	if let Some(ref mut channel) = nodes[0].node.per_peer_state.write().unwrap().get_mut(&nodes[1].node.get_our_node_id())
+			.unwrap().lock().unwrap().channel_by_id.get_mut(&chan.2)
+	{
 		if let Ok((_, _, update)) = channel.commitment_signed(&updates.commitment_signed, &node_cfgs[0].logger) {
 			// Check that even though the persister is returning a TemporaryFailure,
 			// because the update is bogus, ultimately the error that's returned
@@ -1411,9 +1413,12 @@ fn monitor_failed_no_reestablish_response() {
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let channel_id = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known()).2;
 	{
-		let mut lock;
-		get_channel_ref!(nodes[0], lock, channel_id).announcement_sigs_state = AnnouncementSigsState::PeerReceived;
-		get_channel_ref!(nodes[1], lock, channel_id).announcement_sigs_state = AnnouncementSigsState::PeerReceived;
+		let node_0_per_peer_lock = nodes[0].node.per_peer_state.write().unwrap();
+		let mut node_0_peer_state_lock = node_0_per_peer_lock.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+		let node_1_per_peer_lock = nodes[1].node.per_peer_state.write().unwrap();
+		let mut node_1_peer_state_lock = node_1_per_peer_lock.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
+		get_channel_ref!(nodes[0], node_0_peer_state_lock, channel_id).announcement_sigs_state = AnnouncementSigsState::PeerReceived;
+		get_channel_ref!(nodes[1], node_1_peer_state_lock, channel_id).announcement_sigs_state = AnnouncementSigsState::PeerReceived;
 	}
 
 	// Route the payment and deliver the initial commitment_signed (with a monitor update failure

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4828,8 +4828,9 @@ impl<Signer: Sign> Channel<Signer> {
 			// the funding transaction is at least still in the mempool of most nodes).
 			//
 			// Note that ideally we wouldn't force-close if we see *any* reorg on a 1-conf or
-			// 0-conf channel, but not doing so may lead to the `ChannelManager::short_to_id` map
-			// being inconsistent, so we currently have to.
+			// 0-conf channel, but not doing so may lead to the
+			// `ChannelManager::short_to_chan_info` map  being inconsistent, so we currently have
+			// to.
 			if funding_tx_confirmations == 0 && self.funding_tx_confirmed_in.is_some() {
 				let err_reason = format!("Funding transaction was un-confirmed. Locked at {} confs, now have {} confs.",
 					self.minimum_depth.unwrap(), funding_tx_confirmations);

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -790,8 +790,13 @@ pub struct ChannelManager<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, 
 	///
 	/// If we are connected to a peer we always at least have an entry here, even if no channels
 	/// are currently open with that peer.
-	/// Currently, we usually take an outer read lock and then operate on the inner value freely.
-	/// Sadly, this prevents parallel per-peer operation.
+	///
+	/// Because adding or removing an entry is rare, we usually take an outer read lock and then
+	/// operate on the inner value freely. This opens up for parallel per-peer operation for
+	/// channels. Sadly, most functions that operate on the channels currently also require that
+	/// the `channel_state` lock is aquired until more fields from the `channel_state` is moved.
+	/// Aquiring the `channel_state` lock blocks parallel per-peer operation in the cases where it
+	/// is needed.
 	///
 	/// If also holding `channel_state` lock, must lock `channel_state` prior to `per_peer_state`.
 	#[cfg(not(any(test, feature = "_test_utils")))]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1703,12 +1703,18 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			return Err(APIError::APIMisuseError { err: format!("Channel value must be at least 1000 satoshis. It was {}", channel_value_satoshis) });
 		}
 
-		let channel = {
-			let per_peer_state = self.per_peer_state.read().unwrap();
-			match per_peer_state.get(&their_network_key) {
-				Some(peer_state) => {
+		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(&self.total_consistency_lock, &self.persistence_notifier);
+		// We want to make sure the lock is actually acquired by PersistenceNotifierGuard.
+		debug_assert!(&self.total_consistency_lock.try_write().is_err());
+
+		let mut channel_state = self.channel_state.lock().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
+		match per_peer_state.get(&their_network_key) {
+			None => return Err(APIError::ChannelUnavailable { err: format!("Not connected to node: {}", their_network_key) }),
+			Some(peer_state) => {
+				let mut peer_state = peer_state.lock().unwrap();
+				let channel = {
 					let outbound_scid_alias = self.create_and_insert_outbound_scid_alias();
-					let peer_state = peer_state.lock().unwrap();
 					let their_features = &peer_state.latest_features;
 					let config = if override_config.is_some() { override_config.as_ref().unwrap() } else { &self.default_configuration };
 					match Channel::new_outbound(&self.fee_estimator, &self.keys_manager, their_network_key,
@@ -1721,38 +1727,29 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							return Err(e);
 						},
 					}
-				},
-				None => return Err(APIError::ChannelUnavailable { err: format!("Not connected to node: {}", their_network_key) }),
-			}
-		};
-		let res = channel.get_open_channel(self.genesis_hash.clone());
+				};
+				let res = channel.get_open_channel(self.genesis_hash.clone());
 
-		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(&self.total_consistency_lock, &self.persistence_notifier);
-		// We want to make sure the lock is actually acquired by PersistenceNotifierGuard.
-		debug_assert!(&self.total_consistency_lock.try_write().is_err());
+				let temporary_channel_id = channel.channel_id();
 
-		let temporary_channel_id = channel.channel_id();
-		let mut channel_state = self.channel_state.lock().unwrap();
-		let per_peer_state = self.per_peer_state.read().unwrap();
-		if let Some(peer_state_mutex) = per_peer_state.get(&their_network_key){
-			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
-			let peer_state = &mut *peer_state_lock;
-			match peer_state.channel_by_id.entry(temporary_channel_id) {
-				hash_map::Entry::Occupied(_) => {
-					if cfg!(fuzzing) {
-						return Err(APIError::APIMisuseError { err: "Fuzzy bad RNG".to_owned() });
-					} else {
-						panic!("RNG is bad???");
-					}
-				},
-				hash_map::Entry::Vacant(entry) => { entry.insert(channel); }
+				match peer_state.channel_by_id.entry(temporary_channel_id) {
+					hash_map::Entry::Occupied(_) => {
+						if cfg!(fuzzing) {
+							return Err(APIError::APIMisuseError { err: "Fuzzy bad RNG".to_owned() });
+						} else {
+							panic!("RNG is bad???");
+						}
+					},
+					hash_map::Entry::Vacant(entry) => { entry.insert(channel); }
+				}
+
+				channel_state.pending_msg_events.push(events::MessageSendEvent::SendOpenChannel {
+					node_id: their_network_key,
+					msg: res,
+				});
+				Ok(temporary_channel_id)
 			}
-		} else { unreachable!() }
-		channel_state.pending_msg_events.push(events::MessageSendEvent::SendOpenChannel {
-			node_id: their_network_key,
-			msg: res,
-		});
-		Ok(temporary_channel_id)
+		}
 	}
 
 	fn list_channels_with_filter<Fn: FnMut(&(&[u8; 32], &Channel<Signer>)) -> bool + Copy>(&self, f: Fn) -> Vec<ChannelDetails> {
@@ -2789,12 +2786,15 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	fn funding_transaction_generated_intern<FundingOutput: Fn(&Channel<Signer>, &Transaction) -> Result<OutPoint, APIError>>(
 		&self, temporary_channel_id: &[u8; 32], counterparty_node_id: &PublicKey, funding_transaction: Transaction, find_funding_output: FundingOutput
 	) -> Result<(), APIError> {
-		let (chan, msg) = {
-			let (res, chan) = {
-				let per_peer_state = self.per_peer_state.read().unwrap();
-				if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
-					let mut peer_state_lock = peer_state_mutex.lock().unwrap();
-					let peer_state = &mut *peer_state_lock;
+		let mut channel_state_lock = self.channel_state.lock().unwrap();
+		let channel_state = &mut *channel_state_lock;
+		let per_peer_state = self.per_peer_state.read().unwrap();
+		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
+			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
+			let peer_state = &mut *peer_state_lock;
+
+			let (chan, msg) = {
+				let (res, chan) = {
 					match peer_state.channel_by_id.remove(temporary_channel_id) {
 						Some(mut chan) => {
 							let funding_txo = find_funding_output(&chan, &funding_transaction)?;
@@ -2807,31 +2807,22 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						},
 						None => { return Err(APIError::ChannelUnavailable { err: "No such channel".to_owned() }) },
 					}
-				} else {
-					return Err(APIError::APIMisuseError { err: format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id) })
+				};
+				match handle_error!(self, res, chan.get_counterparty_node_id()) {
+					Ok(funding_msg) => {
+						(chan, funding_msg)
+					},
+					Err(_) => { return Err(APIError::ChannelUnavailable {
+						err: "Error deriving keys or signing initial commitment transactions - either our RNG or our counterparty's RNG is broken or the Signer refused to sign".to_owned()
+					}) },
 				}
 			};
-			match handle_error!(self, res, chan.get_counterparty_node_id()) {
-				Ok(funding_msg) => {
-					(chan, funding_msg)
-				},
-				Err(_) => { return Err(APIError::ChannelUnavailable {
-					err: "Error deriving keys or signing initial commitment transactions - either our RNG or our counterparty's RNG is broken or the Signer refused to sign".to_owned()
-				}) },
-			}
-		};
 
-		let mut channel_state_lock = self.channel_state.lock().unwrap();
-		let channel_state = &mut *channel_state_lock;
-		channel_state.pending_msg_events.push(events::MessageSendEvent::SendFundingCreated {
-			node_id: chan.get_counterparty_node_id(),
-			msg,
-		});
-		let per_peer_state = self.per_peer_state.read().unwrap();
-		let chan_id = chan.channel_id();
-		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
-			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
-			let peer_state = &mut *peer_state_lock;
+			channel_state.pending_msg_events.push(events::MessageSendEvent::SendFundingCreated {
+				node_id: chan.get_counterparty_node_id(),
+				msg,
+			});
+			let chan_id = chan.channel_id();
 			match peer_state.channel_by_id.entry(chan_id) {
 				hash_map::Entry::Occupied(_) => {
 					panic!("Generated duplicate funding txid?");
@@ -2844,8 +2835,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					}
 				}
 			}
-		} else { unreachable!(); }
-		Ok(())
+			Ok(())
+		} else {
+			return Err(APIError::APIMisuseError { err: format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id) })
+		}
 	}
 
 	#[cfg(test)]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -406,10 +406,12 @@ pub(super) enum RAACommitmentOrder {
 // Note this is only exposed in cfg(test):
 pub(super) struct ChannelHolder<Signer: Sign> {
 	pub(super) by_id: HashMap<[u8; 32], Channel<Signer>>,
-	/// SCIDs (and outbound SCID aliases) to the real channel id. Outbound SCID aliases are added
-	/// here once the channel is available for normal use, with SCIDs being added once the funding
-	/// transaction is confirmed at the channel's required confirmation depth.
-	pub(super) short_to_id: HashMap<u64, [u8; 32]>,
+	/// SCIDs (and outbound SCID aliases) -> `counterparty_node_id`s and `channel_id`s.
+	///
+	/// Outbound SCID aliases are added here once the channel is available for normal use, with
+	/// SCIDs being added once the funding transaction is confirmed at the channel's required
+	/// confirmation depth.
+	pub(super) short_to_id: HashMap<u64, (PublicKey, [u8; 32])>,
 	/// SCID/SCID Alias -> forward infos. Key of 0 means payments received.
 	///
 	/// Note that because we may have an SCID Alias as the key we can have two entries per channel,
@@ -1412,12 +1414,12 @@ macro_rules! send_channel_ready {
 		});
 		// Note that we may send a `channel_ready` multiple times for a channel if we reconnect, so
 		// we allow collisions, but we shouldn't ever be updating the channel ID pointed to.
-		let outbound_alias_insert = $short_to_id.insert($channel.outbound_scid_alias(), $channel.channel_id());
-		assert!(outbound_alias_insert.is_none() || outbound_alias_insert.unwrap() == $channel.channel_id(),
+		let outbound_alias_insert = $short_to_id.insert($channel.outbound_scid_alias(), ($channel.get_counterparty_node_id(), $channel.channel_id()));
+		assert!(outbound_alias_insert.is_none() || outbound_alias_insert.unwrap() == ($channel.get_counterparty_node_id(), $channel.channel_id()),
 			"SCIDs should never collide - ensure you weren't behind the chain tip by a full month when creating channels");
 		if let Some(real_scid) = $channel.get_short_channel_id() {
-			let scid_insert = $short_to_id.insert(real_scid, $channel.channel_id());
-			assert!(scid_insert.is_none() || scid_insert.unwrap() == $channel.channel_id(),
+			let scid_insert = $short_to_id.insert(real_scid, ($channel.get_counterparty_node_id(), $channel.channel_id()));
+			assert!(scid_insert.is_none() || scid_insert.unwrap() == ($channel.get_counterparty_node_id(), $channel.channel_id()),
 				"SCIDs should never collide - ensure you weren't behind the chain tip by a full month when creating channels");
 		}
 	}
@@ -2223,7 +2225,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 								break Some(("Don't have available channel for forwarding as requested.", 0x4000 | 10, None));
 							}
 						},
-						Some(id) => Some(id.clone()),
+						Some((_cp_id, id)) => Some(id.clone()),
 					};
 					let (chan_update_opt, forwardee_cltv_expiry_delta) = if let Some(forwarding_id) = forwarding_id_opt {
 						let chan = channel_state.as_mut().unwrap().by_id.get_mut(&forwarding_id).unwrap();
@@ -2404,7 +2406,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 			let id = match channel_lock.short_to_id.get(&path.first().unwrap().short_channel_id) {
 				None => return Err(APIError::ChannelUnavailable{err: "No channel available with first hop!".to_owned()}),
-				Some(id) => id.clone(),
+				Some((_cp_id, id)) => id.clone(),
 			};
 
 			macro_rules! insert_outbound_payment {
@@ -2932,7 +2934,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			for (short_chan_id, mut pending_forwards) in channel_state.forward_htlcs.drain() {
 				if short_chan_id != 0 {
 					let forward_chan_id = match channel_state.short_to_id.get(&short_chan_id) {
-						Some(chan_id) => chan_id.clone(),
+						Some((_cp_id, chan_id)) => chan_id.clone(),
 						None => {
 							for forward_info in pending_forwards.drain(..) {
 								match forward_info {
@@ -3349,7 +3351,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		self.process_background_events();
 	}
 
-	fn update_channel_fee(&self, short_to_id: &mut HashMap<u64, [u8; 32]>, pending_msg_events: &mut Vec<events::MessageSendEvent>, chan_id: &[u8; 32], chan: &mut Channel<Signer>, new_feerate: u32) -> (bool, NotifyOption, Result<(), MsgHandleErrInternal>) {
+	fn update_channel_fee(&self, short_to_id: &mut HashMap<u64, (PublicKey, [u8; 32])>, pending_msg_events: &mut Vec<events::MessageSendEvent>, chan_id: &[u8; 32], chan: &mut Channel<Signer>, new_feerate: u32) -> (bool, NotifyOption, Result<(), MsgHandleErrInternal>) {
 		if !chan.is_outbound() { return (true, NotifyOption::SkipPersist, Ok(())); }
 		// If the feerate has decreased by less than half, don't bother
 		if new_feerate <= chan.get_feerate() && new_feerate * 2 > chan.get_feerate() {
@@ -3965,7 +3967,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		//TODO: Delay the claimed_funds relaying just like we do outbound relay!
 		let channel_state = &mut **channel_state_lock;
 		let chan_id = match channel_state.short_to_id.get(&prev_hop.short_channel_id) {
-			Some(chan_id) => chan_id.clone(),
+			Some((_cp_id, chan_id)) => chan_id.clone(),
 			None => {
 				return ClaimFundsFromHop::PrevHopForceClosed
 			}
@@ -4887,7 +4889,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
 		let chan_id = match channel_state.short_to_id.get(&msg.contents.short_channel_id) {
-			Some(chan_id) => chan_id.clone(),
+			Some((_cp_id, chan_id)) => chan_id.clone(),
 			None => {
 				// It's not a local channel
 				return Ok(NotifyOption::SkipPersist)
@@ -5669,8 +5671,8 @@ where
 							// using the real SCID at relay-time (i.e. enforce option_scid_alias
 							// then), and if the funding tx is ever un-confirmed we force-close the
 							// channel, ensuring short_to_id is always consistent.
-							let scid_insert = short_to_id.insert(real_scid, channel.channel_id());
-							assert!(scid_insert.is_none() || scid_insert.unwrap() == channel.channel_id(),
+							let scid_insert = short_to_id.insert(real_scid, (channel.get_counterparty_node_id(), channel.channel_id()));
+							assert!(scid_insert.is_none() || scid_insert.unwrap() == (channel.get_counterparty_node_id(), channel.channel_id()),
 								"SCIDs should never collide - ensure you weren't behind by a full {} blocks when creating channels",
 								fake_scid::MAX_SCID_BLOCKS_FROM_NOW);
 						}
@@ -6713,7 +6715,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 				} else {
 					log_info!(args.logger, "Successfully loaded channel {}", log_bytes!(channel.channel_id()));
 					if let Some(short_channel_id) = channel.get_short_channel_id() {
-						short_to_id.insert(short_channel_id, channel.channel_id());
+						short_to_id.insert(short_channel_id, (channel.get_counterparty_node_id(), channel.channel_id()));
 					}
 					by_id.insert(channel.channel_id(), channel);
 				}
@@ -6972,7 +6974,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 				return Err(DecodeError::InvalidValue);
 			}
 			if chan.is_usable() {
-				if short_to_id.insert(chan.outbound_scid_alias(), *chan_id).is_some() {
+				if short_to_id.insert(chan.outbound_scid_alias(), (chan.get_counterparty_node_id(), *chan_id)).is_some() {
 					// Note that in rare cases its possible to hit this while reading an older
 					// channel if we just happened to pick a colliding outbound alias above.
 					log_error!(args.logger, "Got duplicate outbound SCID alias; {}", chan.outbound_scid_alias());

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -739,6 +739,25 @@ pub struct ChannelManager<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, 
 	/// active channel list on load.
 	outbound_scid_aliases: Mutex<HashSet<u64>>,
 
+	/// `channel_id` -> `counterparty_node_id`.
+	///
+	/// Only `channel_id`s are allowed as keys in this map, and not `temporary_channel_id`s. As
+	/// multiple channels with the same `temporary_channel_id` to different peers can exist,
+	/// allowing `temporary_channel_id`s in this map would cause collisions for such channels.
+	///
+	/// Note that this map should only be used for `MonitorEvent` handling, to be able to access
+	/// the corresponding channel for the event, as we only have access to the `channel_id` during
+	/// the handling of the events.
+	///
+	/// TODO:
+	/// The `counterparty_node_id` isn't passed with `MonitorEvent`s currently. To pass it, we need
+	/// to add the `counterparty_node_id` to `ChannelMonitor`s. However, adding it as a required
+	/// field in `ChannelMonitor`s would break backwards compatability.
+	/// We should add `counterparty_node_id`s to `MonitorEvent`s, and eventually rely on it in the
+	/// future. That would make this map redundant, as only the `ChannelManager::per_peer_state` is
+	/// required to access the channel with the `counterparty_node_id`.
+	id_to_peer: Mutex<HashMap<[u8; 32], PublicKey>>,
+
 	our_network_key: SecretKey,
 	our_network_pubkey: PublicKey,
 
@@ -1244,6 +1263,7 @@ macro_rules! update_maps_on_chan_removal {
 			let alias_removed = $self.outbound_scid_aliases.lock().unwrap().remove(&$channel.outbound_scid_alias());
 			debug_assert!(alias_removed);
 		}
+		$self.id_to_peer.lock().unwrap().remove(&$channel.channel_id());
 		$short_to_chan_info.remove(&$channel.outbound_scid_alias());
 	}
 }
@@ -1589,6 +1609,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			outbound_scid_aliases: Mutex::new(HashSet::new()),
 			pending_inbound_payments: Mutex::new(HashMap::new()),
 			pending_outbound_payments: Mutex::new(HashMap::new()),
+			id_to_peer: Mutex::new(HashMap::new()),
 
 			our_network_key: keys_manager.get_node_secret(Recipient::Node).unwrap(),
 			our_network_pubkey: PublicKey::from_secret_key(&secp_ctx, &keys_manager.get_node_secret(Recipient::Node).unwrap()),
@@ -2756,12 +2777,18 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			node_id: chan.get_counterparty_node_id(),
 			msg,
 		});
-		match channel_state.by_id.entry(chan.channel_id()) {
+		let chan_id = chan.channel_id();
+		match channel_state.by_id.entry(chan_id) {
 			hash_map::Entry::Occupied(_) => {
 				panic!("Generated duplicate funding txid?");
 			},
 			hash_map::Entry::Vacant(e) => {
+				let counterparty_node_id = chan.get_counterparty_node_id();
 				e.insert(chan);
+				let mut id_to_peer = self.id_to_peer.lock().unwrap();
+				if id_to_peer.insert(chan_id, counterparty_node_id).is_some() {
+					panic!("id_to_peer map already contained funding txid, which shouldn't be possible");
+				}
 			}
 		}
 		Ok(())
@@ -4408,9 +4435,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		}
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
-		match channel_state.by_id.entry(funding_msg.channel_id) {
+		let channel_id = funding_msg.channel_id;
+		match channel_state.by_id.entry(channel_id) {
 			hash_map::Entry::Occupied(_) => {
-				return Err(MsgHandleErrInternal::send_err_msg_no_close("Already had channel with the new channel_id".to_owned(), funding_msg.channel_id))
+				return Err(MsgHandleErrInternal::send_err_msg_no_close("Already had channel with the new channel_id".to_owned(), channel_id))
 			},
 			hash_map::Entry::Vacant(e) => {
 				channel_state.pending_msg_events.push(events::MessageSendEvent::SendFundingSigned {
@@ -4421,6 +4449,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					send_channel_ready!(channel_state.short_to_chan_info, channel_state.pending_msg_events, chan, msg);
 				}
 				e.insert(chan);
+				let mut id_to_peer = self.id_to_peer.lock().unwrap();
+				if id_to_peer.insert(channel_id, *counterparty_node_id).is_some() {
+					panic!("id_to_peer map already contained funding txid, which shouldn't be possible");
+				}
 			}
 		}
 		Ok(())
@@ -6676,6 +6708,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 		let channel_count: u64 = Readable::read(reader)?;
 		let mut funding_txo_set = HashSet::with_capacity(cmp::min(channel_count as usize, 128));
 		let mut by_id = HashMap::with_capacity(cmp::min(channel_count as usize, 128));
+		let mut id_to_peer = HashMap::with_capacity(cmp::min(channel_count as usize, 128));
 		let mut short_to_chan_info = HashMap::with_capacity(cmp::min(channel_count as usize, 128));
 		let mut channel_closures = Vec::new();
 		for _ in 0..channel_count {
@@ -6717,6 +6750,9 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 					log_info!(args.logger, "Successfully loaded channel {}", log_bytes!(channel.channel_id()));
 					if let Some(short_channel_id) = channel.get_short_channel_id() {
 						short_to_chan_info.insert(short_channel_id, (channel.get_counterparty_node_id(), channel.channel_id()));
+					}
+					if channel.is_funding_initiated() {
+						id_to_peer.insert(channel.channel_id(), channel.get_counterparty_node_id());
 					}
 					by_id.insert(channel.channel_id(), channel);
 				}
@@ -7044,6 +7080,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 			pending_outbound_payments: Mutex::new(pending_outbound_payments.unwrap()),
 
 			outbound_scid_aliases: Mutex::new(outbound_scid_aliases),
+			id_to_peer: Mutex::new(id_to_peer),
 			fake_scid_rand_bytes: fake_scid_rand_bytes.unwrap(),
 
 			our_network_key,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -411,7 +411,7 @@ pub(super) struct ChannelHolder<Signer: Sign> {
 	/// Outbound SCID aliases are added here once the channel is available for normal use, with
 	/// SCIDs being added once the funding transaction is confirmed at the channel's required
 	/// confirmation depth.
-	pub(super) short_to_id: HashMap<u64, (PublicKey, [u8; 32])>,
+	pub(super) short_to_chan_info: HashMap<u64, (PublicKey, [u8; 32])>,
 	/// SCID/SCID Alias -> forward infos. Key of 0 means payments received.
 	///
 	/// Note that because we may have an SCID Alias as the key we can have two entries per channel,
@@ -1231,9 +1231,9 @@ macro_rules! handle_error {
 }
 
 macro_rules! update_maps_on_chan_removal {
-	($self: expr, $short_to_id: expr, $channel: expr) => {
+	($self: expr, $short_to_chan_info: expr, $channel: expr) => {
 		if let Some(short_id) = $channel.get_short_channel_id() {
-			$short_to_id.remove(&short_id);
+			$short_to_chan_info.remove(&short_id);
 		} else {
 			// If the channel was never confirmed on-chain prior to its closure, remove the
 			// outbound SCID alias we used for it from the collision-prevention set. While we
@@ -1244,13 +1244,13 @@ macro_rules! update_maps_on_chan_removal {
 			let alias_removed = $self.outbound_scid_aliases.lock().unwrap().remove(&$channel.outbound_scid_alias());
 			debug_assert!(alias_removed);
 		}
-		$short_to_id.remove(&$channel.outbound_scid_alias());
+		$short_to_chan_info.remove(&$channel.outbound_scid_alias());
 	}
 }
 
 /// Returns (boolean indicating if we should remove the Channel object from memory, a mapped error)
 macro_rules! convert_chan_err {
-	($self: ident, $err: expr, $short_to_id: expr, $channel: expr, $channel_id: expr) => {
+	($self: ident, $err: expr, $short_to_chan_info: expr, $channel: expr, $channel_id: expr) => {
 		match $err {
 			ChannelError::Warn(msg) => {
 				(false, MsgHandleErrInternal::from_chan_no_close(ChannelError::Warn(msg), $channel_id.clone()))
@@ -1260,14 +1260,14 @@ macro_rules! convert_chan_err {
 			},
 			ChannelError::Close(msg) => {
 				log_error!($self.logger, "Closing channel {} due to close-required error: {}", log_bytes!($channel_id[..]), msg);
-				update_maps_on_chan_removal!($self, $short_to_id, $channel);
+				update_maps_on_chan_removal!($self, $short_to_chan_info, $channel);
 				let shutdown_res = $channel.force_shutdown(true);
 				(true, MsgHandleErrInternal::from_finish_shutdown(msg, *$channel_id, $channel.get_user_id(),
 					shutdown_res, $self.get_channel_update_for_broadcast(&$channel).ok()))
 			},
 			ChannelError::CloseDelayBroadcast(msg) => {
 				log_error!($self.logger, "Channel {} need to be shutdown but closing transactions not broadcast due to {}", log_bytes!($channel_id[..]), msg);
-				update_maps_on_chan_removal!($self, $short_to_id, $channel);
+				update_maps_on_chan_removal!($self, $short_to_chan_info, $channel);
 				let shutdown_res = $channel.force_shutdown(false);
 				(true, MsgHandleErrInternal::from_finish_shutdown(msg, *$channel_id, $channel.get_user_id(),
 					shutdown_res, $self.get_channel_update_for_broadcast(&$channel).ok()))
@@ -1281,7 +1281,7 @@ macro_rules! break_chan_entry {
 		match $res {
 			Ok(res) => res,
 			Err(e) => {
-				let (drop, res) = convert_chan_err!($self, e, $channel_state.short_to_id, $entry.get_mut(), $entry.key());
+				let (drop, res) = convert_chan_err!($self, e, $channel_state.short_to_chan_info, $entry.get_mut(), $entry.key());
 				if drop {
 					$entry.remove_entry();
 				}
@@ -1296,7 +1296,7 @@ macro_rules! try_chan_entry {
 		match $res {
 			Ok(res) => res,
 			Err(e) => {
-				let (drop, res) = convert_chan_err!($self, e, $channel_state.short_to_id, $entry.get_mut(), $entry.key());
+				let (drop, res) = convert_chan_err!($self, e, $channel_state.short_to_chan_info, $entry.get_mut(), $entry.key());
 				if drop {
 					$entry.remove_entry();
 				}
@@ -1310,18 +1310,18 @@ macro_rules! remove_channel {
 	($self: expr, $channel_state: expr, $entry: expr) => {
 		{
 			let channel = $entry.remove_entry().1;
-			update_maps_on_chan_removal!($self, $channel_state.short_to_id, channel);
+			update_maps_on_chan_removal!($self, $channel_state.short_to_chan_info, channel);
 			channel
 		}
 	}
 }
 
 macro_rules! handle_monitor_err {
-	($self: ident, $err: expr, $short_to_id: expr, $chan: expr, $action_type: path, $resend_raa: expr, $resend_commitment: expr, $resend_channel_ready: expr, $failed_forwards: expr, $failed_fails: expr, $failed_finalized_fulfills: expr, $chan_id: expr) => {
+	($self: ident, $err: expr, $short_to_chan_info: expr, $chan: expr, $action_type: path, $resend_raa: expr, $resend_commitment: expr, $resend_channel_ready: expr, $failed_forwards: expr, $failed_fails: expr, $failed_finalized_fulfills: expr, $chan_id: expr) => {
 		match $err {
 			ChannelMonitorUpdateErr::PermanentFailure => {
 				log_error!($self.logger, "Closing channel {} due to monitor update ChannelMonitorUpdateErr::PermanentFailure", log_bytes!($chan_id[..]));
-				update_maps_on_chan_removal!($self, $short_to_id, $chan);
+				update_maps_on_chan_removal!($self, $short_to_chan_info, $chan);
 				// TODO: $failed_fails is dropped here, which will cause other channels to hit the
 				// chain in a confused state! We need to move them into the ChannelMonitor which
 				// will be responsible for failing backwards once things confirm on-chain.
@@ -1361,7 +1361,7 @@ macro_rules! handle_monitor_err {
 		}
 	};
 	($self: ident, $err: expr, $channel_state: expr, $entry: expr, $action_type: path, $resend_raa: expr, $resend_commitment: expr, $resend_channel_ready: expr, $failed_forwards: expr, $failed_fails: expr, $failed_finalized_fulfills: expr) => { {
-		let (res, drop) = handle_monitor_err!($self, $err, $channel_state.short_to_id, $entry.get_mut(), $action_type, $resend_raa, $resend_commitment, $resend_channel_ready, $failed_forwards, $failed_fails, $failed_finalized_fulfills, $entry.key());
+		let (res, drop) = handle_monitor_err!($self, $err, $channel_state.short_to_chan_info, $entry.get_mut(), $action_type, $resend_raa, $resend_commitment, $resend_channel_ready, $failed_forwards, $failed_fails, $failed_finalized_fulfills, $entry.key());
 		if drop {
 			$entry.remove_entry();
 		}
@@ -1407,18 +1407,18 @@ macro_rules! maybe_break_monitor_err {
 }
 
 macro_rules! send_channel_ready {
-	($short_to_id: expr, $pending_msg_events: expr, $channel: expr, $channel_ready_msg: expr) => {
+	($short_to_chan_info: expr, $pending_msg_events: expr, $channel: expr, $channel_ready_msg: expr) => {
 		$pending_msg_events.push(events::MessageSendEvent::SendChannelReady {
 			node_id: $channel.get_counterparty_node_id(),
 			msg: $channel_ready_msg,
 		});
 		// Note that we may send a `channel_ready` multiple times for a channel if we reconnect, so
 		// we allow collisions, but we shouldn't ever be updating the channel ID pointed to.
-		let outbound_alias_insert = $short_to_id.insert($channel.outbound_scid_alias(), ($channel.get_counterparty_node_id(), $channel.channel_id()));
+		let outbound_alias_insert = $short_to_chan_info.insert($channel.outbound_scid_alias(), ($channel.get_counterparty_node_id(), $channel.channel_id()));
 		assert!(outbound_alias_insert.is_none() || outbound_alias_insert.unwrap() == ($channel.get_counterparty_node_id(), $channel.channel_id()),
 			"SCIDs should never collide - ensure you weren't behind the chain tip by a full month when creating channels");
 		if let Some(real_scid) = $channel.get_short_channel_id() {
-			let scid_insert = $short_to_id.insert(real_scid, ($channel.get_counterparty_node_id(), $channel.channel_id()));
+			let scid_insert = $short_to_chan_info.insert(real_scid, ($channel.get_counterparty_node_id(), $channel.channel_id()));
 			assert!(scid_insert.is_none() || scid_insert.unwrap() == ($channel.get_counterparty_node_id(), $channel.channel_id()),
 				"SCIDs should never collide - ensure you weren't behind the chain tip by a full month when creating channels");
 		}
@@ -1459,7 +1459,7 @@ macro_rules! handle_chan_restoration_locked {
 				// Similar to the above, this implies that we're letting the channel_ready fly
 				// before it should be allowed to.
 				assert!(chanmon_update.is_none());
-				send_channel_ready!($channel_state.short_to_id, $channel_state.pending_msg_events, $channel_entry.get(), msg);
+				send_channel_ready!($channel_state.short_to_chan_info, $channel_state.pending_msg_events, $channel_entry.get(), msg);
 			}
 			if let Some(msg) = $announcement_sigs {
 				$channel_state.pending_msg_events.push(events::MessageSendEvent::SendAnnouncementSignatures {
@@ -1581,7 +1581,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 			channel_state: Mutex::new(ChannelHolder{
 				by_id: HashMap::new(),
-				short_to_id: HashMap::new(),
+				short_to_chan_info: HashMap::new(),
 				forward_htlcs: HashMap::new(),
 				claimable_htlcs: HashMap::new(),
 				pending_msg_events: Vec::new(),
@@ -1838,7 +1838,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					if let Some(monitor_update) = monitor_update {
 						if let Err(e) = self.chain_monitor.update_channel(chan_entry.get().get_funding_txo().unwrap(), monitor_update) {
 							let (result, is_permanent) =
-								handle_monitor_err!(self, e, channel_state.short_to_id, chan_entry.get_mut(), RAACommitmentOrder::CommitmentFirst, chan_entry.key(), NO_UPDATE);
+								handle_monitor_err!(self, e, channel_state.short_to_chan_info, chan_entry.get_mut(), RAACommitmentOrder::CommitmentFirst, chan_entry.key(), NO_UPDATE);
 							if is_permanent {
 								remove_channel!(self, channel_state, chan_entry);
 								break result;
@@ -2213,7 +2213,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			// with a short_channel_id of 0. This is important as various things later assume
 			// short_channel_id is non-0 in any ::Forward.
 			if let &PendingHTLCRouting::Forward { ref short_channel_id, .. } = routing {
-				let id_option = channel_state.as_ref().unwrap().short_to_id.get(&short_channel_id).cloned();
+				let id_option = channel_state.as_ref().unwrap().short_to_chan_info.get(&short_channel_id).cloned();
 				if let Some((err, code, chan_update)) = loop {
 					let forwarding_id_opt = match id_option {
 						None => { // unknown_next_peer
@@ -2404,7 +2404,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				}
 			}
 
-			let id = match channel_lock.short_to_id.get(&path.first().unwrap().short_channel_id) {
+			let id = match channel_lock.short_to_chan_info.get(&path.first().unwrap().short_channel_id) {
 				None => return Err(APIError::ChannelUnavailable{err: "No channel available with first hop!".to_owned()}),
 				Some((_cp_id, id)) => id.clone(),
 			};
@@ -2933,7 +2933,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 			for (short_chan_id, mut pending_forwards) in channel_state.forward_htlcs.drain() {
 				if short_chan_id != 0 {
-					let forward_chan_id = match channel_state.short_to_id.get(&short_chan_id) {
+					let forward_chan_id = match channel_state.short_to_chan_info.get(&short_chan_id) {
 						Some((_cp_id, chan_id)) => chan_id.clone(),
 						None => {
 							for forward_info in pending_forwards.drain(..) {
@@ -3351,7 +3351,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		self.process_background_events();
 	}
 
-	fn update_channel_fee(&self, short_to_id: &mut HashMap<u64, (PublicKey, [u8; 32])>, pending_msg_events: &mut Vec<events::MessageSendEvent>, chan_id: &[u8; 32], chan: &mut Channel<Signer>, new_feerate: u32) -> (bool, NotifyOption, Result<(), MsgHandleErrInternal>) {
+	fn update_channel_fee(&self, short_to_chan_info: &mut HashMap<u64, (PublicKey, [u8; 32])>, pending_msg_events: &mut Vec<events::MessageSendEvent>, chan_id: &[u8; 32], chan: &mut Channel<Signer>, new_feerate: u32) -> (bool, NotifyOption, Result<(), MsgHandleErrInternal>) {
 		if !chan.is_outbound() { return (true, NotifyOption::SkipPersist, Ok(())); }
 		// If the feerate has decreased by less than half, don't bother
 		if new_feerate <= chan.get_feerate() && new_feerate * 2 > chan.get_feerate() {
@@ -3371,7 +3371,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let res = match chan.send_update_fee_and_commit(new_feerate, &self.logger) {
 			Ok(res) => Ok(res),
 			Err(e) => {
-				let (drop, res) = convert_chan_err!(self, e, short_to_id, chan, chan_id);
+				let (drop, res) = convert_chan_err!(self, e, short_to_chan_info, chan, chan_id);
 				if drop { retain_channel = false; }
 				Err(res)
 			}
@@ -3379,7 +3379,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let ret_err = match res {
 			Ok(Some((update_fee, commitment_signed, monitor_update))) => {
 				if let Err(e) = self.chain_monitor.update_channel(chan.get_funding_txo().unwrap(), monitor_update) {
-					let (res, drop) = handle_monitor_err!(self, e, short_to_id, chan, RAACommitmentOrder::CommitmentFirst, chan_id, COMMITMENT_UPDATE_ONLY);
+					let (res, drop) = handle_monitor_err!(self, e, short_to_chan_info, chan, RAACommitmentOrder::CommitmentFirst, chan_id, COMMITMENT_UPDATE_ONLY);
 					if drop { retain_channel = false; }
 					res
 				} else {
@@ -3419,9 +3419,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let mut channel_state_lock = self.channel_state.lock().unwrap();
 				let channel_state = &mut *channel_state_lock;
 				let pending_msg_events = &mut channel_state.pending_msg_events;
-				let short_to_id = &mut channel_state.short_to_id;
+				let short_to_chan_info = &mut channel_state.short_to_chan_info;
 				channel_state.by_id.retain(|chan_id, chan| {
-					let (retain_channel, chan_needs_persist, err) = self.update_channel_fee(short_to_id, pending_msg_events, chan_id, chan, new_feerate);
+					let (retain_channel, chan_needs_persist, err) = self.update_channel_fee(short_to_chan_info, pending_msg_events, chan_id, chan, new_feerate);
 					if chan_needs_persist == NotifyOption::DoPersist { should_persist = NotifyOption::DoPersist; }
 					if err.is_err() {
 						handle_errors.push(err);
@@ -3457,10 +3457,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let mut channel_state_lock = self.channel_state.lock().unwrap();
 				let channel_state = &mut *channel_state_lock;
 				let pending_msg_events = &mut channel_state.pending_msg_events;
-				let short_to_id = &mut channel_state.short_to_id;
+				let short_to_chan_info = &mut channel_state.short_to_chan_info;
 				channel_state.by_id.retain(|chan_id, chan| {
 					let counterparty_node_id = chan.get_counterparty_node_id();
-					let (retain_channel, chan_needs_persist, err) = self.update_channel_fee(short_to_id, pending_msg_events, chan_id, chan, new_feerate);
+					let (retain_channel, chan_needs_persist, err) = self.update_channel_fee(short_to_chan_info, pending_msg_events, chan_id, chan, new_feerate);
 					if chan_needs_persist == NotifyOption::DoPersist { should_persist = NotifyOption::DoPersist; }
 					if err.is_err() {
 						handle_errors.push((err, counterparty_node_id));
@@ -3468,7 +3468,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					if !retain_channel { return false; }
 
 					if let Err(e) = chan.timer_check_closing_negotiation_progress() {
-						let (needs_close, err) = convert_chan_err!(self, e, short_to_id, chan, chan_id);
+						let (needs_close, err) = convert_chan_err!(self, e, short_to_chan_info, chan, chan_id);
 						handle_errors.push((Err(err), chan.get_counterparty_node_id()));
 						if needs_close { return false; }
 					}
@@ -3877,7 +3877,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let mut expected_amt_msat = None;
 			let mut valid_mpp = true;
 			for htlc in sources.iter() {
-				if let None = channel_state.as_ref().unwrap().short_to_id.get(&htlc.prev_hop.short_channel_id) {
+				if let None = channel_state.as_ref().unwrap().short_to_chan_info.get(&htlc.prev_hop.short_channel_id) {
 					valid_mpp = false;
 					break;
 				}
@@ -3966,7 +3966,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	fn claim_funds_from_hop(&self, channel_state_lock: &mut MutexGuard<ChannelHolder<Signer>>, prev_hop: HTLCPreviousHopData, payment_preimage: PaymentPreimage) -> ClaimFundsFromHop {
 		//TODO: Delay the claimed_funds relaying just like we do outbound relay!
 		let channel_state = &mut **channel_state_lock;
-		let chan_id = match channel_state.short_to_id.get(&prev_hop.short_channel_id) {
+		let chan_id = match channel_state.short_to_chan_info.get(&prev_hop.short_channel_id) {
 			Some((_cp_id, chan_id)) => chan_id.clone(),
 			None => {
 				return ClaimFundsFromHop::PrevHopForceClosed
@@ -4014,7 +4014,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							payment_preimage, e);
 					}
 					let counterparty_node_id = chan.get().get_counterparty_node_id();
-					let (drop, res) = convert_chan_err!(self, e, channel_state.short_to_id, chan.get_mut(), &chan_id);
+					let (drop, res) = convert_chan_err!(self, e, channel_state.short_to_chan_info, chan.get_mut(), &chan_id);
 					if drop {
 						chan.remove_entry();
 					}
@@ -4418,7 +4418,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					msg: funding_msg,
 				});
 				if let Some(msg) = channel_ready {
-					send_channel_ready!(channel_state.short_to_id, channel_state.pending_msg_events, chan, msg);
+					send_channel_ready!(channel_state.short_to_chan_info, channel_state.pending_msg_events, chan, msg);
 				}
 				e.insert(chan);
 			}
@@ -4453,7 +4453,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						return res
 					}
 					if let Some(msg) = channel_ready {
-						send_channel_ready!(channel_state.short_to_id, channel_state.pending_msg_events, chan.get(), msg);
+						send_channel_ready!(channel_state.short_to_chan_info, channel_state.pending_msg_events, chan.get(), msg);
 					}
 					funding_tx
 				},
@@ -4526,7 +4526,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					if let Some(monitor_update) = monitor_update {
 						if let Err(e) = self.chain_monitor.update_channel(chan_entry.get().get_funding_txo().unwrap(), monitor_update) {
 							let (result, is_permanent) =
-								handle_monitor_err!(self, e, channel_state.short_to_id, chan_entry.get_mut(), RAACommitmentOrder::CommitmentFirst, chan_entry.key(), NO_UPDATE);
+								handle_monitor_err!(self, e, channel_state.short_to_chan_info, chan_entry.get_mut(), RAACommitmentOrder::CommitmentFirst, chan_entry.key(), NO_UPDATE);
 							if is_permanent {
 								remove_channel!(self, channel_state, chan_entry);
 								break result;
@@ -4888,7 +4888,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	fn internal_channel_update(&self, counterparty_node_id: &PublicKey, msg: &msgs::ChannelUpdate) -> Result<NotifyOption, MsgHandleErrInternal> {
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
-		let chan_id = match channel_state.short_to_id.get(&msg.contents.short_channel_id) {
+		let chan_id = match channel_state.short_to_chan_info.get(&msg.contents.short_channel_id) {
 			Some((_cp_id, chan_id)) => chan_id.clone(),
 			None => {
 				// It's not a local channel
@@ -5058,7 +5058,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
 			let by_id = &mut channel_state.by_id;
-			let short_to_id = &mut channel_state.short_to_id;
+			let short_to_chan_info = &mut channel_state.short_to_chan_info;
 			let pending_msg_events = &mut channel_state.pending_msg_events;
 
 			by_id.retain(|channel_id, chan| {
@@ -5074,7 +5074,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						if let Some((commitment_update, monitor_update)) = commitment_opt {
 							if let Err(e) = self.chain_monitor.update_channel(chan.get_funding_txo().unwrap(), monitor_update) {
 								has_monitor_update = true;
-								let (res, close_channel) = handle_monitor_err!(self, e, short_to_id, chan, RAACommitmentOrder::CommitmentFirst, channel_id, COMMITMENT_UPDATE_ONLY);
+								let (res, close_channel) = handle_monitor_err!(self, e, short_to_chan_info, chan, RAACommitmentOrder::CommitmentFirst, channel_id, COMMITMENT_UPDATE_ONLY);
 								handle_errors.push((chan.get_counterparty_node_id(), res));
 								if close_channel { return false; }
 							} else {
@@ -5087,7 +5087,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						true
 					},
 					Err(e) => {
-						let (close_channel, res) = convert_chan_err!(self, e, short_to_id, chan, channel_id);
+						let (close_channel, res) = convert_chan_err!(self, e, short_to_chan_info, chan, channel_id);
 						handle_errors.push((chan.get_counterparty_node_id(), Err(res)));
 						// ChannelClosed event is generated by handle_error for us
 						!close_channel
@@ -5118,7 +5118,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
 			let by_id = &mut channel_state.by_id;
-			let short_to_id = &mut channel_state.short_to_id;
+			let short_to_chan_info = &mut channel_state.short_to_chan_info;
 			let pending_msg_events = &mut channel_state.pending_msg_events;
 
 			by_id.retain(|channel_id, chan| {
@@ -5143,13 +5143,13 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 							log_info!(self.logger, "Broadcasting {}", log_tx!(tx));
 							self.tx_broadcaster.broadcast_transaction(&tx);
-							update_maps_on_chan_removal!(self, short_to_id, chan);
+							update_maps_on_chan_removal!(self, short_to_chan_info, chan);
 							false
 						} else { true }
 					},
 					Err(e) => {
 						has_update = true;
-						let (close_channel, res) = convert_chan_err!(self, e, short_to_id, chan, channel_id);
+						let (close_channel, res) = convert_chan_err!(self, e, short_to_chan_info, chan, channel_id);
 						handle_errors.push((chan.get_counterparty_node_id(), Err(res)));
 						!close_channel
 					}
@@ -5344,7 +5344,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		loop {
 			let scid_candidate = fake_scid::Namespace::Phantom.get_fake_scid(best_block.height(), &self.genesis_hash, &self.fake_scid_rand_bytes, &self.keys_manager);
 			// Ensure the generated scid doesn't conflict with a real channel.
-			match channel_state.short_to_id.entry(scid_candidate) {
+			match channel_state.short_to_chan_info.entry(scid_candidate) {
 				hash_map::Entry::Occupied(_) => continue,
 				hash_map::Entry::Vacant(_) => return scid_candidate
 			}
@@ -5579,7 +5579,7 @@ where
 
 	fn get_relevant_txids(&self) -> Vec<Txid> {
 		let channel_state = self.channel_state.lock().unwrap();
-		let mut res = Vec::with_capacity(channel_state.short_to_id.len());
+		let mut res = Vec::with_capacity(channel_state.short_to_chan_info.len());
 		for chan in channel_state.by_id.values() {
 			if let Some(funding_txo) = chan.get_funding_txo() {
 				res.push(funding_txo.txid);
@@ -5622,7 +5622,7 @@ where
 		{
 			let mut channel_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_lock;
-			let short_to_id = &mut channel_state.short_to_id;
+			let short_to_chan_info = &mut channel_state.short_to_chan_info;
 			let pending_msg_events = &mut channel_state.pending_msg_events;
 			channel_state.by_id.retain(|_, channel| {
 				let res = f(channel);
@@ -5634,7 +5634,7 @@ where
 						}));
 					}
 					if let Some(channel_ready) = channel_ready_opt {
-						send_channel_ready!(short_to_id, pending_msg_events, channel, channel_ready);
+						send_channel_ready!(short_to_chan_info, pending_msg_events, channel, channel_ready);
 						if channel.is_usable() {
 							log_trace!(self.logger, "Sending channel_ready with private initial channel_update for our counterparty on channel {}", log_bytes!(channel.channel_id()));
 							if let Ok(msg) = self.get_channel_update_for_unicast(channel) {
@@ -5667,18 +5667,19 @@ where
 					if channel.is_our_channel_ready() {
 						if let Some(real_scid) = channel.get_short_channel_id() {
 							// If we sent a 0conf channel_ready, and now have an SCID, we add it
-							// to the short_to_id map here. Note that we check whether we can relay
-							// using the real SCID at relay-time (i.e. enforce option_scid_alias
-							// then), and if the funding tx is ever un-confirmed we force-close the
-							// channel, ensuring short_to_id is always consistent.
-							let scid_insert = short_to_id.insert(real_scid, (channel.get_counterparty_node_id(), channel.channel_id()));
+							// to the short_to_chan_info map here. Note that we check whether we
+							// can relay using the real SCID at relay-time (i.e.
+							// enforce option_scid_alias then), and if the funding tx is ever
+							// un-confirmed we force-close the channel, ensuring short_to_chan_info
+							// is always consistent.
+							let scid_insert = short_to_chan_info.insert(real_scid, (channel.get_counterparty_node_id(), channel.channel_id()));
 							assert!(scid_insert.is_none() || scid_insert.unwrap() == (channel.get_counterparty_node_id(), channel.channel_id()),
 								"SCIDs should never collide - ensure you weren't behind by a full {} blocks when creating channels",
 								fake_scid::MAX_SCID_BLOCKS_FROM_NOW);
 						}
 					}
 				} else if let Err(reason) = res {
-					update_maps_on_chan_removal!(self, short_to_id, channel);
+					update_maps_on_chan_removal!(self, short_to_chan_info, channel);
 					// It looks like our counterparty went on-chain or funding transaction was
 					// reorged out of the main chain. Close the channel.
 					failed_channels.push(channel.force_shutdown(true));
@@ -5869,14 +5870,14 @@ impl<Signer: Sign, M: Deref , T: Deref , K: Deref , F: Deref , L: Deref >
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
 			let pending_msg_events = &mut channel_state.pending_msg_events;
-			let short_to_id = &mut channel_state.short_to_id;
+			let short_to_chan_info = &mut channel_state.short_to_chan_info;
 			log_debug!(self.logger, "Marking channels with {} disconnected and generating channel_updates. We believe we {} make future connections to this peer.",
 				log_pubkey!(counterparty_node_id), if no_connection_possible { "cannot" } else { "can" });
 			channel_state.by_id.retain(|_, chan| {
 				if chan.get_counterparty_node_id() == *counterparty_node_id {
 					chan.remove_uncommitted_htlcs_and_mark_paused(&self.logger);
 					if chan.is_shutdown() {
-						update_maps_on_chan_removal!(self, short_to_id, chan);
+						update_maps_on_chan_removal!(self, short_to_chan_info, chan);
 						self.issue_channel_close_events(chan, ClosureReason::DisconnectedPeer);
 						return false;
 					} else {
@@ -6675,7 +6676,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 		let channel_count: u64 = Readable::read(reader)?;
 		let mut funding_txo_set = HashSet::with_capacity(cmp::min(channel_count as usize, 128));
 		let mut by_id = HashMap::with_capacity(cmp::min(channel_count as usize, 128));
-		let mut short_to_id = HashMap::with_capacity(cmp::min(channel_count as usize, 128));
+		let mut short_to_chan_info = HashMap::with_capacity(cmp::min(channel_count as usize, 128));
 		let mut channel_closures = Vec::new();
 		for _ in 0..channel_count {
 			let mut channel: Channel<Signer> = Channel::read(reader, (&args.keys_manager, best_block_height))?;
@@ -6715,7 +6716,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 				} else {
 					log_info!(args.logger, "Successfully loaded channel {}", log_bytes!(channel.channel_id()));
 					if let Some(short_channel_id) = channel.get_short_channel_id() {
-						short_to_id.insert(short_channel_id, (channel.get_counterparty_node_id(), channel.channel_id()));
+						short_to_chan_info.insert(short_channel_id, (channel.get_counterparty_node_id(), channel.channel_id()));
 					}
 					by_id.insert(channel.channel_id(), channel);
 				}
@@ -6974,7 +6975,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 				return Err(DecodeError::InvalidValue);
 			}
 			if chan.is_usable() {
-				if short_to_id.insert(chan.outbound_scid_alias(), (chan.get_counterparty_node_id(), *chan_id)).is_some() {
+				if short_to_chan_info.insert(chan.outbound_scid_alias(), (chan.get_counterparty_node_id(), *chan_id)).is_some() {
 					// Note that in rare cases its possible to hit this while reading an older
 					// channel if we just happened to pick a colliding outbound alias above.
 					log_error!(args.logger, "Got duplicate outbound SCID alias; {}", chan.outbound_scid_alias());
@@ -7033,7 +7034,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 
 			channel_state: Mutex::new(ChannelHolder {
 				by_id,
-				short_to_id,
+				short_to_chan_info,
 				forward_htlcs,
 				claimable_htlcs,
 				pending_msg_events: Vec::new(),

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -64,7 +64,7 @@ use prelude::*;
 use core::{cmp, mem};
 use core::cell::RefCell;
 use io::Read;
-use sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard};
+use sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, FairRwLock};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
 use core::ops::Deref;
@@ -795,9 +795,9 @@ pub struct ChannelManager<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, 
 	///
 	/// If also holding `channel_state` lock, must lock `channel_state` prior to `per_peer_state`.
 	#[cfg(not(any(test, feature = "_test_utils")))]
-	per_peer_state: RwLock<HashMap<PublicKey, Mutex<PeerState<Signer>>>>,
+	per_peer_state: FairRwLock<HashMap<PublicKey, Mutex<PeerState<Signer>>>>,
 	#[cfg(any(test, feature = "_test_utils"))]
-	pub(super) per_peer_state: RwLock<HashMap<PublicKey, Mutex<PeerState<Signer>>>>,
+	pub(super) per_peer_state: FairRwLock<HashMap<PublicKey, Mutex<PeerState<Signer>>>>,
 
 	pending_events: Mutex<Vec<events::Event>>,
 	pending_background_events: Mutex<Vec<BackgroundEvent>>,
@@ -1630,7 +1630,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			last_node_announcement_serial: AtomicUsize::new(0),
 			highest_seen_timestamp: AtomicUsize::new(0),
 
-			per_peer_state: RwLock::new(HashMap::new()),
+			per_peer_state: FairRwLock::new(HashMap::new()),
 
 			pending_events: Mutex::new(Vec::new()),
 			pending_background_events: Mutex::new(Vec::new()),
@@ -1728,7 +1728,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 		let temporary_channel_id = channel.channel_id();
 		let mut channel_state = self.channel_state.lock().unwrap();
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(&their_network_key){
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -1865,7 +1865,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let result: Result<(), _> = loop {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -1986,7 +1986,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let mut chan = {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(peer_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -2281,7 +2281,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						Some((cp_id, id)) => Some((cp_id.clone(), id.clone())),
 					};
 					let (chan_update_opt, forwardee_cltv_expiry_delta) = if let Some((counterparty_node_id, forwarding_id)) = forwarding_chan_info_opt {
-						let per_peer_state = self.per_peer_state.write().unwrap();
+						let per_peer_state = self.per_peer_state.read().unwrap();
 						let peer_state_mutex = per_peer_state.get(&counterparty_node_id).unwrap();
 						let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 						let peer_state = &mut *peer_state_lock;
@@ -2482,7 +2482,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			}
 
 			let channel_state = &mut *channel_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(&counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -2792,7 +2792,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	) -> Result<(), APIError> {
 		let (chan, msg) = {
 			let (res, chan) = {
-				let per_peer_state = self.per_peer_state.write().unwrap();
+				let per_peer_state = self.per_peer_state.read().unwrap();
 				if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 					let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 					let peer_state = &mut *peer_state_lock;
@@ -2828,7 +2828,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			node_id: chan.get_counterparty_node_id(),
 			msg,
 		});
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		let chan_id = chan.channel_id();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
@@ -3017,7 +3017,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		{
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 
 			for (short_chan_id, mut pending_forwards) in channel_state.forward_htlcs.drain() {
 				if short_chan_id != 0 {
@@ -3729,7 +3729,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				HTLCSource::PreviousHopData(HTLCPreviousHopData { .. }) => {
 					let channel_state = self.channel_state.lock().unwrap();
 					let (failure_code, onion_failure_data) = {
-							let per_peer_state = self.per_peer_state.write().unwrap();
+							let per_peer_state = self.per_peer_state.read().unwrap();
 							if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 								let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 								let peer_state = &mut *peer_state_lock;
@@ -4085,7 +4085,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			}
 		};
 
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(&counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -4292,7 +4292,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			if counterparty_node_id.is_none() {
 				return
 			}
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			let mut peer_state_lock;
 			let mut channel = {
 				if let Some(peer_state_mutex) = per_peer_state.get(&counterparty_node_id.unwrap()) {
@@ -4382,7 +4382,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -4445,7 +4445,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		};
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -4489,7 +4489,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let (value, output_script, user_id) = {
 			let mut channel_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -4523,7 +4523,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let best_block = *self.best_block.read().unwrap();
 			let mut channel_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -4568,7 +4568,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		}
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
-		let peer_state_lock = self.per_peer_state.write().unwrap();
+		let peer_state_lock = self.per_peer_state.read().unwrap();
 		let channel_id = funding_msg.channel_id;
 		if let Some(peer_state_mutex) = peer_state_lock.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
@@ -4601,7 +4601,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let best_block = *self.best_block.read().unwrap();
 			let mut channel_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -4645,7 +4645,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	fn internal_channel_ready(&self, counterparty_node_id: &PublicKey, msg: &msgs::ChannelReady) -> Result<(), MsgHandleErrInternal> {
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -4691,7 +4691,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
 
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -4749,7 +4749,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let (tx, chan_option) = {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -4809,7 +4809,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let (pending_forward_info, mut channel_state_lock) = self.decode_update_add_htlc_onion(msg);
 		let channel_state = &mut *channel_state_lock;
 
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -4855,7 +4855,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let mut channel_lock = self.channel_state.lock().unwrap();
 		let (htlc_source, forwarded_htlc_value) = {
 			let channel_state = &mut *channel_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -4879,7 +4879,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	fn internal_update_fail_htlc(&self, counterparty_node_id: &PublicKey, msg: &msgs::UpdateFailHTLC) -> Result<(), MsgHandleErrInternal> {
 		let mut channel_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_lock;
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -4901,7 +4901,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	fn internal_update_fail_malformed_htlc(&self, counterparty_node_id: &PublicKey, msg: &msgs::UpdateFailMalformedHTLC) -> Result<(), MsgHandleErrInternal> {
 		let mut channel_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_lock;
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -4927,7 +4927,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	fn internal_commitment_signed(&self, counterparty_node_id: &PublicKey, msg: &msgs::CommitmentSigned) -> Result<(), MsgHandleErrInternal> {
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -5019,7 +5019,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let res = loop {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -5086,7 +5086,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	fn internal_update_fee(&self, counterparty_node_id: &PublicKey, msg: &msgs::UpdateFee) -> Result<(), MsgHandleErrInternal> {
 		let mut channel_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_lock;
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -5109,7 +5109,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
 
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -5149,7 +5149,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				return Ok(NotifyOption::SkipPersist)
 			}
 		};
-		let per_peer_state = self.per_peer_state.write().unwrap();
+		let per_peer_state = self.per_peer_state.read().unwrap();
 		if let Some(peer_state_mutex) = per_peer_state.get(chan_counterparty_node_id) {
 			let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 			let peer_state = &mut *peer_state_lock;
@@ -5184,7 +5184,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
 
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
@@ -5267,7 +5267,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							id_to_peer.get(&funding_outpoint.to_channel_id()).cloned()
 						};
 						if let Some(counterparty_node_id) = counterparty_node_id_opt {
-							let per_peer_state = self.per_peer_state.write().unwrap();
+							let per_peer_state = self.per_peer_state.read().unwrap();
 							let pending_msg_events = &mut channel_state.pending_msg_events;
 							if let Some(peer_state_mutex) = per_peer_state.get(&counterparty_node_id) {
 								let mut peer_state_lock = peer_state_mutex.lock().unwrap();
@@ -6279,7 +6279,7 @@ impl<Signer: Sign, M: Deref , T: Deref , K: Deref , F: Deref , L: Deref >
 			{
 				// First check if we can advance the channel type and try again.
 				let mut channel_state = self.channel_state.lock().unwrap();
-				let per_peer_state = self.per_peer_state.write().unwrap();
+				let per_peer_state = self.per_peer_state.read().unwrap();
 				if let Some(peer_state_mutex) = per_peer_state.get(counterparty_node_id) {
 					let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 					let peer_state = &mut *peer_state_lock;
@@ -6732,7 +6732,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Writeable f
 		let channel_state = self.channel_state.lock().unwrap();
 		let mut htlc_purposes: Vec<&events::PaymentPurpose> = Vec::new();
 		{
-			let per_peer_state = self.per_peer_state.write().unwrap();
+			let per_peer_state = self.per_peer_state.read().unwrap();
 			let mut unfunded_channels = 0;
 			let mut number_of_channels = 0;
 			for (_, peer_state_mutex) in per_peer_state.iter() {
@@ -7395,7 +7395,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 			last_node_announcement_serial: AtomicUsize::new(last_node_announcement_serial as usize),
 			highest_seen_timestamp: AtomicUsize::new(highest_seen_timestamp as usize),
 
-			per_peer_state: RwLock::new(per_peer_state),
+			per_peer_state: FairRwLock::new(per_peer_state),
 
 			pending_events: Mutex::new(pending_events_read),
 			pending_background_events: Mutex::new(pending_background_events_read),

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7619,6 +7619,121 @@ mod tests {
 		// Check that using the original payment hash succeeds.
 		assert!(inbound_payment::verify(payment_hash, &payment_data, nodes[0].node.highest_seen_timestamp.load(Ordering::Acquire) as u64, &nodes[0].node.inbound_payment_key, &nodes[0].logger).is_ok());
 	}
+
+	#[test]
+	fn test_id_to_peer_coverage() {
+		// Test that the `ChannelManager:id_to_peer` contains channels which have been assigned
+		// an `channel_id` (i.e. have had the funding tx created), and that they are removed once
+		// the channel is successfully closed.
+		let chanmon_cfgs = create_chanmon_cfgs(2);
+		let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+		let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+		let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+		nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 1_000_000, 500_000_000, 42, None).unwrap();
+		let open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
+		nodes[1].node.handle_open_channel(&nodes[0].node.get_our_node_id(), InitFeatures::known(), &open_channel);
+		let accept_channel = get_event_msg!(nodes[1], MessageSendEvent::SendAcceptChannel, nodes[0].node.get_our_node_id());
+		nodes[0].node.handle_accept_channel(&nodes[1].node.get_our_node_id(), InitFeatures::known(), &accept_channel);
+
+		let (temporary_channel_id, tx, _funding_output) = create_funding_transaction(&nodes[0], &nodes[1].node.get_our_node_id(), 1_000_000, 42);
+		let channel_id = &tx.txid().into_inner();
+		{
+			// Ensure that the `id_to_peer` map is empty until either party has recieved the
+			// funding transaction, and have the real `channel_id`.
+			assert_eq!(nodes[0].node.id_to_peer.lock().unwrap().len(), 0);
+			assert_eq!(nodes[1].node.id_to_peer.lock().unwrap().len(), 0);
+		}
+
+		nodes[0].node.funding_transaction_generated(&temporary_channel_id, &nodes[1].node.get_our_node_id(), tx.clone()).unwrap();
+		{
+			// Assert that `nodes[0]`'s `id_to_peer` map is populated with the channel as soon as
+			// as it has the funding transaction.
+			let nodes_0_lock = nodes[0].node.id_to_peer.lock().unwrap();
+			assert_eq!(nodes_0_lock.len(), 1);
+			assert!(nodes_0_lock.contains_key(channel_id));
+
+			assert_eq!(nodes[1].node.id_to_peer.lock().unwrap().len(), 0);
+		}
+
+		let funding_created_msg = get_event_msg!(nodes[0], MessageSendEvent::SendFundingCreated, nodes[1].node.get_our_node_id());
+
+		nodes[1].node.handle_funding_created(&nodes[0].node.get_our_node_id(), &funding_created_msg);
+		{
+			let nodes_0_lock = nodes[0].node.id_to_peer.lock().unwrap();
+			assert_eq!(nodes_0_lock.len(), 1);
+			assert!(nodes_0_lock.contains_key(channel_id));
+
+			// Assert that `nodes[1]`'s `id_to_peer` map is populated with the channel as soon as
+			// as it has the funding transaction.
+			let nodes_1_lock = nodes[1].node.id_to_peer.lock().unwrap();
+			assert_eq!(nodes_1_lock.len(), 1);
+			assert!(nodes_1_lock.contains_key(channel_id));
+		}
+		check_added_monitors!(nodes[1], 1);
+		let funding_signed = get_event_msg!(nodes[1], MessageSendEvent::SendFundingSigned, nodes[0].node.get_our_node_id());
+		nodes[0].node.handle_funding_signed(&nodes[1].node.get_our_node_id(), &funding_signed);
+		check_added_monitors!(nodes[0], 1);
+		let (channel_ready, _) = create_chan_between_nodes_with_value_confirm(&nodes[0], &nodes[1], &tx);
+		let (announcement, nodes_0_update, nodes_1_update) = create_chan_between_nodes_with_value_b(&nodes[0], &nodes[1], &channel_ready);
+		update_nodes_with_chan_announce(&nodes, 0, 1, &announcement, &nodes_0_update, &nodes_1_update);
+
+		nodes[0].node.close_channel(channel_id, &nodes[1].node.get_our_node_id()).unwrap();
+		nodes[1].node.handle_shutdown(&nodes[0].node.get_our_node_id(), &InitFeatures::known(), &get_event_msg!(nodes[0], MessageSendEvent::SendShutdown, nodes[1].node.get_our_node_id()));
+		let nodes_1_shutdown = get_event_msg!(nodes[1], MessageSendEvent::SendShutdown, nodes[0].node.get_our_node_id());
+		nodes[0].node.handle_shutdown(&nodes[1].node.get_our_node_id(), &InitFeatures::known(), &nodes_1_shutdown);
+
+		let closing_signed_node_0 = get_event_msg!(nodes[0], MessageSendEvent::SendClosingSigned, nodes[1].node.get_our_node_id());
+		nodes[1].node.handle_closing_signed(&nodes[0].node.get_our_node_id(), &closing_signed_node_0);
+		{
+			// Assert that the channel is kept in the `id_to_peer` map for both nodes until the
+			// channel can be fully closed by both parties (i.e. no outstanding htlcs exists, the
+			// fee for the closing transaction has been negotiated and the parties has the other
+			// party's signature for the fee negotiated closing transaction.)
+			let nodes_0_lock = nodes[0].node.id_to_peer.lock().unwrap();
+			assert_eq!(nodes_0_lock.len(), 1);
+			assert!(nodes_0_lock.contains_key(channel_id));
+
+			// At this stage, `nodes[1]` has proposed a fee for the closing transaction in the
+			// `handle_closing_signed` call above. As `nodes[1]` has not yet received the signature
+			// from `nodes[0]` for the closing transaction with the proposed fee, the channel is
+			// kept in the `nodes[1]`'s `id_to_peer` map.
+			let nodes_1_lock = nodes[1].node.id_to_peer.lock().unwrap();
+			assert_eq!(nodes_1_lock.len(), 1);
+			assert!(nodes_1_lock.contains_key(channel_id));
+		}
+
+		nodes[0].node.handle_closing_signed(&nodes[1].node.get_our_node_id(), &get_event_msg!(nodes[1], MessageSendEvent::SendClosingSigned, nodes[0].node.get_our_node_id()));
+		{
+			// `nodes[0]` accepts `nodes[1]`'s proposed fee for the closing transaction, and
+			// therefore has all it needs to fully close the channel (both signatures for the
+			// closing transaction).
+			// Assert that the channel is removed from `nodes[0]`'s `id_to_peer` map as it can be
+			// fully closed by `nodes[0]`.
+			assert_eq!(nodes[0].node.id_to_peer.lock().unwrap().len(), 0);
+
+			// Assert that the channel is still in `nodes[1]`'s  `id_to_peer` map, as `nodes[1]`
+			// doesn't have `nodes[0]`'s signature for the closing transaction yet.
+			let nodes_1_lock = nodes[1].node.id_to_peer.lock().unwrap();
+			assert_eq!(nodes_1_lock.len(), 1);
+			assert!(nodes_1_lock.contains_key(channel_id));
+		}
+
+		let (_nodes_0_update, closing_signed_node_0) = get_closing_signed_broadcast!(nodes[0].node, nodes[1].node.get_our_node_id());
+
+		nodes[1].node.handle_closing_signed(&nodes[0].node.get_our_node_id(), &closing_signed_node_0.unwrap());
+		{
+			// Assert that the channel is removed from both parties `id_to_peer` map once they both
+			// have everything required to fully close the channel.
+			assert_eq!(nodes[0].node.id_to_peer.lock().unwrap().len(), 0);
+			assert_eq!(nodes[1].node.id_to_peer.lock().unwrap().len(), 0);
+		}
+		let (_nodes_1_update, _none) = get_closing_signed_broadcast!(nodes[1].node, nodes[0].node.get_our_node_id());
+
+		// Clear the `ChannelClosed` event for the nodes.
+		nodes[0].node.get_and_clear_pending_events();
+		nodes[1].node.get_and_clear_pending_events();
+	}
 }
 
 #[cfg(all(any(test, feature = "_test_utils"), feature = "_bench_unstable"))]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1779,7 +1779,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						channel_id: (*channel_id).clone(),
 						counterparty: ChannelCounterparty {
 							node_id: channel.get_counterparty_node_id(),
-							features: InitFeatures::empty(),
+							features: peer_state.latest_features.clone(),
 							unspendable_punishment_reserve: to_remote_reserve_satoshis,
 							forwarding_info: channel.counterparty_forwarding_info(),
 							// Ensures that we have actually received the `htlc_minimum_msat` value
@@ -1815,12 +1815,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						inbound_htlc_maximum_msat: channel.get_holder_htlc_maximum_msat()
 					});
 				}
-			}
-		}
-		let per_peer_state = self.per_peer_state.read().unwrap();
-		for chan in res.iter_mut() {
-			if let Some(peer_state) = per_peer_state.get(&chan.counterparty.node_id) {
-				chan.counterparty.features = peer_state.lock().unwrap().latest_features.clone();
 			}
 		}
 		res

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1710,7 +1710,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		let mut channel_state = self.channel_state.lock().unwrap();
 		let per_peer_state = self.per_peer_state.read().unwrap();
 		match per_peer_state.get(&their_network_key) {
-			None => return Err(APIError::ChannelUnavailable { err: format!("Not connected to node: {}", their_network_key) }),
+			None => return Err(APIError::APIMisuseError { err: format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", their_network_key) }),
 			Some(peer_state) => {
 				let mut peer_state = peer_state.lock().unwrap();
 				let channel = {
@@ -1867,9 +1867,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(channel_id.clone()) {
 					hash_map::Entry::Occupied(mut chan_entry) => {
-						if *counterparty_node_id != chan_entry.get().get_counterparty_node_id(){
-							return Err(APIError::APIMisuseError { err: "The passed counterparty_node_id doesn't match the channel's counterparty node_id".to_owned() });
-						}
 						let (shutdown_msg, monitor_update, htlcs) = chan_entry.get_mut().get_shutdown(&self.keys_manager, &peer_state.latest_features, target_feerate_sats_per_1000_weight)?;
 						failed_htlcs = htlcs;
 
@@ -1901,10 +1898,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						}
 						break Ok(());
 					},
-					hash_map::Entry::Vacant(_) => return Err(APIError::ChannelUnavailable { err: "No such channel".to_owned() })
+					hash_map::Entry::Vacant(_) => return Err(APIError::ChannelUnavailable{err: format!("No such channel for the passed counterparty_node_id {}", counterparty_node_id) })
 				}
 			} else {
-				return Err(APIError::ChannelUnavailable { err: format!("Not connected to node: {}", counterparty_node_id) });
+				return Err(APIError::APIMisuseError { err: format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id) });
 			}
 		};
 
@@ -1987,9 +1984,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
 				if let hash_map::Entry::Occupied(chan) = peer_state.channel_by_id.entry(channel_id.clone()) {
-					if chan.get().get_counterparty_node_id() != *peer_node_id {
-						return Err(APIError::ChannelUnavailable{err: "No such channel".to_owned()});
-					}
 					if let Some(peer_msg) = peer_msg {
 						self.issue_channel_close_events(chan.get(),ClosureReason::CounterpartyForceClosed { peer_msg: peer_msg.to_string() });
 					} else {
@@ -1997,7 +1991,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					}
 					remove_channel!(self, channel_state, chan)
 				} else {
-					return Err(APIError::ChannelUnavailable{ err: "No such channel".to_owned() });
+					return Err(APIError::ChannelUnavailable{ err: format!("No such channel for the passed counterparty_node_id {}", peer_node_id) });
 				}
 			} else {
 				return Err(APIError::APIMisuseError{ err: format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", peer_node_id) });
@@ -2805,7 +2799,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 								} else { unreachable!(); })
 							, chan)
 						},
-						None => { return Err(APIError::ChannelUnavailable { err: "No such channel".to_owned() }) },
+						None => { return Err(APIError::ChannelUnavailable { err: format!("No such channel for the passed counterparty_node_id {}", counterparty_node_id) }) },
 					}
 				};
 				match handle_error!(self, res, chan.get_counterparty_node_id()) {
@@ -4386,9 +4380,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					if !channel.get().inbound_is_awaiting_accept() {
 						return Err(APIError::APIMisuseError { err: "The channel isn't currently awaiting to be accepted.".to_owned() });
 					}
-					if *counterparty_node_id != channel.get().get_counterparty_node_id() {
-						return Err(APIError::APIMisuseError { err: "The passed counterparty_node_id doesn't match the channel's counterparty node_id".to_owned() });
-					}
 					if accept_0conf {
 						channel.get_mut().set_0conf();
 					} else if channel.get().get_channel_type().requires_zero_conf() {
@@ -4409,7 +4400,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					});
 				}
 				hash_map::Entry::Vacant(_) => {
-					return Err(APIError::ChannelUnavailable { err: "Can't accept a channel that doesn't exist".to_owned() });
+					return Err(APIError::APIMisuseError { err: format!("No such channel for the passed counterparty_node_id {}", counterparty_node_id) });
 				}
 			}
 		} else {
@@ -4490,13 +4481,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(msg.temporary_channel_id) {
 					hash_map::Entry::Occupied(mut chan) => {
-						if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-							return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.temporary_channel_id));
-						}
 						try_chan_entry!(self, chan.get_mut().accept_channel(&msg, &self.default_configuration.channel_handshake_limits, &their_features), channel_state, chan);
 						(chan.get().get_value_satoshis(), chan.get().get_funding_redeemscript().to_v0_p2wsh(), chan.get().get_user_id())
 					},
-					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.temporary_channel_id))
+					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.temporary_channel_id))
 				}
 			} else {
 				return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.temporary_channel_id))
@@ -4524,12 +4512,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(msg.temporary_channel_id.clone()) {
 					hash_map::Entry::Occupied(mut chan) => {
-						if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-							return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.temporary_channel_id));
-						}
 						(try_chan_entry!(self, chan.get_mut().funding_created(msg, best_block, &self.logger), channel_state, chan), chan.remove())
 					},
-					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.temporary_channel_id))
+					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.temporary_channel_id))
 				}
 			} else {
 				return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.temporary_channel_id))
@@ -4602,9 +4587,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(msg.channel_id) {
 					hash_map::Entry::Occupied(mut chan) => {
-						if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-							return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-						}
 						let (monitor, funding_tx, channel_ready) = match chan.get_mut().funding_signed(&msg, best_block, &self.logger) {
 							Ok(update) => update,
 							Err(e) => try_chan_entry!(self, Err(e), channel_state, chan),
@@ -4626,7 +4608,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						}
 						funding_tx
 					},
-					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 				}
 			} else {
 				return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -4646,9 +4628,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let peer_state = &mut *peer_state_lock;
 			match peer_state.channel_by_id.entry(msg.channel_id) {
 				hash_map::Entry::Occupied(mut chan) => {
-					if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-					}
 					let announcement_sigs_opt = try_chan_entry!(self, chan.get_mut().channel_ready(&msg, self.get_our_node_id(),
 						self.genesis_hash.clone(), &self.best_block.read().unwrap(), &self.logger), channel_state, chan);
 					if let Some(announcement_sigs) = announcement_sigs_opt {
@@ -4673,7 +4652,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					}
 					Ok(())
 				},
-				hash_map::Entry::Vacant(_) => Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+				hash_map::Entry::Vacant(_) => Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 			}
 		} else {
 			Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -4692,9 +4671,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(msg.channel_id.clone()) {
 					hash_map::Entry::Occupied(mut chan_entry) => {
-						if chan_entry.get().get_counterparty_node_id() != *counterparty_node_id {
-							return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-						}
 
 						if !chan_entry.get().received_shutdown() {
 							log_info!(self.logger, "Received a shutdown message from our counterparty for channel {}{}.",
@@ -4726,7 +4702,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 						break Ok(());
 					},
-					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 				}
 			} else {
 				return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -4750,9 +4726,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(msg.channel_id.clone()) {
 					hash_map::Entry::Occupied(mut chan_entry) => {
-						if chan_entry.get().get_counterparty_node_id() != *counterparty_node_id {
-							return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-						}
 						let (closing_signed, tx) = try_chan_entry!(self, chan_entry.get_mut().closing_signed(&self.fee_estimator, &msg), channel_state, chan_entry);
 						if let Some(msg) = closing_signed {
 							channel_state.pending_msg_events.push(events::MessageSendEvent::SendClosingSigned {
@@ -4769,7 +4742,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							(tx, Some(remove_channel!(self, channel_state, chan_entry)))
 						} else { (tx, None) }
 					},
-					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 				}
 			} else {
 				return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -4810,9 +4783,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let peer_state = &mut *peer_state_lock;
 			match peer_state.channel_by_id.entry(msg.channel_id) {
 				hash_map::Entry::Occupied(mut chan) => {
-					if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-					}
 
 					let create_pending_htlc_status = |chan: &Channel<Signer>, pending_forward_info: PendingHTLCStatus, error_code: u16| {
 						// If the update_add is completely bogus, the call will Err and we will close,
@@ -4838,7 +4808,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					};
 					try_chan_entry!(self, chan.get_mut().update_add_htlc(&msg, pending_forward_info, create_pending_htlc_status, &self.logger), channel_state, chan);
 				},
-				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 			}
 		} else {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -4856,12 +4826,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(msg.channel_id) {
 					hash_map::Entry::Occupied(mut chan) => {
-						if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-							return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-						}
 						try_chan_entry!(self, chan.get_mut().update_fulfill_htlc(&msg), channel_state, chan)
 					},
-					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 				}
 			} else {
 				return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -4880,12 +4847,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let peer_state = &mut *peer_state_lock;
 			match peer_state.channel_by_id.entry(msg.channel_id) {
 				hash_map::Entry::Occupied(mut chan) => {
-					if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-					}
 					try_chan_entry!(self, chan.get_mut().update_fail_htlc(&msg, HTLCFailReason::LightningError { err: msg.reason.clone() }), channel_state, chan);
 				},
-				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 			}
 		} else {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id));
@@ -4902,9 +4866,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let peer_state = &mut *peer_state_lock;
 			match peer_state.channel_by_id.entry(msg.channel_id) {
 				hash_map::Entry::Occupied(mut chan) => {
-					if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-					}
 					if (msg.failure_code & 0x8000) == 0 {
 						let chan_err: ChannelError = ChannelError::Close("Got update_fail_malformed_htlc with BADONION not set".to_owned());
 						try_chan_entry!(self, Err(chan_err), channel_state, chan);
@@ -4912,7 +4873,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					try_chan_entry!(self, chan.get_mut().update_fail_malformed_htlc(&msg, HTLCFailReason::Reason { failure_code: msg.failure_code, data: Vec::new() }), channel_state, chan);
 					Ok(())
 				},
-				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 			}
 		} else {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -4928,9 +4889,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let peer_state = &mut *peer_state_lock;
 			match peer_state.channel_by_id.entry(msg.channel_id) {
 				hash_map::Entry::Occupied(mut chan) => {
-					if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-					}
 					let (revoke_and_ack, commitment_signed, monitor_update) =
 						match chan.get_mut().commitment_signed(&msg, &self.logger) {
 							Err((None, e)) => try_chan_entry!(self, Err(e), channel_state, chan),
@@ -4964,7 +4922,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					}
 					Ok(())
 				},
-				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 			}
 		} else {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -5020,9 +4978,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(msg.channel_id) {
 					hash_map::Entry::Occupied(mut chan) => {
-						if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-							break Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-						}
 						let was_frozen_for_monitor = chan.get().is_awaiting_monitor_update();
 						let raa_updates = break_chan_entry!(self,
 							chan.get_mut().revoke_and_ack(&msg, &self.logger), channel_state, chan);
@@ -5056,7 +5011,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 									.unwrap_or(chan.get().outbound_scid_alias()),
 								chan.get().get_funding_txo().unwrap()))
 					},
-					hash_map::Entry::Vacant(_) => break Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+					hash_map::Entry::Vacant(_) => break Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 				}
 			} else {
 				break Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
@@ -5087,12 +5042,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let peer_state = &mut *peer_state_lock;
 			match peer_state.channel_by_id.entry(msg.channel_id) {
 				hash_map::Entry::Occupied(mut chan) => {
-					if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-					}
 					try_chan_entry!(self, chan.get_mut().update_fee(&self.fee_estimator, &msg), channel_state, chan);
 				},
-				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 			}
 		} else {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id));
@@ -5110,9 +5062,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			let peer_state = &mut *peer_state_lock;
 			match peer_state.channel_by_id.entry(msg.channel_id) {
 				hash_map::Entry::Occupied(mut chan) => {
-					if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-					}
 					if !chan.get().is_usable() {
 						return Err(MsgHandleErrInternal::from_no_close(LightningError{err: "Got an announcement_signatures before we were ready for it".to_owned(), action: msgs::ErrorAction::IgnoreError}));
 					}
@@ -5125,7 +5074,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						update_msg: self.get_channel_update_for_broadcast(chan.get()).unwrap(),
 					});
 				},
-				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 			}
 		} else {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id));
@@ -5185,9 +5134,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				let peer_state = &mut *peer_state_lock;
 				match peer_state.channel_by_id.entry(msg.channel_id) {
 					hash_map::Entry::Occupied(mut chan) => {
-						if chan.get().get_counterparty_node_id() != *counterparty_node_id {
-							return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
-						}
 						// Currently, we expect all holding cell update_adds to be dropped on peer
 						// disconnect, so Channel's reestablish will never hand us any holding cell
 						// freed HTLCs to fail backwards. If in the future we no longer drop pending
@@ -5221,7 +5167,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						}
 						(responses.holding_cell_failed_htlcs, need_lnd_workaround)
 					},
-					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
+					hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
 				}
 			} else {
 				return Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Can't find a peer with a node_id matching the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id));

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -510,8 +510,10 @@ macro_rules! get_htlc_update_msgs {
 
 #[cfg(test)]
 macro_rules! get_channel_ref {
-	($node: expr, $peer_state_lock: ident, $channel_id: expr) => {
+	($node: expr, $counterparty_node: expr, $per_peer_state_lock: ident, $peer_state_lock: ident, $channel_id: expr) => {
 		{
+			$per_peer_state_lock = $node.node.per_peer_state.write().unwrap();
+			$peer_state_lock = $per_peer_state_lock.get(&$counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
 			$peer_state_lock.channel_by_id.get_mut(&$channel_id).unwrap()
 		}
 	}
@@ -521,9 +523,9 @@ macro_rules! get_channel_ref {
 macro_rules! get_feerate {
 	($node: expr, $counterparty_node: expr, $channel_id: expr) => {
 		{
-			let per_peer_lock = $node.node.per_peer_state.write().unwrap();
-			let mut peer_state_lock = per_peer_lock.get(&$counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
-			let chan = get_channel_ref!($node, peer_state_lock, $channel_id);
+			let mut per_peer_state_lock;
+			let mut peer_state_lock;
+			let chan = get_channel_ref!($node, $counterparty_node, per_peer_state_lock, peer_state_lock, $channel_id);
 			chan.get_feerate()
 		}
 	}
@@ -533,9 +535,9 @@ macro_rules! get_feerate {
 macro_rules! get_opt_anchors {
 	($node: expr, $counterparty_node: expr, $channel_id: expr) => {
 		{
-			let per_peer_lock = $node.node.per_peer_state.write().unwrap();
-			let mut peer_state_lock = per_peer_lock.get(&$counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
-			let chan = get_channel_ref!($node, peer_state_lock, $channel_id);
+			let mut per_peer_state_lock;
+			let mut peer_state_lock;
+			let chan = get_channel_ref!($node, $counterparty_node, per_peer_state_lock, peer_state_lock, $channel_id);
 			chan.opt_anchors()
 		}
 	}

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -520,7 +520,7 @@ macro_rules! get_channel_ref {
 
 #[cfg(test)]
 macro_rules! get_feerate {
-	($node: expr, $channel_id: expr) => {
+	($node: expr, $counterparty_node: expr, $channel_id: expr) => {
 		{
 			let mut lock;
 			let chan = get_channel_ref!($node, lock, $channel_id);
@@ -531,7 +531,7 @@ macro_rules! get_feerate {
 
 #[cfg(test)]
 macro_rules! get_opt_anchors {
-	($node: expr, $channel_id: expr) => {
+	($node: expr, $counterparty_node: expr, $channel_id: expr) => {
 		{
 			let mut lock;
 			let chan = get_channel_ref!($node, lock, $channel_id);
@@ -2181,7 +2181,7 @@ pub fn get_announce_close_broadcast_events<'a, 'b, 'c>(nodes: &Vec<Node<'a, 'b, 
 
 #[cfg(test)]
 macro_rules! get_channel_value_stat {
-	($node: expr, $channel_id: expr) => {{
+	($node: expr, $counterparty_node: expr, $channel_id: expr) => {{
 		let chan_lock = $node.node.channel_state.lock().unwrap();
 		let chan = chan_lock.by_id.get(&$channel_id).unwrap();
 		chan.get_value_stat()

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -510,10 +510,9 @@ macro_rules! get_htlc_update_msgs {
 
 #[cfg(test)]
 macro_rules! get_channel_ref {
-	($node: expr, $lock: ident, $channel_id: expr) => {
+	($node: expr, $peer_state_lock: ident, $channel_id: expr) => {
 		{
-			$lock = $node.node.channel_state.lock().unwrap();
-			$lock.by_id.get_mut(&$channel_id).unwrap()
+			$peer_state_lock.channel_by_id.get_mut(&$channel_id).unwrap()
 		}
 	}
 }
@@ -522,8 +521,9 @@ macro_rules! get_channel_ref {
 macro_rules! get_feerate {
 	($node: expr, $counterparty_node: expr, $channel_id: expr) => {
 		{
-			let mut lock;
-			let chan = get_channel_ref!($node, lock, $channel_id);
+			let per_peer_lock = $node.node.per_peer_state.write().unwrap();
+			let mut peer_state_lock = per_peer_lock.get(&$counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
+			let chan = get_channel_ref!($node, peer_state_lock, $channel_id);
 			chan.get_feerate()
 		}
 	}
@@ -533,8 +533,9 @@ macro_rules! get_feerate {
 macro_rules! get_opt_anchors {
 	($node: expr, $counterparty_node: expr, $channel_id: expr) => {
 		{
-			let mut lock;
-			let chan = get_channel_ref!($node, lock, $channel_id);
+			let per_peer_lock = $node.node.per_peer_state.write().unwrap();
+			let mut peer_state_lock = per_peer_lock.get(&$counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
+			let chan = get_channel_ref!($node, peer_state_lock, $channel_id);
 			chan.opt_anchors()
 		}
 	}
@@ -1689,8 +1690,8 @@ pub fn do_claim_payment_along_route<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, 
 			($node: expr, $prev_node: expr, $next_node: expr, $new_msgs: expr) => {
 				{
 					$node.node.handle_update_fulfill_htlc(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().0);
-					let fee = $node.node.channel_state.lock().unwrap()
-						.by_id.get(&next_msgs.as_ref().unwrap().0.channel_id).unwrap()
+					let fee = $node.node.per_peer_state.read().unwrap().get(&$prev_node.node.get_our_node_id())
+						.unwrap().lock().unwrap().channel_by_id.get(&next_msgs.as_ref().unwrap().0.channel_id).unwrap()
 						.config.options.forwarding_fee_base_msat;
 					expect_payment_forwarded!($node, $next_node, $prev_node, Some(fee as u64), false, false);
 					expected_total_fee_msat += fee as u64;
@@ -2182,8 +2183,9 @@ pub fn get_announce_close_broadcast_events<'a, 'b, 'c>(nodes: &Vec<Node<'a, 'b, 
 #[cfg(test)]
 macro_rules! get_channel_value_stat {
 	($node: expr, $counterparty_node: expr, $channel_id: expr) => {{
-		let chan_lock = $node.node.channel_state.lock().unwrap();
-		let chan = chan_lock.by_id.get(&$channel_id).unwrap();
+		let peer_state_lock = $node.node.per_peer_state.read().unwrap();
+		let chan_lock = peer_state_lock.get(&$counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
+		let chan = chan_lock.channel_by_id.get(&$channel_id).unwrap();
 		chan.get_value_stat()
 	}}
 }

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -171,9 +171,9 @@ fn do_test_counterparty_no_reserve(send_from_initiator: bool) {
 	{
 		let sender_node = if send_from_initiator { &nodes[1] } else { &nodes[0] };
 		let counterparty_node = if send_from_initiator { &nodes[0] } else { &nodes[1] };
-		let per_peer_lock = sender_node.node.per_peer_state.write().unwrap();
-		let mut peer_state_lock = per_peer_lock.get(&counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
-		let mut chan = get_channel_ref!(sender_node, peer_state_lock, temp_channel_id);
+		let mut sender_node_per_peer_lock;
+		let mut sender_node_peer_state_lock;
+		let mut chan = get_channel_ref!(sender_node, counterparty_node, sender_node_per_peer_lock, sender_node_peer_state_lock, temp_channel_id);
 		chan.holder_selected_channel_reserve_satoshis = 0;
 		chan.holder_max_htlc_value_in_flight_msat = 100_000_000;
 	}
@@ -8461,9 +8461,9 @@ fn test_reject_funding_before_inbound_channel_accepted() {
 	// `handle_accept_channel`, which is required in order for `create_funding_transaction` to
 	// succeed when `nodes[0]` is passed to it.
 	{
-		let per_peer_lock = nodes[1].node.per_peer_state.write().unwrap();
-		let mut peer_state_lock = per_peer_lock.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
-		let channel = get_channel_ref!(&nodes[1], peer_state_lock, temp_channel_id);
+		let mut node_1_per_peer_lock;
+		let mut node_1_peer_state_lock;
+		let channel =  get_channel_ref!(&nodes[1], nodes[0], node_1_per_peer_lock, node_1_peer_state_lock, temp_channel_id);
 		let accept_chan_msg = channel.get_accept_channel_message();
 		nodes[0].node.handle_accept_channel(&nodes[1].node.get_our_node_id(), InitFeatures::known(), &accept_chan_msg);
 	}

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -7535,7 +7535,7 @@ fn test_data_loss_protect() {
 		if let MessageSendEvent::HandleError { ref action, .. } = msg {
 			match action {
 				&ErrorAction::SendErrorMessage { ref msg } => {
-					assert_eq!(msg.data, "Failed to find corresponding channel");
+					assert_eq!(msg.data, format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", &nodes[1].node.get_our_node_id()));
 					err_msgs_0.push(msg.clone());
 				},
 				_ => panic!("Unexpected event!"),
@@ -7548,7 +7548,7 @@ fn test_data_loss_protect() {
 	nodes[1].node.handle_error(&nodes[0].node.get_our_node_id(), &err_msgs_0[0]);
 	assert!(nodes[1].node.list_usable_channels().is_empty());
 	check_added_monitors!(nodes[1], 1);
-	check_closed_event!(nodes[1], 1, ClosureReason::CounterpartyForceClosed { peer_msg: "Failed to find corresponding channel".to_owned() });
+	check_closed_event!(nodes[1], 1, ClosureReason::CounterpartyForceClosed { peer_msg: format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", &nodes[1].node.get_our_node_id()) });
 	check_closed_broadcast!(nodes[1], false);
 }
 
@@ -8548,8 +8548,8 @@ fn test_can_not_accept_unknown_inbound_channel() {
 	let unknown_channel_id = [0; 32];
 	let api_res = nodes[0].node.accept_inbound_channel(&unknown_channel_id, &nodes[1].node.get_our_node_id(), 0);
 	match api_res {
-		Err(APIError::ChannelUnavailable { err }) => {
-			assert_eq!(err, "Can't accept a channel that doesn't exist");
+		Err(APIError::APIMisuseError { err }) => {
+			assert_eq!(err, format!("No such channel for the passed counterparty_node_id {}", nodes[1].node.get_our_node_id()));
 		},
 		Ok(_) => panic!("It shouldn't be possible to accept an unkown channel"),
 		Err(_) => panic!("Unexpected Error"),

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -9221,6 +9221,56 @@ fn test_onchain_htlc_settlement_after_close() {
 }
 
 #[test]
+fn test_duplicate_temporary_channel_id_from_different_peers() {
+	// Tests that we can accept two different `OpenChannel` requests with the same
+	// `temporary_channel_id`, as long as they are from different peers.
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+
+	// Create an first channel channel
+	nodes[1].node.create_channel(nodes[0].node.get_our_node_id(), 100000, 10001, 42, None).unwrap();
+	let mut open_chan_msg_chan_1_0 = get_event_msg!(nodes[1], MessageSendEvent::SendOpenChannel, nodes[0].node.get_our_node_id());
+
+	// Create an second channel
+	nodes[2].node.create_channel(nodes[0].node.get_our_node_id(), 100000, 10001, 43, None).unwrap();
+	let mut open_chan_msg_chan_2_0 = get_event_msg!(nodes[2], MessageSendEvent::SendOpenChannel, nodes[0].node.get_our_node_id());
+
+	// Modify the `OpenChannel` from `nodes[2]` to `nodes[0]` to ensure that it uses the same
+	// `temporary_channel_id` as the `OpenChannel` from nodes[1] to nodes[0].
+	open_chan_msg_chan_2_0.temporary_channel_id = open_chan_msg_chan_1_0.temporary_channel_id;
+
+	// Assert that `nodes[0]` can accept both `OpenChannel` requests, even though they use the same
+	// `temporary_channel_id` as they are from different peers.
+	nodes[0].node.handle_open_channel(&nodes[1].node.get_our_node_id(), InitFeatures::known(), &open_chan_msg_chan_1_0);
+	{
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		match &events[0] {
+			MessageSendEvent::SendAcceptChannel { node_id, msg } => {
+				assert_eq!(node_id, &nodes[1].node.get_our_node_id());
+				assert_eq!(msg.temporary_channel_id, open_chan_msg_chan_1_0.temporary_channel_id);
+			},
+			_ => panic!("Unexpected event"),
+		}
+	}
+
+	nodes[0].node.handle_open_channel(&nodes[2].node.get_our_node_id(), InitFeatures::known(), &open_chan_msg_chan_2_0);
+	{
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		match &events[0] {
+			MessageSendEvent::SendAcceptChannel { node_id, msg } => {
+				assert_eq!(node_id, &nodes[2].node.get_our_node_id());
+				assert_eq!(msg.temporary_channel_id, open_chan_msg_chan_1_0.temporary_channel_id);
+			},
+			_ => panic!("Unexpected event"),
+		}
+	}
+}
+
+#[test]
 fn test_duplicate_chan_id() {
 	// Test that if a given peer tries to open a channel with the same channel_id as one that is
 	// already open we reject it and keep the old channel.

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -946,8 +946,8 @@ fn test_update_fee() {
 	check_added_monitors!(nodes[1], 1);
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
 
-	assert_eq!(get_feerate!(nodes[0], channel_id), feerate + 30);
-	assert_eq!(get_feerate!(nodes[1], channel_id), feerate + 30);
+	assert_eq!(get_feerate!(nodes[0], nodes[1], channel_id), feerate + 30);
+	assert_eq!(get_feerate!(nodes[1], nodes[0], channel_id), feerate + 30);
 	close_channel(&nodes[0], &nodes[1], &chan.2, chan.3, true);
 	check_closed_event!(nodes[0], 1, ClosureReason::CooperativeClosure);
 	check_closed_event!(nodes[1], 1, ClosureReason::CooperativeClosure);
@@ -1351,11 +1351,11 @@ fn test_basic_channel_reserve() {
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, InitFeatures::known(), InitFeatures::known());
 
-	let chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	let chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	let channel_reserve = chan_stat.channel_reserve_msat;
 
 	// The 2* and +1 are for the fee spike reserve.
-	let commit_tx_fee = 2 * commit_tx_fee_msat(get_feerate!(nodes[0], chan.2), 1 + 1, get_opt_anchors!(nodes[0], chan.2));
+	let commit_tx_fee = 2 * commit_tx_fee_msat(get_feerate!(nodes[0], nodes[1], chan.2), 1 + 1, get_opt_anchors!(nodes[0], nodes[1], chan.2));
 	let max_can_send = 5000000 - channel_reserve - commit_tx_fee;
 	let (route, our_payment_hash, _, our_payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[1], max_can_send + 1);
 	let err = nodes[0].node.send_payment(&route, our_payment_hash, &Some(our_payment_secret)).err().unwrap();
@@ -1408,7 +1408,7 @@ fn test_fee_spike_violation_fails_htlc() {
 	// nodes[0] just sent. In the code for construction of this message, "local" refers
 	// to the sender of the message, and "remote" refers to the receiver.
 
-	let feerate_per_kw = get_feerate!(nodes[0], chan.2);
+	let feerate_per_kw = get_feerate!(nodes[0], nodes[1], chan.2);
 
 	const INITIAL_COMMITMENT_NUMBER: u64 = (1 << 48) - 1;
 
@@ -1706,9 +1706,9 @@ fn test_chan_reserve_violation_inbound_htlc_inbound_chan() {
 
 	let feemsat = 239;
 	let total_routing_fee_msat = (nodes.len() - 2) as u64 * feemsat;
-	let chan_stat = get_channel_value_stat!(nodes[0], chan.2);
-	let feerate = get_feerate!(nodes[0], chan.2);
-	let opt_anchors = get_opt_anchors!(nodes[0], chan.2);
+	let chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
+	let feerate = get_feerate!(nodes[0], nodes[1], chan.2);
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan.2);
 
 	// Add a 2* and +1 for the fee spike reserve.
 	let commit_tx_fee_2_htlc = 2*commit_tx_fee_msat(feerate, 2 + 1, opt_anchors);
@@ -1796,11 +1796,11 @@ fn test_channel_reserve_holding_cell_htlcs() {
 	let chan_1 = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 190000, 1001, InitFeatures::known(), InitFeatures::known());
 	let chan_2 = create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 190000, 1001, InitFeatures::known(), InitFeatures::known());
 
-	let mut stat01 = get_channel_value_stat!(nodes[0], chan_1.2);
-	let mut stat11 = get_channel_value_stat!(nodes[1], chan_1.2);
+	let mut stat01 = get_channel_value_stat!(nodes[0], nodes[1], chan_1.2);
+	let mut stat11 = get_channel_value_stat!(nodes[1], nodes[0], chan_1.2);
 
-	let mut stat12 = get_channel_value_stat!(nodes[1], chan_2.2);
-	let mut stat22 = get_channel_value_stat!(nodes[2], chan_2.2);
+	let mut stat12 = get_channel_value_stat!(nodes[1], nodes[2], chan_2.2);
+	let mut stat22 = get_channel_value_stat!(nodes[2], nodes[1], chan_2.2);
 
 	macro_rules! expect_forward {
 		($node: expr) => {{
@@ -1814,8 +1814,8 @@ fn test_channel_reserve_holding_cell_htlcs() {
 
 	let feemsat = 239; // set above
 	let total_fee_msat = (nodes.len() - 2) as u64 * feemsat;
-	let feerate = get_feerate!(nodes[0], chan_1.2);
-	let opt_anchors = get_opt_anchors!(nodes[0], chan_1.2);
+	let feerate = get_feerate!(nodes[0], nodes[1], chan_1.2);
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan_1.2);
 
 	let recv_value_0 = stat01.counterparty_max_htlc_value_in_flight_msat - total_fee_msat;
 
@@ -1845,10 +1845,10 @@ fn test_channel_reserve_holding_cell_htlcs() {
 		send_payment(&nodes[0], &vec![&nodes[1], &nodes[2]][..], recv_value_0);
 
 		let (stat01_, stat11_, stat12_, stat22_) = (
-			get_channel_value_stat!(nodes[0], chan_1.2),
-			get_channel_value_stat!(nodes[1], chan_1.2),
-			get_channel_value_stat!(nodes[1], chan_2.2),
-			get_channel_value_stat!(nodes[2], chan_2.2),
+			get_channel_value_stat!(nodes[0], nodes[1], chan_1.2),
+			get_channel_value_stat!(nodes[1], nodes[0], chan_1.2),
+			get_channel_value_stat!(nodes[1], nodes[2], chan_2.2),
+			get_channel_value_stat!(nodes[2], nodes[1], chan_2.2),
 		);
 
 		assert_eq!(stat01_.value_to_self_msat, stat01.value_to_self_msat - amt_msat);
@@ -1899,7 +1899,7 @@ fn test_channel_reserve_holding_cell_htlcs() {
 	let recv_value_21 = recv_value_2/2 - additional_htlc_cost_msat/2;
 	let recv_value_22 = recv_value_2 - recv_value_21 - total_fee_msat - additional_htlc_cost_msat;
 	{
-		let stat = get_channel_value_stat!(nodes[0], chan_1.2);
+		let stat = get_channel_value_stat!(nodes[0], nodes[1], chan_1.2);
 		assert_eq!(stat.value_to_self_msat - (stat.pending_outbound_htlcs_amount_msat + recv_value_21 + recv_value_22 + total_fee_msat + total_fee_msat + commit_tx_fee_3_htlcs), stat.channel_reserve_msat);
 	}
 
@@ -2011,11 +2011,11 @@ fn test_channel_reserve_holding_cell_htlcs() {
 
 	let commit_tx_fee_1_htlc = 2*commit_tx_fee_msat(feerate, 1 + 1, opt_anchors);
 	let expected_value_to_self = stat01.value_to_self_msat - (recv_value_1 + total_fee_msat) - (recv_value_21 + total_fee_msat) - (recv_value_22 + total_fee_msat) - (recv_value_3 + total_fee_msat);
-	let stat0 = get_channel_value_stat!(nodes[0], chan_1.2);
+	let stat0 = get_channel_value_stat!(nodes[0], nodes[1], chan_1.2);
 	assert_eq!(stat0.value_to_self_msat, expected_value_to_self);
 	assert_eq!(stat0.value_to_self_msat, stat0.channel_reserve_msat + commit_tx_fee_1_htlc);
 
-	let stat2 = get_channel_value_stat!(nodes[2], chan_2.2);
+	let stat2 = get_channel_value_stat!(nodes[2], nodes[1], chan_2.2);
 	assert_eq!(stat2.value_to_self_msat, stat22.value_to_self_msat + recv_value_1 + recv_value_21 + recv_value_22 + recv_value_3);
 }
 
@@ -2049,7 +2049,7 @@ fn channel_reserve_in_flight_removes() {
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
 
-	let b_chan_values = get_channel_value_stat!(nodes[1], chan_1.2);
+	let b_chan_values = get_channel_value_stat!(nodes[1], nodes[0], chan_1.2);
 	// Route the first two HTLCs.
 	let payment_value_1 = b_chan_values.channel_reserve_msat - b_chan_values.value_to_self_msat - 10000;
 	let (payment_preimage_1, payment_hash_1, _) = route_payment(&nodes[0], &[&nodes[1]], payment_value_1);
@@ -6187,10 +6187,10 @@ fn test_fail_holding_cell_htlc_upon_free() {
 
 	nodes[1].node.handle_update_fee(&nodes[0].node.get_our_node_id(), update_msg.unwrap());
 
-	let mut chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	let mut chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	let channel_reserve = chan_stat.channel_reserve_msat;
-	let feerate = get_feerate!(nodes[0], chan.2);
-	let opt_anchors = get_opt_anchors!(nodes[0], chan.2);
+	let feerate = get_feerate!(nodes[0], nodes[1], chan.2);
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan.2);
 
 	// 2* and +1 HTLCs on the commit tx fee calculation for the fee spike reserve.
 	let max_can_send = 5000000 - channel_reserve - 2*commit_tx_fee_msat(feerate, 1 + 1, opt_anchors);
@@ -6198,7 +6198,7 @@ fn test_fail_holding_cell_htlc_upon_free() {
 
 	// Send a payment which passes reserve checks but gets stuck in the holding cell.
 	let our_payment_id = nodes[0].node.send_payment(&route, our_payment_hash, &Some(our_payment_secret)).unwrap();
-	chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	assert_eq!(chan_stat.holding_cell_outbound_amount_msat, max_can_send);
 
 	// Flush the pending fee update.
@@ -6211,7 +6211,7 @@ fn test_fail_holding_cell_htlc_upon_free() {
 	// Upon receipt of the RAA, there will be an attempt to resend the holding cell
 	// HTLC, but now that the fee has been raised the payment will now fail, causing
 	// us to surface its failure to the user.
-	chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	assert_eq!(chan_stat.holding_cell_outbound_amount_msat, 0);
 	nodes[0].logger.assert_log("lightning::ln::channel".to_string(), format!("Freeing holding cell with 1 HTLC updates in channel {}", hex::encode(chan.2)), 1);
 	let failure_log = format!("Failed to send HTLC with payment_hash {} due to Cannot send value that would put our balance under counterparty-announced channel reserve value ({}) in channel {}",
@@ -6267,10 +6267,10 @@ fn test_free_and_fail_holding_cell_htlcs() {
 
 	nodes[1].node.handle_update_fee(&nodes[0].node.get_our_node_id(), update_msg.unwrap());
 
-	let mut chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	let mut chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	let channel_reserve = chan_stat.channel_reserve_msat;
-	let feerate = get_feerate!(nodes[0], chan.2);
-	let opt_anchors = get_opt_anchors!(nodes[0], chan.2);
+	let feerate = get_feerate!(nodes[0], nodes[1], chan.2);
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan.2);
 
 	// 2* and +1 HTLCs on the commit tx fee calculation for the fee spike reserve.
 	let amt_1 = 20000;
@@ -6280,10 +6280,10 @@ fn test_free_and_fail_holding_cell_htlcs() {
 
 	// Send 2 payments which pass reserve checks but get stuck in the holding cell.
 	nodes[0].node.send_payment(&route_1, payment_hash_1, &Some(payment_secret_1)).unwrap();
-	chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	assert_eq!(chan_stat.holding_cell_outbound_amount_msat, amt_1);
 	let payment_id_2 = nodes[0].node.send_payment(&route_2, payment_hash_2, &Some(payment_secret_2)).unwrap();
-	chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	assert_eq!(chan_stat.holding_cell_outbound_amount_msat, amt_1 + amt_2);
 
 	// Flush the pending fee update.
@@ -6297,7 +6297,7 @@ fn test_free_and_fail_holding_cell_htlcs() {
 	// Upon receipt of the RAA, there will be an attempt to resend the holding cell HTLCs,
 	// but now that the fee has been raised the second payment will now fail, causing us
 	// to surface its failure to the user. The first payment should succeed.
-	chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	assert_eq!(chan_stat.holding_cell_outbound_amount_msat, 0);
 	nodes[0].logger.assert_log("lightning::ln::channel".to_string(), format!("Freeing holding cell with 2 HTLC updates in channel {}", hex::encode(chan.2)), 1);
 	let failure_log = format!("Failed to send HTLC with payment_hash {} due to Cannot send value that would put our balance under counterparty-announced channel reserve value ({}) in channel {}",
@@ -6395,10 +6395,10 @@ fn test_fail_holding_cell_htlc_upon_free_multihop() {
 
 	nodes[2].node.handle_update_fee(&nodes[1].node.get_our_node_id(), update_msg.unwrap());
 
-	let mut chan_stat = get_channel_value_stat!(nodes[0], chan_0_1.2);
+	let mut chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan_0_1.2);
 	let channel_reserve = chan_stat.channel_reserve_msat;
-	let feerate = get_feerate!(nodes[0], chan_0_1.2);
-	let opt_anchors = get_opt_anchors!(nodes[0], chan_0_1.2);
+	let feerate = get_feerate!(nodes[0], nodes[1], chan_0_1.2);
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan_0_1.2);
 
 	// Send a payment which passes reserve checks but gets stuck in the holding cell.
 	let feemsat = 239;
@@ -6419,7 +6419,7 @@ fn test_fail_holding_cell_htlc_upon_free_multihop() {
 	commitment_signed_dance!(nodes[1], nodes[0], payment_event.commitment_msg, false);
 	expect_pending_htlcs_forwardable!(nodes[1]);
 
-	chan_stat = get_channel_value_stat!(nodes[1], chan_1_2.2);
+	chan_stat = get_channel_value_stat!(nodes[1], nodes[2], chan_1_2.2);
 	assert_eq!(chan_stat.holding_cell_outbound_amount_msat, max_can_send);
 
 	// Flush the pending fee update.
@@ -6623,7 +6623,7 @@ fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_value_in_flight() {
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let channel_value = 100000;
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, channel_value, 0, InitFeatures::known(), InitFeatures::known());
-	let max_in_flight = get_channel_value_stat!(nodes[0], chan.2).counterparty_max_htlc_value_in_flight_msat;
+	let max_in_flight = get_channel_value_stat!(nodes[0], nodes[1], chan.2).counterparty_max_htlc_value_in_flight_msat;
 
 	send_payment(&nodes[0], &vec!(&nodes[1])[..], max_in_flight);
 
@@ -6678,10 +6678,10 @@ fn test_update_add_htlc_bolt2_receiver_sender_can_afford_amount_sent() {
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, InitFeatures::known(), InitFeatures::known());
 
-	let chan_stat = get_channel_value_stat!(nodes[0], chan.2);
+	let chan_stat = get_channel_value_stat!(nodes[0], nodes[1], chan.2);
 	let channel_reserve = chan_stat.channel_reserve_msat;
-	let feerate = get_feerate!(nodes[0], chan.2);
-	let opt_anchors = get_opt_anchors!(nodes[0], chan.2);
+	let feerate = get_feerate!(nodes[0], nodes[1], chan.2);
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan.2);
 	// The 2* and +1 are for the fee spike reserve.
 	let commit_tx_fee_outbound = 2 * commit_tx_fee_msat(feerate, 1 + 1, opt_anchors);
 
@@ -6757,7 +6757,7 @@ fn test_update_add_htlc_bolt2_receiver_check_max_in_flight_msat() {
 	nodes[0].node.send_payment(&route, our_payment_hash, &Some(our_payment_secret)).unwrap();
 	check_added_monitors!(nodes[0], 1);
 	let mut updates = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());
-	updates.update_add_htlcs[0].amount_msat = get_channel_value_stat!(nodes[1], chan.2).counterparty_max_htlc_value_in_flight_msat + 1;
+	updates.update_add_htlcs[0].amount_msat = get_channel_value_stat!(nodes[1], nodes[0], chan.2).counterparty_max_htlc_value_in_flight_msat + 1;
 	nodes[1].node.handle_update_add_htlc(&nodes[0].node.get_our_node_id(), &updates.update_add_htlcs[0]);
 
 	assert!(nodes[1].node.list_channels().is_empty());

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -169,8 +169,11 @@ fn do_test_counterparty_no_reserve(send_from_initiator: bool) {
 	}
 	nodes[0].node.handle_accept_channel(&nodes[1].node.get_our_node_id(), InitFeatures::known(), &accept_channel_message);
 	{
-		let mut lock;
-		let mut chan = get_channel_ref!(if send_from_initiator { &nodes[1] } else { &nodes[0] }, lock, temp_channel_id);
+		let sender_node = if send_from_initiator { &nodes[1] } else { &nodes[0] };
+		let counterparty_node = if send_from_initiator { &nodes[0] } else { &nodes[1] };
+		let per_peer_lock = sender_node.node.per_peer_state.write().unwrap();
+		let mut peer_state_lock = per_peer_lock.get(&counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
+		let mut chan = get_channel_ref!(sender_node, peer_state_lock, temp_channel_id);
 		chan.holder_selected_channel_reserve_satoshis = 0;
 		chan.holder_max_htlc_value_in_flight_msat = 100_000_000;
 	}
@@ -678,16 +681,18 @@ fn test_update_fee_that_funder_cannot_afford() {
 	// Get the EnforcingSigner for each channel, which will be used to (1) get the keys
 	// needed to sign the new commitment tx and (2) sign the new commitment tx.
 	let (local_revocation_basepoint, local_htlc_basepoint, local_funding) = {
-		let chan_lock = nodes[0].node.channel_state.lock().unwrap();
-		let local_chan = chan_lock.by_id.get(&chan.2).unwrap();
+		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
+		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+		let local_chan = chan_lock.channel_by_id.get(&chan.2).unwrap();
 		let chan_signer = local_chan.get_signer();
 		let pubkeys = chan_signer.pubkeys();
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
 		 pubkeys.funding_pubkey)
 	};
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint,remote_point, remote_funding) = {
-		let chan_lock = nodes[1].node.channel_state.lock().unwrap();
-		let remote_chan = chan_lock.by_id.get(&chan.2).unwrap();
+		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
+		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
+		let remote_chan = chan_lock.channel_by_id.get(&chan.2).unwrap();
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
@@ -700,8 +705,9 @@ fn test_update_fee_that_funder_cannot_afford() {
 		&remote_htlc_basepoint, &local_revocation_basepoint, &local_htlc_basepoint).unwrap();
 
 	let res = {
-		let local_chan_lock = nodes[0].node.channel_state.lock().unwrap();
-		let local_chan = local_chan_lock.by_id.get(&chan.2).unwrap();
+		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
+		let local_chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).unwrap();
 		let local_chan_signer = local_chan.get_signer();
 		let mut htlcs: Vec<(HTLCOutputInCommitment, ())> = vec![];
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
@@ -1415,8 +1421,9 @@ fn test_fee_spike_violation_fails_htlc() {
 	// Get the EnforcingSigner for each channel, which will be used to (1) get the keys
 	// needed to sign the new commitment tx and (2) sign the new commitment tx.
 	let (local_revocation_basepoint, local_htlc_basepoint, local_secret, next_local_point, local_funding) = {
-		let chan_lock = nodes[0].node.channel_state.lock().unwrap();
-		let local_chan = chan_lock.by_id.get(&chan.2).unwrap();
+		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
+		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+		let local_chan = chan_lock.channel_by_id.get(&chan.2).unwrap();
 		let chan_signer = local_chan.get_signer();
 		// Make the signer believe we validated another commitment, so we can release the secret
 		chan_signer.get_enforcement_state().last_holder_commitment -= 1;
@@ -1428,8 +1435,9 @@ fn test_fee_spike_violation_fails_htlc() {
 		 chan_signer.pubkeys().funding_pubkey)
 	};
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
-		let chan_lock = nodes[1].node.channel_state.lock().unwrap();
-		let remote_chan = chan_lock.by_id.get(&chan.2).unwrap();
+		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
+		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
+		let remote_chan = chan_lock.channel_by_id.get(&chan.2).unwrap();
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
@@ -1456,8 +1464,9 @@ fn test_fee_spike_violation_fails_htlc() {
 	let commitment_number = INITIAL_COMMITMENT_NUMBER - 1;
 
 	let res = {
-		let local_chan_lock = nodes[0].node.channel_state.lock().unwrap();
-		let local_chan = local_chan_lock.by_id.get(&chan.2).unwrap();
+		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
+		let local_chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).unwrap();
 		let local_chan_signer = local_chan.get_signer();
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
 			commitment_number,
@@ -3098,7 +3107,8 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 	let value = if use_dust {
 		// The dust limit applied to HTLC outputs considers the fee of the HTLC transaction as
 		// well, so HTLCs at exactly the dust limit will not be included in commitment txn.
-		nodes[2].node.channel_state.lock().unwrap().by_id.get(&chan_2.2).unwrap().holder_dust_limit_satoshis * 1000
+		nodes[2].node.per_peer_state.read().unwrap().get(&nodes[1].node.get_our_node_id())
+			.unwrap().lock().unwrap().channel_by_id.get(&chan_2.2).unwrap().holder_dust_limit_satoshis * 1000
 	} else { 3000000 };
 
 	let (_, first_payment_hash, _) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], value);
@@ -5503,7 +5513,8 @@ fn do_test_fail_backwards_unrevoked_remote_announce(deliver_last_raa: bool, anno
 	send_payment(&nodes[1], &[&nodes[2], &nodes[3], &nodes[5]], 500000);
 	assert_eq!(get_local_commitment_txn!(nodes[3], chan.2)[0].output.len(), 2);
 
-	let ds_dust_limit = nodes[3].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().holder_dust_limit_satoshis;
+	let ds_dust_limit = nodes[3].node.per_peer_state.read().unwrap().get(&nodes[2].node.get_our_node_id())
+		.unwrap().lock().unwrap().channel_by_id.get(&chan.2).unwrap().holder_dust_limit_satoshis;
 	// 0th HTLC:
 	let (_, payment_hash_1, _) = route_payment(&nodes[0], &[&nodes[2], &nodes[3], &nodes[4]], ds_dust_limit*1000); // not added < dust limit + HTLC tx fee
 	// 1st HTLC:
@@ -6582,7 +6593,8 @@ fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_num_and_htlc_id_increment()
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 0, InitFeatures::known(), InitFeatures::known());
-	let max_accepted_htlcs = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().counterparty_max_accepted_htlcs as u64;
+	let max_accepted_htlcs = nodes[1].node.per_peer_state.read().unwrap().get(&nodes[0].node.get_our_node_id())
+		.unwrap().lock().unwrap().channel_by_id.get(&chan.2).unwrap().counterparty_max_accepted_htlcs as u64;
 
 	for i in 0..max_accepted_htlcs {
 		let (route, our_payment_hash, _, our_payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[1], 100000);
@@ -6651,8 +6663,9 @@ fn test_update_add_htlc_bolt2_receiver_check_amount_received_more_than_min() {
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, InitFeatures::known(), InitFeatures::known());
 	let htlc_minimum_msat: u64;
 	{
-		let chan_lock = nodes[0].node.channel_state.lock().unwrap();
-		let channel = chan_lock.by_id.get(&chan.2).unwrap();
+		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
+		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+		let channel = chan_lock.channel_by_id.get(&chan.2).unwrap();
 		htlc_minimum_msat = channel.get_holder_htlc_minimum_msat();
 	}
 
@@ -7151,7 +7164,8 @@ fn do_test_failure_delay_dust_htlc_local_commitment(announce_latest: bool) {
 	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let chan =create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
 
-	let bs_dust_limit = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().holder_dust_limit_satoshis;
+	let bs_dust_limit = nodes[1].node.per_peer_state.read().unwrap().get(&nodes[0].node.get_our_node_id())
+		.unwrap().lock().unwrap().channel_by_id.get(&chan.2).unwrap().holder_dust_limit_satoshis;
 
 	// We route 2 dust-HTLCs between A and B
 	let (_, payment_hash_1, _) = route_payment(&nodes[0], &[&nodes[1]], bs_dust_limit*1000);
@@ -7242,7 +7256,8 @@ fn do_test_sweep_outbound_htlc_failure_update(revoked: bool, local: bool) {
 	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
 
-	let bs_dust_limit = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().holder_dust_limit_satoshis;
+	let bs_dust_limit = nodes[1].node.per_peer_state.read().unwrap().get(&nodes[0].node.get_our_node_id())
+		.unwrap().lock().unwrap().channel_by_id.get(&chan.2).unwrap().holder_dust_limit_satoshis;
 
 	let (_payment_preimage_1, dust_hash, _payment_secret_1) = route_payment(&nodes[0], &[&nodes[1]], bs_dust_limit*1000);
 	let (_payment_preimage_2, non_dust_hash, _payment_secret_2) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
@@ -8087,8 +8102,9 @@ fn test_counterparty_raa_skip_no_crash() {
 	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 	let channel_id = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known()).2;
 
-	let mut guard = nodes[0].node.channel_state.lock().unwrap();
-	let keys = guard.by_id.get_mut(&channel_id).unwrap().get_signer();
+	let mut per_peer_state = nodes[0].node.per_peer_state.write().unwrap();
+	let mut guard = per_peer_state.get_mut(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+	let keys = guard.channel_by_id.get_mut(&channel_id).unwrap().get_signer();
 
 	const INITIAL_COMMITMENT_NUMBER: u64 = (1 << 48) - 1;
 
@@ -8445,8 +8461,9 @@ fn test_reject_funding_before_inbound_channel_accepted() {
 	// `handle_accept_channel`, which is required in order for `create_funding_transaction` to
 	// succeed when `nodes[0]` is passed to it.
 	{
-		let mut lock;
-		let channel = get_channel_ref!(&nodes[1], lock, temp_channel_id);
+		let per_peer_lock = nodes[1].node.per_peer_state.write().unwrap();
+		let mut peer_state_lock = per_peer_lock.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
+		let channel = get_channel_ref!(&nodes[1], peer_state_lock, temp_channel_id);
 		let accept_chan_msg = channel.get_accept_channel_message();
 		nodes[0].node.handle_accept_channel(&nodes[1].node.get_our_node_id(), InitFeatures::known(), &accept_chan_msg);
 	}
@@ -8788,7 +8805,9 @@ fn test_update_err_monitor_lockdown() {
 	let updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
 	assert_eq!(updates.update_fulfill_htlcs.len(), 1);
 	nodes[0].node.handle_update_fulfill_htlc(&nodes[1].node.get_our_node_id(), &updates.update_fulfill_htlcs[0]);
-	if let Some(ref mut channel) = nodes[0].node.channel_state.lock().unwrap().by_id.get_mut(&chan_1.2) {
+	if let Some(ref mut channel) = nodes[0].node.per_peer_state.write().unwrap().get_mut(&nodes[1].node.get_our_node_id())
+			.unwrap().lock().unwrap().channel_by_id.get_mut(&chan_1.2)
+	{
 		if let Ok((_, _, update)) = channel.commitment_signed(&updates.commitment_signed, &node_cfgs[0].logger) {
 			if let Err(_) =  watchtower.chain_monitor.update_channel(outpoint, update.clone()) {} else { assert!(false); }
 			if let Ok(_) = nodes[0].chain_monitor.update_channel(outpoint, update) {} else { assert!(false); }
@@ -8879,7 +8898,9 @@ fn test_concurrent_monitor_claim() {
 	let updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
 	assert_eq!(updates.update_add_htlcs.len(), 1);
 	nodes[0].node.handle_update_add_htlc(&nodes[1].node.get_our_node_id(), &updates.update_add_htlcs[0]);
-	if let Some(ref mut channel) = nodes[0].node.channel_state.lock().unwrap().by_id.get_mut(&chan_1.2) {
+	if let Some(ref mut channel) = nodes[0].node.per_peer_state.write().unwrap().get_mut(&nodes[1].node.get_our_node_id())
+			.unwrap().lock().unwrap().channel_by_id.get_mut(&chan_1.2)
+	{
 		if let Ok((_, _, update)) = channel.commitment_signed(&updates.commitment_signed, &node_cfgs[0].logger) {
 			// Watchtower Alice should already have seen the block and reject the update
 			if let Err(_) =  watchtower_alice.chain_monitor.update_channel(outpoint, update.clone()) {} else { assert!(false); }
@@ -9287,12 +9308,13 @@ fn test_duplicate_chan_id() {
 	create_funding_transaction(&nodes[0], &nodes[1].node.get_our_node_id(), 100000, 42); // Get and check the FundingGenerationReady event
 
 	let funding_created = {
-		let mut a_channel_lock = nodes[0].node.channel_state.lock().unwrap();
+		let mut per_peer_state = nodes[0].node.per_peer_state.write().unwrap();
+		let mut a_channel_lock = per_peer_state.get_mut(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
 		// Once we call `get_outbound_funding_created` the channel has a duplicate channel_id as
 		// another channel in the ChannelManager - an invalid state. Thus, we'd panic later when we
 		// try to create another channel. Instead, we drop the channel entirely here (leaving the
 		// channelmanager in a possibly nonsense state instead).
-		let mut as_chan = a_channel_lock.by_id.remove(&open_chan_2_msg.temporary_channel_id).unwrap();
+		let mut as_chan = a_channel_lock.channel_by_id.remove(&open_chan_2_msg.temporary_channel_id).unwrap();
 		let logger = test_utils::TestLogger::new();
 		as_chan.get_outbound_funding_created(tx.clone(), funding_outpoint, &&logger).unwrap()
 	};
@@ -10203,7 +10225,9 @@ fn do_test_max_dust_htlc_exposure(dust_outbound_balance: bool, exposure_breach_e
 	let (temporary_channel_id, tx, _) = create_funding_transaction(&nodes[0], &nodes[1].node.get_our_node_id(), 1_000_000, 42);
 
 	if on_holder_tx {
-		if let Some(mut chan) = nodes[0].node.channel_state.lock().unwrap().by_id.get_mut(&temporary_channel_id) {
+		if let Some(mut chan) = nodes[0].node.per_peer_state.write().unwrap().get_mut(&nodes[1].node.get_our_node_id())
+				.unwrap().lock().unwrap().channel_by_id.get_mut(&temporary_channel_id)
+		{
 			chan.holder_dust_limit_satoshis = 546;
 		}
 	}
@@ -10220,8 +10244,9 @@ fn do_test_max_dust_htlc_exposure(dust_outbound_balance: bool, exposure_breach_e
 	update_nodes_with_chan_announce(&nodes, 0, 1, &announcement, &as_update, &bs_update);
 
 	let dust_buffer_feerate = {
-		let chan_lock = nodes[0].node.channel_state.lock().unwrap();
-		let chan = chan_lock.by_id.get(&channel_id).unwrap();
+		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
+		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+		let chan = chan_lock.channel_by_id.get(&channel_id).unwrap();
 		chan.get_dust_buffer_feerate(None) as u64
 	};
 	let dust_outbound_htlc_on_holder_tx_msat: u64 = (dust_buffer_feerate * htlc_timeout_tx_weight(opt_anchors) / 1000 + open_channel.dust_limit_satoshis - 1) * 1000;

--- a/lightning/src/ln/monitor_tests.rs
+++ b/lightning/src/ln/monitor_tests.rs
@@ -110,8 +110,8 @@ fn chanmon_claim_value_coop_close() {
 	let funding_outpoint = OutPoint { txid: funding_tx.txid(), index: 0 };
 	assert_eq!(funding_outpoint.to_channel_id(), chan_id);
 
-	let chan_feerate = get_feerate!(nodes[0], chan_id) as u64;
-	let opt_anchors = get_opt_anchors!(nodes[0], chan_id);
+	let chan_feerate = get_feerate!(nodes[0], nodes[1], chan_id) as u64;
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan_id);
 
 	assert_eq!(vec![Balance::ClaimableOnChannelClose {
 			claimable_amount_satoshis: 1_000_000 - 1_000 - chan_feerate * channel::commitment_tx_base_weight(opt_anchors) / 1000
@@ -210,8 +210,8 @@ fn do_test_claim_value_force_close(prev_commitment_tx: bool) {
 
 	let htlc_cltv_timeout = nodes[0].best_block_info().1 + TEST_FINAL_CLTV + 1; // Note ChannelManager adds one to CLTV timeouts for safety
 
-	let chan_feerate = get_feerate!(nodes[0], chan_id) as u64;
-	let opt_anchors = get_opt_anchors!(nodes[0], chan_id);
+	let chan_feerate = get_feerate!(nodes[0], nodes[1], chan_id) as u64;
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan_id);
 
 	let remote_txn = get_local_commitment_txn!(nodes[1], chan_id);
 	// Before B receives the payment preimage, it only suggests the push_msat value of 1_000 sats
@@ -557,8 +557,8 @@ fn test_balances_on_local_commitment_htlcs() {
 	check_added_monitors!(nodes[1], 1);
 	expect_payment_claimed!(nodes[1], payment_hash_2, 20_000_000);
 
-	let chan_feerate = get_feerate!(nodes[0], chan_id) as u64;
-	let opt_anchors = get_opt_anchors!(nodes[0], chan_id);
+	let chan_feerate = get_feerate!(nodes[0], nodes[1], chan_id) as u64;
+	let opt_anchors = get_opt_anchors!(nodes[0], nodes[1], chan_id);
 
 	// Get nodes[0]'s commitment transaction and HTLC-Timeout transactions
 	let as_txn = get_local_commitment_txn!(nodes[0], chan_id);

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -490,7 +490,9 @@ fn test_onion_failure() {
 	  Some(NetworkUpdate::ChannelFailure{short_channel_id, is_permanent:true}), Some(short_channel_id));
 
 	let short_channel_id = channels[1].0.contents.short_channel_id;
-	let amt_to_forward = nodes[1].node.channel_state.lock().unwrap().by_id.get(&channels[1].2).unwrap().get_counterparty_htlc_minimum_msat() - 1;
+	let amt_to_forward = nodes[1].node.per_peer_state.read().unwrap().get(&nodes[2].node.get_our_node_id())
+		.unwrap().lock().unwrap().channel_by_id.get(&channels[1].2).unwrap()
+		.get_counterparty_htlc_minimum_msat() - 1;
 	let mut bogus_route = route.clone();
 	let route_len = bogus_route.paths[0].len();
 	bogus_route.paths[0][route_len-1].fee_msat = amt_to_forward;

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -463,7 +463,7 @@ fn do_retry_with_no_persist(confirm_before_reload: bool) {
 		MessageSendEvent::HandleError { node_id, action: msgs::ErrorAction::SendErrorMessage { ref msg } } => {
 			assert_eq!(node_id, nodes[1].node.get_our_node_id());
 			nodes[1].node.handle_error(&nodes[0].node.get_our_node_id(), msg);
-			check_closed_event!(nodes[1], 1, ClosureReason::CounterpartyForceClosed { peer_msg: "Failed to find corresponding channel".to_string() });
+			check_closed_event!(nodes[1], 1, ClosureReason::CounterpartyForceClosed { peer_msg: format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", &nodes[1].node.get_our_node_id()) });
 			check_added_monitors!(nodes[1], 1);
 			assert_eq!(nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap().split_off(0).len(), 1);
 		},

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -531,7 +531,8 @@ fn do_retry_with_no_persist(confirm_before_reload: bool) {
 	// Update the fee on the middle hop to ensure PaymentSent events have the correct (retried) fee
 	// and not the original fee. We also update node[1]'s relevant config as
 	// do_claim_payment_along_route expects us to never overpay.
-	nodes[1].node.channel_state.lock().unwrap().by_id.get_mut(&chan_id_2).unwrap()
+	nodes[1].node.per_peer_state.write().unwrap().get_mut(&nodes[2].node.get_our_node_id())
+		.unwrap().lock().unwrap().channel_by_id.get_mut(&chan_id_2).unwrap()
 		.config.options.forwarding_fee_base_msat += 100_000;
 	new_route.paths[0][0].fee_msat += 100_000;
 

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -202,7 +202,7 @@ fn do_test_unconf_chan(reload_node: bool, reorg_after_reload: bool, use_funding_
 
 	let channel_state = nodes[0].node.channel_state.lock().unwrap();
 	assert_eq!(channel_state.by_id.len(), 1);
-	assert_eq!(channel_state.short_to_id.len(), 2);
+	assert_eq!(channel_state.short_to_chan_info.len(), 2);
 	mem::drop(channel_state);
 
 	if !reorg_after_reload {
@@ -222,7 +222,7 @@ fn do_test_unconf_chan(reload_node: bool, reorg_after_reload: bool, use_funding_
 		{
 			let channel_state = nodes[0].node.channel_state.lock().unwrap();
 			assert_eq!(channel_state.by_id.len(), 0);
-			assert_eq!(channel_state.short_to_id.len(), 0);
+			assert_eq!(channel_state.short_to_chan_info.len(), 0);
 		}
 	}
 
@@ -290,7 +290,7 @@ fn do_test_unconf_chan(reload_node: bool, reorg_after_reload: bool, use_funding_
 		{
 			let channel_state = nodes[0].node.channel_state.lock().unwrap();
 			assert_eq!(channel_state.by_id.len(), 0);
-			assert_eq!(channel_state.short_to_id.len(), 0);
+			assert_eq!(channel_state.short_to_chan_info.len(), 0);
 		}
 	}
 	// With expect_channel_force_closed set the TestChainMonitor will enforce that the next update

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -762,9 +762,9 @@ fn do_test_closing_signed_reinit_timeout(timeout_step: TimeoutStep) {
 		// nodes[1] should happily accept and respond to.
 		node_0_closing_signed.fee_range.as_mut().unwrap().max_fee_satoshis *= 10;
 		{
-			let per_peer_lock = nodes[0].node.per_peer_state.write().unwrap();
-			let mut peer_state_lock = per_peer_lock.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-			get_channel_ref!(nodes[0], peer_state_lock, chan_id).closing_fee_limits.as_mut().unwrap().1 *= 10;
+			let mut node_0_per_peer_lock;
+			let mut node_0_peer_state_lock;
+			get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, chan_id).closing_fee_limits.as_mut().unwrap().1 *= 10;
 		}
 		nodes[1].node.handle_closing_signed(&nodes[0].node.get_our_node_id(), &node_0_closing_signed);
 		let node_1_closing_signed = get_event_msg!(nodes[1], MessageSendEvent::SendClosingSigned, nodes[0].node.get_our_node_id());

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -762,8 +762,9 @@ fn do_test_closing_signed_reinit_timeout(timeout_step: TimeoutStep) {
 		// nodes[1] should happily accept and respond to.
 		node_0_closing_signed.fee_range.as_mut().unwrap().max_fee_satoshis *= 10;
 		{
-			let mut lock;
-			get_channel_ref!(nodes[0], lock, chan_id).closing_fee_limits.as_mut().unwrap().1 *= 10;
+			let per_peer_lock = nodes[0].node.per_peer_state.write().unwrap();
+			let mut peer_state_lock = per_peer_lock.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
+			get_channel_ref!(nodes[0], peer_state_lock, chan_id).closing_fee_limits.as_mut().unwrap().1 *= 10;
 		}
 		nodes[1].node.handle_closing_signed(&nodes[0].node.get_our_node_id(), &node_0_closing_signed);
 		let node_1_closing_signed = get_event_msg!(nodes[1], MessageSendEvent::SendClosingSigned, nodes[0].node.get_our_node_id());

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -381,7 +381,7 @@ fn do_test_shutdown_rebroadcast(recv_count: u8) {
 		// closing_signed so we do it ourselves
 		check_closed_broadcast!(nodes[1], false);
 		check_added_monitors!(nodes[1], 1);
-		check_closed_event!(nodes[1], 1, ClosureReason::CounterpartyForceClosed { peer_msg: "Failed to find corresponding channel".to_string() });
+		check_closed_event!(nodes[1], 1, ClosureReason::CounterpartyForceClosed { peer_msg: format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", &nodes[1].node.get_our_node_id()) });
 	}
 
 	assert!(nodes[0].node.list_channels().is_empty());


### PR DESCRIPTION
Closes #1278.

This PR is based and blocked on #1507, so only the last commits are part of this PR. As #1507 needs to be rebased, this will fail CI currently.

Enables forwarding of htlcs over alternative channels to the same peer, in case forwarding over the channel specified in the onion payload fails.

Pushing this as a draft for now as there are a few things I'd like some guidance for. I'll add some review comments with the  questions I have :).