### PR TITLE
Fix `ProbabilisticScorer` aliasing in `no-std` mode

### DIFF
--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -318,7 +318,7 @@ pub type ProbabilisticScorer<G, L> = ProbabilisticScorerUsingTime::<G, L, std::t
 /// behavior.
 ///
 /// [1]: https://arxiv.org/abs/2107.05322
-pub type ProbabilisticScorer<G, L> = ProbabilisticScorerUsingTime::<G, L, Eternity>;
+pub type ProbabilisticScorer<G, L> = ProbabilisticScorerUsingTime::<G, L, util::time::Eternity>;
 
 /// Probabilistic [`Score`] implementation.
 ///


### PR DESCRIPTION
This fixes a rebase error which causes an undefined reference
compile error.

Fixes edd26f00c67fe20278b04ff8cc29367e2186d0f1