### PR TITLE
Fix date on 0.0.109 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.109 - 2022-06-30
+# 0.0.109 - 2022-07-01
 
 ## API Updates
  * `ChannelManager::update_channel_config` has been added to allow the fields


### PR DESCRIPTION
We slipped by a day and the PR didn't get updated. NBD, though,
the git tag has the correct date.