### PR TITLE
Make ChannelMonitor aware of counterparty's node id

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2209,7 +2209,7 @@ impl<Signer: Sign> Channel<Signer> {
 		                                          &self.channel_transaction_parameters,
 		                                          funding_redeemscript.clone(), self.channel_value_satoshis,
 		                                          obscure_factor,
-		                                          holder_commitment_tx, best_block);
+		                                          holder_commitment_tx, best_block, self.counterparty_node_id);
 
 		channel_monitor.provide_latest_counterparty_commitment_tx(counterparty_initial_commitment_txid, Vec::new(), self.cur_counterparty_commitment_transaction_number, self.counterparty_cur_commitment_point.unwrap(), logger);
 
@@ -2286,7 +2286,7 @@ impl<Signer: Sign> Channel<Signer> {
 		                                          &self.channel_transaction_parameters,
 		                                          funding_redeemscript.clone(), self.channel_value_satoshis,
 		                                          obscure_factor,
-		                                          holder_commitment_tx, best_block);
+		                                          holder_commitment_tx, best_block, self.counterparty_node_id);
 
 		channel_monitor.provide_latest_counterparty_commitment_tx(counterparty_initial_bitcoin_tx.txid, Vec::new(), self.cur_counterparty_commitment_transaction_number, self.counterparty_cur_commitment_point.unwrap(), logger);
 


### PR DESCRIPTION
In #1403, we want to be able to send an `HTLCHandlingFailed` event, which has an enum field, `next_hop_destination: HTLCDestination`, that defines the reason for the error. 

One of the variants is `HTLCDestination::NextHopChannel`, which describes the scenario where we tried forwarding to a channel but failed to do so. 

When processing a channel monitor's events, we can possibly run into a scenario where we are unable to process an HTLC because the channel has closed. `ChannelManager` will also not be aware of the channel as a result, and we will not be able to look it up to say who the HTLC was meant for. 

Therefore, the only way to define the channel counterparty in `HTLCDestination::NextHopChannel` is by making `ChannelMonitor` aware of `counterparty_node_id`, and piping it through `MonitorEvent` for it to be used.

Related discussion: https://github.com/lightningdevkit/rust-lightning/pull/1403#discussion_r908520656