### PR TITLE
Remove scary disconenct warnings on PeerManager new connection fns

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -622,8 +622,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 	/// peer using the init message.
 	/// The user should pass the remote network address of the host they are connected to.
 	///
-	/// Note that if an Err is returned here you MUST NOT call socket_disconnected for the new
-	/// descriptor but must disconnect the connection immediately.
+	/// If an `Err` is returned here you must disconnect the connection immediately.
 	///
 	/// Returns a small number of bytes to send to the remote node (currently always 50).
 	///
@@ -671,9 +670,8 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 	/// The user should pass the remote network address of the host they are connected to.
 	///
 	/// May refuse the connection by returning an Err, but will never write bytes to the remote end
-	/// (outbound connector always speaks first). Note that if an Err is returned here you MUST NOT
-	/// call socket_disconnected for the new descriptor but must disconnect the connection
-	/// immediately.
+	/// (outbound connector always speaks first). If an `Err` is returned here you must disconnect
+	/// the connection immediately.
 	///
 	/// Panics if descriptor is duplicative with some other descriptor which has not yet been
 	/// [`socket_disconnected()`].


### PR DESCRIPTION
In 4703d4e72565ddfd150b9368ea036f4973fd7590 we changed
PeerManager::socket_disconnected to no longer require that sockets
which the PeerManager decided to disconnect not be disconnected.
However, we forgot to remove the scary warnings on the
`new_{inbound,outbound}_connection` functions which warned of the
old behavior.

We do so here.