### PR TITLE
Expose `ChannelMonitor::get_counterparty_node_id`

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1214,7 +1214,11 @@ impl<Signer: Sign> ChannelMonitor<Signer> {
 		self.inner.lock().unwrap().get_cur_holder_commitment_number()
 	}
 
-	pub(crate) fn get_counterparty_node_id(&self) -> Option<PublicKey> {
+	/// Gets the `node_id` of the counterparty for this channel.
+	///
+	/// Will be `None` for channels constructed on LDK versions prior to 0.0.110 and always `Some`
+	/// otherwise.
+	pub fn get_counterparty_node_id(&self) -> Option<PublicKey> {
 		self.inner.lock().unwrap().counterparty_node_id
 	}
 


### PR DESCRIPTION
This fixes an oversight in ac842ed9dd7a36a4a26eb6b856d80ab04eecf750
namely that it left users unable to implement their own
`ChainMonitor` from outside of the `rust-lightning` crate.