### PR TITLE
Add a background processor which is async

### DIFF
--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -17,6 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitcoin = "0.28.1"
 lightning = { version = "0.0.110", path = "../lightning", features = ["std"] }
 lightning-rapid-gossip-sync = { version = "0.0.110", path = "../lightning-rapid-gossip-sync" }
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 lightning = { version = "0.0.110", path = "../lightning", features = ["_test_utils"] }

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -31,6 +31,9 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 use std::ops::Deref;
 
+#[cfg(feature = "futures")]
+use futures::{select, future::FutureExt};
+
 /// `BackgroundProcessor` takes care of tasks that (1) need to happen periodically to keep
 /// Rust-Lightning running properly, and (2) either can or should be run in the background. Its
 /// responsibilities are:
@@ -219,6 +222,203 @@ where A::Target: chain::Access, L::Target: Logger {
 	}
 }
 
+macro_rules! define_run_body {
+	($persister: ident, $event_handler: ident, $chain_monitor: ident, $channel_manager: ident,
+	 $gossip_sync: ident, $peer_manager: ident, $logger: ident, $scorer: ident,
+	 $loop_exit_check: expr, $await: expr)
+	=> { {
+		let event_handler = DecoratingEventHandler {
+			event_handler: $event_handler,
+			gossip_sync: &$gossip_sync,
+		};
+
+		log_trace!($logger, "Calling ChannelManager's timer_tick_occurred on startup");
+		$channel_manager.timer_tick_occurred();
+
+		let mut last_freshness_call = Instant::now();
+		let mut last_ping_call = Instant::now();
+		let mut last_prune_call = Instant::now();
+		let mut last_scorer_persist_call = Instant::now();
+		let mut have_pruned = false;
+
+		loop {
+			$channel_manager.process_pending_events(&event_handler);
+			$chain_monitor.process_pending_events(&event_handler);
+
+			// Note that the PeerManager::process_events may block on ChannelManager's locks,
+			// hence it comes last here. When the ChannelManager finishes whatever it's doing,
+			// we want to ensure we get into `persist_manager` as quickly as we can, especially
+			// without running the normal event processing above and handing events to users.
+			//
+			// Specifically, on an *extremely* slow machine, we may see ChannelManager start
+			// processing a message effectively at any point during this loop. In order to
+			// minimize the time between such processing completing and persisting the updated
+			// ChannelManager, we want to minimize methods blocking on a ChannelManager
+			// generally, and as a fallback place such blocking only immediately before
+			// persistence.
+			$peer_manager.process_events();
+
+			// We wait up to 100ms, but track how long it takes to detect being put to sleep,
+			// see `await_start`'s use below.
+			let await_start = Instant::now();
+			let updates_available = $await;
+			let await_time = await_start.elapsed();
+
+			if updates_available {
+				log_trace!($logger, "Persisting ChannelManager...");
+				$persister.persist_manager(&*$channel_manager)?;
+				log_trace!($logger, "Done persisting ChannelManager.");
+			}
+			// Exit the loop if the background processor was requested to stop.
+			if $loop_exit_check {
+				log_trace!($logger, "Terminating background processor.");
+				break;
+			}
+			if last_freshness_call.elapsed().as_secs() > FRESHNESS_TIMER {
+				log_trace!($logger, "Calling ChannelManager's timer_tick_occurred");
+				$channel_manager.timer_tick_occurred();
+				last_freshness_call = Instant::now();
+			}
+			if await_time > Duration::from_secs(1) {
+				// On various platforms, we may be starved of CPU cycles for several reasons.
+				// E.g. on iOS, if we've been in the background, we will be entirely paused.
+				// Similarly, if we're on a desktop platform and the device has been asleep, we
+				// may not get any cycles.
+				// We detect this by checking if our max-100ms-sleep, above, ran longer than a
+				// full second, at which point we assume sockets may have been killed (they
+				// appear to be at least on some platforms, even if it has only been a second).
+				// Note that we have to take care to not get here just because user event
+				// processing was slow at the top of the loop. For example, the sample client
+				// may call Bitcoin Core RPCs during event handling, which very often takes
+				// more than a handful of seconds to complete, and shouldn't disconnect all our
+				// peers.
+				log_trace!($logger, "100ms sleep took more than a second, disconnecting peers.");
+				$peer_manager.disconnect_all_peers();
+				last_ping_call = Instant::now();
+			} else if last_ping_call.elapsed().as_secs() > PING_TIMER {
+				log_trace!($logger, "Calling PeerManager's timer_tick_occurred");
+				$peer_manager.timer_tick_occurred();
+				last_ping_call = Instant::now();
+			}
+
+			// Note that we want to run a graph prune once not long after startup before
+			// falling back to our usual hourly prunes. This avoids short-lived clients never
+			// pruning their network graph. We run once 60 seconds after startup before
+			// continuing our normal cadence.
+			if last_prune_call.elapsed().as_secs() > if have_pruned { NETWORK_PRUNE_TIMER } else { FIRST_NETWORK_PRUNE_TIMER } {
+				// The network graph must not be pruned while rapid sync completion is pending
+				log_trace!($logger, "Assessing prunability of network graph");
+				if let Some(network_graph) = $gossip_sync.prunable_network_graph() {
+					network_graph.remove_stale_channels();
+
+					if let Err(e) = $persister.persist_graph(network_graph) {
+						log_error!($logger, "Error: Failed to persist network graph, check your disk and permissions {}", e)
+					}
+
+					last_prune_call = Instant::now();
+					have_pruned = true;
+				} else {
+					log_trace!($logger, "Not pruning network graph, either due to pending rapid gossip sync or absence of a prunable graph.");
+				}
+			}
+
+			if last_scorer_persist_call.elapsed().as_secs() > SCORER_PERSIST_TIMER {
+				if let Some(ref scorer) = $scorer {
+					log_trace!($logger, "Persisting scorer");
+					if let Err(e) = $persister.persist_scorer(&scorer) {
+						log_error!($logger, "Error: Failed to persist scorer, check your disk and permissions {}", e)
+					}
+				}
+				last_scorer_persist_call = Instant::now();
+			}
+		}
+
+		// After we exit, ensure we persist the ChannelManager one final time - this avoids
+		// some races where users quit while channel updates were in-flight, with
+		// ChannelMonitor update(s) persisted without a corresponding ChannelManager update.
+		$persister.persist_manager(&*$channel_manager)?;
+
+		// Persist Scorer on exit
+		if let Some(ref scorer) = $scorer {
+			$persister.persist_scorer(&scorer)?;
+		}
+
+		// Persist NetworkGraph on exit
+		if let Some(network_graph) = $gossip_sync.network_graph() {
+			$persister.persist_graph(network_graph)?;
+		}
+
+		Ok(())
+	} }
+}
+
+/// Processes background events in a future.
+///
+/// `sleeper` should return a future which completes in the given amount of time and returns a
+/// boolean indicating whether the background processing should continue. Once `sleeper` returns a
+/// future which outputs false, the loop will exit and this function's future will complete.
+///
+/// See [`BackgroundProcessor::start`] for information on which actions this handles.
+#[cfg(feature = "futures")]
+pub async fn process_events_async<
+	'a,
+	Signer: 'static + Sign,
+	CA: 'static + Deref + Send + Sync,
+	CF: 'static + Deref + Send + Sync,
+	CW: 'static + Deref + Send + Sync,
+	T: 'static + Deref + Send + Sync,
+	K: 'static + Deref + Send + Sync,
+	F: 'static + Deref + Send + Sync,
+	G: 'static + Deref<Target = NetworkGraph<L>> + Send + Sync,
+	L: 'static + Deref + Send + Sync,
+	P: 'static + Deref + Send + Sync,
+	Descriptor: 'static + SocketDescriptor + Send + Sync,
+	CMH: 'static + Deref + Send + Sync,
+	RMH: 'static + Deref + Send + Sync,
+	EH: 'static + EventHandler + Send,
+	PS: 'static + Deref + Send,
+	M: 'static + Deref<Target = ChainMonitor<Signer, CF, T, F, L, P>> + Send + Sync,
+	CM: 'static + Deref<Target = ChannelManager<Signer, CW, T, K, F, L>> + Send + Sync,
+	PGS: 'static + Deref<Target = P2PGossipSync<G, CA, L>> + Send + Sync,
+	RGS: 'static + Deref<Target = RapidGossipSync<G, L>> + Send,
+	UMH: 'static + Deref + Send + Sync,
+	PM: 'static + Deref<Target = PeerManager<Descriptor, CMH, RMH, L, UMH>> + Send + Sync,
+	S: 'static + Deref<Target = SC> + Send + Sync,
+	SC: WriteableScore<'a>,
+	SleepFuture: core::future::Future<Output = bool>,
+	Sleeper: Fn(Duration) -> SleepFuture
+>(
+	persister: PS, event_handler: EH, chain_monitor: M, channel_manager: CM,
+	gossip_sync: GossipSync<PGS, RGS, G, CA, L>, peer_manager: PM, logger: L, scorer: Option<S>,
+	sleeper: Sleeper,
+) -> Result<(), std::io::Error>
+where
+	CA::Target: 'static + chain::Access,
+	CF::Target: 'static + chain::Filter,
+	CW::Target: 'static + chain::Watch<Signer>,
+	T::Target: 'static + BroadcasterInterface,
+	K::Target: 'static + KeysInterface<Signer = Signer>,
+	F::Target: 'static + FeeEstimator,
+	L::Target: 'static + Logger,
+	P::Target: 'static + Persist<Signer>,
+	CMH::Target: 'static + ChannelMessageHandler,
+	RMH::Target: 'static + RoutingMessageHandler,
+	UMH::Target: 'static + CustomMessageHandler,
+	PS::Target: 'static + Persister<'a, Signer, CW, T, K, F, L, SC>,
+{
+	let mut should_continue = true;
+	define_run_body!(persister, event_handler, chain_monitor, channel_manager,
+		gossip_sync, peer_manager, logger, scorer, should_continue, {
+			select! {
+				_ = channel_manager.get_persistable_update_future().fuse() => true,
+				cont = sleeper(Duration::from_millis(100)).fuse() => {
+					should_continue = cont;
+					false
+				}
+			}
+		})
+}
+
 impl BackgroundProcessor {
 	/// Start a background thread that takes care of responsibilities enumerated in the [top-level
 	/// documentation].
@@ -310,129 +510,9 @@ impl BackgroundProcessor {
 		let stop_thread = Arc::new(AtomicBool::new(false));
 		let stop_thread_clone = stop_thread.clone();
 		let handle = thread::spawn(move || -> Result<(), std::io::Error> {
-			let event_handler = DecoratingEventHandler {
-				event_handler,
-				gossip_sync: &gossip_sync,
-			};
-
-			log_trace!(logger, "Calling ChannelManager's timer_tick_occurred on startup");
-			channel_manager.timer_tick_occurred();
-
-			let mut last_freshness_call = Instant::now();
-			let mut last_ping_call = Instant::now();
-			let mut last_prune_call = Instant::now();
-			let mut last_scorer_persist_call = Instant::now();
-			let mut have_pruned = false;
-
-			loop {
-				channel_manager.process_pending_events(&event_handler);
-				chain_monitor.process_pending_events(&event_handler);
-
-				// Note that the PeerManager::process_events may block on ChannelManager's locks,
-				// hence it comes last here. When the ChannelManager finishes whatever it's doing,
-				// we want to ensure we get into `persist_manager` as quickly as we can, especially
-				// without running the normal event processing above and handing events to users.
-				//
-				// Specifically, on an *extremely* slow machine, we may see ChannelManager start
-				// processing a message effectively at any point during this loop. In order to
-				// minimize the time between such processing completing and persisting the updated
-				// ChannelManager, we want to minimize methods blocking on a ChannelManager
-				// generally, and as a fallback place such blocking only immediately before
-				// persistence.
-				peer_manager.process_events();
-
-				// We wait up to 100ms, but track how long it takes to detect being put to sleep,
-				// see `await_start`'s use below.
-				let await_start = Instant::now();
-				let updates_available =
-					channel_manager.await_persistable_update_timeout(Duration::from_millis(100));
-				let await_time = await_start.elapsed();
-
-				if updates_available {
-					log_trace!(logger, "Persisting ChannelManager...");
-					persister.persist_manager(&*channel_manager)?;
-					log_trace!(logger, "Done persisting ChannelManager.");
-				}
-				// Exit the loop if the background processor was requested to stop.
-				if stop_thread.load(Ordering::Acquire) == true {
-					log_trace!(logger, "Terminating background processor.");
-					break;
-				}
-				if last_freshness_call.elapsed().as_secs() > FRESHNESS_TIMER {
-					log_trace!(logger, "Calling ChannelManager's timer_tick_occurred");
-					channel_manager.timer_tick_occurred();
-					last_freshness_call = Instant::now();
-				}
-				if await_time > Duration::from_secs(1) {
-					// On various platforms, we may be starved of CPU cycles for several reasons.
-					// E.g. on iOS, if we've been in the background, we will be entirely paused.
-					// Similarly, if we're on a desktop platform and the device has been asleep, we
-					// may not get any cycles.
-					// We detect this by checking if our max-100ms-sleep, above, ran longer than a
-					// full second, at which point we assume sockets may have been killed (they
-					// appear to be at least on some platforms, even if it has only been a second).
-					// Note that we have to take care to not get here just because user event
-					// processing was slow at the top of the loop. For example, the sample client
-					// may call Bitcoin Core RPCs during event handling, which very often takes
-					// more than a handful of seconds to complete, and shouldn't disconnect all our
-					// peers.
-					log_trace!(logger, "100ms sleep took more than a second, disconnecting peers.");
-					peer_manager.disconnect_all_peers();
-					last_ping_call = Instant::now();
-				} else if last_ping_call.elapsed().as_secs() > PING_TIMER {
-					log_trace!(logger, "Calling PeerManager's timer_tick_occurred");
-					peer_manager.timer_tick_occurred();
-					last_ping_call = Instant::now();
-				}
-
-				// Note that we want to run a graph prune once not long after startup before
-				// falling back to our usual hourly prunes. This avoids short-lived clients never
-				// pruning their network graph. We run once 60 seconds after startup before
-				// continuing our normal cadence.
-				if last_prune_call.elapsed().as_secs() > if have_pruned { NETWORK_PRUNE_TIMER } else { FIRST_NETWORK_PRUNE_TIMER } {
-					// The network graph must not be pruned while rapid sync completion is pending
-					log_trace!(logger, "Assessing prunability of network graph");
-					if let Some(network_graph) = gossip_sync.prunable_network_graph() {
-						network_graph.remove_stale_channels();
-
-						if let Err(e) = persister.persist_graph(network_graph) {
-							log_error!(logger, "Error: Failed to persist network graph, check your disk and permissions {}", e)
-						}
-
-						last_prune_call = Instant::now();
-						have_pruned = true;
-					} else {
-						log_trace!(logger, "Not pruning network graph, either due to pending rapid gossip sync or absence of a prunable graph.");
-					}
-				}
-
-				if last_scorer_persist_call.elapsed().as_secs() > SCORER_PERSIST_TIMER {
-					if let Some(ref scorer) = scorer {
-						log_trace!(logger, "Persisting scorer");
-						if let Err(e) = persister.persist_scorer(&scorer) {
-							log_error!(logger, "Error: Failed to persist scorer, check your disk and permissions {}", e)
-						}
-					}
-					last_scorer_persist_call = Instant::now();
-				}
-			}
-
-			// After we exit, ensure we persist the ChannelManager one final time - this avoids
-			// some races where users quit while channel updates were in-flight, with
-			// ChannelMonitor update(s) persisted without a corresponding ChannelManager update.
-			persister.persist_manager(&*channel_manager)?;
-
-			// Persist Scorer on exit
-			if let Some(ref scorer) = scorer {
-				persister.persist_scorer(&scorer)?;
-			}
-
-			// Persist NetworkGraph on exit
-			if let Some(network_graph) = gossip_sync.network_graph() {
-				persister.persist_graph(network_graph)?;
-			}
-
-			Ok(())
+			define_run_body!(persister, event_handler, chain_monitor, channel_manager,
+				gossip_sync, peer_manager, logger, scorer, stop_thread.load(Ordering::Acquire),
+				channel_manager.await_persistable_update_timeout(Duration::from_millis(100)))
 		});
 		Self { stop_thread: stop_thread_clone, thread_handle: Some(handle) }
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5990,7 +5990,7 @@ where
 
 	#[cfg(any(test, feature = "_test_utils"))]
 	pub fn get_persistence_condvar_value(&self) -> bool {
-		self.persistence_notifier.needs_persist()
+		self.persistence_notifier.notify_pending()
 	}
 
 	/// Gets the latest best block which was connected either via the [`chain::Listen`] or

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -55,7 +55,7 @@ use util::config::{UserConfig, ChannelConfig};
 use util::events::{EventHandler, EventsProvider, MessageSendEvent, MessageSendEventsProvider, ClosureReason, HTLCDestination};
 use util::{byte_utils, events};
 use util::crypto::sign;
-use util::wakers::Notifier;
+use util::wakers::{Future, Notifier};
 use util::scid_utils::fake_scid;
 use util::ser::{BigSize, FixedLengthReader, Readable, ReadableArgs, MaybeReadable, Writeable, Writer, VecWriter};
 use util::logger::{Level, Logger};
@@ -5986,6 +5986,13 @@ where
 	/// up.
 	pub fn await_persistable_update(&self) {
 		self.persistence_notifier.wait()
+	}
+
+	/// Gets a [`Future`] that completes when a persistable update is available. Note that
+	/// callbacks registered on the [`Future`] MUST NOT call back into this [`ChannelManager`] and
+	/// should instead register actions to be taken later.
+	pub fn get_persistable_update_future(&self) -> Future {
+		self.persistence_notifier.get_future()
 	}
 
 	#[cfg(any(test, feature = "_test_utils"))]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -54,6 +54,8 @@ use chain::keysinterface::{Sign, KeysInterface, KeysManager, InMemorySigner, Rec
 use util::config::{UserConfig, ChannelConfig};
 use util::events::{EventHandler, EventsProvider, MessageSendEvent, MessageSendEventsProvider, ClosureReason, HTLCDestination};
 use util::{byte_utils, events};
+use util::crypto::sign;
+use util::wakers::PersistenceNotifier;
 use util::scid_utils::fake_scid;
 use util::ser::{BigSize, FixedLengthReader, Readable, ReadableArgs, MaybeReadable, Writeable, Writer, VecWriter};
 use util::logger::{Level, Logger};
@@ -64,14 +66,10 @@ use prelude::*;
 use core::{cmp, mem};
 use core::cell::RefCell;
 use io::Read;
-use sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard};
+use sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
 use core::ops::Deref;
-
-#[cfg(any(test, feature = "std"))]
-use std::time::Instant;
-use util::crypto::sign;
 
 // We hold various information about HTLC relay in the HTLC objects in Channel itself:
 //
@@ -5992,10 +5990,7 @@ where
 
 	#[cfg(any(test, feature = "_test_utils"))]
 	pub fn get_persistence_condvar_value(&self) -> bool {
-		let mutcond = &self.persistence_notifier.persistence_lock;
-		let &(ref mtx, _) = mutcond;
-		let guard = mtx.lock().unwrap();
-		*guard
+		self.persistence_notifier.needs_persist()
 	}
 
 	/// Gets the latest best block which was connected either via the [`chain::Listen`] or
@@ -6234,77 +6229,6 @@ impl<Signer: Sign, M: Deref , T: Deref , K: Deref , F: Deref , L: Deref >
 			// Untrusted messages from peer, we throw away the error if id points to a non-existent channel
 			let _ = self.force_close_channel_with_peer(&msg.channel_id, counterparty_node_id, Some(&msg.data), true);
 		}
-	}
-}
-
-/// Used to signal to the ChannelManager persister that the manager needs to be re-persisted to
-/// disk/backups, through `await_persistable_update_timeout` and `await_persistable_update`.
-struct PersistenceNotifier {
-	/// Users won't access the persistence_lock directly, but rather wait on its bool using
-	/// `wait_timeout` and `wait`.
-	persistence_lock: (Mutex<bool>, Condvar),
-}
-
-impl PersistenceNotifier {
-	fn new() -> Self {
-		Self {
-			persistence_lock: (Mutex::new(false), Condvar::new()),
-		}
-	}
-
-	fn wait(&self) {
-		loop {
-			let &(ref mtx, ref cvar) = &self.persistence_lock;
-			let mut guard = mtx.lock().unwrap();
-			if *guard {
-				*guard = false;
-				return;
-			}
-			guard = cvar.wait(guard).unwrap();
-			let result = *guard;
-			if result {
-				*guard = false;
-				return
-			}
-		}
-	}
-
-	#[cfg(any(test, feature = "std"))]
-	fn wait_timeout(&self, max_wait: Duration) -> bool {
-		let current_time = Instant::now();
-		loop {
-			let &(ref mtx, ref cvar) = &self.persistence_lock;
-			let mut guard = mtx.lock().unwrap();
-			if *guard {
-				*guard = false;
-				return true;
-			}
-			guard = cvar.wait_timeout(guard, max_wait).unwrap().0;
-			// Due to spurious wakeups that can happen on `wait_timeout`, here we need to check if the
-			// desired wait time has actually passed, and if not then restart the loop with a reduced wait
-			// time. Note that this logic can be highly simplified through the use of
-			// `Condvar::wait_while` and `Condvar::wait_timeout_while`, if and when our MSRV is raised to
-			// 1.42.0.
-			let elapsed = current_time.elapsed();
-			let result = *guard;
-			if result || elapsed >= max_wait {
-				*guard = false;
-				return result;
-			}
-			match max_wait.checked_sub(elapsed) {
-				None => return result,
-				Some(_) => continue
-			}
-		}
-	}
-
-	// Signal to the ChannelManager persister that there are updates necessitating persisting to disk.
-	fn notify(&self) {
-		let &(ref persist_mtx, ref cnd) = &self.persistence_lock;
-		let mut persistence_lock = persist_mtx.lock().unwrap();
-		*persistence_lock = true;
-		mem::drop(persistence_lock);
-		cnd.notify_all();
 	}
 }
 
@@ -7354,54 +7278,6 @@ mod tests {
 	use util::events::{Event, HTLCDestination, MessageSendEvent, MessageSendEventsProvider, ClosureReason};
 	use util::test_utils;
 	use chain::keysinterface::KeysInterface;
-
-	#[cfg(feature = "std")]
-	#[test]
-	fn test_wait_timeout() {
-		use ln::channelmanager::PersistenceNotifier;
-		use sync::Arc;
-		use core::sync::atomic::AtomicBool;
-		use std::thread;
-
-		let persistence_notifier = Arc::new(PersistenceNotifier::new());
-		let thread_notifier = Arc::clone(&persistence_notifier);
-
-		let exit_thread = Arc::new(AtomicBool::new(false));
-		let exit_thread_clone = exit_thread.clone();
-		thread::spawn(move || {
-			loop {
-				let &(ref persist_mtx, ref cnd) = &thread_notifier.persistence_lock;
-				let mut persistence_lock = persist_mtx.lock().unwrap();
-				*persistence_lock = true;
-				cnd.notify_all();
-
-				if exit_thread_clone.load(Ordering::SeqCst) {
-					break
-				}
-			}
-		});
-
-		// Check that we can block indefinitely until updates are available.
-		let _ = persistence_notifier.wait();
-
-		// Check that the PersistenceNotifier will return after the given duration if updates are
-		// available.
-		loop {
-			if persistence_notifier.wait_timeout(Duration::from_millis(100)) {
-				break
-			}
-		}
-
-		exit_thread.store(true, Ordering::SeqCst);
-
-		// Check that the PersistenceNotifier will return after the given duration even if no updates
-		// are available.
-		loop {
-			if !persistence_notifier.wait_timeout(Duration::from_millis(100)) {
-				break
-			}
-		}
-	}
 
 	#[test]
 	fn test_notify_limits() {

--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -21,6 +21,7 @@ pub mod ser;
 pub mod message_signing;
 pub mod invoice;
 pub mod persist;
+pub mod wakers;
 
 pub(crate) mod atomic_counter;
 pub(crate) mod byte_utils;

--- a/lightning/src/util/wakers.rs
+++ b/lightning/src/util/wakers.rs
@@ -18,6 +18,8 @@ use core::mem;
 use core::time::Duration;
 use sync::{Condvar, Mutex};
 
+use prelude::{Box, Vec};
+
 #[cfg(any(test, feature = "std"))]
 use std::time::Instant;
 

--- a/lightning/src/util/wakers.rs
+++ b/lightning/src/util/wakers.rs
@@ -1,0 +1,150 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Utilities which allow users to block on some future notification from LDK. These are
+//! specifically used by [`ChannelManager`] to allow waiting until the [`ChannelManager`] needs to
+//! be re-persisted.
+//!
+//! [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
+
+use core::mem;
+use core::time::Duration;
+use sync::{Condvar, Mutex};
+
+#[cfg(any(test, feature = "std"))]
+use std::time::Instant;
+
+/// Used to signal to the ChannelManager persister that the manager needs to be re-persisted to
+/// disk/backups, through `await_persistable_update_timeout` and `await_persistable_update`.
+pub(crate) struct PersistenceNotifier {
+	/// Users won't access the persistence_lock directly, but rather wait on its bool using
+	/// `wait_timeout` and `wait`.
+	persistence_lock: (Mutex<bool>, Condvar),
+}
+
+impl PersistenceNotifier {
+	pub(crate) fn new() -> Self {
+		Self {
+			persistence_lock: (Mutex::new(false), Condvar::new()),
+		}
+	}
+
+	pub(crate) fn wait(&self) {
+		loop {
+			let &(ref mtx, ref cvar) = &self.persistence_lock;
+			let mut guard = mtx.lock().unwrap();
+			if *guard {
+				*guard = false;
+				return;
+			}
+			guard = cvar.wait(guard).unwrap();
+			let result = *guard;
+			if result {
+				*guard = false;
+				return
+			}
+		}
+	}
+
+	#[cfg(any(test, feature = "std"))]
+	pub(crate) fn wait_timeout(&self, max_wait: Duration) -> bool {
+		let current_time = Instant::now();
+		loop {
+			let &(ref mtx, ref cvar) = &self.persistence_lock;
+			let mut guard = mtx.lock().unwrap();
+			if *guard {
+				*guard = false;
+				return true;
+			}
+			guard = cvar.wait_timeout(guard, max_wait).unwrap().0;
+			// Due to spurious wakeups that can happen on `wait_timeout`, here we need to check if the
+			// desired wait time has actually passed, and if not then restart the loop with a reduced wait
+			// time. Note that this logic can be highly simplified through the use of
+			// `Condvar::wait_while` and `Condvar::wait_timeout_while`, if and when our MSRV is raised to
+			// 1.42.0.
+			let elapsed = current_time.elapsed();
+			let result = *guard;
+			if result || elapsed >= max_wait {
+				*guard = false;
+				return result;
+			}
+			match max_wait.checked_sub(elapsed) {
+				None => return result,
+				Some(_) => continue
+			}
+		}
+	}
+
+	/// Wake waiters, tracking that persistence needs to occur.
+	pub(crate) fn notify(&self) {
+		let &(ref persist_mtx, ref cnd) = &self.persistence_lock;
+		let mut persistence_lock = persist_mtx.lock().unwrap();
+		*persistence_lock = true;
+		mem::drop(persistence_lock);
+		cnd.notify_all();
+	}
+
+	#[cfg(any(test, feature = "_test_utils"))]
+	pub fn needs_persist(&self) -> bool {
+		let &(ref mtx, _) = &self.persistence_lock;
+		let guard = mtx.lock().unwrap();
+		*guard
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#[cfg(feature = "std")]
+	#[test]
+	fn test_wait_timeout() {
+		use super::*;
+		use sync::Arc;
+		use core::sync::atomic::{AtomicBool, Ordering};
+		use std::thread;
+
+		let persistence_notifier = Arc::new(PersistenceNotifier::new());
+		let thread_notifier = Arc::clone(&persistence_notifier);
+
+		let exit_thread = Arc::new(AtomicBool::new(false));
+		let exit_thread_clone = exit_thread.clone();
+		thread::spawn(move || {
+			loop {
+				let &(ref persist_mtx, ref cnd) = &thread_notifier.persistence_lock;
+				let mut persistence_lock = persist_mtx.lock().unwrap();
+				*persistence_lock = true;
+				cnd.notify_all();
+
+				if exit_thread_clone.load(Ordering::SeqCst) {
+					break
+				}
+			}
+		});
+
+		// Check that we can block indefinitely until updates are available.
+		let _ = persistence_notifier.wait();
+
+		// Check that the PersistenceNotifier will return after the given duration if updates are
+		// available.
+		loop {
+			if persistence_notifier.wait_timeout(Duration::from_millis(100)) {
+				break
+			}
+		}
+
+		exit_thread.store(true, Ordering::SeqCst);
+
+		// Check that the PersistenceNotifier will return after the given duration even if no updates
+		// are available.
+		loop {
+			if !persistence_notifier.wait_timeout(Duration::from_millis(100)) {
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
This adds a new Future (which implements std::future::Future) which stores a list of callbacks to call upon completion. This is exposed from ChannelManager as an alternative way to be woken up when persistence needs to happen. Then, we add a new method in the background processor crate which works the same as the backgroundprocessor but async instead of in a thread.

Fixes #1595