### PR TITLE
Allow `get_persistence_condvar_value` outside of tests

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5990,7 +5990,8 @@ where
 		self.persistence_notifier.wait()
 	}
 
-	#[cfg(any(test, feature = "_test_utils"))]
+	/// Immediately returns whether ChannelManager needs to be persisted.
+	/// Can be used to 'poll' for persistence updates.
 	pub fn get_persistence_condvar_value(&self) -> bool {
 		let mutcond = &self.persistence_notifier.persistence_lock;
 		let &(ref mtx, _) = mutcond;


### PR DESCRIPTION
## Summary

Allow usage of `ChannelManager::get_persistence_condvar_value` outside of tests.

## Motivation

### Polling

We implemented a Tokio-based background processor that runs entirely in a single task and which doesn't need its own thread. Accordingly, we made our entire node single-threaded. However, the only exposed methods for determining whether a `ChannelManager` has a persistable update require blocking (`await_persistable_update`, `await_persistable_update_timeout`), and the only way to simulate 'polling' is to do something like the following:

```rust
let needs_persist = channel_manager.await_persistable_update_timeout(Duration::from_millis(10));
```

Which is really just a jank way of doing what we really want: to inspect the value inside the persistence condvar. This PR removes the `cfg`s on `get_persistence_condvar_value` and allows us to poll for persistence updates in a completely non-blocking manner.

### Performance

This impacts performance too: with a polling frequency of 100ms (the default in rust-lightning background processor) and a poll timeout of 10ms, using `await_persistable_update_timeout` as above causes our single-threaded node to be blocked and unable to do anything else about 10% of the time.