### PR TITLE
Workaround GH Actions issue for 1.45

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Pin tokio to 1.14 for Rust 1.45
         if: "matrix.build-net-old-tokio"
         run: cargo update -p tokio --precise "1.14.0" --verbose
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       - name: Build on Rust ${{ matrix.toolchain }} with net-tokio
         if: "matrix.build-net-tokio && !matrix.coverage"
         run: cargo build --verbose --color always


### PR DESCRIPTION
See https://github.com/rust-lang/cargo/issues/10303

It seems we were only having that particular issue when pinning tokio to 1.14 for Rust 1.45. I'm not sure if it happens at later steps and didn't want to enable these env vars globally across the other jobs.