### PR TITLE
Handle monotonic clock going backwards during runtime

### DIFF
--- a/lightning/src/util/time.rs
+++ b/lightning/src/util/time.rs
@@ -65,7 +65,12 @@ impl Time for std::time::Instant {
 	}
 
 	fn duration_since(&self, earlier: Self) -> Duration {
-		self.duration_since(earlier)
+		// On rust prior to 1.60 `Instant::duration_since` will panic if time goes backwards.
+		// However, we support rust versions prior to 1.60 and some users appear to have "monotonic
+		// clocks" that go backwards in practice (likely relatively ancient kernels/etc). Thus, we
+		// manually check for time going backwards here and return a duration of zero in that case.
+		let now = Self::now();
+		if now > earlier { now - earlier } else { Duration::from_secs(0) }
 	}
 
 	fn duration_since_epoch() -> Duration {


### PR DESCRIPTION
We've had some users complain that `duration_since` is panic'ing
for them. This is possible if the machine being run on is buggy and
the "monotonic clock" goes backwards, which sadly some ancient
systems can do.

Rust addressed this issue in 1.60 by forcing
`Instant::duration_since` to not panic if the machine is buggy
(and time goes backwards), but for users on older rust versions we
do the same by hand here.