### PR TITLE
Ensure we log private channel_updates at a non-GOSSIP log level

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5154,6 +5154,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				if were_node_one == msg_from_node_one {
 					return Ok(NotifyOption::SkipPersist);
 				} else {
+					log_debug!(self.logger, "Received channel_update for channel {}.", log_bytes!(chan_id));
 					try_chan_entry!(self, chan.get_mut().channel_update(&msg), channel_state, chan);
 				}
 			},


### PR DESCRIPTION
If we receive a channel_update for one of our private channels, we
will not log the message at the usual TRACE log level as the
message falls into the gossip range. However, for our own channels
they aren't *just* gossip, as we store that info and it changes
how we generate invoices. Thus, we add a log in `ChannelManager`
here at the DEBUG log level.