### PR TITLE
Allow keys to be unpersisted

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -717,6 +717,14 @@ mod tests {
 
 			self.filesystem_persister.persist(key, object)
 		}
+
+		fn unpersist(&self, key: &str) -> std::io::Result<bool> {
+			if key == "manager" || key == "network_graph" || key == "scorer" {
+				return Err(std::io::Error::new(std::io::ErrorKind::Other, "Refusing to unpersist this key"));
+			}
+
+			self.filesystem_persister.unpersist(key)
+		}
 	}
 
 	fn get_full_filepath(filepath: String, filename: String) -> String {

--- a/lightning-persister/src/lib.rs
+++ b/lightning-persister/src/lib.rs
@@ -128,6 +128,12 @@ impl KVStorePersister for FilesystemPersister {
 		dest_file.push(key);
 		util::write_to_file(dest_file, object)
 	}
+
+	fn unpersist(&self, key: &str) -> std::io::Result<bool> {
+		let mut dest_file = PathBuf::from(self.path_to_channel_data.clone());
+		dest_file.push(key);
+		util::delete_file(dest_file)
+	}
 }
 
 #[cfg(test)]

--- a/lightning-persister/src/util.rs
+++ b/lightning-persister/src/util.rs
@@ -85,7 +85,10 @@ pub(crate) fn delete_file(dest_file: PathBuf) -> std::io::Result<bool> {
 	fs::remove_file(&dest_file)?;
 	let parent_directory = dest_file.parent().unwrap();
 	let dir_file = fs::OpenOptions::new().read(true).open(parent_directory)?;
-	unsafe { libc::fsync(dir_file.as_raw_fd()); }
+	#[cfg(not(target_os = "windows"))]
+	{
+		unsafe { libc::fsync(dir_file.as_raw_fd()); }
+	}
 
 	if dest_file.is_file() {
 		return Err(std::io::Error::new(std::io::ErrorKind::Other, "Unpersisting key failed"));

--- a/lightning/src/util/persist.rs
+++ b/lightning/src/util/persist.rs
@@ -21,8 +21,12 @@ use super::{logger::Logger, ser::Writeable};
 /// and [`Persist`] traits.  It uses "manager", "network_graph",
 /// and "monitors/{funding_txo_id}_{funding_txo_index}" for keys.
 pub trait KVStorePersister {
-	/// Persist the given writeable using the provided key
+	/// Persist the given writeable using the provided key.
 	fn persist<W: Writeable>(&self, key: &str, object: &W) -> io::Result<()>;
+
+	/// Unpersist (i.e., remove) the writeable previously persisted under the provided key.
+	/// Returns `true` if the key was present, and `false` otherwise.
+	fn unpersist(&self, key: &str) -> io::Result<bool>;
 }
 
 /// Trait that handles persisting a [`ChannelManager`], [`NetworkGraph`], and [`WriteableScore`] to disk.


### PR DESCRIPTION
Previously the `KVStorePersister` only allowed to `persist` a `Writeables` under a given key. However, we may want to be able to remove this set key after the fact. Here we therefore extend the trait with a `unpersist` method and implement it for `FilesystemPersister`.

I also added a commit rewording the `FilesystemPersister` docs to reflect the broader use case it fulfils by now.