### PR TITLE
Derive `Debug` for `AccessError`

### DIFF
--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -61,7 +61,7 @@ impl BestBlock {
 }
 
 /// An error when accessing the chain via [`Access`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum AccessError {
 	/// The requested chain is unknown.
 	UnknownChain,


### PR DESCRIPTION
Just a tiny change that makes error handling a little bit easier downstream.