### PR TITLE
Fix spurious panic on receipt of a block while awaiting funding

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4755,6 +4755,9 @@ impl<Signer: Sign> Channel<Signer> {
 	}
 
 	fn check_get_channel_ready(&mut self, height: u32) -> Option<msgs::ChannelReady> {
+		// Called:
+		//  * always when a new block/transactions are confirmed with the new height
+		//  * when funding is signed with a height of 0
 		if self.funding_tx_confirmation_height == 0 && self.minimum_depth != Some(0) {
 			return None;
 		}
@@ -4780,7 +4783,7 @@ impl<Signer: Sign> Channel<Signer> {
 			// We got a reorg but not enough to trigger a force close, just ignore.
 			false
 		} else {
-			if self.channel_state < ChannelState::ChannelFunded as u32 {
+			if self.funding_tx_confirmation_height != 0 && self.channel_state < ChannelState::ChannelFunded as u32 {
 				// We should never see a funding transaction on-chain until we've received
 				// funding_signed (if we're an outbound channel), or seen funding_generated (if we're
 				// an inbound channel - before that we have no known funding TXID). The fuzzer,


### PR DESCRIPTION
When we receive a block we always test if we should send our channel_ready via `check_get_channel_ready`. If the channel in question requires confirmations, we quickly return if the funding transaction has not yet confirmed (or even been defined), however for 0conf channels the checks are necessarily more involved.

In any case, we wish to panic if the funding transaction has confirmations prior to when it should have been broadcasted. This is useful as it is easy for users to violate our broadcast-time invariants without noticing and the panic gives us an opportunity to catch it.

Sadly, in the case of 0conf channels, if we hadn't yet seen the funding transaction at all but receive a block we would hit this sanity check as we don't check whether there are actually funding transaction confirmations prior to panicing.