### PR TITLE
Correct `get_claimable_balance` version info

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1630,7 +1630,7 @@ impl<Signer: Sign> ChannelMonitor<Signer> {
 	/// confirmations on the claim transaction.
 	///
 	/// Note that for `ChannelMonitors` which track a channel which went on-chain with versions of
-	/// LDK prior to 0.0.108, balances may not be fully captured if our counterparty broadcasted
+	/// LDK prior to 0.0.111, balances may not be fully captured if our counterparty broadcasted
 	/// a revoked state.
 	///
 	/// See [`Balance`] for additional details on the types of claimable balances which


### PR DESCRIPTION
5a8ede09fb3c8bbcd8694d94c12dac9ea7485537 updated the documentation on `get_claimable_balance` to note that if a channel went on-chain with an LDK version older than 0.0.108 some
counterparty-revoked-output claimable balances my be missing. However, this failed to account for the fact that we rely on the entirely-new-in-0.0.111
`confirmed_commitment_tx_counterparty_output` field for some balances as well.

Thus, the comment should have been in terms of 0.0.111, not 0.0.108.