### PR TITLE
Fix encryption of broadcasted gossip messages

### DIFF
--- a/fuzz/src/peer_crypt.rs
+++ b/fuzz/src/peer_crypt.rs
@@ -74,7 +74,7 @@ pub fn do_test(data: &[u8]) {
 	};
 	loop {
 		if get_slice!(1)[0] == 0 {
-			crypter.encrypt_message(get_slice!(slice_to_be16(get_slice!(2))));
+			crypter.encrypt_buffer(get_slice!(slice_to_be16(get_slice!(2))));
 		} else {
 			let len = match crypter.decrypt_length_header(get_slice!(16+2)) {
 				Ok(len) => len,

--- a/lightning/src/util/chacha20poly1305rfc.rs
+++ b/lightning/src/util/chacha20poly1305rfc.rs
@@ -74,6 +74,11 @@ mod real_chachapoly {
 			self.mac.raw_result(out_tag);
 		}
 
+		pub fn encrypt_full_message_in_place(&mut self, input_output: &mut [u8], out_tag: &mut [u8]) {
+			self.encrypt_in_place(input_output);
+			self.finish_and_get_tag(out_tag);
+		}
+
 		// Encrypt `input_output` in-place. To finish and calculate the tag, use `finish_and_get_tag`
 		// below.
 		pub(super) fn encrypt_in_place(&mut self, input_output: &mut [u8]) {
@@ -282,6 +287,11 @@ mod fuzzy_chachapoly {
 			output.copy_from_slice(&input);
 			out_tag.copy_from_slice(&self.tag);
 			self.finished = true;
+		}
+
+		pub fn encrypt_full_message_in_place(&mut self, input_output: &mut [u8], out_tag: &mut [u8]) {
+			self.encrypt_in_place(input_output);
+			self.finish_and_get_tag(out_tag);
 		}
 
 		pub(super) fn encrypt_in_place(&mut self, _input_output: &mut [u8]) {


### PR DESCRIPTION
In https://github.com/lightningdevkit/rust-lightning/commit/47e818f198abafba01b9ad278582886f9007dac2, forwarding broadcasted
gossip messages was split into a separate per-peer message buffer.
However, both it and the original regular-message queue are
encrypted immediately when the messages are enqueued. Because the
lightning P2P encryption algorithm is order-dependent, this causes
messages to fail their MAC checks as the messages from the two
queues may not be sent to peers in the order in which they were
encrypted.

The fix is to simply queue broadcast gossip messages unencrypted,
encrypting them when we add them to the regular outbound buffer.

We also take this opportunity to optimize non-gossip message sending by avoiding allocating two buffers.