### PR TITLE
Track lowest inbound channel fees per channel direction

### DIFF
--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -813,8 +813,8 @@ impl Readable for ChannelInfo {
 		let mut two_to_one_wrap: Option<ChannelUpdateInfoDeserWrapper> = None;
 		init_tlv_field_var!(capacity_sats, required);
 		init_tlv_field_var!(announcement_message, required);
-		init_tlv_field_var!(lowest_inbound_channel_fees_to_one, option);
-		init_tlv_field_var!(lowest_inbound_channel_fees_to_two, option);
+		let mut lowest_inbound_channel_fees_to_one = None;
+		let mut lowest_inbound_channel_fees_to_two = None;
 		read_tlv_fields!(reader, {
 			(0, features, required),
 			(1, announcement_received_time, (default_value, 0)),

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -483,6 +483,16 @@ impl<'a> CandidateRouteHop<'a> {
 			CandidateRouteHop::PrivateHop { .. } => EffectiveCapacity::Infinite,
 		}
 	}
+
+	fn lowest_inbound_channel_fees(&self) -> Option<RoutingFees> {
+		match self {
+			CandidateRouteHop::FirstHop { .. } => Some(RoutingFees {
+				base_msat: 0, proportional_millionths: 0,
+			}),
+			CandidateRouteHop::PublicHop { info, .. } => info.lowest_inbound_channel_fees(),
+			CandidateRouteHop::PrivateHop { .. } => None,
+		}
+	}
 }
 
 #[inline]
@@ -1070,7 +1080,7 @@ where L::Target: Logger {
 							// as a way to reach the $dest_node_id.
 							let mut fee_base_msat = 0;
 							let mut fee_proportional_millionths = 0;
-							if let Some(Some(fees)) = network_nodes.get(&$src_node_id).map(|node| node.lowest_inbound_channel_fees) {
+							if let Some(fees) = $candidate.lowest_inbound_channel_fees() {
 								fee_base_msat = fees.base_msat;
 								fee_proportional_millionths = fees.proportional_millionths;
 							}


### PR DESCRIPTION
This allows to avoid iterating through the nodes data to see what would be the cost to reach a given node while routing.

Closes #1686.