### PR TITLE
Support onion message pathfinding

### DIFF
--- a/lightning/src/routing/mod.rs
+++ b/lightning/src/routing/mod.rs
@@ -11,6 +11,9 @@
 
 pub mod utxo;
 pub mod gossip;
+#[allow(unused)]
+// Keep this module private until scoring is added.
+mod onion_message;
 pub mod router;
 pub mod scoring;
 #[cfg(test)]

--- a/lightning/src/routing/onion_message.rs
+++ b/lightning/src/routing/onion_message.rs
@@ -1,0 +1,188 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! [Onion message] pathfinding lives here.
+//!
+//! Finding paths for onion messages is necessary for retrieving invoices and fulfilling invoice
+//! requests from [offers]. It differs from payment pathfinding in that channel liquidity, fees, and
+//! knobs such as `htlc_maximum_msat` do not factor into path selection -- onion messages require a
+//! peer connection and nothing more. However, we still use the network graph because onion messages
+//! between channel peers are likely to be prioritized over those between non-channel peers.
+//!
+//! [Onion message]: crate::onion_message
+//! [offers]: <https://github.com/lightning/bolts/pull/798>
+
+use bitcoin::secp256k1::{self, PublicKey};
+
+use crate::ln::channelmanager::ChannelDetails;
+use crate::routing::gossip::{NetworkGraph, NodeId};
+use crate::util::logger::Logger;
+
+use alloc::collections::BinaryHeap;
+use core::cmp;
+use core::fmt;
+use core::ops::Deref;
+use crate::prelude::*;
+
+/// Finds a route from us to the given `destination` node.
+/// If we have private channels, it may be useful to fill in `first_hops` with the results from
+/// [`ChannelManager::list_usable_channels`]. If `first_hops` is not filled in, connected peers
+/// without public channels will not be forwarded over.
+///
+/// [`ChannelManager::list_usable_channels`]: crate::ln::channelmanager::ChannelManager::list_usable_channels
+pub fn find_path<L: Deref, GL: Deref>(
+	our_node_pubkey: &PublicKey, destination: &PublicKey, network_graph: &NetworkGraph<GL>, first_hops: Option<&[&ChannelDetails]>, logger: L
+) -> Result<Vec<PublicKey>, Error> where L::Target: Logger, GL::Target: Logger
+{
+	log_trace!(logger, "Searching for an onion message path from origin {} to destination {} and {} first hops {}overriding the network graph",
+		our_node_pubkey, destination, first_hops.map(|hops| hops.len()).unwrap_or(0),
+		if first_hops.is_some() { "" } else { "not " });
+	let graph_lock = network_graph.read_only();
+	let network_channels = graph_lock.channels();
+	let network_nodes = graph_lock.nodes();
+	let our_node_id = NodeId::from_pubkey(our_node_pubkey);
+	let dest_node_id = NodeId::from_pubkey(destination);
+
+	// Add our start and first-hops to `frontier`, which is the set of hops that we'll next explore.
+	let start = NodeId::from_pubkey(&our_node_pubkey);
+	let mut frontier = BinaryHeap::new();
+	frontier.push(PathBuildingHop { cost: 0, node_id: start, parent_node_id: start });
+	if let Some(first_hops) = first_hops {
+		for hop in first_hops {
+			if !hop.counterparty.features.supports_onion_messages() { continue; }
+			let node_id = NodeId::from_pubkey(&hop.counterparty.node_id);
+			frontier.push(PathBuildingHop { cost: 1, node_id, parent_node_id: start });
+		}
+	}
+
+	let mut visited = HashMap::new();
+	while let Some(PathBuildingHop { cost, node_id, parent_node_id }) = frontier.pop() {
+		match visited.entry(node_id) {
+			hash_map::Entry::Occupied(_) => continue,
+			hash_map::Entry::Vacant(e) => e.insert(parent_node_id),
+		};
+		if node_id == dest_node_id {
+			let path = reverse_path(visited, our_node_id, dest_node_id)?;
+			log_info!(logger, "Got route to {:?}: {:?}", destination, path);
+			return Ok(path)
+		}
+		if let Some(node_info) = network_nodes.get(&node_id) {
+			for scid in &node_info.channels {
+				if let Some(chan_info) = network_channels.get(&scid) {
+					if let Some((_, successor)) = chan_info.as_directed_from(&node_id) {
+						// We may push a given successor multiple times, but the heap should sort its best entry
+						// to the top. We do this because there is no way to adjust the priority of an existing
+						// entry in `BinaryHeap`.
+						frontier.push(PathBuildingHop {
+							cost: cost + 1,
+							node_id: *successor,
+							parent_node_id: node_id,
+						});
+					}
+				}
+			}
+		}
+	}
+
+	Err(Error::PathNotFound)
+}
+
+#[derive(Debug, PartialEq)]
+/// Errors that might occur running [`find_path`].
+pub enum Error {
+	/// We failed to find a path to the destination.
+	PathNotFound,
+	/// We failed to convert this node id into a [`PublicKey`].
+	InvalidNodeId(secp256k1::Error),
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			Error::PathNotFound => write!(f, "Failed to find a path to the destination"),
+			Error::InvalidNodeId(e) =>
+				write!(f, "Failed to convert a node id into a PublicKey with error: {}", e),
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+#[derive(Eq, PartialEq)]
+struct PathBuildingHop {
+	cost: u64,
+	node_id: NodeId,
+	parent_node_id: NodeId,
+}
+
+impl PartialOrd for PathBuildingHop {
+	fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+		// We need a min-heap, whereas `BinaryHeap`s are a max-heap, so compare the costs in reverse.
+		other.cost.partial_cmp(&self.cost)
+	}
+}
+
+impl Ord for PathBuildingHop {
+	fn cmp(&self, other: &Self) -> cmp::Ordering {
+		self.partial_cmp(other).unwrap()
+	}
+}
+
+fn reverse_path(
+	parents: HashMap<NodeId, NodeId>, our_node_id: NodeId, destination: NodeId
+)-> Result<Vec<PublicKey>, Error>
+{
+	let mut path = Vec::new();
+	let mut curr = destination;
+	loop {
+		match PublicKey::from_slice(curr.as_slice()) {
+			Ok(pk) => path.push(pk),
+			Err(e) => return Err(Error::InvalidNodeId(e))
+		}
+		match parents.get(&curr) {
+			None => return Err(Error::PathNotFound),
+			Some(parent) => {
+				if *parent == our_node_id { break; }
+				curr = *parent;
+			}
+		}
+	}
+
+	path.reverse();
+	Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::routing::test_utils;
+
+	use crate::sync::Arc;
+
+	#[test]
+	fn three_hops() {
+		let (secp_ctx, network_graph, _, _, logger) = test_utils::build_graph();
+		let (_, our_id, _, node_pks) = test_utils::get_nodes(&secp_ctx);
+
+		let mut path = super::find_path(&our_id, &node_pks[5], &network_graph, None, Arc::clone(&logger)).unwrap();
+		assert_eq!(path.len(), 3);
+		assert!(path[0] == node_pks[1] || path[0] == node_pks[7] || path[0] == node_pks[0]);
+		path.remove(0);
+		assert_eq!(path, vec![node_pks[2], node_pks[5]]);
+	}
+
+	#[test]
+	fn long_path() {
+		let (secp_ctx, network_graph, _, _, logger) = test_utils::build_line_graph();
+		let (_, our_id, _, node_pks) = test_utils::get_nodes(&secp_ctx);
+
+		let path = super::find_path(&our_id, &node_pks[18], &network_graph, None, Arc::clone(&logger)).unwrap();
+		assert_eq!(path.len(), 19);
+	}
+}

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -5291,7 +5291,8 @@ mod tests {
 
 	#[test]
 	fn limits_path_length() {
-		let (secp_ctx, network, _, _, logger) = build_line_graph();
+		let features = NodeFeatures::from_le_bytes(id_to_feature_flags(1));
+		let (secp_ctx, network, _, _, logger) = build_line_graph_with_features(features);
 		let (_, our_id, _, nodes) = get_nodes(&secp_ctx);
 		let network_graph = network.read_only();
 
@@ -5569,7 +5570,8 @@ mod tests {
 
 	#[test]
 	fn honors_manual_penalties() {
-		let (secp_ctx, network_graph, _, _, logger) = build_line_graph();
+		let features = NodeFeatures::from_le_bytes(id_to_feature_flags(1));
+		let (secp_ctx, network_graph, _, _, logger) = build_line_graph_with_features(features);
 		let (_, our_id, _, nodes) = get_nodes(&secp_ctx);
 
 		let keys_manager = ln_test_utils::TestKeysInterface::new(&[0u8; 32], Network::Testnet);

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -2147,8 +2147,7 @@ mod tests {
 		PaymentParameters, Route, RouteHint, RouteHintHop, RouteHop, RoutingFees,
 		DEFAULT_MAX_TOTAL_CLTV_EXPIRY_DELTA, MAX_PATH_LENGTH_ESTIMATE};
 	use crate::routing::scoring::{ChannelUsage, FixedPenaltyScorer, Score, ProbabilisticScorer, ProbabilisticScoringParameters};
-	use crate::routing::test_utils::{add_channel, add_or_update_node, build_graph, build_line_graph, id_to_feature_flags, get_nodes, update_channel};
-	use crate::chain::transaction::OutPoint;
+	use crate::routing::test_utils::*;
 	use crate::chain::keysinterface::EntropySource;
 	use crate::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 	use crate::ln::msgs::{ErrorAction, LightningError, UnsignedChannelUpdate, MAX_VALUE_MSAT};
@@ -2159,7 +2158,6 @@ mod tests {
 	#[cfg(c_bindings)]
 	use crate::util::ser::{Writeable, Writer};
 
-	use bitcoin::hashes::Hash;
 	use bitcoin::network::constants::Network;
 	use bitcoin::blockdata::constants::genesis_block;
 	use bitcoin::blockdata::script::Builder;
@@ -2175,41 +2173,6 @@ mod tests {
 	use crate::sync::Arc;
 
 	use core::convert::TryInto;
-
-	fn get_channel_details(short_channel_id: Option<u64>, node_id: PublicKey,
-			features: InitFeatures, outbound_capacity_msat: u64) -> channelmanager::ChannelDetails {
-		channelmanager::ChannelDetails {
-			channel_id: [0; 32],
-			counterparty: channelmanager::ChannelCounterparty {
-				features,
-				node_id,
-				unspendable_punishment_reserve: 0,
-				forwarding_info: None,
-				outbound_htlc_minimum_msat: None,
-				outbound_htlc_maximum_msat: None,
-			},
-			funding_txo: Some(OutPoint { txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(), index: 0 }),
-			channel_type: None,
-			short_channel_id,
-			outbound_scid_alias: None,
-			inbound_scid_alias: None,
-			channel_value_satoshis: 0,
-			user_channel_id: 0,
-			balance_msat: 0,
-			outbound_capacity_msat,
-			next_outbound_htlc_limit_msat: outbound_capacity_msat,
-			inbound_capacity_msat: 42,
-			unspendable_punishment_reserve: None,
-			confirmations_required: None,
-			confirmations: None,
-			force_close_spend_delay: None,
-			is_outbound: true, is_channel_ready: true,
-			is_usable: true, is_public: true,
-			inbound_htlc_minimum_msat: None,
-			inbound_htlc_maximum_msat: None,
-			config: None,
-		}
-	}
 
 	#[test]
 	fn simple_route_test() {

--- a/lightning/src/routing/test_utils.rs
+++ b/lightning/src/routing/test_utils.rs
@@ -170,7 +170,7 @@ pub(super) fn id_to_feature_flags(id: u8) -> Vec<u8> {
 	}
 }
 
-pub(super) fn build_line_graph() -> (
+pub(super) fn build_line_graph_with_features(node_features: NodeFeatures) -> (
 	Secp256k1<All>, sync::Arc<NetworkGraph<Arc<test_utils::TestLogger>>>,
 	P2PGossipSync<sync::Arc<NetworkGraph<Arc<test_utils::TestLogger>>>, sync::Arc<test_utils::TestChainSource>, sync::Arc<test_utils::TestLogger>>,
 	sync::Arc<test_utils::TestChainSource>, sync::Arc<test_utils::TestLogger>,
@@ -215,13 +215,33 @@ pub(super) fn build_line_graph() -> (
 				excess_data: Vec::new()
 			});
 			add_or_update_node(&gossip_sync, &secp_ctx, &next_privkey,
-				NodeFeatures::from_le_bytes(id_to_feature_flags(1)), 0);
+				node_features.clone(), 0);
 		}
 
 	(secp_ctx, network_graph, gossip_sync, chain_monitor, logger)
 }
 
 pub(super) fn build_graph() -> (
+	Secp256k1<All>,
+	sync::Arc<NetworkGraph<Arc<test_utils::TestLogger>>>,
+	P2PGossipSync<sync::Arc<NetworkGraph<Arc<test_utils::TestLogger>>>, sync::Arc<test_utils::TestChainSource>, sync::Arc<test_utils::TestLogger>>,
+	sync::Arc<test_utils::TestChainSource>,
+	sync::Arc<test_utils::TestLogger>,
+) {
+	build_graph_inner(None)
+}
+
+pub(super) fn build_graph_with_features(features: NodeFeatures) -> (
+	Secp256k1<All>,
+	sync::Arc<NetworkGraph<Arc<test_utils::TestLogger>>>,
+	P2PGossipSync<sync::Arc<NetworkGraph<Arc<test_utils::TestLogger>>>, sync::Arc<test_utils::TestChainSource>, sync::Arc<test_utils::TestLogger>>,
+	sync::Arc<test_utils::TestChainSource>,
+	sync::Arc<test_utils::TestLogger>,
+) {
+	build_graph_inner(Some(features))
+}
+
+fn build_graph_inner(features: Option<NodeFeatures>) -> (
 	Secp256k1<All>,
 	sync::Arc<NetworkGraph<Arc<test_utils::TestLogger>>>,
 	P2PGossipSync<sync::Arc<NetworkGraph<Arc<test_utils::TestLogger>>>, sync::Arc<test_utils::TestChainSource>, sync::Arc<test_utils::TestLogger>>,
@@ -308,7 +328,7 @@ pub(super) fn build_graph() -> (
 		excess_data: Vec::new()
 	});
 
-	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[0], NodeFeatures::from_le_bytes(id_to_feature_flags(1)), 0);
+	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[0], features.clone().unwrap_or_else(|| NodeFeatures::from_le_bytes(id_to_feature_flags(1))), 0);
 
 	add_channel(&gossip_sync, &secp_ctx, &our_privkey, &privkeys[1], ChannelFeatures::from_le_bytes(id_to_feature_flags(2)), 2);
 	update_channel(&gossip_sync, &secp_ctx, &our_privkey, UnsignedChannelUpdate {
@@ -336,7 +356,7 @@ pub(super) fn build_graph() -> (
 		excess_data: Vec::new()
 	});
 
-	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[1], NodeFeatures::from_le_bytes(id_to_feature_flags(2)), 0);
+	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[1], features.clone().unwrap_or_else(|| NodeFeatures::from_le_bytes(id_to_feature_flags(2))), 0);
 
 	add_channel(&gossip_sync, &secp_ctx, &our_privkey, &privkeys[7], ChannelFeatures::from_le_bytes(id_to_feature_flags(12)), 12);
 	update_channel(&gossip_sync, &secp_ctx, &our_privkey, UnsignedChannelUpdate {
@@ -364,7 +384,7 @@ pub(super) fn build_graph() -> (
 		excess_data: Vec::new()
 	});
 
-	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[7], NodeFeatures::from_le_bytes(id_to_feature_flags(8)), 0);
+	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[7], features.clone().unwrap_or_else(|| NodeFeatures::from_le_bytes(id_to_feature_flags(8))), 0);
 
 	add_channel(&gossip_sync, &secp_ctx, &privkeys[0], &privkeys[2], ChannelFeatures::from_le_bytes(id_to_feature_flags(3)), 3);
 	update_channel(&gossip_sync, &secp_ctx, &privkeys[0], UnsignedChannelUpdate {
@@ -444,7 +464,7 @@ pub(super) fn build_graph() -> (
 		excess_data: Vec::new()
 	});
 
-	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[2], NodeFeatures::from_le_bytes(id_to_feature_flags(3)), 0);
+	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[2], features.clone().unwrap_or_else(|| NodeFeatures::from_le_bytes(id_to_feature_flags(3))), 0);
 
 	add_channel(&gossip_sync, &secp_ctx, &privkeys[2], &privkeys[4], ChannelFeatures::from_le_bytes(id_to_feature_flags(6)), 6);
 	update_channel(&gossip_sync, &secp_ctx, &privkeys[2], UnsignedChannelUpdate {
@@ -498,9 +518,9 @@ pub(super) fn build_graph() -> (
 		excess_data: Vec::new()
 	});
 
-	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[4], NodeFeatures::from_le_bytes(id_to_feature_flags(5)), 0);
+	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[4], features.clone().unwrap_or_else(|| NodeFeatures::from_le_bytes(id_to_feature_flags(5))), 0);
 
-	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[3], NodeFeatures::from_le_bytes(id_to_feature_flags(4)), 0);
+	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[3], features.clone().unwrap_or_else(|| NodeFeatures::from_le_bytes(id_to_feature_flags(4))), 0);
 
 	add_channel(&gossip_sync, &secp_ctx, &privkeys[2], &privkeys[5], ChannelFeatures::from_le_bytes(id_to_feature_flags(7)), 7);
 	update_channel(&gossip_sync, &secp_ctx, &privkeys[2], UnsignedChannelUpdate {
@@ -528,7 +548,7 @@ pub(super) fn build_graph() -> (
 		excess_data: Vec::new()
 	});
 
-	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[5], NodeFeatures::from_le_bytes(id_to_feature_flags(6)), 0);
+	add_or_update_node(&gossip_sync, &secp_ctx, &privkeys[5], features.clone().unwrap_or_else(|| NodeFeatures::from_le_bytes(id_to_feature_flags(6))), 0);
 
 	(secp_ctx, network_graph, gossip_sync, chain_monitor, logger)
 }

--- a/lightning/src/routing/test_utils.rs
+++ b/lightning/src/routing/test_utils.rs
@@ -7,8 +7,10 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
+use crate::chain::transaction::OutPoint;
 use crate::routing::gossip::{NetworkGraph, P2PGossipSync};
-use crate::ln::features::{ChannelFeatures, NodeFeatures};
+use crate::ln::channelmanager::{ChannelCounterparty, ChannelDetails};
+use crate::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 use crate::ln::msgs::{UnsignedChannelAnnouncement, ChannelAnnouncement, RoutingMessageHandler,
 	NodeAnnouncement, UnsignedNodeAnnouncement, ChannelUpdate, UnsignedChannelUpdate, MAX_VALUE_MSAT};
 use crate::util::test_utils;
@@ -28,6 +30,41 @@ use crate::prelude::*;
 use crate::sync::{self, Arc};
 
 use crate::routing::gossip::NodeId;
+
+pub(super) fn get_channel_details(short_channel_id: Option<u64>, node_id: PublicKey,
+	features: InitFeatures, outbound_capacity_msat: u64) -> ChannelDetails {
+	ChannelDetails {
+		channel_id: [0; 32],
+		counterparty: ChannelCounterparty {
+			features,
+			node_id,
+			unspendable_punishment_reserve: 0,
+			forwarding_info: None,
+			outbound_htlc_minimum_msat: None,
+			outbound_htlc_maximum_msat: None,
+		},
+		funding_txo: Some(OutPoint { txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(), index: 0 }),
+		channel_type: None,
+		short_channel_id,
+		outbound_scid_alias: None,
+		inbound_scid_alias: None,
+		channel_value_satoshis: 0,
+		user_channel_id: 0,
+		balance_msat: 0,
+		outbound_capacity_msat,
+		next_outbound_htlc_limit_msat: outbound_capacity_msat,
+		inbound_capacity_msat: 42,
+		unspendable_punishment_reserve: None,
+		confirmations_required: None,
+		confirmations: None,
+		force_close_spend_delay: None,
+		is_outbound: true, is_channel_ready: true,
+		is_usable: true, is_public: true,
+		inbound_htlc_minimum_msat: None,
+		inbound_htlc_maximum_msat: None,
+		config: None,
+	}
+}
 
 // Using the same keys for LN and BTC ids
 pub(super) fn add_channel(


### PR DESCRIPTION
Take 2, Github wouldn't let me reopen #1669 🤔 

We could reuse router::get_route, but it's better to start from scratch
because get_route includes a lot of payment-specific computations that impact
performance.

- [x] check for OM feature bit
- [x] finish tests

Partially addresses https://github.com/lightningdevkit/rust-lightning/issues/1607

~Based on #1731~ 

Known followups:
* scoring
* benchmarking (will need to update the netgraph file to support the OM feature bit)