### PR TITLE
Stop building with lockorder debugging in benchmarks

### DIFF
--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -173,18 +173,18 @@ mod prelude {
 	pub use alloc::string::ToString;
 }
 
-#[cfg(all(feature = "std", test))]
+#[cfg(all(not(feature = "_bench_unstable"), feature = "std", test))]
 mod debug_sync;
-#[cfg(all(feature = "backtrace", feature = "std", test))]
+#[cfg(all(not(feature = "_bench_unstable"), feature = "backtrace", feature = "std", test))]
 extern crate backtrace;
 
 #[cfg(feature = "std")]
 mod sync {
-	#[cfg(test)]
+	#[cfg(all(not(feature = "_bench_unstable"), test))]
 	pub use debug_sync::*;
-	#[cfg(not(test))]
+	#[cfg(any(feature = "_bench_unstable", not(test)))]
 	pub use ::std::sync::{Arc, Mutex, Condvar, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
-	#[cfg(not(test))]
+	#[cfg(any(feature = "_bench_unstable", not(test)))]
 	pub use crate::util::fairrwlock::FairRwLock;
 }
 

--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -26,7 +26,7 @@ pub mod wakers;
 pub(crate) mod atomic_counter;
 pub(crate) mod byte_utils;
 pub(crate) mod chacha20;
-#[cfg(all(not(test), feature = "std"))]
+#[cfg(all(any(feature = "_bench_unstable", not(test)), feature = "std"))]
 pub(crate) mod fairrwlock;
 #[cfg(fuzzing)]
 pub mod zbase32;


### PR DESCRIPTION
`cargo bench` sets `#[cfg(test)]` so our current checks for enabling our lockorder debugging end up matching when we're trying to build performance benchmarks.

This adds explicit checks to our debug_lockorder logic to filter out `feature = "_bench_unstable"` builds.