### PR TITLE
Downgrade `hashbrown` to meet MSRV

### DIFF
--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ lightning = { version = "0.0.111", path = "../lightning", default-features = fal
 secp256k1 = { version = "0.24.0", default-features = false, features = ["recovery", "alloc"] }
 num-traits = { version = "0.2.8", default-features = false }
 bitcoin_hashes = { version = "0.11", default-features = false }
-hashbrown = { version = "0.11", optional = true }
+hashbrown = { version = "0.8", optional = true }
 serde = { version = "1.0.118", optional = true }
 
 [dev-dependencies]

--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -149,6 +149,7 @@ use lightning::routing::router::{PaymentParameters, Route, RouteHop, RouteParame
 use lightning::util::errors::APIError;
 use lightning::util::events::{Event, EventHandler};
 use lightning::util::logger::Logger;
+use lightning::util::ser::Writeable;
 use time_utils::Time;
 use crate::sync::Mutex;
 
@@ -746,7 +747,7 @@ impl InFlightHtlcs {
 	}
 }
 
-impl lightning::util::ser::Writeable for InFlightHtlcs {
+impl Writeable for InFlightHtlcs {
 	fn write<W: lightning::util::ser::Writer>(&self, writer: &mut W) -> Result<(), io::Error> { self.0.write(writer) }
 }
 

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -40,7 +40,7 @@ default = ["std", "grind_signatures"]
 [dependencies]
 bitcoin = { version = "0.29.0", default-features = false, features = ["secp-recovery"] }
 
-hashbrown = { version = "0.11", optional = true }
+hashbrown = { version = "0.8", optional = true }
 hex = { version = "0.4", optional = true }
 regex = { version = "1.5.6", optional = true }
 backtrace = { version = "0.3", optional = true }


### PR DESCRIPTION
`hashbrown` depends on `ahash` which depends on `once_cell`. Sadly, in https://github.com/matklad/once_cell/issues/201 the `once_cell` maintainer decided they didn't want to do the work of having an MSRV policy for `once_cell`, making `ahash`, and thus `hashbrown` require the latest compiler. I've reached out to `ahash` to suggest they drop the dependency (as they could trivially work around not having it), but until then we simply downgrade `hashbrown`.

`rust-bitcoin` also requires an older `hashbrown` so we're actually reducing our total `no-std` code here anyway.