### PR TITLE
BOLT 12 `invoice_request` encoding and building

### DIFF
--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -158,6 +158,7 @@ mod sealed {
 		BasicMPP,
 	]);
 	define_context!(OfferContext, []);
+	define_context!(InvoiceRequestContext, []);
 	// This isn't a "real" feature context, and is only used in the channel_type field in an
 	// `OpenChannel` message.
 	define_context!(ChannelTypeContext, [
@@ -367,7 +368,8 @@ mod sealed {
 		supports_keysend, requires_keysend);
 
 	#[cfg(test)]
-	define_feature!(123456789, UnknownFeature, [NodeContext, ChannelContext, InvoiceContext, OfferContext],
+	define_feature!(123456789, UnknownFeature,
+		[NodeContext, ChannelContext, InvoiceContext, OfferContext, InvoiceRequestContext],
 		"Feature flags for an unknown feature used in testing.", set_unknown_feature_optional,
 		set_unknown_feature_required, supports_unknown_test_feature, requires_unknown_test_feature);
 }
@@ -426,8 +428,10 @@ pub type NodeFeatures = Features<sealed::NodeContext>;
 pub type ChannelFeatures = Features<sealed::ChannelContext>;
 /// Features used within an invoice.
 pub type InvoiceFeatures = Features<sealed::InvoiceContext>;
-/// Features used within an offer.
+/// Features used within an `offer`.
 pub type OfferFeatures = Features<sealed::OfferContext>;
+/// Features used within an `invoice_request`.
+pub type InvoiceRequestFeatures = Features<sealed::InvoiceRequestContext>;
 
 /// Features used within the channel_type field in an OpenChannel message.
 ///
@@ -735,6 +739,7 @@ macro_rules! impl_feature_tlv_write {
 
 impl_feature_tlv_write!(ChannelTypeFeatures);
 impl_feature_tlv_write!(OfferFeatures);
+impl_feature_tlv_write!(InvoiceRequestFeatures);
 
 #[cfg(test)]
 mod tests {

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1,0 +1,101 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Data structures and encoding for `invoice_request` messages.
+
+use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::schnorr::Signature;
+use crate::ln::features::InvoiceRequestFeatures;
+use crate::offers::offer::OfferContents;
+use crate::offers::payer::PayerContents;
+use crate::util::string::PrintableString;
+
+use crate::prelude::*;
+
+/// An `InvoiceRequest` is a request for an `Invoice` formulated from an [`Offer`].
+///
+/// An offer may provide choices such as quantity, amount, chain, features, etc. An invoice request
+/// specifies these such that its recipient can send an invoice for payment.
+///
+/// [`Offer`]: crate::offers::offer::Offer
+#[derive(Clone, Debug)]
+pub struct InvoiceRequest {
+	bytes: Vec<u8>,
+	contents: InvoiceRequestContents,
+	signature: Option<Signature>,
+}
+
+/// The contents of an [`InvoiceRequest`], which may be shared with an `Invoice`.
+#[derive(Clone, Debug)]
+pub(crate) struct InvoiceRequestContents {
+	payer: PayerContents,
+	offer: OfferContents,
+	chain: Option<ChainHash>,
+	amount_msats: Option<u64>,
+	features: InvoiceRequestFeatures,
+	quantity: Option<u64>,
+	payer_id: PublicKey,
+	payer_note: Option<String>,
+}
+
+impl InvoiceRequest {
+	/// An unpredictable series of bytes, typically containing information about the derivation of
+	/// [`payer_id`].
+	///
+	/// [`payer_id`]: Self::payer_id
+	pub fn metadata(&self) -> &[u8] {
+		&self.contents.payer.0[..]
+	}
+
+	/// A chain from [`Offer::chains`] that the offer is valid for.
+	///
+	/// [`Offer::chains`]: crate::offers::offer::Offer::chains
+	pub fn chain(&self) -> ChainHash {
+		self.contents.chain.unwrap_or_else(|| self.contents.offer.implied_chain())
+	}
+
+	/// The amount to pay in msats (i.e., the minimum lightning-payable unit for [`chain`]), which
+	/// must be greater than or equal to [`Offer::amount`], converted if necessary.
+	///
+	/// [`chain`]: Self::chain
+	/// [`Offer::amount`]: crate::offers::offer::Offer::amount
+	pub fn amount_msats(&self) -> Option<u64> {
+		self.contents.amount_msats
+	}
+
+	/// Features for paying the invoice.
+	pub fn features(&self) -> &InvoiceRequestFeatures {
+		&self.contents.features
+	}
+
+	/// The quantity of the offer's item conforming to [`Offer::supported_quantity`].
+	///
+	/// [`Offer::supported_quantity`]: crate::offers::offer::Offer::supported_quantity
+	pub fn quantity(&self) -> Option<u64> {
+		self.contents.quantity
+	}
+
+	/// A possibly transient pubkey used to sign the invoice request.
+	pub fn payer_id(&self) -> PublicKey {
+		self.contents.payer_id
+	}
+
+	/// Payer provided note to include in the invoice.
+	pub fn payer_note(&self) -> Option<PrintableString> {
+		self.contents.payer_note.as_ref().map(|payer_note| PrintableString(payer_note.as_str()))
+	}
+
+	/// Signature of the invoice request using [`payer_id`].
+	///
+	/// [`payer_id`]: Self::payer_id
+	pub fn signature(&self) -> Option<Signature> {
+		self.signature
+	}
+}

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -8,22 +8,207 @@
 // licenses.
 
 //! Data structures and encoding for `invoice_request` messages.
+//!
+//! An [`InvoiceRequest`] can be either built from a parsed [`Offer`] as an "offer to be paid" or
+//! built directly as an "offer for money" (e.g., refund, ATM withdrawal). In the former case, it is
+//! typically constructed by a customer and sent to the merchant who had published the corresponding
+//! offer. In the latter case, an offer doesn't exist as a precursor to the request. Rather the
+//! merchant would typically construct the invoice request and present it to the customer.
+//!
+//! The recipient of the request responds with an `Invoice`.
+//!
+//! ```ignore
+//! extern crate bitcoin;
+//! extern crate lightning;
+//!
+//! use bitcoin::network::constants::Network;
+//! use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, SecretKey};
+//! use core::convert::Infallible;
+//! use lightning::ln::features::OfferFeatures;
+//! use lightning::offers::offer::Offer;
+//! use lightning::util::ser::Writeable;
+//!
+//! # fn parse() -> Result<(), lightning::offers::parse::ParseError> {
+//! let secp_ctx = Secp256k1::new();
+//! let keys = KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32])?);
+//! let pubkey = PublicKey::from(keys);
+//! let mut buffer = Vec::new();
+//!
+//! // "offer to be paid" flow
+//! "lno1qcp4256ypq"
+//!     .parse::<Offer>()?
+//!     .request_invoice(vec![42; 64], pubkey)?
+//!     .chain(Network::Testnet)?
+//!     .amount_msats(1000)?
+//!     .quantity(5)?
+//!     .payer_note("foo".to_string())
+//!     .build()?
+//!     .sign::<_, Infallible>(|digest| Ok(secp_ctx.sign_schnorr_no_aux_rand(digest, &keys)))
+//!     .expect("failed verifying signature")
+//!     .write(&mut buffer)
+//!     .unwrap();
+//! # Ok(())
+//! # }
+//! ```
 
 use bitcoin::blockdata::constants::ChainHash;
-use bitcoin::secp256k1::PublicKey;
+use bitcoin::network::constants::Network;
+use bitcoin::secp256k1::{Message, PublicKey};
 use bitcoin::secp256k1::schnorr::Signature;
 use core::convert::TryFrom;
 use crate::io;
 use crate::ln::features::InvoiceRequestFeatures;
 use crate::ln::msgs::DecodeError;
-use crate::offers::merkle::{SignatureTlvStream, self};
-use crate::offers::offer::{Amount, OfferContents, OfferTlvStream};
+use crate::offers::merkle::{SignError, SignatureTlvStream, SignatureTlvStreamRef, self};
+use crate::offers::offer::{Offer, OfferContents, OfferTlvStream, OfferTlvStreamRef};
 use crate::offers::parse::{ParseError, ParsedMessage, SemanticError};
-use crate::offers::payer::{PayerContents, PayerTlvStream};
+use crate::offers::payer::{PayerContents, PayerTlvStream, PayerTlvStreamRef};
 use crate::util::ser::{HighZeroBytesDroppedBigSize, SeekReadable, WithoutLength, Writeable, Writer};
 use crate::util::string::PrintableString;
 
 use crate::prelude::*;
+
+const SIGNATURE_TAG: &'static str = concat!("lightning", "invoice_request", "signature");
+
+/// Builds an [`InvoiceRequest`] from an [`Offer`] for the "offer to be paid" flow.
+///
+/// See [module-level documentation] for usage.
+///
+/// [module-level documentation]: self
+pub struct InvoiceRequestBuilder<'a> {
+	offer: &'a Offer,
+	invoice_request: InvoiceRequestContents,
+}
+
+impl<'a> InvoiceRequestBuilder<'a> {
+	pub(super) fn new(offer: &'a Offer, metadata: Vec<u8>, payer_id: PublicKey) -> Self {
+		Self {
+			offer,
+			invoice_request: InvoiceRequestContents {
+				payer: PayerContents(metadata), offer: offer.contents.clone(), chain: None,
+				amount_msats: None, features: InvoiceRequestFeatures::empty(), quantity: None,
+				payer_id, payer_note: None,
+			},
+		}
+	}
+
+	/// Sets the [`InvoiceRequest::chain`] of the given [`Network`] for paying an invoice. If not
+	/// called, [`Network::Bitcoin`] is assumed. Errors if the chain for `network` is not supported
+	/// by the offer.
+	///
+	/// Successive calls to this method will override the previous setting.
+	pub fn chain(mut self, network: Network) -> Result<Self, SemanticError> {
+		let chain = ChainHash::using_genesis_block(network);
+		if !self.offer.supports_chain(chain) {
+			return Err(SemanticError::UnsupportedChain);
+		}
+
+		self.invoice_request.chain = Some(chain);
+		Ok(self)
+	}
+
+	/// Sets the [`InvoiceRequest::amount_msats`] for paying an invoice. Errors if `amount_msats` is
+	/// not at least the expected invoice amount (i.e., [`Offer::amount`] times [`quantity`]).
+	///
+	/// Successive calls to this method will override the previous setting.
+	///
+	/// [`quantity`]: Self::quantity
+	pub fn amount_msats(mut self, amount_msats: u64) -> Result<Self, SemanticError> {
+		self.invoice_request.offer.check_amount_msats_for_quantity(
+			Some(amount_msats), self.invoice_request.quantity
+		)?;
+		self.invoice_request.amount_msats = Some(amount_msats);
+		Ok(self)
+	}
+
+	/// Sets [`InvoiceRequest::quantity`] of items. If not set, `1` is assumed. Errors if `quantity`
+	/// does not conform to [`Offer::is_valid_quantity`].
+	///
+	/// Successive calls to this method will override the previous setting.
+	pub fn quantity(mut self, quantity: u64) -> Result<Self, SemanticError> {
+		self.invoice_request.offer.check_quantity(Some(quantity))?;
+		self.invoice_request.quantity = Some(quantity);
+		Ok(self)
+	}
+
+	/// Sets the [`InvoiceRequest::payer_note`].
+	///
+	/// Successive calls to this method will override the previous setting.
+	pub fn payer_note(mut self, payer_note: String) -> Self {
+		self.invoice_request.payer_note = Some(payer_note);
+		self
+	}
+
+	/// Builds an unsigned [`InvoiceRequest`] after checking for valid semantics. It can be signed
+	/// by [`UnsignedInvoiceRequest::sign`].
+	pub fn build(mut self) -> Result<UnsignedInvoiceRequest<'a>, SemanticError> {
+		#[cfg(feature = "std")] {
+			if self.offer.is_expired() {
+				return Err(SemanticError::AlreadyExpired);
+			}
+		}
+
+		let chain = self.invoice_request.chain();
+		if !self.offer.supports_chain(chain) {
+			return Err(SemanticError::UnsupportedChain);
+		}
+
+		if chain == self.offer.implied_chain() {
+			self.invoice_request.chain = None;
+		}
+
+		if self.offer.amount().is_none() && self.invoice_request.amount_msats.is_none() {
+			return Err(SemanticError::MissingAmount);
+		}
+
+		self.invoice_request.offer.check_quantity(self.invoice_request.quantity)?;
+		self.invoice_request.offer.check_amount_msats_for_quantity(
+			self.invoice_request.amount_msats, self.invoice_request.quantity
+		)?;
+
+		let InvoiceRequestBuilder { offer, invoice_request } = self;
+		Ok(UnsignedInvoiceRequest { offer, invoice_request })
+	}
+}
+
+/// A semantically valid [`InvoiceRequest`] that hasn't been signed.
+pub struct UnsignedInvoiceRequest<'a> {
+	offer: &'a Offer,
+	invoice_request: InvoiceRequestContents,
+}
+
+impl<'a> UnsignedInvoiceRequest<'a> {
+	/// Signs the invoice request using the given function.
+	pub fn sign<F, E>(self, sign: F) -> Result<InvoiceRequest, SignError<E>>
+	where
+		F: FnOnce(&Message) -> Result<Signature, E>
+	{
+		// Use the offer bytes instead of the offer TLV stream as the offer may have contained
+		// unknown TLV records, which are not stored in `OfferContents`.
+		let (payer_tlv_stream, _offer_tlv_stream, invoice_request_tlv_stream) =
+			self.invoice_request.as_tlv_stream();
+		let offer_bytes = WithoutLength(&self.offer.bytes);
+		let unsigned_tlv_stream = (payer_tlv_stream, offer_bytes, invoice_request_tlv_stream);
+
+		let mut bytes = Vec::new();
+		unsigned_tlv_stream.write(&mut bytes).unwrap();
+
+		let pubkey = self.invoice_request.payer_id;
+		let signature = Some(merkle::sign_message(sign, SIGNATURE_TAG, &bytes, pubkey)?);
+
+		// Append the signature TLV record to the bytes.
+		let signature_tlv_stream = SignatureTlvStreamRef {
+			signature: signature.as_ref(),
+		};
+		signature_tlv_stream.write(&mut bytes).unwrap();
+
+		Ok(InvoiceRequest {
+			bytes,
+			contents: self.invoice_request,
+			signature,
+		})
+	}
+}
 
 /// An `InvoiceRequest` is a request for an `Invoice` formulated from an [`Offer`].
 ///
@@ -61,17 +246,14 @@ impl InvoiceRequest {
 	}
 
 	/// A chain from [`Offer::chains`] that the offer is valid for.
-	///
-	/// [`Offer::chains`]: crate::offers::offer::Offer::chains
 	pub fn chain(&self) -> ChainHash {
-		self.contents.chain.unwrap_or_else(|| self.contents.offer.implied_chain())
+		self.contents.chain()
 	}
 
 	/// The amount to pay in msats (i.e., the minimum lightning-payable unit for [`chain`]), which
 	/// must be greater than or equal to [`Offer::amount`], converted if necessary.
 	///
 	/// [`chain`]: Self::chain
-	/// [`Offer::amount`]: crate::offers::offer::Offer::amount
 	pub fn amount_msats(&self) -> Option<u64> {
 		self.contents.amount_msats
 	}
@@ -82,8 +264,6 @@ impl InvoiceRequest {
 	}
 
 	/// The quantity of the offer's item conforming to [`Offer::is_valid_quantity`].
-	///
-	/// [`Offer::is_valid_quantity`]: crate::offers::offer::Offer::is_valid_quantity
 	pub fn quantity(&self) -> Option<u64> {
 		self.contents.quantity
 	}
@@ -93,7 +273,8 @@ impl InvoiceRequest {
 		self.contents.payer_id
 	}
 
-	/// Payer provided note to include in the invoice.
+	/// A payer-provided note which will be seen by the recipient and reflected back in the invoice
+	/// response.
 	pub fn payer_note(&self) -> Option<PrintableString> {
 		self.contents.payer_note.as_ref().map(|payer_note| PrintableString(payer_note.as_str()))
 	}
@@ -106,9 +287,45 @@ impl InvoiceRequest {
 	}
 }
 
+impl InvoiceRequestContents {
+	fn chain(&self) -> ChainHash {
+		self.chain.unwrap_or_else(|| self.offer.implied_chain())
+	}
+
+	pub(super) fn as_tlv_stream(&self) -> PartialInvoiceRequestTlvStreamRef {
+		let payer = PayerTlvStreamRef {
+			metadata: Some(&self.payer.0),
+		};
+
+		let offer = self.offer.as_tlv_stream();
+
+		let features = {
+			if self.features == InvoiceRequestFeatures::empty() { None }
+			else { Some(&self.features) }
+		};
+
+		let invoice_request = InvoiceRequestTlvStreamRef {
+			chain: self.chain.as_ref(),
+			amount: self.amount_msats,
+			features,
+			quantity: self.quantity,
+			payer_id: Some(&self.payer_id),
+			payer_note: self.payer_note.as_ref(),
+		};
+
+		(payer, offer, invoice_request)
+	}
+}
+
 impl Writeable for InvoiceRequest {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
 		WithoutLength(&self.bytes).write(writer)
+	}
+}
+
+impl Writeable for InvoiceRequestContents {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+		self.as_tlv_stream().write(writer)
 	}
 }
 
@@ -137,6 +354,12 @@ impl SeekReadable for FullInvoiceRequestTlvStream {
 
 type PartialInvoiceRequestTlvStream = (PayerTlvStream, OfferTlvStream, InvoiceRequestTlvStream);
 
+type PartialInvoiceRequestTlvStreamRef<'a> = (
+	PayerTlvStreamRef<'a>,
+	OfferTlvStreamRef<'a>,
+	InvoiceRequestTlvStreamRef<'a>,
+);
+
 impl TryFrom<Vec<u8>> for InvoiceRequest {
 	type Error = ParseError;
 
@@ -152,8 +375,7 @@ impl TryFrom<Vec<u8>> for InvoiceRequest {
 		)?;
 
 		if let Some(signature) = &signature {
-			let tag = concat!("lightning", "invoice_request", "signature");
-			merkle::verify_signature(signature, tag, &bytes, contents.payer_id)?;
+			merkle::verify_signature(signature, SIGNATURE_TAG, &bytes, contents.payer_id)?;
 		}
 
 		Ok(InvoiceRequest { bytes, contents, signature })
@@ -180,31 +402,14 @@ impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 			return Err(SemanticError::UnsupportedChain);
 		}
 
-		let amount_msats = match (offer.amount(), amount) {
-			(None, None) => return Err(SemanticError::MissingAmount),
-			(Some(Amount::Currency { .. }), _) => return Err(SemanticError::UnsupportedCurrency),
-			(_, amount_msats) => amount_msats,
-		};
+		if offer.amount().is_none() && amount.is_none() {
+			return Err(SemanticError::MissingAmount);
+		}
+
+		offer.check_quantity(quantity)?;
+		offer.check_amount_msats_for_quantity(amount, quantity)?;
 
 		let features = features.unwrap_or_else(InvoiceRequestFeatures::empty);
-
-		let expects_quantity = offer.expects_quantity();
-		let quantity = match quantity {
-			None if expects_quantity => return Err(SemanticError::MissingQuantity),
-			Some(_) if !expects_quantity => return Err(SemanticError::UnexpectedQuantity),
-			Some(quantity) if !offer.is_valid_quantity(quantity) => {
-				return Err(SemanticError::InvalidQuantity);
-			}
-			quantity => quantity,
-		};
-
-		{
-			let amount_msats = amount_msats.unwrap_or(offer.amount_msats());
-			let quantity = quantity.unwrap_or(1);
-			if amount_msats < offer.expected_invoice_amount_msats(quantity) {
-				return Err(SemanticError::InsufficientAmount);
-			}
-		}
 
 		let payer_id = match payer_id {
 			None => return Err(SemanticError::MissingPayerId),
@@ -212,7 +417,43 @@ impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 		};
 
 		Ok(InvoiceRequestContents {
-			payer, offer, chain, amount_msats, features, quantity, payer_id, payer_note,
+			payer, offer, chain, amount_msats: amount, features, quantity, payer_id, payer_note,
 		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::InvoiceRequest;
+
+	use bitcoin::secp256k1::{KeyPair, Secp256k1, SecretKey};
+	use core::convert::{Infallible, TryFrom};
+	use crate::ln::msgs::DecodeError;
+	use crate::offers::offer::OfferBuilder;
+	use crate::offers::parse::ParseError;
+	use crate::util::ser::{BigSize, Writeable};
+
+	#[test]
+	fn fails_parsing_invoice_request_with_extra_tlv_records() {
+		let secp_ctx = Secp256k1::new();
+		let keys = KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
+		let invoice_request = OfferBuilder::new("foo".into(), keys.public_key())
+			.amount_msats(1000)
+			.build().unwrap()
+			.request_invoice(vec![1; 32], keys.public_key()).unwrap()
+			.build().unwrap()
+			.sign::<_, Infallible>(|digest| Ok(secp_ctx.sign_schnorr_no_aux_rand(digest, &keys)))
+			.unwrap();
+
+		let mut encoded_invoice_request = Vec::new();
+		invoice_request.write(&mut encoded_invoice_request).unwrap();
+		BigSize(1002).write(&mut encoded_invoice_request).unwrap();
+		BigSize(32).write(&mut encoded_invoice_request).unwrap();
+		[42u8; 32].write(&mut encoded_invoice_request).unwrap();
+
+		match InvoiceRequest::try_from(encoded_invoice_request) {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, ParseError::Decode(DecodeError::InvalidValue)),
+		}
 	}
 }

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -12,9 +12,15 @@
 use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::schnorr::Signature;
+use core::convert::TryFrom;
+use crate::io;
 use crate::ln::features::InvoiceRequestFeatures;
-use crate::offers::offer::OfferContents;
-use crate::offers::payer::PayerContents;
+use crate::ln::msgs::DecodeError;
+use crate::offers::merkle::{SignatureTlvStream, self};
+use crate::offers::offer::{Amount, OfferContents, OfferTlvStream};
+use crate::offers::parse::{ParseError, ParsedMessage, SemanticError};
+use crate::offers::payer::{PayerContents, PayerTlvStream};
+use crate::util::ser::{HighZeroBytesDroppedBigSize, SeekReadable, WithoutLength, Writeable, Writer};
 use crate::util::string::PrintableString;
 
 use crate::prelude::*;
@@ -34,7 +40,7 @@ pub struct InvoiceRequest {
 
 /// The contents of an [`InvoiceRequest`], which may be shared with an `Invoice`.
 #[derive(Clone, Debug)]
-pub(crate) struct InvoiceRequestContents {
+pub(super) struct InvoiceRequestContents {
 	payer: PayerContents,
 	offer: OfferContents,
 	chain: Option<ChainHash>,
@@ -75,9 +81,9 @@ impl InvoiceRequest {
 		&self.contents.features
 	}
 
-	/// The quantity of the offer's item conforming to [`Offer::supported_quantity`].
+	/// The quantity of the offer's item conforming to [`Offer::is_valid_quantity`].
 	///
-	/// [`Offer::supported_quantity`]: crate::offers::offer::Offer::supported_quantity
+	/// [`Offer::is_valid_quantity`]: crate::offers::offer::Offer::is_valid_quantity
 	pub fn quantity(&self) -> Option<u64> {
 		self.contents.quantity
 	}
@@ -97,5 +103,116 @@ impl InvoiceRequest {
 	/// [`payer_id`]: Self::payer_id
 	pub fn signature(&self) -> Option<Signature> {
 		self.signature
+	}
+}
+
+impl Writeable for InvoiceRequest {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+		WithoutLength(&self.bytes).write(writer)
+	}
+}
+
+tlv_stream!(InvoiceRequestTlvStream, InvoiceRequestTlvStreamRef, 80..160, {
+	(80, chain: ChainHash),
+	(82, amount: (u64, HighZeroBytesDroppedBigSize)),
+	(84, features: InvoiceRequestFeatures),
+	(86, quantity: (u64, HighZeroBytesDroppedBigSize)),
+	(88, payer_id: PublicKey),
+	(89, payer_note: (String, WithoutLength)),
+});
+
+type FullInvoiceRequestTlvStream =
+	(PayerTlvStream, OfferTlvStream, InvoiceRequestTlvStream, SignatureTlvStream);
+
+impl SeekReadable for FullInvoiceRequestTlvStream {
+	fn read<R: io::Read + io::Seek>(r: &mut R) -> Result<Self, DecodeError> {
+		let payer = SeekReadable::read(r)?;
+		let offer = SeekReadable::read(r)?;
+		let invoice_request = SeekReadable::read(r)?;
+		let signature = SeekReadable::read(r)?;
+
+		Ok((payer, offer, invoice_request, signature))
+	}
+}
+
+type PartialInvoiceRequestTlvStream = (PayerTlvStream, OfferTlvStream, InvoiceRequestTlvStream);
+
+impl TryFrom<Vec<u8>> for InvoiceRequest {
+	type Error = ParseError;
+
+	fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+		let invoice_request = ParsedMessage::<FullInvoiceRequestTlvStream>::try_from(bytes)?;
+		let ParsedMessage { bytes, tlv_stream } = invoice_request;
+		let (
+			payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream,
+			SignatureTlvStream { signature },
+		) = tlv_stream;
+		let contents = InvoiceRequestContents::try_from(
+			(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream)
+		)?;
+
+		if let Some(signature) = &signature {
+			let tag = concat!("lightning", "invoice_request", "signature");
+			merkle::verify_signature(signature, tag, &bytes, contents.payer_id)?;
+		}
+
+		Ok(InvoiceRequest { bytes, contents, signature })
+	}
+}
+
+impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
+	type Error = SemanticError;
+
+	fn try_from(tlv_stream: PartialInvoiceRequestTlvStream) -> Result<Self, Self::Error> {
+		let (
+			PayerTlvStream { metadata },
+			offer_tlv_stream,
+			InvoiceRequestTlvStream { chain, amount, features, quantity, payer_id, payer_note },
+		) = tlv_stream;
+
+		let payer = match metadata {
+			None => return Err(SemanticError::MissingPayerMetadata),
+			Some(metadata) => PayerContents(metadata),
+		};
+		let offer = OfferContents::try_from(offer_tlv_stream)?;
+
+		if !offer.supports_chain(chain.unwrap_or_else(|| offer.implied_chain())) {
+			return Err(SemanticError::UnsupportedChain);
+		}
+
+		let amount_msats = match (offer.amount(), amount) {
+			(None, None) => return Err(SemanticError::MissingAmount),
+			(Some(Amount::Currency { .. }), _) => return Err(SemanticError::UnsupportedCurrency),
+			(_, amount_msats) => amount_msats,
+		};
+
+		let features = features.unwrap_or_else(InvoiceRequestFeatures::empty);
+
+		let expects_quantity = offer.expects_quantity();
+		let quantity = match quantity {
+			None if expects_quantity => return Err(SemanticError::MissingQuantity),
+			Some(_) if !expects_quantity => return Err(SemanticError::UnexpectedQuantity),
+			Some(quantity) if !offer.is_valid_quantity(quantity) => {
+				return Err(SemanticError::InvalidQuantity);
+			}
+			quantity => quantity,
+		};
+
+		{
+			let amount_msats = amount_msats.unwrap_or(offer.amount_msats());
+			let quantity = quantity.unwrap_or(1);
+			if amount_msats < offer.expected_invoice_amount_msats(quantity) {
+				return Err(SemanticError::InsufficientAmount);
+			}
+		}
+
+		let payer_id = match payer_id {
+			None => return Err(SemanticError::MissingPayerId),
+			Some(payer_id) => payer_id,
+		};
+
+		Ok(InvoiceRequestContents {
+			payer, offer, chain, amount_msats, features, quantity, payer_id, payer_note,
+		})
 	}
 }

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -194,7 +194,7 @@ impl<'a> InvoiceRequestBuilder<'a> {
 		self
 	}
 
-	fn build_unchecked(self) -> UnsignedInvoiceRequest<'a> {
+	pub(super) fn build_unchecked(self) -> UnsignedInvoiceRequest<'a> {
 		let InvoiceRequestBuilder { offer, invoice_request } = self;
 		UnsignedInvoiceRequest { offer, invoice_request }
 	}
@@ -247,7 +247,7 @@ impl<'a> UnsignedInvoiceRequest<'a> {
 /// [`Offer`]: crate::offers::offer::Offer
 #[derive(Clone, Debug)]
 pub struct InvoiceRequest {
-	bytes: Vec<u8>,
+	pub(super) bytes: Vec<u8>,
 	contents: InvoiceRequestContents,
 	signature: Option<Signature>,
 }

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -25,7 +25,7 @@ tlv_stream!(SignatureTlvStream, SignatureTlvStreamRef, SIGNATURE_TYPES, {
 });
 
 /// Error when signing messages.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum SignError<E> {
 	/// User-defined error when signing the message.
 	Signing(E),

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -1,0 +1,167 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Tagged hashes for use in signature calculation and verification.
+
+use bitcoin::hashes::{Hash, HashEngine, sha256};
+use crate::io;
+use crate::util::ser::{BigSize, Readable};
+
+use crate::prelude::*;
+
+/// Valid type range for signature TLV records.
+const SIGNATURE_TYPES: core::ops::RangeInclusive<u64> = 240..=1000;
+
+/// Computes a merkle root hash for the given data, which must be a well-formed TLV stream
+/// containing at least one TLV record.
+fn root_hash(data: &[u8]) -> sha256::Hash {
+	let mut tlv_stream = TlvStream::new(&data[..]).peekable();
+	let nonce_tag = tagged_hash_engine(sha256::Hash::from_engine({
+		let mut engine = sha256::Hash::engine();
+		engine.input("LnNonce".as_bytes());
+		engine.input(tlv_stream.peek().unwrap().record_bytes);
+		engine
+	}));
+	let leaf_tag = tagged_hash_engine(sha256::Hash::hash("LnLeaf".as_bytes()));
+	let branch_tag = tagged_hash_engine(sha256::Hash::hash("LnBranch".as_bytes()));
+
+	let mut leaves = Vec::new();
+	for record in tlv_stream {
+		if !SIGNATURE_TYPES.contains(&record.r#type) {
+			leaves.push(tagged_hash_from_engine(leaf_tag.clone(), &record));
+			leaves.push(tagged_hash_from_engine(nonce_tag.clone(), &record.type_bytes));
+		}
+	}
+
+	// Calculate the merkle root hash in place.
+	let num_leaves = leaves.len();
+	for level in 0.. {
+		let step = 2 << level;
+		let offset = step / 2;
+		if offset >= num_leaves {
+			break;
+		}
+
+		let left_branches = (0..num_leaves).step_by(step);
+		let right_branches = (offset..num_leaves).step_by(step);
+		for (i, j) in left_branches.zip(right_branches) {
+			leaves[i] = tagged_branch_hash_from_engine(branch_tag.clone(), leaves[i], leaves[j]);
+		}
+	}
+
+	*leaves.first().unwrap()
+}
+
+fn tagged_hash<T: AsRef<[u8]>>(tag: sha256::Hash, msg: T) -> sha256::Hash {
+	let engine = tagged_hash_engine(tag);
+	tagged_hash_from_engine(engine, msg)
+}
+
+fn tagged_hash_engine(tag: sha256::Hash) -> sha256::HashEngine {
+	let mut engine = sha256::Hash::engine();
+	engine.input(tag.as_ref());
+	engine.input(tag.as_ref());
+	engine
+}
+
+fn tagged_hash_from_engine<T: AsRef<[u8]>>(mut engine: sha256::HashEngine, msg: T) -> sha256::Hash {
+	engine.input(msg.as_ref());
+	sha256::Hash::from_engine(engine)
+}
+
+fn tagged_branch_hash_from_engine(
+	mut engine: sha256::HashEngine, leaf1: sha256::Hash, leaf2: sha256::Hash,
+) -> sha256::Hash {
+	if leaf1 < leaf2 {
+		engine.input(leaf1.as_ref());
+		engine.input(leaf2.as_ref());
+	} else {
+		engine.input(leaf2.as_ref());
+		engine.input(leaf1.as_ref());
+	};
+	sha256::Hash::from_engine(engine)
+}
+
+/// [`Iterator`] over a sequence of bytes yielding [`TlvRecord`]s. The input is assumed to be a
+/// well-formed TLV stream.
+struct TlvStream<'a> {
+	data: io::Cursor<&'a [u8]>,
+}
+
+impl<'a> TlvStream<'a> {
+	fn new(data: &'a [u8]) -> Self {
+		Self {
+			data: io::Cursor::new(data),
+		}
+	}
+}
+
+/// A slice into a [`TlvStream`] for a record.
+struct TlvRecord<'a> {
+	r#type: u64,
+	type_bytes: &'a [u8],
+	// The entire TLV record.
+	record_bytes: &'a [u8],
+}
+
+impl AsRef<[u8]> for TlvRecord<'_> {
+	fn as_ref(&self) -> &[u8] { &self.record_bytes }
+}
+
+impl<'a> Iterator for TlvStream<'a> {
+	type Item = TlvRecord<'a>;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		if self.data.position() < self.data.get_ref().len() as u64 {
+			let start = self.data.position();
+
+			let r#type = <BigSize as Readable>::read(&mut self.data).unwrap().0;
+			let offset = self.data.position();
+			let type_bytes = &self.data.get_ref()[start as usize..offset as usize];
+
+			let length = <BigSize as Readable>::read(&mut self.data).unwrap().0;
+			let offset = self.data.position();
+			let end = offset + length;
+
+			let _value = &self.data.get_ref()[offset as usize..end as usize];
+			let record_bytes = &self.data.get_ref()[start as usize..end as usize];
+
+			self.data.set_position(end);
+
+			Some(TlvRecord { r#type, type_bytes, record_bytes })
+		} else {
+			None
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use bitcoin::hashes::{Hash, sha256};
+
+	#[test]
+	fn calculates_merkle_root_hash() {
+		// BOLT 12 test vectors
+		macro_rules! tlv1 { () => { "010203e8" } }
+		macro_rules! tlv2 { () => { "02080000010000020003" } }
+		macro_rules! tlv3 { () => { "03310266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c0351800000000000000010000000000000002" } }
+		assert_eq!(
+			super::root_hash(&hex::decode(tlv1!()).unwrap()),
+			sha256::Hash::from_slice(&hex::decode("b013756c8fee86503a0b4abdab4cddeb1af5d344ca6fc2fa8b6c08938caa6f93").unwrap()).unwrap(),
+		);
+		assert_eq!(
+			super::root_hash(&hex::decode(concat!(tlv1!(), tlv2!())).unwrap()),
+			sha256::Hash::from_slice(&hex::decode("c3774abbf4815aa54ccaa026bff6581f01f3be5fe814c620a252534f434bc0d1").unwrap()).unwrap(),
+		);
+		assert_eq!(
+			super::root_hash(&hex::decode(concat!(tlv1!(), tlv2!(), tlv3!())).unwrap()),
+			sha256::Hash::from_slice(&hex::decode("ab2e79b1283b0b31e0b035258de23782df6b89a38cfa7237bde69aed1a658c5d").unwrap()).unwrap(),
+		);
+	}
+}

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -10,6 +10,8 @@
 //! Tagged hashes for use in signature calculation and verification.
 
 use bitcoin::hashes::{Hash, HashEngine, sha256};
+use bitcoin::secp256k1::{Message, PublicKey, Secp256k1, self};
+use bitcoin::secp256k1::schnorr::Signature;
 use crate::io;
 use crate::util::ser::{BigSize, Readable};
 
@@ -17,6 +19,25 @@ use crate::prelude::*;
 
 /// Valid type range for signature TLV records.
 const SIGNATURE_TYPES: core::ops::RangeInclusive<u64> = 240..=1000;
+
+tlv_stream!(SignatureTlvStream, SignatureTlvStreamRef, SIGNATURE_TYPES, {
+	(240, signature: Signature),
+});
+
+/// Verifies the signature with a pubkey over the given bytes using a tagged hash as the message
+/// digest.
+///
+/// Panics if `bytes` is not a well-formed TLV stream containing at least one TLV record.
+pub(super) fn verify_signature(
+	signature: &Signature, tag: &str, bytes: &[u8], pubkey: PublicKey,
+) -> Result<(), secp256k1::Error> {
+	let tag = sha256::Hash::hash(tag.as_bytes());
+	let merkle_root = root_hash(bytes);
+	let digest = Message::from_slice(&tagged_hash(tag, merkle_root)).unwrap();
+	let pubkey = pubkey.into();
+	let secp_ctx = Secp256k1::verification_only();
+	secp_ctx.verify_schnorr(signature, &digest, &pubkey)
+}
 
 /// Computes a merkle root hash for the given data, which must be a well-formed TLV stream
 /// containing at least one TLV record.

--- a/lightning/src/offers/mod.rs
+++ b/lightning/src/offers/mod.rs
@@ -13,6 +13,7 @@
 //! Offers are a flexible protocol for Lightning payments.
 
 pub mod invoice_request;
+mod merkle;
 pub mod offer;
 pub mod parse;
 mod payer;

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -242,7 +242,7 @@ pub struct Offer {
 
 /// The contents of an [`Offer`], which may be shared with an `InvoiceRequest` or an `Invoice`.
 #[derive(Clone, Debug)]
-pub(crate) struct OfferContents {
+pub(super) struct OfferContents {
 	chains: Option<Vec<ChainHash>>,
 	metadata: Option<Vec<u8>>,
 	amount: Option<Amount>,

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -137,7 +137,7 @@ impl OfferBuilder {
 	/// Sets the [`Offer::amount`] as an [`Amount::Bitcoin`].
 	///
 	/// Successive calls to this method will override the previous setting.
-	pub fn amount_msats(mut self, amount_msats: u64) -> Self {
+	pub fn amount_msats(self, amount_msats: u64) -> Self {
 		self.amount(Amount::Bitcoin { amount_msats })
 	}
 

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -224,7 +224,7 @@ impl OfferBuilder {
 
 /// An `Offer` is a potentially long-lived proposal for payment of a good or service.
 ///
-/// An offer is a precursor to an `InvoiceRequest`. A merchant publishes an offer from which a
+/// An offer is a precursor to an [`InvoiceRequest`]. A merchant publishes an offer from which a
 /// customer may request an `Invoice` for a specific quantity and using an amount sufficient to
 /// cover that quantity (i.e., at least `quantity * amount`). See [`Offer::amount`].
 ///
@@ -232,6 +232,8 @@ impl OfferBuilder {
 /// latter.
 ///
 /// Through the use of [`BlindedPath`]s, offers provide recipient privacy.
+///
+/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 #[derive(Clone, Debug)]
 pub struct Offer {
 	// The serialized offer. Needed when creating an `InvoiceRequest` if the offer contains unknown
@@ -240,7 +242,9 @@ pub struct Offer {
 	contents: OfferContents,
 }
 
-/// The contents of an [`Offer`], which may be shared with an `InvoiceRequest` or an `Invoice`.
+/// The contents of an [`Offer`], which may be shared with an [`InvoiceRequest`] or an `Invoice`.
+///
+/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 #[derive(Clone, Debug)]
 pub(super) struct OfferContents {
 	chains: Option<Vec<ChainHash>>,
@@ -263,10 +267,7 @@ impl Offer {
 	/// Payments must be denominated in units of the minimal lightning-payable unit (e.g., msats)
 	/// for the selected chain.
 	pub fn chains(&self) -> Vec<ChainHash> {
-		self.contents.chains
-			.as_ref()
-			.cloned()
-			.unwrap_or_else(|| vec![self.contents.implied_chain()])
+		self.contents.chains()
 	}
 
 	// TODO: Link to corresponding method in `InvoiceRequest`.
@@ -346,6 +347,10 @@ impl AsRef<[u8]> for Offer {
 }
 
 impl OfferContents {
+	pub fn chains(&self) -> Vec<ChainHash> {
+		self.chains.as_ref().cloned().unwrap_or_else(|| vec![self.implied_chain()])
+	}
+
 	pub fn implied_chain(&self) -> ChainHash {
 		ChainHash::using_genesis_block(Network::Bitcoin)
 	}

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -145,7 +145,7 @@ impl OfferBuilder {
 	/// Sets the [`Offer::amount`].
 	///
 	/// Successive calls to this method will override the previous setting.
-	fn amount(mut self, amount: Amount) -> Self {
+	pub(super) fn amount(mut self, amount: Amount) -> Self {
 		self.offer.amount = Some(amount);
 		self
 	}
@@ -219,6 +219,13 @@ impl OfferBuilder {
 	fn features_unchecked(mut self, features: OfferFeatures) -> Self {
 		self.offer.features = features;
 		self
+	}
+
+	pub(super) fn build_unchecked(self) -> Offer {
+		let mut bytes = Vec::new();
+		self.offer.write(&mut bytes).unwrap();
+
+		Offer { bytes, contents: self.offer }
 	}
 }
 
@@ -379,7 +386,7 @@ impl Offer {
 	}
 
 	#[cfg(test)]
-	fn as_tlv_stream(&self) -> OfferTlvStreamRef {
+	pub(super) fn as_tlv_stream(&self) -> OfferTlvStreamRef {
 		self.contents.as_tlv_stream()
 	}
 }

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -11,6 +11,7 @@
 
 use bitcoin::bech32;
 use bitcoin::bech32::{FromBase32, ToBase32};
+use bitcoin::secp256k1;
 use core::convert::TryFrom;
 use core::fmt;
 use crate::io;
@@ -115,23 +116,37 @@ pub enum ParseError {
 	Decode(DecodeError),
 	/// The parsed message has invalid semantics.
 	InvalidSemantics(SemanticError),
+	/// The parsed message has an invalid signature.
+	InvalidSignature(secp256k1::Error),
 }
 
 /// Error when interpreting a TLV stream as a specific type.
 #[derive(Debug, PartialEq)]
 pub enum SemanticError {
+	/// The provided chain hash does not correspond to a supported chain.
+	UnsupportedChain,
 	/// An amount was expected but was missing.
 	MissingAmount,
 	/// The amount exceeded the total bitcoin supply.
 	InvalidAmount,
+	/// An amount was provided but was not sufficient in value.
+	InsufficientAmount,
 	/// A currency was provided that is not supported.
 	UnsupportedCurrency,
 	/// A required description was not provided.
 	MissingDescription,
 	/// A signing pubkey was not provided.
 	MissingSigningPubkey,
+	/// A quantity was expected but was missing.
+	MissingQuantity,
 	/// An unsupported quantity was provided.
 	InvalidQuantity,
+	/// A quantity or quantity bounds was provided but was not expected.
+	UnexpectedQuantity,
+	/// Payer metadata was expected but was missing.
+	MissingPayerMetadata,
+	/// A payer id was expected but was missing.
+	MissingPayerId,
 }
 
 impl From<bech32::Error> for ParseError {
@@ -149,5 +164,11 @@ impl From<DecodeError> for ParseError {
 impl From<SemanticError> for ParseError {
 	fn from(error: SemanticError) -> Self {
 		Self::InvalidSemantics(error)
+	}
+}
+
+impl From<secp256k1::Error> for ParseError {
+	fn from(error: secp256k1::Error) -> Self {
+		Self::InvalidSignature(error)
 	}
 }

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -123,6 +123,8 @@ pub enum ParseError {
 /// Error when interpreting a TLV stream as a specific type.
 #[derive(Debug, PartialEq)]
 pub enum SemanticError {
+	/// The current [`std::time::SystemTime`] is past the offer or invoice's expiration.
+	AlreadyExpired,
 	/// The provided chain hash does not correspond to a supported chain.
 	UnsupportedChain,
 	/// An amount was expected but was missing.
@@ -133,6 +135,8 @@ pub enum SemanticError {
 	InsufficientAmount,
 	/// A currency was provided that is not supported.
 	UnsupportedCurrency,
+	/// A feature was required but is unknown.
+	UnknownRequiredFeatures,
 	/// A required description was not provided.
 	MissingDescription,
 	/// A signing pubkey was not provided.

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -20,7 +20,7 @@ use crate::util::ser::SeekReadable;
 use crate::prelude::*;
 
 /// Indicates a message can be encoded using bech32.
-pub(crate) trait Bech32Encode: AsRef<[u8]> + TryFrom<Vec<u8>, Error=ParseError> {
+pub(super) trait Bech32Encode: AsRef<[u8]> + TryFrom<Vec<u8>, Error=ParseError> {
 	/// Human readable part of the message's bech32 encoding.
 	const BECH32_HRP: &'static str;
 
@@ -78,7 +78,7 @@ impl<'a> AsRef<str> for Bech32String<'a> {
 
 /// A wrapper for reading a message as a TLV stream `T` from a byte sequence, while still
 /// maintaining ownership of the bytes for later use.
-pub(crate) struct ParsedMessage<T: SeekReadable> {
+pub(super) struct ParsedMessage<T: SeekReadable> {
 	pub bytes: Vec<u8>,
 	pub tlv_stream: T,
 }

--- a/lightning/src/offers/payer.rs
+++ b/lightning/src/offers/payer.rs
@@ -7,12 +7,13 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-//! Implementation of Lightning Offers
-//! ([BOLT 12](https://github.com/lightning/bolts/blob/master/12-offer-encoding.md)).
-//!
-//! Offers are a flexible protocol for Lightning payments.
+//! Data structures and encoding for `invoice_request_metadata` records.
 
-pub mod invoice_request;
-pub mod offer;
-pub mod parse;
-mod payer;
+use crate::prelude::*;
+
+/// An unpredictable sequence of bytes typically containing information needed to derive
+/// [`InvoiceRequest::payer_id`].
+///
+/// [`InvoiceRequest::payer_id`]: crate::offers::invoice_request::InvoiceRequest::payer_id
+#[derive(Clone, Debug)]
+pub(crate) struct PayerContents(pub Vec<u8>);

--- a/lightning/src/offers/payer.rs
+++ b/lightning/src/offers/payer.rs
@@ -9,6 +9,8 @@
 
 //! Data structures and encoding for `invoice_request_metadata` records.
 
+use crate::util::ser::WithoutLength;
+
 use crate::prelude::*;
 
 /// An unpredictable sequence of bytes typically containing information needed to derive
@@ -16,4 +18,8 @@ use crate::prelude::*;
 ///
 /// [`InvoiceRequest::payer_id`]: crate::offers::invoice_request::InvoiceRequest::payer_id
 #[derive(Clone, Debug)]
-pub(crate) struct PayerContents(pub Vec<u8>);
+pub(super) struct PayerContents(pub Vec<u8>);
+
+tlv_stream!(PayerTlvStream, PayerTlvStreamRef, 0..1, {
+	(0, metadata: (Vec<u8>, WithoutLength)),
+});

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -20,8 +20,9 @@ use core::convert::TryFrom;
 use core::ops::Deref;
 
 use bitcoin::secp256k1::{PublicKey, SecretKey};
-use bitcoin::secp256k1::constants::{PUBLIC_KEY_SIZE, SECRET_KEY_SIZE, COMPACT_SIGNATURE_SIZE};
-use bitcoin::secp256k1::ecdsa::Signature;
+use bitcoin::secp256k1::constants::{PUBLIC_KEY_SIZE, SECRET_KEY_SIZE, COMPACT_SIGNATURE_SIZE, SCHNORR_SIGNATURE_SIZE};
+use bitcoin::secp256k1::ecdsa;
+use bitcoin::secp256k1::schnorr;
 use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::blockdata::script::Script;
 use bitcoin::blockdata::transaction::{OutPoint, Transaction, TxOut};
@@ -499,7 +500,7 @@ impl_array!(12); // for OnionV2
 impl_array!(16); // for IPv6
 impl_array!(32); // for channel id & hmac
 impl_array!(PUBLIC_KEY_SIZE); // for PublicKey
-impl_array!(COMPACT_SIGNATURE_SIZE); // for Signature
+impl_array!(64); // for ecdsa::Signature and schnorr::Signature
 impl_array!(1300); // for OnionPacket.hop_data
 
 impl Writeable for [u16; 8] {
@@ -664,7 +665,7 @@ impl Readable for Vec<u8> {
 		Ok(ret)
 	}
 }
-impl Writeable for Vec<Signature> {
+impl Writeable for Vec<ecdsa::Signature> {
 	#[inline]
 	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
 		(self.len() as u16).write(w)?;
@@ -675,7 +676,7 @@ impl Writeable for Vec<Signature> {
 	}
 }
 
-impl Readable for Vec<Signature> {
+impl Readable for Vec<ecdsa::Signature> {
 	#[inline]
 	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		let len: u16 = Readable::read(r)?;
@@ -764,20 +765,32 @@ impl Readable for Sha256dHash {
 	}
 }
 
-impl Writeable for Signature {
+impl Writeable for ecdsa::Signature {
 	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
 		self.serialize_compact().write(w)
 	}
-	#[inline]
-	fn serialized_length(&self) -> usize {
-		COMPACT_SIGNATURE_SIZE
+}
+
+impl Readable for ecdsa::Signature {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+		let buf: [u8; COMPACT_SIGNATURE_SIZE] = Readable::read(r)?;
+		match ecdsa::Signature::from_compact(&buf) {
+			Ok(sig) => Ok(sig),
+			Err(_) => return Err(DecodeError::InvalidValue),
+		}
 	}
 }
 
-impl Readable for Signature {
+impl Writeable for schnorr::Signature {
+	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+		self.as_ref().write(w)
+	}
+}
+
+impl Readable for schnorr::Signature {
 	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
-		let buf: [u8; COMPACT_SIGNATURE_SIZE] = Readable::read(r)?;
-		match Signature::from_compact(&buf) {
+		let buf: [u8; SCHNORR_SIGNATURE_SIZE] = Readable::read(r)?;
+		match schnorr::Signature::from_slice(&buf) {
 			Ok(sig) => Ok(sig),
 			Err(_) => return Err(DecodeError::InvalidValue),
 		}

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -504,15 +504,15 @@ macro_rules! tlv_stream {
 		$(($type:expr, $field:ident : $fieldty:tt)),* $(,)*
 	}) => {
 		#[derive(Debug)]
-		pub(crate) struct $name {
+		pub(super) struct $name {
 			$(
 				$field: Option<tlv_record_type!($fieldty)>,
 			)*
 		}
 
-		pub(crate) struct $nameref<'a> {
+		pub(super) struct $nameref<'a> {
 			$(
-				pub(crate) $field: Option<tlv_record_ref_type!($fieldty)>,
+				pub(super) $field: Option<tlv_record_ref_type!($fieldty)>,
 			)*
 		}
 

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -506,7 +506,7 @@ macro_rules! tlv_stream {
 		#[derive(Debug)]
 		pub(super) struct $name {
 			$(
-				$field: Option<tlv_record_type!($fieldty)>,
+				pub(super) $field: Option<tlv_record_type!($fieldty)>,
 			)*
 		}
 


### PR DESCRIPTION
Define an interface for BOLT 12 `invoice_request` messages. The underlying format consists of the original bytes and the parsed contents.

The bytes are later needed when constructing an `invoice` message. This is because it must mirror all the `offer` and `invoice_request` TLV records, including unknown ones, which aren't represented in the contents.

The contents will be used in `invoice` messages to avoid duplication. Some fields while required in a typical user-pays-merchant flow may not be necessary in the merchant-pays-user flow (e.g., refund, ATM).

Also, defines a builder for constructing an invoice request from an offer given a required payer id.

See #1597 for ongoing BOLT 12 work depending on this PR.