### PR TITLE
[0.0.111-bindings] Don't make references to `std` in `lightning-invoice` in bindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,8 @@ jobs:
           cargo test --verbose --color always --no-default-features --features no-std
           # check if there is a conflict between no-std and the default std feature
           cargo test --verbose --color always --features no-std
+          # check if there is a conflict between no-std and the c_bindings cfg
+          RUSTFLAGS="--cfg=c_bindings" cargo test --verbose --color always --no-default-features --features=no-std
           # check no-std compatibility across dependencies
           cd ..
           cd no-std-check

--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -1912,7 +1912,7 @@ mod tests {
 
 	#[cfg(c_bindings)]
 	impl lightning::util::ser::Writeable for TestScorer {
-		fn write<W: lightning::util::ser::Writer>(&self, _: &mut W) -> Result<(), std::io::Error> { unreachable!(); }
+		fn write<W: lightning::util::ser::Writer>(&self, _: &mut W) -> Result<(), lightning::io::Error> { unreachable!(); }
 	}
 
 	impl Score for TestScorer {

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -559,7 +559,7 @@ impl<'a, S: Score> ScorerAccountingForInFlightHtlcs<'a, S> {
 
 #[cfg(c_bindings)]
 impl<'a, S:Score> lightning::util::ser::Writeable for ScorerAccountingForInFlightHtlcs<'a, S> {
-	fn write<W: lightning::util::ser::Writer>(&self, writer: &mut W) -> Result<(), std::io::Error> { self.scorer.write(writer) }
+	fn write<W: lightning::util::ser::Writer>(&self, writer: &mut W) -> Result<(), lightning::io::Error> { self.scorer.write(writer) }
 }
 
 impl<'a, S: Score> Score for ScorerAccountingForInFlightHtlcs<'a, S> {


### PR DESCRIPTION
As we support `no-std` for `lightning-invoice` builds, we should support them in `c_bindings` as well, which we add a test for in CI here.

Ugh, yet another one...hopefully the last...