### PR TITLE
[0.0.111-bindings] Correct `rapid-gossip-sync` `no-std` build and test

### DIFF
--- a/lightning-rapid-gossip-sync/Cargo.toml
+++ b/lightning-rapid-gossip-sync/Cargo.toml
@@ -16,7 +16,7 @@ std = ["lightning/std"]
 _bench_unstable = []
 
 [dependencies]
-lightning = { version = "0.0.111", path = "../lightning" }
+lightning = { version = "0.0.111", path = "../lightning", default-features = false }
 bitcoin = { version = "0.29.0", default-features = false }
 
 [dev-dependencies]

--- a/lightning-rapid-gossip-sync/src/error.rs
+++ b/lightning-rapid-gossip-sync/src/error.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use std::fmt::Formatter;
+use core::fmt::Formatter;
 use lightning::ln::msgs::{DecodeError, LightningError};
 
 /// All-encompassing standard error type that processing can return
@@ -12,8 +12,8 @@ pub enum GraphSyncError {
 	LightningError(LightningError),
 }
 
-impl From<std::io::Error> for GraphSyncError {
-	fn from(error: std::io::Error) -> Self {
+impl From<lightning::io::Error> for GraphSyncError {
+	fn from(error: lightning::io::Error) -> Self {
 		Self::DecodeError(DecodeError::Io(error.kind()))
 	}
 }
@@ -31,7 +31,7 @@ impl From<LightningError> for GraphSyncError {
 }
 
 impl Debug for GraphSyncError {
-	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
 		match self {
 			GraphSyncError::DecodeError(e) => f.write_fmt(format_args!("DecodeError: {:?}", e)),
 			GraphSyncError::LightningError(e) => f.write_fmt(format_args!("LightningError: {:?}", e))

--- a/lightning-rapid-gossip-sync/src/lib.rs
+++ b/lightning-rapid-gossip-sync/src/lib.rs
@@ -60,10 +60,15 @@
 //! ```
 //! [sync_network_graph_with_file_path]: RapidGossipSync::sync_network_graph_with_file_path
 
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
 // Allow and import test features for benching
 #![cfg_attr(all(test, feature = "_bench_unstable"), feature(test))]
 #[cfg(all(test, feature = "_bench_unstable"))]
 extern crate test;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 #[cfg(feature = "std")]
 use std::fs::File;
@@ -156,6 +161,7 @@ mod tests {
 	use crate::RapidGossipSync;
 
 	#[test]
+	#[cfg(feature = "std")]
 	fn test_sync_from_file() {
 		struct FileSyncTest {
 			directory: String,
@@ -243,6 +249,7 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "std")]
 	fn measure_native_read_from_file() {
 		let block_hash = genesis_block(Network::Bitcoin).block_hash();
 		let logger = TestLogger::new();

--- a/lightning-rapid-gossip-sync/src/processing.rs
+++ b/lightning-rapid-gossip-sync/src/processing.rs
@@ -16,6 +16,9 @@ use lightning::io;
 use crate::error::GraphSyncError;
 use crate::RapidGossipSync;
 
+#[cfg(not(feature = "std"))]
+use alloc::{vec::Vec, borrow::ToOwned};
+
 /// The purpose of this prefix is to identify the serialization format, should other rapid gossip
 /// sync formats arise in the future.
 ///
@@ -47,7 +50,7 @@ impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L
 		let backdated_timestamp = latest_seen_timestamp.saturating_sub(24 * 3600 * 7);
 
 		let node_id_count: u32 = Readable::read(read_cursor)?;
-		let mut node_ids: Vec<PublicKey> = Vec::with_capacity(std::cmp::min(
+		let mut node_ids: Vec<PublicKey> = Vec::with_capacity(core::cmp::min(
 			node_id_count,
 			MAX_INITIAL_NODE_ID_VECTOR_CAPACITY,
 		) as usize);
@@ -132,7 +135,7 @@ impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L
 					htlc_maximum_msat: default_htlc_maximum_msat,
 					fee_base_msat: default_fee_base_msat,
 					fee_proportional_millionths: default_fee_proportional_millionths,
-					excess_data: vec![],
+					excess_data: Vec::new(),
 				}
 			} else {
 				// incremental update, field flags will indicate mutated values
@@ -162,7 +165,7 @@ impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L
 					htlc_maximum_msat: directional_info.htlc_maximum_msat,
 					fee_base_msat: directional_info.fees.base_msat,
 					fee_proportional_millionths: directional_info.fees.proportional_millionths,
-					excess_data: vec![],
+					excess_data: Vec::new(),
 				}
 			};
 


### PR DESCRIPTION
This is a backport of the top commit from #1756 to 0.0.111-bindings.

While `rapid-gossip-sync` recently gained a `no-std` feature, it didn't actually work, as there were still dangling references to `std` and prelude assumptions. This makes `rapid-gossip-sync` build (and test) properly in `no-std`.