### PR TITLE
Add logging in route hint filtering

### DIFF
--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -2199,8 +2199,8 @@ mod tests {
 		let invoice_payer = InvoicePayer::new(nodes[0].node, router, nodes[0].logger, event_handler, Retry::Attempts(1));
 
 		assert!(invoice_payer.pay_invoice(&create_invoice_from_channelmanager_and_duration_since_epoch(
-			&nodes[1].node, nodes[1].keys_manager, Currency::Bitcoin, Some(100_010_000), "Invoice".to_string(),
-			duration_since_epoch(), 3600).unwrap())
+			&nodes[1].node, nodes[1].keys_manager, nodes[1].logger, Currency::Bitcoin,
+			Some(100_010_000), "Invoice".to_string(), duration_since_epoch(), 3600).unwrap())
 			.is_ok());
 		let htlc_msgs = nodes[0].node.get_and_clear_pending_msg_events();
 		assert_eq!(htlc_msgs.len(), 2);
@@ -2244,8 +2244,8 @@ mod tests {
 		let invoice_payer = InvoicePayer::new(nodes[0].node, router, nodes[0].logger, event_handler, Retry::Attempts(1));
 
 		assert!(invoice_payer.pay_invoice(&create_invoice_from_channelmanager_and_duration_since_epoch(
-			&nodes[1].node, nodes[1].keys_manager, Currency::Bitcoin, Some(100_010_000), "Invoice".to_string(),
-			duration_since_epoch(), 3600).unwrap())
+			&nodes[1].node, nodes[1].keys_manager, nodes[1].logger, Currency::Bitcoin,
+			Some(100_010_000), "Invoice".to_string(), duration_since_epoch(), 3600).unwrap())
 			.is_ok());
 		let htlc_msgs = nodes[0].node.get_and_clear_pending_msg_events();
 		assert_eq!(htlc_msgs.len(), 2);
@@ -2325,8 +2325,8 @@ mod tests {
 		let invoice_payer = InvoicePayer::new(nodes[0].node, router, nodes[0].logger, event_handler, Retry::Attempts(1));
 
 		assert!(invoice_payer.pay_invoice(&create_invoice_from_channelmanager_and_duration_since_epoch(
-			&nodes[1].node, nodes[1].keys_manager, Currency::Bitcoin, Some(100_010_000), "Invoice".to_string(),
-			duration_since_epoch(), 3600).unwrap())
+			&nodes[1].node, nodes[1].keys_manager, nodes[1].logger, Currency::Bitcoin,
+			Some(100_010_000), "Invoice".to_string(), duration_since_epoch(), 3600).unwrap())
 			.is_ok());
 		let htlc_updates = SendEvent::from_node(&nodes[0]);
 		check_added_monitors!(nodes[0], 1);

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -439,8 +439,10 @@ fn filter_channels(channels: Vec<ChannelDetails>, min_inbound_capacity_msat: Opt
 	// the payment value and where we're currently connected to the channel counterparty.
 	// Even if we cannot satisfy both goals, always ensure we include *some* hints, preferring
 	// those which meet at least one criteria.
-	filtered_channels.into_iter()
-		.filter(|(_counterparty_id, channel)| {
+	filtered_channels
+		.into_iter()
+		.map(|(_, channel)| channel)
+		.filter(|channel| {
 			if online_min_capacity_channel_exists {
 				channel.inbound_capacity_msat >= min_inbound_capacity && channel.is_usable
 			} else if min_capacity_channel_exists && online_channel_exists {
@@ -454,7 +456,7 @@ fn filter_channels(channels: Vec<ChannelDetails>, min_inbound_capacity_msat: Opt
 				channel.is_usable
 			} else { true }
 		})
-		.map(|(_counterparty_id, channel)| route_hint_from_channel(channel))
+		.map(route_hint_from_channel)
 		.collect::<Vec<RouteHint>>()
 }
 

--- a/lightning/src/util/logger.rs
+++ b/lightning/src/util/logger.rs
@@ -14,6 +14,8 @@
 //! The second one, client-side by implementing check against Record Level field.
 //! Each module may have its own Logger or share one.
 
+use bitcoin::secp256k1::PublicKey;
+
 use core::cmp;
 use core::fmt;
 
@@ -136,6 +138,19 @@ impl<'a> Record<'a> {
 pub trait Logger {
 	/// Logs the `Record`
 	fn log(&self, record: &Record);
+}
+
+/// Wrapper for logging a [`PublicKey`] in hex format.
+/// (C-not exported) as fmt can't be used in C
+#[doc(hidden)]
+pub struct DebugPubKey<'a>(pub &'a PublicKey);
+impl<'a> core::fmt::Display for DebugPubKey<'a> {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+		for i in self.0.serialize().iter() {
+			write!(f, "{:02x}", i)?;
+		}
+		Ok(())
+	}
 }
 
 /// Wrapper for logging byte slices in hex format.

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -12,24 +12,16 @@ use chain::keysinterface::SpendableOutputDescriptor;
 
 use bitcoin::hash_types::Txid;
 use bitcoin::blockdata::transaction::Transaction;
-use bitcoin::secp256k1::PublicKey;
 
 use routing::router::Route;
 use ln::chan_utils::HTLCClaim;
 use util::logger::DebugBytes;
 
-pub(crate) struct DebugPubKey<'a>(pub &'a PublicKey);
-impl<'a> core::fmt::Display for DebugPubKey<'a> {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
-		for i in self.0.serialize().iter() {
-			write!(f, "{:02x}", i)?;
-		}
-		Ok(())
-	}
-}
+/// Logs a pubkey in hex format.
+#[macro_export]
 macro_rules! log_pubkey {
 	($obj: expr) => {
-		::util::macro_logger::DebugPubKey(&$obj)
+		$crate::util::logger::DebugPubKey(&$obj)
 	}
 }
 


### PR DESCRIPTION
Knowing why a channel was not included as an invoice route hint can be valuable. Add logging on the decisions made when filtering channels.