### PR TITLE
disable automatic formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
I'd love it if this project adopted rustfmt but in the meantime I think it's a nicer first experience to not accidentally have my editor format the code on save (default behavior, at least on vs code + rust analyzer) and then I need to remember to disable rustfmt for this specific project. Rustfmt has a flag for this: https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#disable_all_formatting.

There's also an "ignore" flag but that didn't work when I tried it.

related to https://github.com/lightningdevkit/rust-lightning/issues/410