### PR TITLE
Add `WriteableScore` bindings impl for `MultiThreadedLockableScore`

### DIFF
--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -226,6 +226,16 @@ impl<'a, T: Score + 'a> LockableScore<'a> for MultiThreadedLockableScore<T> {
 }
 
 #[cfg(c_bindings)]
+impl<T: Score> Writeable for MultiThreadedLockableScore<T> {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+		self.lock().write(writer)
+	}
+}
+
+#[cfg(c_bindings)]
+impl<'a, T: Score + 'a> WriteableScore<'a> for MultiThreadedLockableScore<T> {}
+
+#[cfg(c_bindings)]
 impl<T: Score> MultiThreadedLockableScore<T> {
 	/// Creates a new [`MultiThreadedLockableScore`] given an underlying [`Score`].
 	pub fn new(score: T) -> Self {


### PR DESCRIPTION
In 56b07e52aabdaca521987e765f1fa864966a5d49 we made `MultiThreadedLockableScore` fully bindings-compatible. However, it did not add a `WriteableScore` implementation for it. This was an oversight as it is a `WriteableScore` in Rust and needs to be for use in other parts of the API.

Here we add the required impl in a way that the bindings generator is able to handle it and add conversion utilities.