### PR TITLE
Export io::ErrorKind in bindings

### DIFF
--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -66,8 +66,7 @@ pub enum DecodeError {
 	/// A length descriptor in the packet didn't describe the later data correctly
 	BadLengthDescriptor,
 	/// Error from std::io
-	Io(/// (C-not exported) as ErrorKind doesn't have a reasonable mapping
-        io::ErrorKind),
+	Io(io::ErrorKind),
 	/// The message included zlib-compressed values, which we don't support.
 	UnsupportedCompression,
 }


### PR DESCRIPTION
The bindings have exported `io::Error` as, basically, `io::ErrorKind`, for quite some time, so there's little reason to not just export `io::ErrorKind` as well.