### PR TITLE
Move `InflightHtlcs` and `Router` trait into `ChannelManager`

### DIFF
--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -606,9 +606,8 @@ where
 		self.payment_cache.lock().unwrap().remove(payment_hash);
 	}
 
-	/// Given a [`PaymentHash`], this function looks up inflight path attempts in the payment_cache.
-	/// Then, it uses the path information inside the cache to construct a HashMap mapping a channel's
-	/// short channel id and direction to the amount being sent through it.
+	/// Use path information in the payment_cache to construct a HashMap mapping a channel's short
+	/// channel id and direction to the amount being sent through it.
 	///
 	/// This function should be called whenever we need information about currently used up liquidity
 	/// across payments.

--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -73,7 +73,7 @@
 //! # struct FakeRouter {}
 //! # impl Router for FakeRouter {
 //! #     fn find_route(
-//! #         &self, payer: &PublicKey, params: &RouteParameters, payment_hash: &PaymentHash,
+//! #         &self, payer: &PublicKey, params: &RouteParameters,
 //! #         first_hops: Option<&[&ChannelDetails]>, _inflight_htlcs: InFlightHtlcs
 //! #     ) -> Result<Route, LightningError> { unimplemented!() }
 //! #
@@ -270,7 +270,7 @@ pub trait Payer {
 pub trait Router {
 	/// Finds a [`Route`] between `payer` and `payee` for a payment with the given values.
 	fn find_route(
-		&self, payer: &PublicKey, route_params: &RouteParameters, payment_hash: &PaymentHash,
+		&self, payer: &PublicKey, route_params: &RouteParameters,
 		first_hops: Option<&[&ChannelDetails]>, inflight_htlcs: InFlightHtlcs
 	) -> Result<Route, LightningError>;
 	/// Lets the router know that payment through a specific path has failed.
@@ -447,8 +447,7 @@ where
 		let first_hops = self.payer.first_hops();
 		let inflight_htlcs = self.create_inflight_map();
 		let route = self.router.find_route(
-			&payer, &params, &payment_hash, Some(&first_hops.iter().collect::<Vec<_>>()),
-			inflight_htlcs
+			&payer, &params, Some(&first_hops.iter().collect::<Vec<_>>()), inflight_htlcs
 		).map_err(|e| PaymentError::Routing(e))?;
 
 		match send_payment(&route) {
@@ -552,8 +551,7 @@ where
 		let inflight_htlcs = self.create_inflight_map();
 
 		let route = self.router.find_route(
-			&payer, &params, &payment_hash, Some(&first_hops.iter().collect::<Vec<_>>()),
-			inflight_htlcs
+			&payer, &params, Some(&first_hops.iter().collect::<Vec<_>>()), inflight_htlcs
 		);
 
 		if route.is_err() {
@@ -1812,7 +1810,7 @@ mod tests {
 
 	impl Router for TestRouter {
 		fn find_route(
-			&self, payer: &PublicKey, route_params: &RouteParameters, _payment_hash: &PaymentHash,
+			&self, payer: &PublicKey, route_params: &RouteParameters,
 			_first_hops: Option<&[&ChannelDetails]>, inflight_htlcs: InFlightHtlcs
 		) -> Result<Route, LightningError> {
 			// Simulate calling the Scorer just as you would in find_route
@@ -1865,8 +1863,8 @@ mod tests {
 
 	impl Router for FailingRouter {
 		fn find_route(
-			&self, _payer: &PublicKey, _params: &RouteParameters, _payment_hash: &PaymentHash,
-			_first_hops: Option<&[&ChannelDetails]>, _inflight_htlcs: InFlightHtlcs
+			&self, _payer: &PublicKey, _params: &RouteParameters, _first_hops: Option<&[&ChannelDetails]>,
+			_inflight_htlcs: InFlightHtlcs
 		) -> Result<Route, LightningError> {
 			Err(LightningError { err: String::new(), action: ErrorAction::IgnoreError })
 		}
@@ -2127,8 +2125,8 @@ mod tests {
 
 	impl Router for ManualRouter {
 		fn find_route(
-			&self, _payer: &PublicKey, _params: &RouteParameters, _payment_hash: &PaymentHash,
-			_first_hops: Option<&[&ChannelDetails]>, _inflight_htlcs: InFlightHtlcs
+			&self, _payer: &PublicKey, _params: &RouteParameters, _first_hops: Option<&[&ChannelDetails]>,
+			_inflight_htlcs: InFlightHtlcs
 		) -> Result<Route, LightningError> {
 			self.0.borrow_mut().pop_front().unwrap()
 		}

--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -35,7 +35,7 @@
 //! #
 //! # use lightning::io;
 //! # use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
-//! # use lightning::ln::channelmanager::{ChannelDetails, PaymentId, PaymentSendFailure};
+//! # use lightning::ln::channelmanager::{ChannelDetails, InFlightHtlcs, PaymentId, PaymentSendFailure};
 //! # use lightning::ln::msgs::LightningError;
 //! # use lightning::routing::gossip::NodeId;
 //! # use lightning::routing::router::{Route, RouteHop, RouteParameters};
@@ -44,7 +44,7 @@
 //! # use lightning::util::logger::{Logger, Record};
 //! # use lightning::util::ser::{Writeable, Writer};
 //! # use lightning_invoice::Invoice;
-//! # use lightning_invoice::payment::{InFlightHtlcs, InvoicePayer, Payer, Retry, Router};
+//! # use lightning_invoice::payment::{InvoicePayer, Payer, Retry, Router};
 //! # use secp256k1::PublicKey;
 //! # use std::cell::RefCell;
 //! # use std::ops::Deref;
@@ -140,16 +140,14 @@ use bitcoin_hashes::Hash;
 use bitcoin_hashes::sha256::Hash as Sha256;
 
 use crate::prelude::*;
-use lightning::io;
 use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
-use lightning::ln::channelmanager::{ChannelDetails, PaymentId, PaymentSendFailure};
+use lightning::ln::channelmanager::{ChannelDetails, InFlightHtlcs, PaymentId, PaymentSendFailure};
 use lightning::ln::msgs::LightningError;
 use lightning::routing::gossip::NodeId;
 use lightning::routing::router::{PaymentParameters, Route, RouteHop, RouteParameters};
 use lightning::util::errors::APIError;
 use lightning::util::events::{Event, EventHandler};
 use lightning::util::logger::Logger;
-use lightning::util::ser::Writeable;
 use crate::time_utils::Time;
 use crate::sync::Mutex;
 
@@ -641,7 +639,7 @@ where
 			}
 		}
 
-		InFlightHtlcs(total_inflight_map)
+		InFlightHtlcs::new(total_inflight_map)
 	}
 }
 
@@ -727,31 +725,6 @@ where
 
 		// Delegate to the decorated event handler unless the payment is retried.
 		self.event_handler.handle_event(event)
-	}
-}
-
-/// A map with liquidity value (in msat) keyed by a short channel id and the direction the HTLC
-/// is traveling in. The direction boolean is determined by checking if the HTLC source's public
-/// key is less than its destination. See [`InFlightHtlcs::used_liquidity_msat`] for more
-/// details.
-pub struct InFlightHtlcs(HashMap<(u64, bool), u64>);
-
-impl InFlightHtlcs {
-	/// Returns liquidity in msat given the public key of the HTLC source, target, and short channel
-	/// id.
-	pub fn used_liquidity_msat(&self, source: &NodeId, target: &NodeId, channel_scid: u64) -> Option<u64> {
-		self.0.get(&(channel_scid, source < target)).map(|v| *v)
-	}
-}
-
-impl Writeable for InFlightHtlcs {
-	fn write<W: lightning::util::ser::Writer>(&self, writer: &mut W) -> Result<(), io::Error> { self.0.write(writer) }
-}
-
-impl lightning::util::ser::Readable for InFlightHtlcs {
-	fn read<R: io::Read>(reader: &mut R) -> Result<Self, lightning::ln::msgs::DecodeError> {
-		let infight_map: HashMap<(u64, bool), u64> = lightning::util::ser::Readable::read(reader)?;
-		Ok(Self(infight_map))
 	}
 }
 
@@ -1811,7 +1784,7 @@ mod tests {
 	impl Router for TestRouter {
 		fn find_route(
 			&self, payer: &PublicKey, route_params: &RouteParameters,
-			_first_hops: Option<&[&ChannelDetails]>, inflight_htlcs: InFlightHtlcs
+			_first_hops: Option<&[&ChannelDetails]>, inflight_htlcs: channelmanager::InFlightHtlcs
 		) -> Result<Route, LightningError> {
 			// Simulate calling the Scorer just as you would in find_route
 			let route = Self::route_for_value(route_params.final_value_msat);
@@ -1864,7 +1837,7 @@ mod tests {
 	impl Router for FailingRouter {
 		fn find_route(
 			&self, _payer: &PublicKey, _params: &RouteParameters, _first_hops: Option<&[&ChannelDetails]>,
-			_inflight_htlcs: InFlightHtlcs
+			_inflight_htlcs: channelmanager::InFlightHtlcs
 		) -> Result<Route, LightningError> {
 			Err(LightningError { err: String::new(), action: ErrorAction::IgnoreError })
 		}
@@ -2126,7 +2099,7 @@ mod tests {
 	impl Router for ManualRouter {
 		fn find_route(
 			&self, _payer: &PublicKey, _params: &RouteParameters, _first_hops: Option<&[&ChannelDetails]>,
-			_inflight_htlcs: InFlightHtlcs
+			_inflight_htlcs: channelmanager::InFlightHtlcs
 		) -> Result<Route, LightningError> {
 			self.0.borrow_mut().pop_front().unwrap()
 		}

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -552,8 +552,8 @@ impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, S: Deref> Router for DefaultR
 	S::Target: for <'a> LockableScore<'a>,
 {
 	fn find_route(
-		&self, payer: &PublicKey, params: &RouteParameters, _payment_hash: &PaymentHash,
-		first_hops: Option<&[&ChannelDetails]>, inflight_htlcs: InFlightHtlcs
+		&self, payer: &PublicKey, params: &RouteParameters, first_hops: Option<&[&ChannelDetails]>,
+		inflight_htlcs: InFlightHtlcs
 	) -> Result<Route, LightningError> {
 		let random_seed_bytes = {
 			let mut locked_random_seed_bytes = self.random_seed_bytes.lock().unwrap();

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -1,7 +1,7 @@
 //! Convenient utilities to create an invoice.
 
 use crate::{CreationError, Currency, Invoice, InvoiceBuilder, SignOrCreationError};
-use crate::payment::{InFlightHtlcs, Payer, Router};
+use crate::payment::{Payer, Router};
 
 use crate::{prelude::*, Description, InvoiceDescription, Sha256};
 use bech32::ToBase32;
@@ -10,7 +10,7 @@ use lightning::chain;
 use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use lightning::chain::keysinterface::{Recipient, KeysInterface, Sign};
 use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
-use lightning::ln::channelmanager::{ChannelDetails, ChannelManager, PaymentId, PaymentSendFailure, MIN_FINAL_CLTV_EXPIRY};
+use lightning::ln::channelmanager::{ChannelDetails, ChannelManager, InFlightHtlcs, PaymentId, PaymentSendFailure, MIN_FINAL_CLTV_EXPIRY};
 #[cfg(feature = "std")]
 use lightning::ln::channelmanager::{PhantomRouteHints, MIN_CLTV_EXPIRY_DELTA};
 use lightning::ln::inbound_payment::{create, create_from_hash, ExpandedKey};

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -1,7 +1,7 @@
 //! Convenient utilities to create an invoice.
 
 use crate::{CreationError, Currency, Invoice, InvoiceBuilder, SignOrCreationError};
-use crate::payment::{Payer, Router};
+use crate::payment::{Payer, ProbingRouter};
 
 use crate::{prelude::*, Description, InvoiceDescription, Sha256};
 use bech32::ToBase32;
@@ -10,7 +10,7 @@ use lightning::chain;
 use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use lightning::chain::keysinterface::{Recipient, KeysInterface, Sign};
 use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
-use lightning::ln::channelmanager::{ChannelDetails, ChannelManager, InFlightHtlcs, PaymentId, PaymentSendFailure, MIN_FINAL_CLTV_EXPIRY};
+use lightning::ln::channelmanager::{ChannelDetails, ChannelManager, InFlightHtlcs, PaymentId, PaymentSendFailure, MIN_FINAL_CLTV_EXPIRY, Router};
 #[cfg(feature = "std")]
 use lightning::ln::channelmanager::{PhantomRouteHints, MIN_CLTV_EXPIRY_DELTA};
 use lightning::ln::inbound_payment::{create, create_from_hash, ExpandedKey};
@@ -575,7 +575,12 @@ impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, S: Deref> Router for DefaultR
 	fn notify_payment_path_successful(&self, path: &[&RouteHop]) {
 		self.scorer.lock().payment_path_successful(path);
 	}
+}
 
+impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, S: Deref> ProbingRouter for DefaultRouter<G, L, S> where
+	L::Target: Logger,
+	S::Target: for <'a> LockableScore<'a>,
+{
 	fn notify_payment_probe_successful(&self, path: &[&RouteHop]) {
 		self.scorer.lock().probe_successful(path);
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -106,6 +106,19 @@ impl Readable for InFlightHtlcs {
 	}
 }
 
+/// A trait defining behavior for routing an payment.
+pub trait Router {
+	/// Finds a [`Route`] between `payer` and `payee` for a payment with the given values.
+	fn find_route(
+		&self, payer: &PublicKey, route_params: &RouteParameters,
+		first_hops: Option<&[&ChannelDetails]>, inflight_htlcs: InFlightHtlcs
+	) -> Result<Route, LightningError>;
+	/// Lets the router know that payment through a specific path has failed.
+	fn notify_payment_path_failed(&self, path: &[&RouteHop], short_channel_id: u64);
+	/// Lets the router know that payment through a specific path was successful.
+	fn notify_payment_path_successful(&self, path: &[&RouteHop]);
+}
+
 // We hold various information about HTLC relay in the HTLC objects in Channel itself:
 //
 // Upon receipt of an HTLC from a peer, we'll give it a PendingHTLCStatus indicating if it should


### PR DESCRIPTION
This prepares us to parameterize `ChannelManager` with a `Router` trait, which will then be used to fetch routes on-the-fly for trampoline payments. 

Relates to https://github.com/lightningdevkit/rust-lightning/issues/1157 although trampoline is not blocked by it -- `ChannelManager` can just not factor in in-flight HTLCs for now. 