### PR TITLE
Require directional updates for a DirectionalChannelInfo

### DIFF
--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -874,7 +874,7 @@ impl<'a> DirectedChannelInfo<'a> {
 		let effective_capacity = match capacity_msat {
 			Some(capacity_msat) => {
 				htlc_maximum_msat = cmp::min(htlc_maximum_msat, capacity_msat);
-				EffectiveCapacity::Total { capacity_msat, htlc_maximum_msat: Some(htlc_maximum_msat) }
+				EffectiveCapacity::Total { capacity_msat, htlc_maximum_msat: htlc_maximum_msat }
 			},
 			None => EffectiveCapacity::MaximumHTLC { amount_msat: htlc_maximum_msat },
 		};
@@ -939,7 +939,7 @@ pub enum EffectiveCapacity {
 		/// The funding amount denominated in millisatoshi.
 		capacity_msat: u64,
 		/// The maximum HTLC amount denominated in millisatoshi.
-		htlc_maximum_msat: Option<u64>
+		htlc_maximum_msat: u64
 	},
 	/// A capacity sufficient to route any payment, typically used for private channels provided by
 	/// an invoice.

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -494,10 +494,8 @@ fn max_htlc_from_capacity(capacity: EffectiveCapacity, max_channel_saturation_po
 		EffectiveCapacity::Unknown => EffectiveCapacity::Unknown.as_msat(),
 		EffectiveCapacity::MaximumHTLC { amount_msat } =>
 			amount_msat.checked_shr(saturation_shift).unwrap_or(0),
-		EffectiveCapacity::Total { capacity_msat, htlc_maximum_msat: None } =>
-			capacity_msat.checked_shr(saturation_shift).unwrap_or(0),
-		EffectiveCapacity::Total { capacity_msat, htlc_maximum_msat: Some(htlc_max) } =>
-			cmp::min(capacity_msat.checked_shr(saturation_shift).unwrap_or(0), htlc_max),
+		EffectiveCapacity::Total { capacity_msat, htlc_maximum_msat } =>
+			cmp::min(capacity_msat.checked_shr(saturation_shift).unwrap_or(0), htlc_maximum_msat),
 	}
 }
 
@@ -5391,7 +5389,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 0,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: 1_000 },
 		};
 		scorer.set_manual_penalty(&NodeId::from_pubkey(&nodes[3]), 123);
 		scorer.set_manual_penalty(&NodeId::from_pubkey(&nodes[4]), 456);

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -17,7 +17,7 @@ use bitcoin::secp256k1::PublicKey;
 use crate::ln::channelmanager::ChannelDetails;
 use crate::ln::features::{ChannelFeatures, InvoiceFeatures, NodeFeatures};
 use crate::ln::msgs::{DecodeError, ErrorAction, LightningError, MAX_VALUE_MSAT};
-use crate::routing::gossip::{DirectedChannelInfoWithUpdate, EffectiveCapacity, ReadOnlyNetworkGraph, NetworkGraph, NodeId, RoutingFees};
+use crate::routing::gossip::{DirectedChannelInfo, EffectiveCapacity, ReadOnlyNetworkGraph, NetworkGraph, NodeId, RoutingFees};
 use crate::routing::scoring::{ChannelUsage, Score};
 use crate::util::ser::{Writeable, Readable, Writer};
 use crate::util::logger::{Level, Logger};
@@ -421,7 +421,7 @@ enum CandidateRouteHop<'a> {
 	},
 	/// A hop found in the [`ReadOnlyNetworkGraph`], where the channel capacity may be unknown.
 	PublicHop {
-		info: DirectedChannelInfoWithUpdate<'a>,
+		info: DirectedChannelInfo<'a>,
 		short_channel_id: u64,
 	},
 	/// A hop to the payee found in the payment invoice, though not necessarily a direct channel.
@@ -1276,13 +1276,11 @@ where L::Target: Logger {
 					for chan_id in $node.channels.iter() {
 						let chan = network_channels.get(chan_id).unwrap();
 						if !chan.features.requires_unknown_bits() {
-							let (directed_channel, source) =
-								chan.as_directed_to(&$node_id).expect("inconsistent NetworkGraph");
-							if first_hops.is_none() || *source != our_node_id {
-								if let Some(direction) = directed_channel.direction() {
-									if direction.enabled {
+							if let Some((directed_channel, source)) = chan.as_directed_to(&$node_id) {
+								if first_hops.is_none() || *source != our_node_id {
+									if directed_channel.direction().enabled {
 										let candidate = CandidateRouteHop::PublicHop {
-											info: directed_channel.with_update().unwrap(),
+											info: directed_channel,
 											short_channel_id: *chan_id,
 										};
 										add_entry!(candidate, *source, $node_id,
@@ -1367,8 +1365,7 @@ where L::Target: Logger {
 					let candidate = network_channels
 						.get(&hop.short_channel_id)
 						.and_then(|channel| channel.as_directed_to(&target))
-						.and_then(|(channel, _)| channel.with_update())
-						.map(|info| CandidateRouteHop::PublicHop {
+						.map(|(info, _)| CandidateRouteHop::PublicHop {
 							info,
 							short_channel_id: hop.short_channel_id,
 						})
@@ -1816,10 +1813,8 @@ fn add_random_cltv_offset(route: &mut Route, payment_params: &PaymentParameters,
 							random_channel.as_directed_from(&cur_node_id).map(|(dir_info, next_id)| {
 								if !nodes_to_avoid.iter().any(|x| x == next_id) {
 									nodes_to_avoid[random_hop] = *next_id;
-									dir_info.direction().map(|channel_update_info| {
-										random_hop_offset = channel_update_info.cltv_expiry_delta.into();
-										cur_hop = Some(*next_id);
-									});
+									random_hop_offset = dir_info.direction().cltv_expiry_delta.into();
+									cur_hop = Some(*next_id);
 								}
 							});
 						}
@@ -5214,14 +5209,12 @@ mod tests {
 					for channel_id in &cur_node.channels {
 						if let Some(channel_info) = network_channels.get(&channel_id) {
 							if let Some((dir_info, next_id)) = channel_info.as_directed_from(&cur_node_id) {
-								if let Some(channel_update_info) = dir_info.direction() {
-									let next_cltv_expiry_delta = channel_update_info.cltv_expiry_delta as u32;
-									if cur_path_cltv_deltas.iter().sum::<u32>()
-										.saturating_add(next_cltv_expiry_delta) <= observed_cltv_expiry_delta {
-										let mut new_path_cltv_deltas = cur_path_cltv_deltas.clone();
-										new_path_cltv_deltas.push(next_cltv_expiry_delta);
-										candidates.push_back((*next_id, new_path_cltv_deltas));
-									}
+								let next_cltv_expiry_delta = dir_info.direction().cltv_expiry_delta as u32;
+								if cur_path_cltv_deltas.iter().sum::<u32>()
+									.saturating_add(next_cltv_expiry_delta) <= observed_cltv_expiry_delta {
+									let mut new_path_cltv_deltas = cur_path_cltv_deltas.clone();
+									new_path_cltv_deltas.push(next_cltv_expiry_delta);
+									candidates.push_back((*next_id, new_path_cltv_deltas));
 								}
 							}
 						}

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -1113,7 +1113,7 @@ impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, T: Time> Score for Probabilis
 					return base_penalty_msat;
 				}
 			},
-			EffectiveCapacity::Total { capacity_msat, htlc_maximum_msat: Some(htlc_maximum_msat) } => {
+			EffectiveCapacity::Total { capacity_msat, htlc_maximum_msat } => {
 				if htlc_maximum_msat >= capacity_msat/2 {
 					anti_probing_penalty_msat = self.params.anti_probing_penalty_msat;
 				}
@@ -1985,7 +1985,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 1_024,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: 1_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 0);
 		let usage = ChannelUsage { amount_msat: 10_240, ..usage };
@@ -1998,7 +1998,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 128,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: 1_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 58);
 		let usage = ChannelUsage { amount_msat: 256, ..usage };
@@ -2038,7 +2038,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 39,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 100, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 100, htlc_maximum_msat: 1_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 0);
 		let usage = ChannelUsage { amount_msat: 50, ..usage };
@@ -2062,7 +2062,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 500,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: 1_000 },
 		};
 		let failed_path = payment_path_for_amount(500);
 		let successful_path = payment_path_for_amount(200);
@@ -2092,7 +2092,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 250,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: 1_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 128);
 		let usage = ChannelUsage { amount_msat: 500, ..usage };
@@ -2127,7 +2127,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 250,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: 1_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 128);
 		let usage = ChannelUsage { amount_msat: 500, ..usage };
@@ -2161,7 +2161,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 250,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: 1_000 },
 		};
 		let path = payment_path_for_amount(500);
 
@@ -2193,7 +2193,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 0,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: Some(1_024) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: 1_024 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 0);
 		let usage = ChannelUsage { amount_msat: 1_023, ..usage };
@@ -2271,7 +2271,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 256,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: 1_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 125);
 
@@ -2302,7 +2302,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 512,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: 1_000 },
 		};
 
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 300);
@@ -2347,7 +2347,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 500,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: 1_000 },
 		};
 
 		scorer.payment_path_failed(&payment_path_for_amount(500).iter().collect::<Vec<_>>(), 42);
@@ -2384,7 +2384,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 500,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: 1_000 },
 		};
 
 		scorer.payment_path_failed(&payment_path_for_amount(500).iter().collect::<Vec<_>>(), 42);
@@ -2421,47 +2421,47 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 100_000_000,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 950_000_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 950_000_000, htlc_maximum_msat: 1_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 4375);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 2739);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 2_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 2_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 2236);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 3_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 3_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 1983);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 4_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 4_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 1637);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 5_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 5_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 1606);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 6_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 6_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 1331);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 7_450_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 7_450_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 1387);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 7_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 7_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 1379);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 8_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 8_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 1363);
 		let usage = ChannelUsage {
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 9_950_000_000, htlc_maximum_msat: Some(1_000) }, ..usage
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 9_950_000_000, htlc_maximum_msat: 1_000 }, ..usage
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 1355);
 	}
@@ -2475,7 +2475,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 128,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: 1_000 },
 		};
 
 		let params = ProbabilisticScoringParameters {
@@ -2511,7 +2511,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 512_000,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: 1_000 },
 		};
 
 		let params = ProbabilisticScoringParameters {
@@ -2566,7 +2566,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 750,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_000, htlc_maximum_msat: 1_000 },
 		};
 		assert_ne!(scorer.channel_penalty_msat(42, &source, &target, usage), u64::max_value());
 
@@ -2615,7 +2615,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 100,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: Some(1_024) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024, htlc_maximum_msat: 1_024 },
 		};
 		// With no historical data the normal liquidity penalty calculation is used.
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 47);
@@ -2650,7 +2650,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 512_000,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: Some(1_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: 1_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 0);
 
@@ -2658,7 +2658,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 512_000,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: Some(1_024_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: 1_024_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 500);
 
@@ -2666,7 +2666,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 512_000,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: Some(512_000) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: 512_000 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 500);
 
@@ -2674,7 +2674,7 @@ mod tests {
 		let usage = ChannelUsage {
 			amount_msat: 512_000,
 			inflight_htlc_msat: 0,
-			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: Some(511_999) },
+			effective_capacity: EffectiveCapacity::Total { capacity_msat: 1_024_000, htlc_maximum_msat: 511_999 },
 		};
 		assert_eq!(scorer.channel_penalty_msat(42, &source, &target, usage), 0);
 	}


### PR DESCRIPTION
We currently construct `DirectedChannelInfo`s for routing before
checking if the given direction has its directional info filled in.
We then always check for directional info before actually deciding
to route over a channel, as otherwise we assume the channel is not
online.

This makes for somewhat redundant checks, and `DirectedCHannelInfo`
isn't, by itself, a very useful API. Because fetching the HTLC-max
or effective channel capacity gives spurious data if no directional
info is available, there's little reason to have that data
available, and so we here check for directional info first. This
effectively merges `DirectionalChannelInfo` and
`DirectionalChannelInfoWithUpdate`.