### PR TITLE
Implement Hash for ConfirmationTarget

### DIFF
--- a/lightning/src/chain/chaininterface.rs
+++ b/lightning/src/chain/chaininterface.rs
@@ -25,7 +25,7 @@ pub trait BroadcasterInterface {
 
 /// An enum that represents the speed at which we want a transaction to confirm used for feerate
 /// estimation.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub enum ConfirmationTarget {
 	/// We are happy with this transaction confirming slowly when feerate drops some.
 	Background,


### PR DESCRIPTION
In the ldk sample `ConfirmationTarget` is remade so it can be used in a `HashMap`. This should allow it a simplification for the sample node and likely other projects.