### PR TITLE
Ignore RGS channel updates for unknown channels

### DIFF
--- a/lightning-rapid-gossip-sync/src/processing.rs
+++ b/lightning-rapid-gossip-sync/src/processing.rs
@@ -72,6 +72,7 @@ impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L
 
 			let node_id_1_index: BigSize = Readable::read(read_cursor)?;
 			let node_id_2_index: BigSize = Readable::read(read_cursor)?;
+
 			if max(node_id_1_index.0, node_id_2_index.0) >= node_id_count as u64 {
 				return Err(DecodeError::InvalidValue.into());
 			};
@@ -120,49 +121,43 @@ impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L
 			// flags are always sent in full, and hence always need updating
 			let standard_channel_flags = channel_flags & 0b_0000_0011;
 
-			let mut synthetic_update = if channel_flags & 0b_1000_0000 == 0 {
-				// full update, field flags will indicate deviations from the default
-				UnsignedChannelUpdate {
-					chain_hash,
-					short_channel_id,
-					timestamp: backdated_timestamp,
-					flags: standard_channel_flags,
-					cltv_expiry_delta: default_cltv_expiry_delta,
-					htlc_minimum_msat: default_htlc_minimum_msat,
-					htlc_maximum_msat: default_htlc_maximum_msat,
-					fee_base_msat: default_fee_base_msat,
-					fee_proportional_millionths: default_fee_proportional_millionths,
-					excess_data: Vec::new(),
-				}
-			} else {
+			let mut synthetic_update = UnsignedChannelUpdate {
+				chain_hash,
+				short_channel_id,
+				timestamp: backdated_timestamp,
+				flags: standard_channel_flags,
+				cltv_expiry_delta: default_cltv_expiry_delta,
+				htlc_minimum_msat: default_htlc_minimum_msat,
+				htlc_maximum_msat: default_htlc_maximum_msat,
+				fee_base_msat: default_fee_base_msat,
+				fee_proportional_millionths: default_fee_proportional_millionths,
+				excess_data: Vec::new(),
+			};
+
+			let mut skip_update_for_unknown_channel = false;
+
+			if (channel_flags & 0b_1000_0000) != 0 {
 				// incremental update, field flags will indicate mutated values
 				let read_only_network_graph = network_graph.read_only();
-				let channel = read_only_network_graph
+				if let Some(channel) = read_only_network_graph
 					.channels()
-					.get(&short_channel_id)
-					.ok_or(LightningError {
-						err: "Couldn't find channel for update".to_owned(),
-						action: ErrorAction::IgnoreError,
-					})?;
+					.get(&short_channel_id) {
 
-				let directional_info = channel
-					.get_directional_info(channel_flags)
-					.ok_or(LightningError {
-						err: "Couldn't find previous directional data for update".to_owned(),
-						action: ErrorAction::IgnoreError,
-					})?;
+					let directional_info = channel
+						.get_directional_info(channel_flags)
+						.ok_or(LightningError {
+							err: "Couldn't find previous directional data for update".to_owned(),
+							action: ErrorAction::IgnoreError,
+						})?;
 
-				UnsignedChannelUpdate {
-					chain_hash,
-					short_channel_id,
-					timestamp: backdated_timestamp,
-					flags: standard_channel_flags,
-					cltv_expiry_delta: directional_info.cltv_expiry_delta,
-					htlc_minimum_msat: directional_info.htlc_minimum_msat,
-					htlc_maximum_msat: directional_info.htlc_maximum_msat,
-					fee_base_msat: directional_info.fees.base_msat,
-					fee_proportional_millionths: directional_info.fees.proportional_millionths,
-					excess_data: Vec::new(),
+					synthetic_update.cltv_expiry_delta = directional_info.cltv_expiry_delta;
+					synthetic_update.htlc_minimum_msat = directional_info.htlc_minimum_msat;
+					synthetic_update.htlc_maximum_msat = directional_info.htlc_maximum_msat;
+					synthetic_update.fee_base_msat = directional_info.fees.base_msat;
+					synthetic_update.fee_proportional_millionths = directional_info.fees.proportional_millionths;
+
+				} else {
+					skip_update_for_unknown_channel = true;
 				}
 			};
 
@@ -189,6 +184,10 @@ impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L
 			if channel_flags & 0b_0000_0100 > 0 {
 				let htlc_maximum_msat: u64 = Readable::read(read_cursor)?;
 				synthetic_update.htlc_maximum_msat = htlc_maximum_msat;
+			}
+
+			if skip_update_for_unknown_channel {
+				continue;
 			}
 
 			match network_graph.update_channel_unsigned(&synthetic_update) {
@@ -251,7 +250,7 @@ mod tests {
 	}
 
 	#[test]
-	fn incremental_only_update_fails_without_prior_announcements() {
+	fn incremental_only_update_ignores_missing_channel() {
 		let incremental_update_input = vec![
 			76, 68, 75, 1, 111, 226, 140, 10, 182, 241, 179, 114, 193, 166, 162, 70, 174, 99, 247,
 			79, 147, 30, 131, 101, 225, 90, 8, 156, 104, 214, 25, 0, 0, 0, 0, 0, 97, 229, 183, 167,
@@ -268,12 +267,7 @@ mod tests {
 
 		let rapid_sync = RapidGossipSync::new(&network_graph);
 		let update_result = rapid_sync.update_network_graph(&incremental_update_input[..]);
-		assert!(update_result.is_err());
-		if let Err(GraphSyncError::LightningError(lightning_error)) = update_result {
-			assert_eq!(lightning_error.err, "Couldn't find channel for update");
-		} else {
-			panic!("Unexpected update result: {:?}", update_result)
-		}
+		assert!(update_result.is_ok());
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes #1784 by ignoring channel updates for channels our graph doesn't know about instead of returning an error.  Also includes a minor style change with added test for unknown version header.  I can remove that part but was just something I noticed when first reviewing RGS client code.  Maybe there's a reason it was using the empty match arm style that I'm unaware of?