### PR TITLE
Fix persistence-required futures always completing instantly

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5916,18 +5916,25 @@ where
 
 	/// Blocks until ChannelManager needs to be persisted or a timeout is reached. It returns a bool
 	/// indicating whether persistence is necessary. Only one listener on
-	/// `await_persistable_update` or `await_persistable_update_timeout` is guaranteed to be woken
-	/// up.
+	/// [`await_persistable_update`], [`await_persistable_update_timeout`], or a future returned by
+	/// [`get_persistable_update_future`] is guaranteed to be woken up.
 	///
 	/// Note that this method is not available with the `no-std` feature.
+	///
+	/// [`await_persistable_update`]: Self::await_persistable_update
+	/// [`await_persistable_update_timeout`]: Self::await_persistable_update_timeout
+	/// [`get_persistable_update_future`]: Self::get_persistable_update_future
 	#[cfg(any(test, feature = "std"))]
 	pub fn await_persistable_update_timeout(&self, max_wait: Duration) -> bool {
 		self.persistence_notifier.wait_timeout(max_wait)
 	}
 
 	/// Blocks until ChannelManager needs to be persisted. Only one listener on
-	/// `await_persistable_update` or `await_persistable_update_timeout` is guaranteed to be woken
-	/// up.
+	/// [`await_persistable_update`], `await_persistable_update_timeout`, or a future returned by
+	/// [`get_persistable_update_future`] is guaranteed to be woken up.
+	///
+	/// [`await_persistable_update`]: Self::await_persistable_update
+	/// [`get_persistable_update_future`]: Self::get_persistable_update_future
 	pub fn await_persistable_update(&self) {
 		self.persistence_notifier.wait()
 	}


### PR DESCRIPTION
After the first persistence-required `Future` wakeup, we'll always complete additional futures instantly as we don't clear the "need wake" bit. Instead, we need to just assume that if a future was generated (and not immediately drop'd) that its sufficient to notify the user.