### PR TITLE
Introduce `lightning-htlc-scorer` crate as a jamming mitigation strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ members = [
     "lightning-net-tokio",
     "lightning-persister",
     "lightning-background-processor",
-    "lightning-rapid-gossip-sync"
+    "lightning-rapid-gossip-sync",
+    "lightning-htlc-scorer"
 ]
 
 exclude = [

--- a/lightning-htlc-scorer/Cargo.toml
+++ b/lightning-htlc-scorer/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "lightning-htlc-scorer"
+description = "Process the jamming risk of forward HTLC"
+version = "0.1.0"
+authors = ["Antoine Riard <dev@ariard.me>"]
+documentation = "https://docs.rs/lightning-htlc-scorer"
+license = "MIT OR Apache-2.0"
+keyswords = [ "lightning", "bitcoin", "jamming" ]
+readme = "README.md"
+repository = "https://github.com/lightningdevkit/rust-lightning/"
+edition = "2018"
+
+[features]
+default = ["std"]
+no-std = ["hashbrown", "lightning/no-std"]
+std = ["lightning/std"]
+
+[dependencies]
+bitcoin = { version = "0.29.0", default-features = false, features = ["secp-recovery"] }
+lightning = { version = "0.0.112", path = "../lightning", default-features = false }
+hashbrown = { version = "0.8", optional = true }

--- a/lightning-htlc-scorer/src/lib.rs
+++ b/lightning-htlc-scorer/src/lib.rs
@@ -1,0 +1,181 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+#![crate_name = "lightning_htlc_scorer"]
+
+//! This crates provides a module to control liquidity flows of a routing node,
+//! among other managing congestion, arising from spontaneous or malicious activity.
+//!
+//! The HTLCScorer is the main chunk of channel jamming logic, implementing
+//! the additional HTLC forward policy checks, maintaining credit score for the
+//! HTLC forward, pushing policy updates over the gossip network and receiving
+//! credentials proofs over the onion communication channels.
+
+extern crate bitcoin;
+extern crate lightning;
+extern crate alloc;
+#[cfg(any(test, feature = "std"))]
+extern crate core;
+
+mod prelude {
+	#[cfg(feature = "hashbrown")]
+	extern crate hashbrown;
+
+	pub use alloc::{vec, vec::Vec, string::String, collections::VecDeque, boxed::Box};
+	#[cfg(not(feature = "hashbrown"))]
+	pub use std::collections::{HashMap, HashSet, hash_map};
+	#[cfg(feature = "hashbrown")]
+	pub use self::hashbrown::{HashMap, HashSet, hash_map};
+}
+
+/// Sync compat for std/no_std
+#[cfg(feature = "std")]
+mod sync {
+	pub use ::std::sync::{Mutex, MutexGuard};
+}
+
+/// Sync compat for std/no_std
+#[cfg(not(feature = "std"))]
+mod sync;
+
+use lightning::util::logger::Logger;
+use lightning::util::events::Event;
+use lightning::util::credentials_utils::SignedCredential;
+use lightning::ln::channelmanager::InterceptId;
+
+use bitcoin::secp256k1::{SecretKey, PublicKey, Secp256k1, Message};
+use bitcoin::secp256k1;
+
+use crate::prelude::*;
+use crate::sync::Mutex;
+use core::ops::Deref;
+
+/// Routing policy which apply on a per-HTLC forward basis and may change at runtime.
+///
+/// Routing policy can be announced network-wide via gossips or on a HTLC sender basis
+/// via onion communication channels.
+#[derive(Copy, Clone, Debug)]
+struct RoutingPolicy {
+	/// The number of credentials we require to grant channel liquidity to a HTLC
+	/// forward request.
+	///
+	/// Default value: 1 credential unit = 1 btc liquidity per block.
+	credential_to_liquidity_unit: u64,
+	/// Height at which all issues routing credentials are expiring.
+	///
+	/// Default value: 0 (never expires).
+	credential_expiration_height: u32,
+}
+
+impl Default for RoutingPolicy {
+	fn default() -> Self {
+		RoutingPolicy {
+			credential_to_liquidity_unit: 1,
+			credential_expiration_height: 0
+		}
+	}
+}
+
+/// HTLC scorer which keeps track of the accepted HTLC forward requests and process
+/// the settlement result accordingly when they're routed backward.
+pub struct HTLCScorer<L: Deref>
+	where L::Target: Logger,
+{
+	forward_state: Mutex<HashMap<InterceptId, Vec<SignedCredential>>>,
+	// backward_state: Mutex<HashMap<InterceptId, Vec<UnsignedCredentials>>
+
+	routing_policy: RoutingPolicy,
+
+	scorer_pubkey: PublicKey,
+	//TODO: move behind keysinterface
+	scorer_seckey: SecretKey,
+
+	secp_ctx: Secp256k1<secp256k1::All>,
+
+	logger: L,
+}
+
+impl<L: Deref> HTLCScorer<L>
+	where L::Target: Logger,
+{
+	pub fn new(logger: L, scorer_seckey: SecretKey) -> Self {
+		let mut secp_ctx = Secp256k1::new();
+		let scorer_pubkey = PublicKey::from_secret_key(&secp_ctx, &scorer_seckey);
+		HTLCScorer {
+			forward_state: Mutex::new(HashMap::new()),
+			routing_policy: RoutingPolicy::default(),
+			scorer_pubkey,
+			scorer_seckey,
+			secp_ctx,
+			logger,
+		}
+	}
+
+	pub fn process_htlc_forward(&self, event: &Event) -> bool {
+		match event {
+			Event::PaymentIntercepted { intercept_id, expected_outbound_amount_msat, outbound_block_value, forward_credentials, backward_credentials, .. } => {
+
+				// Verify credentials authenticity
+				for signed_credential in forward_credentials {
+					let message = Message::from_slice(&signed_credential.credential).unwrap();
+					match self.secp_ctx.verify_ecdsa(&message, &signed_credential.signature, &self.scorer_pubkey) {
+						Ok(_) => {},
+						Err(_) => { return false; }
+					}
+				}
+
+				// Verify forward credentials satisfy routing policy.
+				let requested_lockup_liquidity_units = expected_outbound_amount_msat * (*outbound_block_value) as u64 / 100_000_000_000;
+				let credit_liquidity_units = self.routing_policy.credential_to_liquidity_unit * forward_credentials.len() as u64;
+				if requested_lockup_liquidity_units > credit_liquidity_units {
+					//TODO: introduce new onion error messages ?
+					return false;
+				}
+
+				// Register the backward credentials when the HTLC is settled back (either `update_fulfill_htlc`/`update_fail_htlc`).
+				let mut forward_state = self.forward_state.lock().unwrap();
+				forward_state.insert(*intercept_id, backward_credentials.to_vec());
+			},
+			_ => { panic!("Received non compatible event for module !"); }
+		}
+		return true;
+	}
+
+	pub fn process_htlc_backward(&self, event: &Event) -> Result<Vec<SignedCredential>, ()> {
+		match event {
+			Event::HTLCBackwardIntercepted { intercept_id, result } => {
+
+				// If the HTLC has successfully paid back fees, counter-sign the registered
+				// credentials and relay them back to HTLC sender.
+				//
+				// Note, if the HTLC has been failed on our outgoing link, credentials *might*
+				// be counter-signed, as the failure can be assigned to our channel peering
+				// strategy.
+				if *result {
+					let mut forward_state = self.forward_state.lock().unwrap();
+					if let Some(backward_credentials) = forward_state.remove(intercept_id) {
+						let mut result_credentials = Vec::with_capacity(backward_credentials.len());
+						for credential in backward_credentials {
+							let message = Message::from_slice(&credential.credential).unwrap();
+							let sig = self.secp_ctx.sign_ecdsa(&message, &self.scorer_seckey);
+							let new_credential = SignedCredential {
+								credential: credential.credential,
+								signature: sig,
+							};
+							result_credentials.push(new_credential);
+						}
+						return Ok(result_credentials);
+					}
+				}
+			}
+			_ => { panic!("Receive non compatible event for module !"); }
+		}
+		return Err(());
+	}
+}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -113,6 +113,7 @@ pub(super) struct PendingHTLCInfo {
 	pub(super) incoming_shared_secret: [u8; 32],
 	payment_hash: PaymentHash,
 	pub(super) amt_to_forward: u64,
+	pub(super) amt_incoming: Option<u64>, // Added in 0.0.113
 	pub(super) outgoing_cltv_value: u32,
 }
 
@@ -2196,6 +2197,7 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 			routing,
 			payment_hash,
 			incoming_shared_secret: shared_secret,
+			amt_incoming: Some(amt_msat),
 			amt_to_forward: amt_msat,
 			outgoing_cltv_value: hop_data.outgoing_cltv_value,
 		})
@@ -2292,6 +2294,7 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 					},
 					payment_hash: msg.payment_hash.clone(),
 					incoming_shared_secret: shared_secret,
+					amt_incoming: Some(msg.amount_msat),
 					amt_to_forward: next_hop_data.amt_to_forward,
 					outgoing_cltv_value: next_hop_data.outgoing_cltv_value,
 				})
@@ -3155,7 +3158,7 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 										prev_short_channel_id, prev_htlc_id, prev_funding_outpoint,
 										forward_info: PendingHTLCInfo {
 											routing, incoming_shared_secret, payment_hash, amt_to_forward,
-											outgoing_cltv_value
+											outgoing_cltv_value, amt_incoming: _
 										}
 									}) => {
 										macro_rules! failure_handler {
@@ -3263,7 +3266,8 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 										forward_info: PendingHTLCInfo {
 											routing: PendingHTLCRouting::Forward {
 												onion_packet, ..
-											}, incoming_shared_secret, payment_hash, amt_to_forward, outgoing_cltv_value
+											}, incoming_shared_secret, payment_hash, amt_to_forward, outgoing_cltv_value,
+											amt_incoming: _
 										},
 									}) => {
 										log_trace!(self.logger, "Adding HTLC from short id {} with payment_hash {} to channel with short id {} after delay", prev_short_channel_id, log_bytes!(payment_hash.0), short_chan_id);
@@ -6471,7 +6475,8 @@ impl_writeable_tlv_based!(PendingHTLCInfo, {
 	(2, incoming_shared_secret, required),
 	(4, payment_hash, required),
 	(6, amt_to_forward, required),
-	(8, outgoing_cltv_value, required)
+	(8, outgoing_cltv_value, required),
+	(9, amt_incoming, option),
 });
 
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -206,6 +206,24 @@ impl Readable for PaymentId {
 		Ok(PaymentId(buf))
 	}
 }
+
+/// An identifier used to uniquely identify an intercepted HTLC to LDK.
+/// (C-not exported) as we just use [u8; 32] directly
+#[derive(Hash, Copy, Clone, PartialEq, Eq, Debug)]
+pub struct InterceptId(pub [u8; 32]);
+
+impl Writeable for InterceptId {
+	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+		self.0.write(w)
+	}
+}
+
+impl Readable for InterceptId {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+		let buf: [u8; 32] = Readable::read(r)?;
+		Ok(InterceptId(buf))
+	}
+}
 /// Tracks the inbound corresponding to an outbound HTLC
 #[allow(clippy::derive_hash_xor_eq)] // Our Hash is faithful to the data, we just don't have SecretKey::hash
 #[derive(Clone, PartialEq, Eq)]
@@ -755,6 +773,9 @@ pub struct ChannelManager<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 	pub(super) forward_htlcs: Mutex<HashMap<u64, Vec<HTLCForwardInfo>>>,
 	#[cfg(not(test))]
 	forward_htlcs: Mutex<HashMap<u64, Vec<HTLCForwardInfo>>>,
+	/// Storage for PendingInterceptedHTLCs that have been intercepted and bubbled up to the user. We
+	/// hold them here until the user tells us what we should to with them.
+	pending_intercepted_payments: Mutex<HashMap<InterceptId, PendingAddHTLCInfo>>,
 
 	/// The set of outbound SCID aliases across all our channels, including unconfirmed channels
 	/// and some closed channels which reached a usable state prior to being closed. This is used
@@ -1667,6 +1688,7 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 			pending_inbound_payments: Mutex::new(HashMap::new()),
 			pending_outbound_payments: Mutex::new(HashMap::new()),
 			forward_htlcs: Mutex::new(HashMap::new()),
+			pending_intercepted_payments: Mutex::new(HashMap::new()),
 			id_to_peer: Mutex::new(HashMap::new()),
 			short_to_chan_info: FairRwLock::new(HashMap::new()),
 
@@ -6878,8 +6900,15 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Writeable for ChannelMana
 				_ => {},
 			}
 		}
+
+		let mut pending_intercepted_payments = None;
+		let our_pending_intercepts = self.pending_intercepted_payments.lock().unwrap();
+		if our_pending_intercepts.len() != 0 {
+			pending_intercepted_payments = Some(our_pending_intercepts);
+		}
 		write_tlv_fields!(writer, {
 			(1, pending_outbound_payments_no_retry, required),
+			(2, pending_intercepted_payments, option),
 			(3, pending_outbound_payments, required),
 			(5, self.our_network_pubkey, required),
 			(7, self.fake_scid_rand_bytes, required),
@@ -7193,12 +7222,14 @@ impl<'a, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 		// pending_outbound_payments_no_retry is for compatibility with 0.0.101 clients.
 		let mut pending_outbound_payments_no_retry: Option<HashMap<PaymentId, HashSet<[u8; 32]>>> = None;
 		let mut pending_outbound_payments = None;
+		let mut pending_intercepted_payments: Option<HashMap<InterceptId, PendingAddHTLCInfo>> = Some(HashMap::new());
 		let mut received_network_pubkey: Option<PublicKey> = None;
 		let mut fake_scid_rand_bytes: Option<[u8; 32]> = None;
 		let mut probing_cookie_secret: Option<[u8; 32]> = None;
 		let mut claimable_htlc_purposes = None;
 		read_tlv_fields!(reader, {
 			(1, pending_outbound_payments_no_retry, option),
+			(2, pending_intercepted_payments, option),
 			(3, pending_outbound_payments, option),
 			(5, received_network_pubkey, option),
 			(7, fake_scid_rand_bytes, option),
@@ -7414,6 +7445,7 @@ impl<'a, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 			inbound_payment_key: expanded_inbound_key,
 			pending_inbound_payments: Mutex::new(pending_inbound_payments),
 			pending_outbound_payments: Mutex::new(pending_outbound_payments.unwrap()),
+			pending_intercepted_payments: Mutex::new(pending_intercepted_payments.unwrap()),
 
 			forward_htlcs: Mutex::new(forward_htlcs),
 			outbound_scid_aliases: Mutex::new(outbound_scid_aliases),

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -129,20 +129,22 @@ pub(super) enum PendingHTLCStatus {
 	Fail(HTLCFailureMsg),
 }
 
-pub(super) enum HTLCForwardInfo {
-	AddHTLC {
-		forward_info: PendingHTLCInfo,
+pub(super) struct PendingAddHTLCInfo {
+	pub(super) forward_info: PendingHTLCInfo,
 
-		// These fields are produced in `forward_htlcs()` and consumed in
-		// `process_pending_htlc_forwards()` for constructing the
-		// `HTLCSource::PreviousHopData` for failed and forwarded
-		// HTLCs.
-		//
-		// Note that this may be an outbound SCID alias for the associated channel.
-		prev_short_channel_id: u64,
-		prev_htlc_id: u64,
-		prev_funding_outpoint: OutPoint,
-	},
+	// These fields are produced in `forward_htlcs()` and consumed in
+	// `process_pending_htlc_forwards()` for constructing the
+	// `HTLCSource::PreviousHopData` for failed and forwarded
+	// HTLCs.
+	//
+	// Note that this may be an outbound SCID alias for the associated channel.
+	prev_short_channel_id: u64,
+	prev_htlc_id: u64,
+	prev_funding_outpoint: OutPoint,
+}
+
+pub(super) enum HTLCForwardInfo {
+	AddHTLC(PendingAddHTLCInfo),
 	FailHTLC {
 		htlc_id: u64,
 		err_packet: msgs::OnionErrorPacket,
@@ -3149,9 +3151,13 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 						() => {
 							for forward_info in pending_forwards.drain(..) {
 								match forward_info {
-									HTLCForwardInfo::AddHTLC { prev_short_channel_id, prev_htlc_id, forward_info: PendingHTLCInfo {
-										routing, incoming_shared_secret, payment_hash, amt_to_forward, outgoing_cltv_value },
-										prev_funding_outpoint } => {
+									HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo {
+										prev_short_channel_id, prev_htlc_id, prev_funding_outpoint,
+										forward_info: PendingHTLCInfo {
+											routing, incoming_shared_secret, payment_hash, amt_to_forward,
+											outgoing_cltv_value
+										}
+									}) => {
 											macro_rules! failure_handler {
 												($msg: expr, $err_code: expr, $err_data: expr, $phantom_ss: expr, $next_hop_unknown: expr) => {
 													log_info!(self.logger, "Failed to accept/forward incoming HTLC: {}", $msg);
@@ -3252,11 +3258,14 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 							let mut fail_htlc_msgs = Vec::new();
 							for forward_info in pending_forwards.drain(..) {
 								match forward_info {
-									HTLCForwardInfo::AddHTLC { prev_short_channel_id, prev_htlc_id, forward_info: PendingHTLCInfo {
+									HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo {
+										prev_short_channel_id, prev_htlc_id, prev_funding_outpoint ,
+										forward_info: PendingHTLCInfo {
 											routing: PendingHTLCRouting::Forward {
 												onion_packet, ..
-											}, incoming_shared_secret, payment_hash, amt_to_forward, outgoing_cltv_value },
-											prev_funding_outpoint } => {
+											}, incoming_shared_secret, payment_hash, amt_to_forward, outgoing_cltv_value
+										},
+									}) => {
 										log_trace!(self.logger, "Adding HTLC from short id {} with payment_hash {} to channel with short id {} after delay", prev_short_channel_id, log_bytes!(payment_hash.0), short_chan_id);
 										let htlc_source = HTLCSource::PreviousHopData(HTLCPreviousHopData {
 											short_channel_id: prev_short_channel_id,
@@ -3377,9 +3386,12 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 				} else {
 					for forward_info in pending_forwards.drain(..) {
 						match forward_info {
-							HTLCForwardInfo::AddHTLC { prev_short_channel_id, prev_htlc_id, forward_info: PendingHTLCInfo {
-									routing, incoming_shared_secret, payment_hash, amt_to_forward, .. },
-									prev_funding_outpoint } => {
+							HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo {
+								prev_short_channel_id, prev_htlc_id, prev_funding_outpoint,
+								forward_info: PendingHTLCInfo {
+									routing, incoming_shared_secret, payment_hash, amt_to_forward, ..
+								}
+							}) => {
 								let (cltv_expiry, onion_payload, payment_data, phantom_shared_secret) = match routing {
 									PendingHTLCRouting::Receive { payment_data, incoming_cltv_expiry, phantom_shared_secret } => {
 										let _legacy_hop_data = Some(payment_data.clone());
@@ -5089,12 +5101,12 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 							PendingHTLCRouting::ReceiveKeysend { .. } => 0,
 					}) {
 						hash_map::Entry::Occupied(mut entry) => {
-							entry.get_mut().push(HTLCForwardInfo::AddHTLC { prev_short_channel_id, prev_funding_outpoint,
-							                                                prev_htlc_id, forward_info });
+							entry.get_mut().push(HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo {
+								prev_short_channel_id, prev_funding_outpoint, prev_htlc_id, forward_info }));
 						},
 						hash_map::Entry::Vacant(entry) => {
-							entry.insert(vec!(HTLCForwardInfo::AddHTLC { prev_short_channel_id, prev_funding_outpoint,
-							                                             prev_htlc_id, forward_info }));
+							entry.insert(vec!(HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo {
+								prev_short_channel_id, prev_funding_outpoint, prev_htlc_id, forward_info })));
 						}
 					}
 				}
@@ -6681,18 +6693,20 @@ impl_writeable_tlv_based_enum!(HTLCFailReason,
 	},
 ;);
 
+impl_writeable_tlv_based!(PendingAddHTLCInfo, {
+	(0, forward_info, required),
+	(2, prev_short_channel_id, required),
+	(4, prev_htlc_id, required),
+	(6, prev_funding_outpoint, required),
+});
+
 impl_writeable_tlv_based_enum!(HTLCForwardInfo,
-	(0, AddHTLC) => {
-		(0, forward_info, required),
-		(2, prev_short_channel_id, required),
-		(4, prev_htlc_id, required),
-		(6, prev_funding_outpoint, required),
-	},
 	(1, FailHTLC) => {
 		(0, htlc_id, required),
 		(2, err_packet, required),
-	},
-;);
+	};
+	(0, AddHTLC)
+);
 
 impl_writeable_tlv_based!(PendingInboundPayment, {
 	(0, payment_secret, required),

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -19,7 +19,8 @@ use crate::ln::channel::EXPIRE_PREV_CONFIG_TICKS;
 use crate::ln::channelmanager::{self, BREAKDOWN_TIMEOUT, ChannelManager, ChannelManagerReadArgs, MPP_TIMEOUT_TICKS, MIN_CLTV_EXPIRY_DELTA, PaymentId, PaymentSendFailure, IDEMPOTENCY_TIMEOUT_TICKS};
 use crate::ln::msgs;
 use crate::ln::msgs::ChannelMessageHandler;
-use crate::routing::router::{PaymentParameters, get_route};
+use crate::routing::gossip::RoutingFees;
+use crate::routing::router::{find_route, get_route, PaymentParameters, RouteHint, RouteHintHop, RouteParameters};
 use crate::util::events::{ClosureReason, Event, HTLCDestination, MessageSendEvent, MessageSendEventsProvider};
 use crate::util::test_utils;
 use crate::util::errors::APIError;
@@ -1384,4 +1385,116 @@ fn abandoned_send_payment_idempotent() {
 	check_added_monitors!(nodes[0], 1);
 	pass_along_route(&nodes[0], &[&[&nodes[1]]], 100_000, second_payment_hash, second_payment_secret);
 	claim_payment(&nodes[0], &[&nodes[1]], second_payment_preimage);
+}
+
+#[test]
+fn forward_intercepted_payment() {
+	// Test that detecting an intercept scid on payment forward will signal LDK to generate an
+	// intercept event, which the LSP can then use to open a JIT channel to forward the payment.
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	let scorer = test_utils::TestScorer::with_penalty(0);
+	let random_seed_bytes = chanmon_cfgs[0].keys_manager.get_secure_random_bytes();
+
+	let _ = create_announced_chan_between_nodes(&nodes, 0, 1, channelmanager::provided_init_features(), channelmanager::provided_init_features()).2;
+
+	let amt_msat = 100_000;
+	let intercept_scid = nodes[1].node.get_intercept_scid();
+	let payment_params = PaymentParameters::from_node_id(nodes[2].node.get_our_node_id())
+		.with_route_hints(vec![
+			RouteHint(vec![RouteHintHop {
+				src_node_id: nodes[1].node.get_our_node_id(),
+				short_channel_id: intercept_scid,
+				fees: RoutingFees {
+					base_msat: 1000,
+					proportional_millionths: 0,
+				},
+				cltv_expiry_delta: 130,
+				htlc_minimum_msat: None,
+				htlc_maximum_msat: None,
+			}])
+		])
+		.with_features(channelmanager::provided_invoice_features());
+	let route_params = RouteParameters {
+		payment_params,
+		final_value_msat: amt_msat,
+		final_cltv_expiry_delta: TEST_FINAL_CLTV,
+	};
+	let route = find_route(
+		&nodes[0].node.get_our_node_id(), &route_params, &nodes[0].network_graph, None, nodes[0].logger,
+		&scorer, &random_seed_bytes
+	).unwrap();
+
+	let (payment_hash, payment_secret) = nodes[2].node.create_inbound_payment(Some(amt_msat), 60 * 60).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash, &Some(payment_secret), PaymentId(payment_hash.0)).unwrap();
+	let payment_event = {
+		{
+			let mut added_monitors = nodes[0].chain_monitor.added_monitors.lock().unwrap();
+			assert_eq!(added_monitors.len(), 1);
+			added_monitors.clear();
+		}
+		let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		SendEvent::from_event(events.remove(0))
+	};
+	nodes[1].node.handle_update_add_htlc(&nodes[0].node.get_our_node_id(), &payment_event.msgs[0]);
+	commitment_signed_dance!(nodes[1], nodes[0], &payment_event.commitment_msg, false, true);
+
+	// Check that we generate the PaymentIntercepted event when an intercept forward is detected.
+	let events = nodes[1].node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	let (intercept_id, expected_outbound_amount_msat) = match events[0] {
+		crate::util::events::Event::PaymentIntercepted {
+			intercept_id, expected_outbound_amount_msat, payment_hash: pmt_hash, inbound_amount_msat, short_channel_id
+		} => {
+			assert_eq!(pmt_hash, payment_hash);
+			assert_eq!(inbound_amount_msat, route.get_total_amount() + route.get_total_fees());
+			assert_eq!(short_channel_id, intercept_scid);
+			(intercept_id, expected_outbound_amount_msat)
+		},
+		_ => panic!()
+	};
+
+	// Open the just-in-time channel so the payment can then be forwarded.
+	let scid = create_announced_chan_between_nodes(&nodes, 1, 2, channelmanager::provided_init_features(), channelmanager::provided_init_features()).0.contents.short_channel_id;
+
+	// Finally, forward the intercepted payment through and claim it.
+	nodes[1].node.forward_intercepted_payment(intercept_id, scid, expected_outbound_amount_msat).unwrap();
+	expect_pending_htlcs_forwardable!(nodes[1]);
+
+	let payment_event = {
+		{
+			let mut added_monitors = nodes[1].chain_monitor.added_monitors.lock().unwrap();
+			assert_eq!(added_monitors.len(), 1);
+			added_monitors.clear();
+		}
+		let mut events = nodes[1].node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		SendEvent::from_event(events.remove(0))
+	};
+	nodes[2].node.handle_update_add_htlc(&nodes[1].node.get_our_node_id(), &payment_event.msgs[0]);
+	commitment_signed_dance!(nodes[2], nodes[1], &payment_event.commitment_msg, false, true);
+	expect_pending_htlcs_forwardable!(nodes[2]);
+
+	let payment_preimage = nodes[2].node.get_payment_preimage(payment_hash, payment_secret).unwrap();
+	expect_payment_received!(&nodes[2], payment_hash, payment_secret, amt_msat, Some(payment_preimage));
+	do_claim_payment_along_route(&nodes[0], &vec!(&vec!(&nodes[1], &nodes[2])[..]), false, payment_preimage);
+	let events = nodes[0].node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 2);
+	match events[0] {
+		Event::PaymentSent { payment_preimage: ref ev_preimage, payment_hash: ref ev_hash, ref fee_paid_msat, .. } => {
+			assert_eq!(payment_preimage, *ev_preimage);
+			assert_eq!(payment_hash, *ev_hash);
+			assert_eq!(fee_paid_msat, &Some(1000));
+		},
+		_ => panic!("Unexpected event")
+	}
+	match events[1] {
+		Event::PaymentPathSuccessful { payment_hash: hash, .. } => {
+			assert_eq!(hash, Some(payment_hash));
+		},
+		_ => panic!("Unexpected event")
+	}
 }

--- a/lightning/src/util/credentials_utils.rs
+++ b/lightning/src/util/credentials_utils.rs
@@ -1,0 +1,48 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Credentials utilities for HTLC scoring live here.
+
+use crate::io;
+use crate::io::Read;
+use crate::util::ser::{Readable, Writeable, Writer};
+use crate::ln::msgs::DecodeError;
+use bitcoin::secp256k1::ecdsa::Signature;
+
+/// A credential (random 32-byte) and the issuer signature
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SignedCredential {
+	/// 32-byte random string issued by the HTLC sender
+	pub credential: [u8; 32],
+	/// ECDSA Signature from routing node scorer
+	pub signature: Signature, //TODO: make signature optional
+}
+
+impl Writeable for SignedCredential {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+		write_tlv_fields!(writer, {
+			(0, self.credential, required),
+			(2, self.signature, required),
+		});
+		Ok(())
+	}
+
+	fn serialized_length(&self) -> usize {
+		self.credential.serialized_length() + self.signature.serialized_length()
+	}
+}
+
+impl Readable for SignedCredential {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+		Ok(Self {
+			credential: Readable::read(r)?,
+			signature: Readable::read(r)?,
+		})
+	}
+}

--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -22,6 +22,7 @@ pub mod message_signing;
 pub mod invoice;
 pub mod persist;
 pub mod wakers;
+pub mod credentials_utils;
 
 pub(crate) mod atomic_counter;
 pub(crate) mod byte_utils;

--- a/lightning/src/util/scid_utils.rs
+++ b/lightning/src/util/scid_utils.rs
@@ -158,7 +158,7 @@ pub(crate) mod fake_scid {
 		let tx_index = scid_utils::tx_index_from_scid(&scid);
 		let namespace = Namespace::Phantom;
 		let valid_vout = namespace.get_encrypted_vout(block_height, tx_index, fake_scid_rand_bytes);
-		valid_vout == scid_utils::vout_from_scid(&scid) as u8
+		scid != 0 && valid_vout == scid_utils::vout_from_scid(&scid) as u8
 	}
 
 	/// Returns whether the given fake scid falls into the intercept namespace.
@@ -167,7 +167,7 @@ pub(crate) mod fake_scid {
 		let tx_index = scid_utils::tx_index_from_scid(&scid);
 		let namespace = Namespace::Intercept;
 		let valid_vout = namespace.get_encrypted_vout(block_height, tx_index, fake_scid_rand_bytes);
-		valid_vout == scid_utils::vout_from_scid(&scid) as u8
+		scid != 0 && valid_vout == scid_utils::vout_from_scid(&scid) as u8
 	}
 
 	#[cfg(test)]

--- a/lightning/src/util/scid_utils.rs
+++ b/lightning/src/util/scid_utils.rs
@@ -63,6 +63,7 @@ pub fn scid_from_parts(block: u64, tx_index: u64, vout_index: u64) -> Result<u64
 /// LDK has multiple reasons to generate fake short channel ids:
 /// 1) outbound SCID aliases we use for private channels
 /// 2) phantom node payments, to get an scid for the phantom node's phantom channel
+/// 3) payments intended to be intercepted will route using a fake scid
 pub(crate) mod fake_scid {
 	use bitcoin::hash_types::BlockHash;
 	use bitcoin::hashes::hex::FromHex;
@@ -91,6 +92,7 @@ pub(crate) mod fake_scid {
 	pub(crate) enum Namespace {
 		Phantom,
 		OutboundAlias,
+		Intercept
 	}
 
 	impl Namespace {
@@ -150,7 +152,7 @@ pub(crate) mod fake_scid {
 		}
 	}
 
-	/// Returns whether the given fake scid falls into the given namespace.
+	/// Returns whether the given fake scid falls into the phantom namespace.
 	pub fn is_valid_phantom(fake_scid_rand_bytes: &[u8; 32], scid: u64) -> bool {
 		let block_height = scid_utils::block_from_scid(&scid);
 		let tx_index = scid_utils::tx_index_from_scid(&scid);
@@ -159,11 +161,20 @@ pub(crate) mod fake_scid {
 		valid_vout == scid_utils::vout_from_scid(&scid) as u8
 	}
 
+	/// Returns whether the given fake scid falls into the intercept namespace.
+	pub fn is_valid_intercept(fake_scid_rand_bytes: &[u8; 32], scid: u64) -> bool {
+		let block_height = scid_utils::block_from_scid(&scid);
+		let tx_index = scid_utils::tx_index_from_scid(&scid);
+		let namespace = Namespace::Intercept;
+		let valid_vout = namespace.get_encrypted_vout(block_height, tx_index, fake_scid_rand_bytes);
+		valid_vout == scid_utils::vout_from_scid(&scid) as u8
+	}
+
 	#[cfg(test)]
 	mod tests {
 		use bitcoin::blockdata::constants::genesis_block;
 		use bitcoin::network::constants::Network;
-		use crate::util::scid_utils::fake_scid::{is_valid_phantom, MAINNET_SEGWIT_ACTIVATION_HEIGHT, MAX_TX_INDEX, MAX_NAMESPACES, Namespace, NAMESPACE_ID_BITMASK, segwit_activation_height, TEST_SEGWIT_ACTIVATION_HEIGHT};
+		use crate::util::scid_utils::fake_scid::{is_valid_intercept, is_valid_phantom, MAINNET_SEGWIT_ACTIVATION_HEIGHT, MAX_TX_INDEX, MAX_NAMESPACES, Namespace, NAMESPACE_ID_BITMASK, segwit_activation_height, TEST_SEGWIT_ACTIVATION_HEIGHT};
 		use crate::util::scid_utils;
 		use crate::util::test_utils;
 		use crate::sync::Arc;
@@ -199,6 +210,17 @@ pub(crate) mod fake_scid {
 			assert!(is_valid_phantom(&fake_scid_rand_bytes, valid_fake_scid));
 			let invalid_fake_scid = scid_utils::scid_from_parts(0, 0, 12).unwrap();
 			assert!(!is_valid_phantom(&fake_scid_rand_bytes, invalid_fake_scid));
+		}
+
+		#[test]
+		fn test_is_valid_intercept() {
+			let namespace = Namespace::Intercept;
+			let fake_scid_rand_bytes = [0; 32];
+			let valid_encrypted_vout = namespace.get_encrypted_vout(0, 0, &fake_scid_rand_bytes);
+			let valid_fake_scid = scid_utils::scid_from_parts(0, 0, valid_encrypted_vout as u64).unwrap();
+			assert!(is_valid_intercept(&fake_scid_rand_bytes, valid_fake_scid));
+			let invalid_fake_scid = scid_utils::scid_from_parts(0, 0, 12).unwrap();
+			assert!(!is_valid_intercept(&fake_scid_rand_bytes, invalid_fake_scid));
 		}
 
 		#[test]


### PR DESCRIPTION
This PR introduces a `HTLCScorer`, a new module to mitigate against channel jamming attacks and to allow a routing node to control its incoming liquidity flows. The strategy is an experimental implementation of previous channel jamming research ideas ("[the Channel Jamming book"](https://jamming-dev.github.io/book/about.html) and "[Unjamming Lightning: A Systematic Approach](https://eprint.iacr.org/2022/1454.pdf)"). 

The `HTLCScorer` consumes the new `Event::PaymentIntercept` from #1835 (dependent on generic interception followups) and apply additional routing checks defined by a `RoutingPolicy`. Notably, this routing policy quotes a `credential_to_liquidity_unit`, i.e the number of credentials we require from a HTLC forward request to grant corresponding outbound channel liquidity. The credentials (`SignedCredentials`) are attached in the HTLC onion payload (`NonFinalNodeAndCredentials`) and stored until HTLC settlement (`process_htlc_backward()`). In function of the HTLC settlement result (either `update_add_htlc` / `update_fail_htlc`), we send back new counter-signed credentials.  

Credentials redemption should be anonymized to maintain confidentiality of the payer from a routing hop viewpoint. The payer should be able to receive a significant amount of credentials for each challenge they solve without the routing hop being able to link the credential to a persistent identity (in this direction e.g IETF's [Privacy Pass](https://www.petsymposium.org/2018/files/papers/issue3/popets-2018-0026.pdf)).

The original dissemination of the reputation credentials can be based on the payment of unconditional fees/upfront fees to the routing hops during an initial bootstrapping phase.

Working on BOLT extensions to define the credential data format, the routing policy fields, new BOLT error messages and new onion TLV records.

This PR is open as an experiment only, mostly to illustrate how a reputation-based channel jamming would architecturally plug with our current `Event` interfaces.