### PR TITLE
Add time support for wasm environments

### DIFF
--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -21,6 +21,7 @@ bitcoin = "0.29.0"
 lightning = { version = "0.0.112", path = "../lightning", features = ["std"] }
 lightning-rapid-gossip-sync = { version = "0.0.112", path = "../lightning-rapid-gossip-sync" }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro"], optional = true }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [dev-dependencies]
 lightning = { version = "0.0.112", path = "../lightning", features = ["_test_utils"] }

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use instant::{Duration, Instant};
 use std::ops::Deref;
 
 #[cfg(feature = "futures")]

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -27,6 +27,7 @@ num-traits = { version = "0.2.8", default-features = false }
 bitcoin_hashes = { version = "0.11", default-features = false }
 hashbrown = { version = "0.8", optional = true }
 serde = { version = "1.0.118", optional = true }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [dev-dependencies]
 lightning = { version = "0.0.112", path = "../lightning", default-features = false, features = ["_test_utils"] }

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -42,7 +42,7 @@ extern crate core;
 extern crate serde;
 
 #[cfg(feature = "std")]
-use std::time::SystemTime;
+use instant::SystemTime;
 
 use bech32::u5;
 use bitcoin_hashes::Hash;
@@ -1850,7 +1850,7 @@ mod test {
 		use lightning::routing::router::RouteHintHop;
 		use secp256k1::Secp256k1;
 		use secp256k1::{SecretKey, PublicKey};
-		use std::time::{UNIX_EPOCH, Duration};
+		use instant::{SystemTime, Duration};
 
 		let secp_ctx = Secp256k1::new();
 
@@ -1939,7 +1939,7 @@ mod test {
 		assert_eq!(invoice.currency(), Currency::BitcoinTestnet);
 		#[cfg(feature = "std")]
 		assert_eq!(
-			invoice.timestamp().duration_since(UNIX_EPOCH).unwrap().as_secs(),
+			invoice.timestamp().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs(),
 			1234567
 		);
 		assert_eq!(invoice.payee_pub_key(), Some(&public_key));

--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -161,7 +161,7 @@ use core::future::Future;
 use core::ops::Deref;
 use core::time::Duration;
 #[cfg(feature = "std")]
-use std::time::SystemTime;
+use instant::SystemTime;
 
 /// A utility for paying [`Invoice`]s and sending spontaneous payments.
 ///
@@ -171,7 +171,7 @@ use std::time::SystemTime;
 pub type InvoicePayer<P, R, L, E> = InvoicePayerUsingTime::<P, R, L, E, ConfiguredTime>;
 
 #[cfg(not(feature = "no-std"))]
-type ConfiguredTime = std::time::Instant;
+type ConfiguredTime = instant::Instant;
 #[cfg(feature = "no-std")]
 use crate::time_utils;
 #[cfg(feature = "no-std")]
@@ -891,7 +891,7 @@ mod tests {
 	use std::cell::RefCell;
 	use std::collections::VecDeque;
 	use std::ops::DerefMut;
-	use std::time::{SystemTime, Duration};
+	use instant::{SystemTime, Duration};
 	use crate::time_utils::tests::SinceEpoch;
 	use crate::DEFAULT_EXPIRY_TIME;
 	use lightning::util::errors::APIError::{ChannelUnavailable, MonitorUpdateInProgress};

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -128,7 +128,7 @@ where
 	K::Target: KeysInterface,
 	L::Target: Logger,
 {
-	use std::time::{SystemTime, UNIX_EPOCH};
+	use instant::SystemTime;
 
 	if phantom_route_hints.len() == 0 {
 		return Err(SignOrCreationError::CreationError(
@@ -152,7 +152,7 @@ where
 			payment_hash,
 			invoice_expiry_delta_secs,
 			SystemTime::now()
-				.duration_since(UNIX_EPOCH)
+				.duration_since(SystemTime::UNIX_EPOCH)
 				.expect("Time must be > 1970")
 				.as_secs(),
 		)
@@ -165,7 +165,7 @@ where
 			invoice_expiry_delta_secs,
 			&keys_manager,
 			SystemTime::now()
-				.duration_since(UNIX_EPOCH)
+				.duration_since(SystemTime::UNIX_EPOCH)
 				.expect("Time must be > 1970")
 				.as_secs(),
 		)
@@ -246,7 +246,7 @@ where
 	F::Target: FeeEstimator,
 	L::Target: Logger,
 {
-	use std::time::SystemTime;
+	use instant::SystemTime;
 	let duration = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)
 		.expect("for the foreseeable future this shouldn't happen");
 	create_invoice_from_channelmanager_and_duration_since_epoch(
@@ -277,7 +277,7 @@ where
 	F::Target: FeeEstimator,
 	L::Target: Logger,
 {
-	use std::time::SystemTime;
+	use instant::SystemTime;
 
 	let duration = SystemTime::now()
 		.duration_since(SystemTime::UNIX_EPOCH)

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -40,6 +40,7 @@ default = ["std", "grind_signatures"]
 
 [dependencies]
 bitcoin = { version = "0.29.0", default-features = false, features = ["secp-recovery"] }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 hashbrown = { version = "0.8", optional = true }
 hex = { version = "0.4", optional = true }

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -29,7 +29,7 @@
 //!
 //! # use lightning::onion_message::BlindedPath;
 //! # #[cfg(feature = "std")]
-//! # use std::time::SystemTime;
+//! # use instant::SystemTime;
 //! #
 //! # fn create_blinded_path() -> BlindedPath { unimplemented!() }
 //! # fn create_another_blinded_path() -> BlindedPath { unimplemented!() }
@@ -84,7 +84,7 @@ use crate::util::string::PrintableString;
 use crate::prelude::*;
 
 #[cfg(feature = "std")]
-use std::time::SystemTime;
+use instant::SystemTime;
 
 /// Builds an [`Offer`] for the "offer to be paid" flow.
 ///

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -317,7 +317,7 @@ impl ReadableArgs<u64> for FixedPenaltyScorer {
 }
 
 #[cfg(not(feature = "no-std"))]
-type ConfiguredTime = std::time::Instant;
+type ConfiguredTime = instant::Instant;
 #[cfg(feature = "no-std")]
 use crate::util::time::Eternity;
 #[cfg(feature = "no-std")]

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -51,7 +51,7 @@ use bitcoin::bech32::u5;
 use crate::chain::keysinterface::{InMemorySigner, Recipient, KeyMaterial};
 
 #[cfg(feature = "std")]
-use std::time::{SystemTime, UNIX_EPOCH};
+use instant::SystemTime;
 use bitcoin::Sequence;
 
 pub struct TestVecWriter(pub Vec<u8>);
@@ -476,7 +476,7 @@ impl msgs::RoutingMessageHandler for TestRoutingMessageHandler {
 		let mut gossip_start_time = 0;
 		#[cfg(feature = "std")]
 		{
-			gossip_start_time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time must be > 1970").as_secs();
+			gossip_start_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).expect("Time must be > 1970").as_secs();
 			if self.request_full_sync.load(Ordering::Acquire) {
 				gossip_start_time -= 60 * 60 * 24 * 7 * 2; // 2 weeks ago
 			} else {

--- a/lightning/src/util/time.rs
+++ b/lightning/src/util/time.rs
@@ -59,9 +59,9 @@ impl Sub<Duration> for Eternity {
 }
 
 #[cfg(not(feature = "no-std"))]
-impl Time for std::time::Instant {
+impl Time for instant::Instant {
 	fn now() -> Self {
-		std::time::Instant::now()
+		instant::Instant::now()
 	}
 
 	fn duration_since(&self, earlier: Self) -> Duration {
@@ -74,11 +74,11 @@ impl Time for std::time::Instant {
 	}
 
 	fn duration_since_epoch() -> Duration {
-		use std::time::SystemTime;
+		use instant::SystemTime;
 		SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap()
 	}
 	fn elapsed(&self) -> Duration {
-		std::time::Instant::elapsed(self)
+		instant::Instant::elapsed(self)
 	}
 }
 

--- a/lightning/src/util/wakers.rs
+++ b/lightning/src/util/wakers.rs
@@ -20,7 +20,7 @@ use crate::sync::{Condvar, Mutex, MutexGuard};
 use crate::prelude::*;
 
 #[cfg(any(test, feature = "std"))]
-use std::time::{Duration, Instant};
+use instant::{Duration, Instant};
 
 use core::future::Future as StdFuture;
 use core::task::{Context, Poll};


### PR DESCRIPTION
This allows ldk to work on wasm targets too, where `std::time` isn't available. The [instant](https://crates.io/crates/instant) crate emulates the behavior of `std::time::SystemTime` and `std::time::Instant` by using javascript functions like `Date.now()` and `performance.now()` if the build target is wasm. It's just a wrapper over `std::time` otherwise. This removes the necessity to use the `no-std` feature when working with wasm.