### PR TITLE
Relock `channel_state` in for each HTLC in `claim_funds` and lay the groundwork for async event generation

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4425,6 +4425,10 @@ impl<M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<M, T, K, F
 					match self.chain_monitor.update_channel(chan.get().get_funding_txo().unwrap(), monitor_update) {
 						ChannelMonitorUpdateStatus::Completed => {},
 						e => {
+							// TODO: This needs to be handled somehow - if we receive a monitor update
+							// with a preimage we *must* somehow manage to propagate it to the upstream
+							// channel, or we must have an ability to receive the same update and try
+							// again on restart.
 							log_given_level!(self.logger, if e == ChannelMonitorUpdateStatus::PermanentFailure { Level::Error } else { Level::Info },
 								"Failed to update channel monitor with preimage {:?} immediately prior to force-close: {:?}",
 								payment_preimage, e);


### PR DESCRIPTION
In order to lay the groundwork for adding event barrier support and more robust async monitor updates, this adds some structs that allow us to track events to generate after a monitor update completes. Its separated out to keep the next PR(s) smaller, but also because it changes the locking of `claim_funds` which may be useful in #1507, see individual commits for more details.