### PR TITLE
Clean up docs in `keysinterface.rs`

### DIFF
--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -5258,9 +5258,10 @@ fn test_dynamic_spendable_outputs_local_htlc_timeout_tx() {
 
 #[test]
 fn test_key_derivation_params() {
-	// This test is a copy of test_dynamic_spendable_outputs_local_htlc_timeout_tx, with
-	// a key manager rotation to test that key_derivation_params returned in DynamicOutputP2WSH
-	// let us re-derive the channel key set to then derive a delayed_payment_key.
+	// This test is a copy of test_dynamic_spendable_outputs_local_htlc_timeout_tx, with a key
+	// manager rotation to test that `channel_keys_id` returned in
+	// [`SpendableOutputDescriptor::DelayedPaymentOutput`] let us re-derive the channel key set to
+	// then derive a `delayed_payment_key`.
 
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 


### PR DESCRIPTION
Started off when I found some room for improvement in the docs of `SpendableOutputDescriptor`, took me down the rabbit hole of "since I'm already here"...

Hope this doesn't have too many conflicts with #1867 (but if I see correctly, it shouldn't)...

