### PR TITLE
Avoid redundant broadcast of local commitment transaction

### DIFF
--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -751,10 +751,8 @@ fn do_test_dup_htlc_onchain_fails_on_reload(persist_manager_post_event: bool, co
 	check_added_monitors!(nodes[1], 1);
 	check_closed_event!(nodes[1], 1, ClosureReason::CommitmentTxConfirmed);
 	let claim_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap().split_off(0);
-	assert_eq!(claim_txn.len(), 3);
+	assert_eq!(claim_txn.len(), 1);
 	check_spends!(claim_txn[0], node_txn[1]);
-	check_spends!(claim_txn[1], funding_tx);
-	check_spends!(claim_txn[2], claim_txn[1]);
 
 	header.prev_blockhash = nodes[0].best_block_hash();
 	connect_block(&nodes[0], &Block { header, txdata: vec![node_txn[1].clone()]});


### PR DESCRIPTION
This change follows the rationale of commit 62236c7 and addresses the last remaining redundant local commitment broadcast.

There's no need to broadcast our local commitment transaction if we've already seen a confirmed one as it'll be immediately rejected as a duplicate/conflict.

This will also help prevent dispatching spurious events for bumping commitment and HTLC transactions through anchor outputs since the dispatch for said events follows the same flow as our usual commitment broadcast.

The bulk of this patch is addressing a series of test failures resulting from the broadcast logic change.