### PR TITLE
Pre-work for BOLT 12 invoices

### DIFF
--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -159,6 +159,14 @@ mod sealed {
 	]);
 	define_context!(OfferContext, []);
 	define_context!(InvoiceRequestContext, []);
+	define_context!(Bolt12InvoiceContext, [
+		// Byte 0
+		,
+		// Byte 1
+		,
+		// Byte 2
+		BasicMPP,
+	]);
 	// This isn't a "real" feature context, and is only used in the channel_type field in an
 	// `OpenChannel` message.
 	define_context!(ChannelTypeContext, [
@@ -342,7 +350,7 @@ mod sealed {
 	define_feature!(15, PaymentSecret, [InitContext, NodeContext, InvoiceContext],
 		"Feature flags for `payment_secret`.", set_payment_secret_optional, set_payment_secret_required,
 		supports_payment_secret, requires_payment_secret);
-	define_feature!(17, BasicMPP, [InitContext, NodeContext, InvoiceContext],
+	define_feature!(17, BasicMPP, [InitContext, NodeContext, InvoiceContext, Bolt12InvoiceContext],
 		"Feature flags for `basic_mpp`.", set_basic_mpp_optional, set_basic_mpp_required,
 		supports_basic_mpp, requires_basic_mpp);
 	define_feature!(19, Wumbo, [InitContext, NodeContext],
@@ -369,7 +377,7 @@ mod sealed {
 
 	#[cfg(test)]
 	define_feature!(123456789, UnknownFeature,
-		[NodeContext, ChannelContext, InvoiceContext, OfferContext, InvoiceRequestContext],
+		[NodeContext, ChannelContext, InvoiceContext, OfferContext, InvoiceRequestContext, Bolt12InvoiceContext],
 		"Feature flags for an unknown feature used in testing.", set_unknown_feature_optional,
 		set_unknown_feature_required, supports_unknown_test_feature, requires_unknown_test_feature);
 }
@@ -432,6 +440,8 @@ pub type InvoiceFeatures = Features<sealed::InvoiceContext>;
 pub type OfferFeatures = Features<sealed::OfferContext>;
 /// Features used within an `invoice_request`.
 pub type InvoiceRequestFeatures = Features<sealed::InvoiceRequestContext>;
+/// Features used within an `invoice`.
+pub type Bolt12InvoiceFeatures = Features<sealed::Bolt12InvoiceContext>;
 
 /// Features used within the channel_type field in an OpenChannel message.
 ///

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -167,6 +167,7 @@ mod sealed {
 		// Byte 2
 		BasicMPP,
 	]);
+	define_context!(BlindedHopContext, []);
 	// This isn't a "real" feature context, and is only used in the channel_type field in an
 	// `OpenChannel` message.
 	define_context!(ChannelTypeContext, [
@@ -377,7 +378,7 @@ mod sealed {
 
 	#[cfg(test)]
 	define_feature!(123456789, UnknownFeature,
-		[NodeContext, ChannelContext, InvoiceContext, OfferContext, InvoiceRequestContext, Bolt12InvoiceContext],
+		[NodeContext, ChannelContext, InvoiceContext, OfferContext, InvoiceRequestContext, Bolt12InvoiceContext, BlindedHopContext],
 		"Feature flags for an unknown feature used in testing.", set_unknown_feature_optional,
 		set_unknown_feature_required, supports_unknown_test_feature, requires_unknown_test_feature);
 }
@@ -442,6 +443,8 @@ pub type OfferFeatures = Features<sealed::OfferContext>;
 pub type InvoiceRequestFeatures = Features<sealed::InvoiceRequestContext>;
 /// Features used within an `invoice`.
 pub type Bolt12InvoiceFeatures = Features<sealed::Bolt12InvoiceContext>;
+/// Features used within BOLT 4 encrypted_data_tlv and BOLT 12 blinded_payinfo
+pub type BlindedHopFeatures = Features<sealed::BlindedHopContext>;
 
 /// Features used within the channel_type field in an OpenChannel message.
 ///
@@ -729,6 +732,7 @@ impl_feature_len_prefixed_write!(InitFeatures);
 impl_feature_len_prefixed_write!(ChannelFeatures);
 impl_feature_len_prefixed_write!(NodeFeatures);
 impl_feature_len_prefixed_write!(InvoiceFeatures);
+impl_feature_len_prefixed_write!(BlindedHopFeatures);
 
 // Some features only appear inside of TLVs, so they don't have a length prefix when serialized.
 macro_rules! impl_feature_tlv_write {

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -371,7 +371,7 @@ impl Writeable for InvoiceRequestContents {
 tlv_stream!(InvoiceRequestTlvStream, InvoiceRequestTlvStreamRef, 80..160, {
 	(80, chain: ChainHash),
 	(82, amount: (u64, HighZeroBytesDroppedBigSize)),
-	(84, features: InvoiceRequestFeatures),
+	(84, features: (InvoiceRequestFeatures, WithoutLength)),
 	(86, quantity: (u64, HighZeroBytesDroppedBigSize)),
 	(88, payer_id: PublicKey),
 	(89, payer_note: (String, WithoutLength)),

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -567,7 +567,7 @@ tlv_stream!(OfferTlvStream, OfferTlvStreamRef, 1..80, {
 	(6, currency: CurrencyCode),
 	(8, amount: (u64, HighZeroBytesDroppedBigSize)),
 	(10, description: (String, WithoutLength)),
-	(12, features: OfferFeatures),
+	(12, features: (OfferFeatures, WithoutLength)),
 	(14, absolute_expiry: (u64, HighZeroBytesDroppedBigSize)),
 	(16, paths: (Vec<BlindedPath>, WithoutLength)),
 	(18, issuer: (String, WithoutLength)),

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -159,6 +159,8 @@ pub enum SemanticError {
 	MissingPayerMetadata,
 	/// A payer id was expected but was missing.
 	MissingPayerId,
+	/// A signature was expected but was missing.
+	MissingSignature,
 }
 
 impl From<bech32::Error> for ParseError {

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -102,8 +102,8 @@ pub struct RefundBuilder {
 }
 
 impl RefundBuilder {
-	/// Creates a new builder for a refund using the [`Refund::payer_id`] for signing invoices. Use
-	/// a different pubkey per refund to avoid correlating refunds.
+	/// Creates a new builder for a refund using the [`Refund::payer_id`] for the public node id to
+	/// send to if no [`Refund::paths`] are set. Otherwise, it may be a transient pubkey.
 	///
 	/// Additionally, sets the required [`Refund::description`], [`Refund::metadata`], and
 	/// [`Refund::amount_msats`].
@@ -285,7 +285,10 @@ impl Refund {
 		&self.contents.features
 	}
 
-	/// A possibly transient pubkey used to sign the refund.
+	/// A public node id to send to in the case where there are no [`paths`]. Otherwise, a possibly
+	/// transient pubkey.
+	///
+	/// [`paths`]: Self::paths
 	pub fn payer_id(&self) -> PublicKey {
 		self.contents.payer_id
 	}


### PR DESCRIPTION
Some fixes and pre-work for BOLT 12 invoices taken from #1926.
- Corrects some documentation pertaining to `Refund::payer_id`
- Removes an unnecessary `Option` from `InvoiceRequest`'s interface
- Adds `Features` for `Invoice`