### PR TITLE
Make the no-std `RwLockGuard` `try_lock` actually try

### DIFF
--- a/lightning/src/sync.rs
+++ b/lightning/src/sync.rs
@@ -109,8 +109,10 @@ impl<T> RwLock<T> {
 	}
 
 	pub fn try_write<'a>(&'a self) -> LockResult<RwLockWriteGuard<'a, T>> {
-		// There is no try, grasshopper - only used for tests and expected to fail
-		Err(())
+		match self.inner.try_borrow_mut() {
+			Ok(lock) => Ok(RwLockWriteGuard { lock }),
+			Err(_) => Err(())
+		}
 	}
 }
 


### PR DESCRIPTION
There doesn't appear to be any reason to have `try_lock` fail, and future work shouldn't need to check for std to use `try_lock`.