### PR TITLE
Don't rebroadcast redundant closing TX upon restart

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1216,6 +1216,8 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitor<Signer> {
 	{
 		let mut locked_inner = self.inner.lock().unwrap();
 		if !locked_inner.detected_funding_spend() {
+			log_info!(logger, "Broadcasting latest holder commitment transaction for channel {}",
+				log_bytes!(locked_inner.get_funding_txo().0.to_channel_id()));
 			locked_inner.broadcast_latest_holder_commitment_txn(broadcaster, logger);
 		}
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7209,7 +7209,6 @@ where
 
 		for (funding_txo, monitor) in args.channel_monitors.iter_mut() {
 			if !funding_txo_set.contains(funding_txo) {
-				log_info!(args.logger, "Broadcasting latest holder commitment transaction for closed channel {}", log_bytes!(funding_txo.to_channel_id()));
 				// There's no need to broadcast our commitment transaction if
 				// we've seen one confirmed (even with 1 confirmation) as it'll
 				// be rejected as duplicate/conflicting.


### PR DESCRIPTION
As of #1922, we don't rebroadcast the latest holder commitment transactions in `ChannelMonitor::update_monitor()` anymore if we had previously seen a closing tx on-chain. However, we still do so upon restarting / deserialization of `ChannelManager`.

With this change, we now also refrain from rebroadcasting upon restarting.


Let me know if there is a reason we always need to rebroadcast immediately.