### PR TITLE
Support auto-retrying keysend payments in `ChannelManager`

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7367,6 +7367,7 @@ where
 										session_privs: [session_priv_bytes].iter().map(|a| *a).collect(),
 										payment_hash: htlc.payment_hash,
 										payment_secret,
+										keysend_preimage: None, // only used for retries, and we'll never retry on startup
 										pending_amt_msat: path_amt,
 										pending_fee_msat: Some(path_fee),
 										total_msat: path_amt,

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -453,10 +453,8 @@ impl OutboundPayments {
 		F: Fn(&Vec<RouteHop>, &Option<PaymentParameters>, &PaymentHash, &Option<PaymentSecret>, u64,
 			 u32, PaymentId, &Option<PaymentPreimage>, [u8; 32]) -> Result<(), APIError>,
 	{
-		let preimage = match payment_preimage {
-			Some(p) => p,
-			None => PaymentPreimage(entropy_source.get_secure_random_bytes()),
-		};
+		let preimage = payment_preimage
+			.unwrap_or_else(|| PaymentPreimage(entropy_source.get_secure_random_bytes()));
 		let payment_hash = PaymentHash(Sha256::hash(&preimage.0).into_inner());
 		self.pay_internal(payment_id, Some((payment_hash, &None, Some(preimage), retry_strategy)),
 			route_params, router, first_hops, inflight_htlcs, entropy_source, node_signer,
@@ -475,10 +473,8 @@ impl OutboundPayments {
 		F: Fn(&Vec<RouteHop>, &Option<PaymentParameters>, &PaymentHash, &Option<PaymentSecret>, u64,
 		   u32, PaymentId, &Option<PaymentPreimage>, [u8; 32]) -> Result<(), APIError>
 	{
-		let preimage = match payment_preimage {
-			Some(p) => p,
-			None => PaymentPreimage(entropy_source.get_secure_random_bytes()),
-		};
+		let preimage = payment_preimage
+			.unwrap_or_else(|| PaymentPreimage(entropy_source.get_secure_random_bytes()));
 		let payment_hash = PaymentHash(Sha256::hash(&preimage.0).into_inner());
 		let onion_session_privs = self.add_new_pending_payment(payment_hash, None, payment_id, Some(preimage), &route, None, None, entropy_source, best_block_height)?;
 


### PR DESCRIPTION
Supports sending spontaneous payments with a retry strategy as part of moving all payment retries into `ChannelManager` 

Partially addresses #1932. 

~Based on #1994~