### PR TITLE
Only import lightning::io if futures are enabled

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -37,7 +37,6 @@ use lightning::util::events::{Event, EventHandler, EventsProvider};
 use lightning::util::logger::Logger;
 use lightning::util::persist::Persister;
 use lightning_rapid_gossip_sync::RapidGossipSync;
-use lightning::io;
 
 use core::ops::Deref;
 use core::time::Duration;
@@ -431,7 +430,7 @@ pub async fn process_events_async<
 	persister: PS, event_handler: EventHandler, chain_monitor: M, channel_manager: CM,
 	gossip_sync: GossipSync<PGS, RGS, G, UL, L>, peer_manager: PM, logger: L, scorer: Option<S>,
 	sleeper: Sleeper,
-) -> Result<(), io::Error>
+) -> Result<(), lightning::io::Error>
 where
 	UL::Target: 'static + UtxoLookup,
 	CF::Target: 'static + chain::Filter,


### PR DESCRIPTION
Another option is to import under `#[cfg(feature = "futures")]`

Rationale: avoids unnecessary warnings on `check` and `clippy` with default features