### PR TITLE
Do not auto-select the lightning `std` feature from tx-sync crate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
           done
           # check no-std compatibility across dependencies
           cd no-std-check
-          cargo check --verbose --color always
+          cargo check --verbose --color always --features lightning-transaction-sync
       - name: Build no-std-check on Rust ${{ matrix.toolchain }} for ARM Embedded
         if: "matrix.build-no-std && matrix.platform == 'ubuntu-latest'"
         run: |

--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -20,13 +20,14 @@ esplora-blocking = ["esplora-client/blocking"]
 async-interface = []
 
 [dependencies]
-lightning = { version = "0.0.113", path = "../lightning" }
-bitcoin = "0.29.0"
+lightning = { version = "0.0.113", path = "../lightning", default-features = false }
+bitcoin = { version = "0.29.0", default-features = false }
 bdk-macros = "0.6"
 futures = { version = "0.3", optional = true }
 esplora-client = { version = "0.3.0", default-features = false, optional = true }
 
 [dev-dependencies]
+lightning = { version = "0.0.113", path = "../lightning", features = ["std"] }
 electrsd = { version = "0.22.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_23_0"] }
 electrum-client = "0.12.0"
 once_cell = "1.16.0"

--- a/no-std-check/Cargo.toml
+++ b/no-std-check/Cargo.toml
@@ -11,3 +11,7 @@ lightning = { path = "../lightning", default-features = false }
 lightning-invoice = { path = "../lightning-invoice", default-features = false }
 lightning-rapid-gossip-sync = { path = "../lightning-rapid-gossip-sync", default-features = false }
 lightning-background-processor = { path = "../lightning-background-processor", features = ["futures"], default-features = false }
+
+# Obviously lightning-transaction-sync doesn't support no-std, but it should build
+# even if lightning is built with no-std.
+lightning-transaction-sync = { path = "../lightning-transaction-sync", optional = true }


### PR DESCRIPTION
We have some downstream folks who are using LDK in wasm compiled via the normal rust wasm path. To ensure nothing breaks they want to use `no-std` on the lightning crate, disabling time calls as those panic. However, the HTTP logic in
`lightning-transaction-sync` gets automatically stubbed out by the HTTP client crates when targeting wasm via `wasm_bindgen`, so it works fine despite the std restrictions.

In order to make both work, `lightning-transaction-sync` can remain `std`, but needs to not automatically enable the `std` flag on the `lightning` crate, ie by setting `default-features = false`. We do so here.