### PR TITLE
Make `fuzz_threaded_connections` more robust

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -2334,7 +2334,7 @@ mod tests {
 					let addr_b = NetAddress::IPv4{addr: [127, 0, 0, 1], port: 1001};
 					let initial_data = peers[1].new_outbound_connection(id_a, fd_b.clone(), Some(addr_a.clone())).unwrap();
 					peers[0].new_inbound_connection(fd_a.clone(), Some(addr_b.clone())).unwrap();
-					assert_eq!(peers[0].read_event(&mut fd_a, &initial_data).unwrap(), false);
+					if peers[0].read_event(&mut fd_a, &initial_data).is_err() { break; }
 
 					while start_time.elapsed() < std::time::Duration::from_secs(1) {
 						peers[0].process_events();
@@ -2364,8 +2364,10 @@ mod tests {
 								},
 							});
 
-						peers[0].timer_tick_occurred();
-						peers[1].timer_tick_occurred();
+						if ctr % 2 == 0 {
+							peers[0].timer_tick_occurred();
+							peers[1].timer_tick_occurred();
+						}
 					}
 
 					peers[0].socket_disconnected(&fd_a);


### PR DESCRIPTION
In `fuzz_threaded_connections`, if one thread is being run while another is starved, and the running thread manages to call `timer_tick_ocurred` twice after the starved thread constructs the inbound connection but before it delivers the first bytes, we'll receive an immediate error and `unwrap` it, causing failure.

The fix is trivial, simply remove the unwrap and return if we're already disconnected when we do the initial read.

While we're here, we also reduce the frequency of the `timer_tick_ocurred` calls to give us a chance to occasionally deliver some additional messages.

Fixes #2073