### PR TITLE
Avoid `poll`ing completed futures in the `background-processor`

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -349,9 +349,9 @@ macro_rules! define_run_body {
 						log_error!($logger, "Error: Failed to persist network graph, check your disk and permissions {}", e)
 					}
 
-					last_prune_call = $get_timer(NETWORK_PRUNE_TIMER);
 					have_pruned = true;
 				}
+				last_prune_call = $get_timer(NETWORK_PRUNE_TIMER);
 			}
 
 			if $timer_elapsed(&mut last_scorer_persist_call, SCORER_PERSIST_TIMER) {


### PR DESCRIPTION
`poll`ing completed futures invokes undefined behavior in Rust (panics, etc, obviously not memory corruption as its not unsafe). Sadly, in our futures-based version of
`lightning-background-processor` we have one case where we can `poll` a completed future - if the timer for the network graph prune + persist completes without a network graph to prune + persist we'll happily poll the same future over and over again, likely panicing in user code.