### PR TITLE
Add `ChannelPending` event emitted upon `funding_signed`

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -526,7 +526,18 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out) {
 					msg.clone()
 				} else { panic!("Wrong event type"); }
 			};
+			let events = $dest.get_and_clear_pending_events();
+			assert_eq!(events.len(), 1);
+			if let events::Event::ChannelPending{ ref counterparty_node_id, .. } = events[0] {
+				assert_eq!(counterparty_node_id, &$source.get_our_node_id());
+			} else { panic!("Wrong event type"); }
+
 			$source.handle_funding_signed(&$dest.get_our_node_id(), &funding_signed);
+			let events = $source.get_and_clear_pending_events();
+			assert_eq!(events.len(), 1);
+			if let events::Event::ChannelPending{ ref counterparty_node_id, .. } = events[0] {
+				assert_eq!(counterparty_node_id, &$dest.get_our_node_id());
+			} else { panic!("Wrong event type"); }
 
 			funding_output
 		} }

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -710,7 +710,7 @@ mod tests {
 	use lightning::chain::keysinterface::{InMemorySigner, KeysManager};
 	use lightning::chain::transaction::OutPoint;
 	use lightning::events::{Event, PathFailure, MessageSendEventsProvider, MessageSendEvent};
-	use lightning::get_event_msg;
+	use lightning::{get_event_msg, get_event};
 	use lightning::ln::PaymentHash;
 	use lightning::ln::channelmanager;
 	use lightning::ln::channelmanager::{BREAKDOWN_TIMEOUT, ChainParameters, MIN_CLTV_EXPIRY_DELTA, PaymentId};
@@ -1058,7 +1058,10 @@ mod tests {
 		($node_a: expr, $node_b: expr, $temporary_channel_id: expr, $tx: expr) => {{
 			$node_a.node.funding_transaction_generated(&$temporary_channel_id, &$node_b.node.get_our_node_id(), $tx.clone()).unwrap();
 			$node_b.node.handle_funding_created(&$node_a.node.get_our_node_id(), &get_event_msg!($node_a, MessageSendEvent::SendFundingCreated, $node_b.node.get_our_node_id()));
+			get_event!($node_b, Event::ChannelPending);
+
 			$node_a.node.handle_funding_signed(&$node_b.node.get_our_node_id(), &get_event_msg!($node_b, MessageSendEvent::SendFundingSigned, $node_a.node.get_our_node_id()));
+			get_event!($node_a, Event::ChannelPending);
 		}}
 	}
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -541,6 +541,8 @@ fn do_test_sanity_on_in_flight_opens(steps: u8) {
 		assert_eq!(added_monitors[0].0, funding_output);
 		added_monitors.clear();
 	}
+	expect_channel_pending_event(&nodes[1], &nodes[0].node.get_our_node_id());
+
 	let funding_signed = get_event_msg!(nodes[1], MessageSendEvent::SendFundingSigned, nodes[0].node.get_our_node_id());
 
 	if steps & 0x0f == 5 { return; }
@@ -552,6 +554,7 @@ fn do_test_sanity_on_in_flight_opens(steps: u8) {
 		added_monitors.clear();
 	}
 
+	expect_channel_pending_event(&nodes[0], &nodes[1].node.get_our_node_id());
 	let events_4 = nodes[0].node.get_and_clear_pending_events();
 	assert_eq!(events_4.len(), 0);
 
@@ -8854,6 +8857,8 @@ fn test_duplicate_chan_id() {
 		assert_eq!(added_monitors[0].0, funding_output);
 		added_monitors.clear();
 	}
+	expect_channel_pending_event(&nodes[1], &nodes[0].node.get_our_node_id());
+
 	let funding_signed_msg = get_event_msg!(nodes[1], MessageSendEvent::SendFundingSigned, nodes[0].node.get_our_node_id());
 
 	let funding_outpoint = crate::chain::transaction::OutPoint { txid: funding_created_msg.funding_txid, index: funding_created_msg.funding_output_index };
@@ -8929,6 +8934,7 @@ fn test_duplicate_chan_id() {
 		assert_eq!(added_monitors[0].0, funding_output);
 		added_monitors.clear();
 	}
+	expect_channel_pending_event(&nodes[0], &nodes[1].node.get_our_node_id());
 
 	let events_4 = nodes[0].node.get_and_clear_pending_events();
 	assert_eq!(events_4.len(), 0);
@@ -9043,9 +9049,11 @@ fn test_invalid_funding_tx() {
 	nodes[0].node.funding_transaction_generated_unchecked(&temporary_channel_id, &nodes[1].node.get_our_node_id(), tx.clone(), 0).unwrap();
 	nodes[1].node.handle_funding_created(&nodes[0].node.get_our_node_id(), &get_event_msg!(nodes[0], MessageSendEvent::SendFundingCreated, nodes[1].node.get_our_node_id()));
 	check_added_monitors!(nodes[1], 1);
+	expect_channel_pending_event(&nodes[1], &nodes[0].node.get_our_node_id());
 
 	nodes[0].node.handle_funding_signed(&nodes[1].node.get_our_node_id(), &get_event_msg!(nodes[1], MessageSendEvent::SendFundingSigned, nodes[0].node.get_our_node_id()));
 	check_added_monitors!(nodes[0], 1);
+	expect_channel_pending_event(&nodes[0], &nodes[1].node.get_our_node_id());
 
 	let events_1 = nodes[0].node.get_and_clear_pending_events();
 	assert_eq!(events_1.len(), 0);
@@ -9575,9 +9583,11 @@ fn do_test_max_dust_htlc_exposure(dust_outbound_balance: bool, exposure_breach_e
 	nodes[0].node.funding_transaction_generated(&temporary_channel_id, &nodes[1].node.get_our_node_id(), tx.clone()).unwrap();
 	nodes[1].node.handle_funding_created(&nodes[0].node.get_our_node_id(), &get_event_msg!(nodes[0], MessageSendEvent::SendFundingCreated, nodes[1].node.get_our_node_id()));
 	check_added_monitors!(nodes[1], 1);
+	expect_channel_pending_event(&nodes[1], &nodes[0].node.get_our_node_id());
 
 	nodes[0].node.handle_funding_signed(&nodes[1].node.get_our_node_id(), &get_event_msg!(nodes[1], MessageSendEvent::SendFundingSigned, nodes[0].node.get_our_node_id()));
 	check_added_monitors!(nodes[0], 1);
+	expect_channel_pending_event(&nodes[0], &nodes[1].node.get_our_node_id());
 
 	let (channel_ready, channel_id) = create_chan_between_nodes_with_value_confirm(&nodes[0], &nodes[1], &tx);
 	let (announcement, as_update, bs_update) = create_chan_between_nodes_with_value_b(&nodes[0], &nodes[1], &channel_ready);

--- a/lightning/src/ln/reload_tests.rs
+++ b/lightning/src/ln/reload_tests.rs
@@ -261,6 +261,9 @@ fn test_manager_serialize_deserialize_events() {
 	}
 	// Normally, this is where node_a would broadcast the funding transaction, but the test de/serializes first instead
 
+	expect_channel_pending_event(&node_a, &node_b.node.get_our_node_id());
+	expect_channel_pending_event(&node_b, &node_a.node.get_our_node_id());
+
 	nodes.push(node_a);
 	nodes.push(node_b);
 


### PR DESCRIPTION
Users currently don't have good way of being notified when channel open negotiations have succeeded and new channels are pending confirmation on chain. 

To this end, we add a new `ChannelPending` event that is emitted when send or receive a `funding_signed` message, i.e., at the last moment before waiting for the confirmation period.