### PR TITLE
Pin tokio to 1.26 on windows to fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,11 @@ jobs:
         run: cargo update -p tokio --precise "1.14.0" --verbose
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      - name: Pin tokio to 1.26 for Windows
+        if: "matrix.platform == 'windows-latest'"
+        run: cargo update -p tokio --precise "1.26.0" --verbose
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       - name: Build on Rust ${{ matrix.toolchain }} with net-tokio
         if: "matrix.build-net-tokio && !matrix.coverage"
         run: cargo build --verbose --color always

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -28,4 +28,4 @@ chunked_transfer = { version = "1.4", optional = true }
 
 [dev-dependencies]
 lightning = { version = "0.0.114", path = "../lightning", features = ["_test_utils"] }
-tokio = { version = "~1.14", features = [ "macros", "rt" ] }
+tokio = { version = "1.14", features = [ "macros", "rt" ] }

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -20,5 +20,5 @@ lightning = { version = "0.0.114", path = "../lightning" }
 tokio = { version = "1.0", features = [ "io-util", "macros", "rt", "sync", "net", "time" ] }
 
 [dev-dependencies]
-tokio = { version = "~1.14", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
+tokio = { version = "1.14", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 lightning = { version = "0.0.114", path = "../lightning", features = ["_test_utils"] }


### PR DESCRIPTION
We pin tokio to version 1.26 on Windows, which fixes CI on the Rust beta channel.

This raises MSRV for Windows to 1.49, but we only ever had CI jobs for stable and beta anyways.