### PR TITLE
Support manual signaling of channel readiness

### DIFF
--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -149,6 +149,17 @@ pub struct ChannelHandshakeConfig {
 	/// Maximum value: 1,000,000, any values larger than 1 Million will be treated as 1 Million (or 100%)
 	///                instead, although channel negotiations will fail in that case.
 	pub their_channel_reserve_proportional_millionths: u32,
+	/// If this is set to true, the user needs to manually signal readiness for an inbound channel.
+	///
+	/// When set to true, [`Event::PendingChannelReady`] will be triggered once LDK has seen sufficient
+	/// confirmations of the funding transaction. In that case, a [`msgs::ChannelReady`] message will not be 
+	/// sent to the counterparty node unless the user explicitly chooses to signal readiness.
+	///
+	/// Default value: false.
+	///
+	/// [`Event::PendingChannelReady`]: crate::util::events::Event::PendingChannelReady
+	/// [`msgs::ChannelReady`]: crate::ln::msgs::ChannelReady
+	pub manually_signal_channel_ready: bool,
 	#[cfg(anchors)]
 	/// If set, we attempt to negotiate the `anchors_zero_fee_htlc_tx`option for outbound channels.
 	///
@@ -183,6 +194,7 @@ impl Default for ChannelHandshakeConfig {
 			announced_channel: false,
 			commit_upfront_shutdown_pubkey: true,
 			their_channel_reserve_proportional_millionths: 10_000,
+			manually_signal_channel_ready: false,
 			#[cfg(anchors)]
 			negotiate_anchors_zero_fee_htlc_tx: false,
 		}

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -15,6 +15,7 @@
 //! few other things.
 
 use crate::chain::keysinterface::SpendableOutputDescriptor;
+use crate::chain::transaction::OutPoint;
 #[cfg(anchors)]
 use crate::ln::chan_utils::{self, ChannelTransactionParameters, HTLCOutputInCommitment};
 use crate::ln::channelmanager::{InterceptId, PaymentId};
@@ -817,6 +818,50 @@ pub enum Event {
 		/// transaction.
 		claim_from_onchain_tx: bool,
 	},
+	/// Indicates a channel has received sufficient confirmations and LDK is ready to send [`msgs::ChannelReady`].
+	///
+	/// To signal readiness, call [`ChannelManager::signal_channel_readiness`]. To reject the
+	/// request, call [`ChannelManager::force_close_without_broadcasting_txn`].
+	///
+	/// The event is only triggered when the [`UserConfig::manually_signal_channel_ready`] 
+	/// config flag is set to true.
+	///
+	/// [`ChannelManager::signal_channel_readiness`]: crate::ln::channelmanager::ChannelManager::signal_channel_readiness
+	/// [`ChannelManager::force_close_without_broadcasting_txn`]: crate::ln::channelmanager::ChannelManager::force_close_without_broadcasting_txn
+	/// [`UserConfig::manually_signal_channel_ready`]: crate::util::config::UserConfig::manually_signal_channel_ready
+	/// [`msgs::ChannelReady`]: crate::ln::msgs::ChannelReady
+	PendingChannelReady {
+		/// The channel ID of the channel.
+		///
+		/// When responding to the request, the `channel_id` should be passed
+		/// back to the ChannelManager through [`ChannelManager::signal_channel_readiness`] to signal,
+		/// or through [`ChannelManager::force_close_without_broadcasting_txn`] to reject.
+		///
+		/// [`ChannelManager::signal_channel_readiness`]: crate::ln::channelmanager::ChannelManager::signal_channel_readiness
+		/// [`ChannelManager::force_close_without_broadcasting_txn`]: crate::ln::channelmanager::ChannelManager::force_close_without_broadcasting_txn
+		channel_id: [u8; 32],
+		/// The `user_channel_id` value passed in to [`ChannelManager::create_channel`] for outbound
+		/// channels, or to [`ChannelManager::accept_inbound_channel`] for inbound channels if
+		/// [`UserConfig::manually_accept_inbound_channels`] config flag is set to true. Otherwise
+		/// `user_channel_id` will be randomized for an inbound channel.
+		///
+		/// [`ChannelManager::create_channel`]: crate::ln::channelmanager::ChannelManager::create_channel
+		/// [`ChannelManager::accept_inbound_channel`]: crate::ln::channelmanager::ChannelManager::accept_inbound_channel
+		/// [`UserConfig::manually_accept_inbound_channels`]: crate::util::config::UserConfig::manually_accept_inbound_channels
+		user_channel_id: u128,
+		/// The node_id of the counterparty requesting to open the channel.
+		///
+		/// When responding to the request, the `counterparty_node_id` should be passed
+		/// back to the `ChannelManager` through [`ChannelManager::signal_channel_readiness`] to
+		/// signal readiness, or through [`ChannelManager::force_close_without_broadcasting_txn`] to reject the
+		/// request.
+		///
+		/// [`ChannelManager::signal_channel_readiness`]: crate::ln::channelmanager::ChannelManager::signal_channel_readiness
+		/// [`ChannelManager::force_close_without_broadcasting_txn`]: crate::ln::channelmanager::ChannelManager::force_close_without_broadcasting_txn
+		counterparty_node_id: PublicKey,
+		/// The outpoint that holds the channel funds on-chain.
+		funding_outpoint: OutPoint,
+	},
 	/// Used to indicate that a channel with the given `channel_id` is ready to
 	/// be used. This event is emitted either when the funding transaction has been confirmed
 	/// on-chain, or, in case of a 0conf channel, when both parties have confirmed the channel
@@ -1134,6 +1179,15 @@ impl Writeable for Event {
 					(2, user_channel_id, required),
 					(4, counterparty_node_id, required),
 					(6, channel_type, required),
+				});
+			},
+			&Event::PendingChannelReady { ref channel_id, ref user_channel_id, ref counterparty_node_id, ref funding_outpoint } => {
+				31u8.write(writer)?;
+				write_tlv_fields!(writer, {
+					(0, channel_id, required),
+					(2, user_channel_id, required),
+					(4, counterparty_node_id, required),
+					(6, funding_outpoint, required)
 				});
 			},
 			// Note that, going forward, all new events must only write data inside of
@@ -1467,6 +1521,28 @@ impl MaybeReadable for Event {
 						user_channel_id,
 						counterparty_node_id: counterparty_node_id.0.unwrap(),
 						channel_type: channel_type.0.unwrap()
+					}))
+				};
+				f()
+			},
+			31u8 => {
+				let f = || {
+					let mut channel_id = [0; 32];
+					let mut user_channel_id: u128 = 0;
+					let mut counterparty_node_id = RequiredWrapper(None);
+					let mut funding_outpoint = RequiredWrapper(None);
+					read_tlv_fields!(reader, {
+						(0, channel_id, required),
+						(2, user_channel_id, required),
+						(4, counterparty_node_id, required),
+						(6, funding_outpoint, required),
+					});
+
+					Ok(Some(Event::PendingChannelReady {
+						channel_id,
+						user_channel_id,
+						counterparty_node_id: counterparty_node_id.0.unwrap(),
+						funding_outpoint: funding_outpoint.0.unwrap()
 					}))
 				};
 				f()


### PR DESCRIPTION
First pass at implementing #2106 

A lot of the naming here is likely not great. Please make recommendations for `Event::PendingChannelReady`, `signal_channel_readiness`, and `manually_signal_channel_ready`.

I wasn't sure if it was a great idea to make `check_get_channel_ready` public but it has all the logic I need to implement `signal_channel_readiness`.

I ended up adding the logic for conditionally sending the `ChannelReady` message inside of the `send_channel_ready` macro which might not be great but it was the simplest place to put it to guarantee it would re-trigger the event should the user have the feature enabled.

Fixes #2106