### PR TITLE
Delay RAA-after-next processing until PaymentSent is are handled

### DIFF
--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -1373,22 +1373,7 @@ mod test {
 		assert_eq!(other_events.borrow().len(), 1);
 		check_payment_claimable(&other_events.borrow()[0], payment_hash, payment_secret, payment_amt, payment_preimage_opt, invoice.recover_payee_pub_key());
 		do_claim_payment_along_route(&nodes[0], &[&vec!(&nodes[fwd_idx])[..]], false, payment_preimage);
-		let events = nodes[0].node.get_and_clear_pending_events();
-		assert_eq!(events.len(), 2);
-		match events[0] {
-			Event::PaymentSent { payment_preimage: ref ev_preimage, payment_hash: ref ev_hash, ref fee_paid_msat, .. } => {
-				assert_eq!(payment_preimage, *ev_preimage);
-				assert_eq!(payment_hash, *ev_hash);
-				assert_eq!(fee_paid_msat, &Some(0));
-			},
-			_ => panic!("Unexpected event")
-		}
-		match events[1] {
-			Event::PaymentPathSuccessful { payment_hash: hash, .. } => {
-				assert_eq!(hash, Some(payment_hash));
-			},
-			_ => panic!("Unexpected event")
-		}
+		expect_payment_sent(&nodes[0], payment_preimage, None, true, true);
 	}
 
 	#[test]

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -805,7 +805,7 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner, C: Deref, T: Deref, F: Deref, L
 #[cfg(test)]
 mod tests {
 	use crate::{check_added_monitors, check_closed_broadcast, check_closed_event};
-	use crate::{expect_payment_sent, expect_payment_claimed, expect_payment_sent_without_paths, expect_payment_path_successful, get_event_msg};
+	use crate::{expect_payment_claimed, expect_payment_path_successful, get_event_msg};
 	use crate::{get_htlc_update_msgs, get_local_commitment_txn, get_revoke_commit_msgs, get_route_and_payment_hash, unwrap_send_err};
 	use crate::chain::{ChannelMonitorUpdateStatus, Confirm, Watch};
 	use crate::chain::channelmonitor::LATENCY_GRACE_PERIOD_BLOCKS;
@@ -888,7 +888,7 @@ mod tests {
 
 		let updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
 		nodes[0].node.handle_update_fulfill_htlc(&nodes[1].node.get_our_node_id(), &updates.update_fulfill_htlcs[0]);
-		expect_payment_sent_without_paths!(nodes[0], payment_preimage_1);
+		expect_payment_sent(&nodes[0], payment_preimage_1, None, false, false);
 		nodes[0].node.handle_commitment_signed(&nodes[1].node.get_our_node_id(), &updates.commitment_signed);
 		check_added_monitors!(nodes[0], 1);
 		let (as_first_raa, as_first_update) = get_revoke_commit_msgs!(nodes[0], nodes[1].node.get_our_node_id());
@@ -901,7 +901,7 @@ mod tests {
 		let bs_first_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[0].node.get_our_node_id());
 
 		nodes[0].node.handle_update_fulfill_htlc(&nodes[1].node.get_our_node_id(), &bs_second_updates.update_fulfill_htlcs[0]);
-		expect_payment_sent_without_paths!(nodes[0], payment_preimage_2);
+		expect_payment_sent(&nodes[0], payment_preimage_2, None, false, false);
 		nodes[0].node.handle_commitment_signed(&nodes[1].node.get_our_node_id(), &bs_second_updates.commitment_signed);
 		check_added_monitors!(nodes[0], 1);
 		nodes[0].node.handle_revoke_and_ack(&nodes[1].node.get_our_node_id(), &bs_first_raa);
@@ -985,7 +985,7 @@ mod tests {
 			}
 		}
 
-		expect_payment_sent!(nodes[0], payment_preimage);
+		expect_payment_sent(&nodes[0], payment_preimage, None, true, false);
 	}
 
 	#[test]

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -507,6 +507,11 @@ pub enum Event {
 	/// payment is no longer retryable, due either to the [`Retry`] provided or
 	/// [`ChannelManager::abandon_payment`] having been called for the corresponding payment.
 	///
+	/// In exceedingly rare cases, it is possible that an [`Event::PaymentFailed`] is generated for
+	/// a payment after an [`Event::PaymentSent`] event for this same payment has already been
+	/// received and processed. In this case, the [`Event::PaymentFailed`] event MUST be ignored,
+	/// and the payment MUST be treated as having succeeded.
+	///
 	/// [`Retry`]: crate::ln::channelmanager::Retry
 	/// [`ChannelManager::abandon_payment`]: crate::ln::channelmanager::ChannelManager::abandon_payment
 	PaymentFailed {

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -1177,7 +1177,7 @@ impl OutboundPayments {
 
 	pub(super) fn claim_htlc<L: Deref>(
 		&self, payment_id: PaymentId, payment_preimage: PaymentPreimage, session_priv: SecretKey,
-		path: Path, from_onchain: bool,
+		path: Path, from_onchain: bool, ev_completion_action: EventCompletionAction,
 		pending_events: &Mutex<VecDeque<(events::Event, Option<EventCompletionAction>)>>,
 		logger: &L,
 	) where L::Target: Logger {
@@ -1194,7 +1194,7 @@ impl OutboundPayments {
 					payment_preimage,
 					payment_hash,
 					fee_paid_msat,
-				}, None));
+				}, Some(ev_completion_action.clone())));
 				payment.get_mut().mark_fulfilled();
 			}
 
@@ -1211,7 +1211,7 @@ impl OutboundPayments {
 						payment_id,
 						payment_hash,
 						path,
-					}, None));
+					}, Some(ev_completion_action)));
 				}
 			}
 		} else {

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -230,7 +230,7 @@ fn test_counterparty_revoked_reorg() {
 
 	// Connect the HTLC claim transaction for HTLC 3
 	mine_transaction(&nodes[1], &unrevoked_local_txn[2]);
-	expect_payment_sent!(nodes[1], payment_preimage_3);
+	expect_payment_sent(&nodes[1], payment_preimage_3, None, true, false);
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
 
 	// Connect blocks to confirm the unrevoked commitment transaction

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -345,7 +345,7 @@ fn htlc_fail_async_shutdown() {
 	nodes[1].node.handle_commitment_signed(&nodes[0].node.get_our_node_id(), &updates.commitment_signed);
 	check_added_monitors!(nodes[1], 1);
 	nodes[1].node.handle_shutdown(&nodes[0].node.get_our_node_id(), &node_0_shutdown);
-	commitment_signed_dance!(nodes[1], nodes[0], (), false, true, false);
+	commitment_signed_dance!(nodes[1], nodes[0], (), false, true, false, false);
 
 	let updates_2 = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
 	assert!(updates_2.update_add_htlcs.is_empty());


### PR DESCRIPTION
    In 0ad1f4c943bdc9037d0c43d1b74c745befa065f0 we fixed a nasty bug
    where a failure to persist a `ChannelManager` faster than a
    `ChannelMonitor` could result in the loss of a `PaymentSent` event,
    eventually resulting in a `PaymentFailed` instead!
    
    As noted in that commit, there's still some risk, though its been
    substantially reduced - if we receive an `update_fulfill_htlc`
    message for an outbound payment, and persist the initial removal
    `ChannelMonitorUpdate`, then respond with our own
    `commitment_signed` + `revoke_and_ack`, followed by receiving our
    peer's final `revoke_and_ack`, and then persist the
    `ChannelMonitorUpdate` generated from that, all prior to completing
    a `ChannelManager` persistence, we'll still forget the HTLC and
    eventually trigger a `PaymentFailed` rather than the correct
    `PaymentSent`.
    
    Here we fully fix the issue by delaying the final
    `ChannelMonitorUpdate` persistence until the `PaymentSent` event
    has been processed and document the fact that a spurious
    `PaymentFailed` event can still be generated for a sent payment.
    
    The original fix in 0ad1f4c943bdc9037d0c43d1b74c745befa065f0 is
    still incredibly useful here, allowing us to avoid blocking the
    first `ChannelMonitorUpdate` until the event processing completes,
    as this would cause us to add event-processing delay in our general
    commitment update latency. Instead, we ultimately race the user
    handling the `PaymentSent` event with how long it takes our
    `revoke_and_ack` + `commitment_signed` to make it to our
    counterparty and receive the response `revoke_and_ack`. This should
    give the user plenty of time to handle the event before we need to
    make progress.
    
    Sadly, because we change our `ChannelMonitorUpdate` semantics, this
    change requires a number of test changes, avoiding checking for a
    post-RAA `ChannelMonitorUpdate` until after we process a
    `PaymentSent` event. Note that this does not apply to payments we
    learned the preimage for on-chain - ensuring `PaymentSent` events
    from such resolutions will be addressed in a future PR. Thus, tests
    which resolve payments on-chain switch to a direct call to the
    `expect_payment_sent` function with the claim-expected flag unset.


Depends on #2111, is just the last commit on it. See discussion there for merge-ordering.