### PR TITLE
Drop `serde` dependency from `lightning-block-sync`

### DIFF
--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -14,15 +14,14 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-rest-client = [ "serde", "serde_json", "chunked_transfer" ]
-rpc-client = [ "serde", "serde_json", "chunked_transfer" ]
+rest-client = [ "serde_json", "chunked_transfer" ]
+rpc-client = [ "serde_json", "chunked_transfer" ]
 
 [dependencies]
 bitcoin = "0.29.0"
 lightning = { version = "0.0.114", path = "../lightning" }
 futures-util = { version = "0.3" }
 tokio = { version = "1.0", features = [ "io-util", "net", "time" ], optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 chunked_transfer = { version = "1.4", optional = true }
 


### PR DESCRIPTION
`serde` doesn't bother with MSRVs, so its expected to break frequently. Yesterday, the `derive` feature had its MSRV broken in a patch version without care.

Luckily its trivial for us to remove the `serde` dependency in `lightning-block-sync`, using only `serde_json` for the JSON deserialization part. It even ends up net-negative on LoC.