### PR TITLE
Pin`tokio` to fix CI

### DIFF
--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -4,8 +4,9 @@ set -eox pipefail
 RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
 HOST_PLATFORM="$(rustc --version --verbose | grep "host:" | awk '{ print $2 }')"
 
-# Tokio MSRV on versions newer than 1.14 is rustc 1.49
+# Tokio MSRV on versions 1.17 through 1.26 is rustc 1.49. Above 1.26 MSRV is 1.56.
 [ "$RUSTC_MINOR_VERSION" -lt 49 ] && cargo update -p tokio --precise "1.14.0" --verbose
+[[ "$RUSTC_MINOR_VERSION" -gt 48  &&  "$RUSTC_MINOR_VERSION" -lt 56 ]] && cargo update -p tokio --precise "1.26.0" --verbose
 [ "$LDK_COVERAGE_BUILD" != "" ] && export RUSTFLAGS="-C link-dead-code"
 
 export RUST_BACKTRACE=1


### PR DESCRIPTION
Recently, `tokio` got updated to 1.27.0, which bumped MSRV from 1.49 to 1.56.

Here we pin `tokio` accordingly to unbreak CI.