### PR TITLE
Implement `chain::Confirm` without mandating any owned values

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -3674,8 +3674,9 @@ where
 	}
 }
 
-impl<Signer: WriteableEcdsaChannelSigner, T: Deref, F: Deref, L: Deref> chain::Confirm for (ChannelMonitor<Signer>, T, F, L)
+impl<Signer: WriteableEcdsaChannelSigner, M, T: Deref, F: Deref, L: Deref> chain::Confirm for (M, T, F, L)
 where
+	M: Deref<Target = ChannelMonitor<Signer>>,
 	T::Target: BroadcasterInterface,
 	F::Target: FeeEstimator,
 	L::Target: Logger,


### PR DESCRIPTION
This makes it a bit more convenient to use the `chain::Confirm` trait.