### PR TITLE
Add some trivial logging during RGS update processing.

### DIFF
--- a/lightning-rapid-gossip-sync/src/lib.rs
+++ b/lightning-rapid-gossip-sync/src/lib.rs
@@ -49,7 +49,7 @@
 //! # use lightning::util::logger::{Logger, Record};
 //! # struct FakeLogger {}
 //! # impl Logger for FakeLogger {
-//! #     fn log(&self, record: &Record) { unimplemented!() }
+//! #     fn log(&self, record: &Record) { }
 //! # }
 //! # let logger = FakeLogger {};
 //!


### PR DESCRIPTION
Rather than being totally silent, we need to at least note that we are processing an RGS update when doing so in the logs, which we do here.

Fixes #1981.