### PR TITLE
lightning-transaction-sync: Bump esplora to 0.4

### DIFF
--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -25,7 +25,7 @@ lightning = { version = "0.0.114", path = "../lightning", default-features = fal
 bitcoin = { version = "0.29.0", default-features = false }
 bdk-macros = "0.6"
 futures = { version = "0.3", optional = true }
-esplora-client = { version = "0.3", default-features = false, optional = true }
+esplora-client = { version = "0.4", default-features = false, optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This bumps esplora to 0.4 for the lightning-transaction-sync crate.

The main reason I would like this is for `rust-bitcoin` default features to be turned off: https://github.com/bitcoindevkit/rust-esplora-client/pull/39

Here is the version diff, doesn't seem too impactful so there should be no problems: https://github.com/bitcoindevkit/rust-esplora-client/compare/v0.3.0...v0.4.0