### PR TITLE
Fix deserialization of u16 arrays

### DIFF
--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -596,7 +596,7 @@ impl Readable for [u16; 8] {
 		r.read_exact(&mut buf)?;
 		let mut res = [0u16; 8];
 		for (idx, v) in res.iter_mut().enumerate() {
-			*v = (buf[idx] as u16) << 8 | (buf[idx + 1] as u16)
+			*v = (buf[idx*2] as u16) << 8 | (buf[idx*2 + 1] as u16)
 		}
 		Ok(res)
 	}


### PR DESCRIPTION
u16 arrays are used in the historical liquidity range tracker. Previously, we read them without applying the stride multiple, reading bytes repeatedly and at an offset, corrupting data as we go.

This applies the correct stride multiplayer fixing the issue.