### PR TITLE
Mark the invoice `Network` getter no-export

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -1360,6 +1360,8 @@ impl Invoice {
 	}
 
 	/// Returns the network for which the invoice was issued
+	///
+	/// This is not exported to bindings users, see [`Self::currency`] instead.
 	pub fn network(&self) -> Network {
 		self.signed_invoice.currency().into()
 	}


### PR DESCRIPTION
...as it is redundant with the `currency` getter if we're not using the rust-bitcoin types natively.