### PR TITLE
Clarify the error message when we disconnect a peer

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -2103,7 +2103,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, OM: Deref, L: Deref, CM
 						if let Some((node_id, _)) = peer.their_node_id {
 							self.node_id_to_descriptor.lock().unwrap().remove(&node_id);
 						}
-						self.do_disconnect(descriptor, &*peer, "ping timeout");
+						self.do_disconnect(descriptor, &*peer, "ping/handshake timeout");
 					}
 				}
 			}


### PR DESCRIPTION
We very regularly receive confusion over the super generic "Peer sent invalid data or we decided to disconnect due to a protocol error" message, which doesn't say very much. Usually, we end up disconnecting because we have a duplicate connection with a peer, which doesn't merit such a scary message.

Instead, here we clarify the error message to just refer to the fact that we're disconnecting, and note that its usually a dup connection in a parenthetical.