### PR TITLE
Fix overflow in `awaiting_pong_timer...` with too many peers

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -416,7 +416,7 @@ struct Peer {
 	sync_status: InitSyncTracker,
 
 	msgs_sent_since_pong: usize,
-	awaiting_pong_timer_tick_intervals: i8,
+	awaiting_pong_timer_tick_intervals: i64,
 	received_message_since_timer_tick: bool,
 	sent_gossip_timestamp_filter: bool,
 


### PR DESCRIPTION
If we have more than
127 / `MAX_BUFFER_DRAIN_TICK_INTERVALS_PER_PEER` (31) peers, `awaiting_pong_timer_tick_intervals` can overflow before we hit the limit. This isn't super harmful, we'll still disconnect peers as long as they don't send *any* messages between two pings, but it does cause us to not disconnect peers which are extremely slow in responding to messages, e.g. because they are overloaded.