### PR TITLE
Attributable failures

### DIFF
--- a/fuzz/src/process_onion_failure.rs
+++ b/fuzz/src/process_onion_failure.rs
@@ -118,7 +118,8 @@ fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 		HTLCSource::OutboundRoute { path, session_priv, first_hop_htlc_msat: 0, payment_id };
 
 	let failure_len = get_u16!();
-	let encrypted_packet = OnionErrorPacket { data: get_slice!(failure_len).into() };
+	let encrypted_packet =
+		OnionErrorPacket { data: get_slice!(failure_len).into(), attribution_data: None };
 
 	lightning::ln::process_onion_failure(&secp_ctx, &logger, &htlc_source, encrypted_packet);
 }

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -59,7 +59,7 @@ use crate::types::features::Bolt11InvoiceFeatures;
 use crate::routing::router::{BlindedTail, InFlightHtlcs, Path, Payee, PaymentParameters, RouteParameters, RouteParametersConfig, Router, FixedRouter, Route};
 use crate::ln::onion_payment::{check_incoming_htlc_cltv, create_recv_pending_htlc_info, create_fwd_pending_htlc_info, decode_incoming_update_add_htlc_onion, HopConnector, InboundHTLCErr, NextPacketDetails};
 use crate::ln::msgs;
-use crate::ln::onion_utils;
+use crate::ln::onion_utils::{self};
 use crate::ln::onion_utils::{HTLCFailReason, INVALID_ONION_BLINDING};
 use crate::ln::msgs::{BaseMessageHandler, ChannelMessageHandler, CommitmentUpdate, DecodeError, LightningError, MessageSendEvent};
 #[cfg(test)]
@@ -4481,6 +4481,7 @@ where
 			channel_id: msg.channel_id,
 			htlc_id: msg.htlc_id,
 			reason: failure.data,
+			attribution_data: failure.attribution_data,
 		})
 	}
 
@@ -4510,6 +4511,7 @@ where
 						channel_id: msg.channel_id,
 						htlc_id: msg.htlc_id,
 						reason: failure.data,
+						attribution_data: failure.attribution_data,
 					}));
 				}
 			}
@@ -12924,11 +12926,15 @@ impl_writeable_tlv_based!(PendingHTLCInfo, {
 impl Writeable for HTLCFailureMsg {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
 		match self {
-			HTLCFailureMsg::Relay(msgs::UpdateFailHTLC { channel_id, htlc_id, reason }) => {
+			HTLCFailureMsg::Relay(msgs::UpdateFailHTLC { channel_id, htlc_id, reason, attribution_data }) => {
 				0u8.write(writer)?;
 				channel_id.write(writer)?;
 				htlc_id.write(writer)?;
 				reason.write(writer)?;
+
+				// This code will only ever be hit for legacy data that is re-serialized. It isn't necessary to try
+				// writing out attribution data, because it can never be present.
+				debug_assert!(attribution_data.is_none());
 			},
 			HTLCFailureMsg::Malformed(msgs::UpdateFailMalformedHTLC {
 				channel_id, htlc_id, sha256_of_onion, failure_code
@@ -12953,6 +12959,7 @@ impl Readable for HTLCFailureMsg {
 					channel_id: Readable::read(reader)?,
 					htlc_id: Readable::read(reader)?,
 					reason: Readable::read(reader)?,
+					attribution_data: None,
 				}))
 			},
 			1 => {
@@ -13183,6 +13190,7 @@ impl Writeable for HTLCForwardInfo {
 				write_tlv_fields!(w, {
 					(0, htlc_id, required),
 					(2, err_packet.data, required),
+					(5, err_packet.attribution_data, option),
 				});
 			},
 			Self::FailMalformedHTLC { htlc_id, failure_code, sha256_of_onion } => {
@@ -13213,8 +13221,12 @@ impl Readable for HTLCForwardInfo {
 					(1, malformed_htlc_failure_code, option),
 					(2, err_packet, required),
 					(3, sha256_of_onion, option),
+					(5, attribution_data, option),
 				});
 				if let Some(failure_code) = malformed_htlc_failure_code {
+					if attribution_data.is_some() {
+						return Err(DecodeError::InvalidValue);
+					}
 					Self::FailMalformedHTLC {
 						htlc_id: _init_tlv_based_struct_field!(htlc_id, required),
 						failure_code,
@@ -13225,6 +13237,7 @@ impl Readable for HTLCForwardInfo {
 						htlc_id: _init_tlv_based_struct_field!(htlc_id, required),
 						err_packet: crate::ln::msgs::OnionErrorPacket {
 							data: _init_tlv_based_struct_field!(err_packet, required),
+							attribution_data: _init_tlv_based_struct_field!(attribution_data, option),
 						},
 					}
 				}
@@ -14910,6 +14923,7 @@ mod tests {
 	use bitcoin::secp256k1::ecdh::SharedSecret;
 	use core::sync::atomic::Ordering;
 	use crate::events::{Event, HTLCDestination, ClosureReason};
+	use crate::ln::onion_utils::AttributionData;
 	use crate::ln::types::ChannelId;
 	use crate::types::payment::{PaymentPreimage, PaymentHash, PaymentSecret};
 	use crate::ln::channelmanager::{create_recv_pending_htlc_info, inbound_payment, ChannelConfigOverrides, HTLCForwardInfo, InterceptId, PaymentId, RecipientOnionFields};
@@ -16232,7 +16246,7 @@ mod tests {
 		let mut nodes = create_network(1, &node_cfg, &chanmgrs);
 
 		let dummy_failed_htlc = |htlc_id| {
-			HTLCForwardInfo::FailHTLC { htlc_id, err_packet: msgs::OnionErrorPacket { data: vec![42] } }
+			HTLCForwardInfo::FailHTLC { htlc_id, err_packet: msgs::OnionErrorPacket { data: vec![42], attribution_data: Some(AttributionData::new()) } }
 		};
 		let dummy_malformed_htlc = |htlc_id| {
 			HTLCForwardInfo::FailMalformedHTLC { htlc_id, failure_code: 0x4000, sha256_of_onion: [0; 32] }

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -38,6 +38,7 @@ use crate::util::errors::APIError;
 use crate::util::ser::{Writeable, ReadableArgs};
 use crate::util::string::UntrustedString;
 use crate::util::config::{ChannelConfigOverrides, ChannelHandshakeConfigUpdate, ChannelConfigUpdate, MaxDustHTLCExposure, UserConfig};
+use crate::ln::onion_utils::AttributionData;
 
 use bitcoin::hash_types::BlockHash;
 use bitcoin::locktime::absolute::LockTime;
@@ -7114,7 +7115,7 @@ pub fn test_update_fulfill_htlc_bolt2_update_fail_htlc_before_commitment() {
 		channel_id: chan.2,
 		htlc_id: 0,
 		reason: Vec::new(),
-		attribution_data: None,
+		attribution_data: Some(AttributionData::new())
 	};
 
 	nodes[0].node.handle_update_fail_htlc(nodes[1].node.get_our_node_id(), &update_msg);

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -7114,6 +7114,7 @@ pub fn test_update_fulfill_htlc_bolt2_update_fail_htlc_before_commitment() {
 		channel_id: chan.2,
 		htlc_id: 0,
 		reason: Vec::new(),
+		attribution_data: None,
 	};
 
 	nodes[0].node.handle_update_fail_htlc(nodes[1].node.get_our_node_id(), &update_msg);

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -54,6 +54,9 @@ pub use onion_utils::create_payment_onion;
 #[cfg(fuzzing)]
 pub use onion_utils::process_onion_failure;
 
+#[cfg(fuzzing)]
+pub use onion_utils::AttributionData;
+
 #[cfg(test)]
 #[allow(unused_mut)]
 pub mod bolt11_payment_tests;

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -534,6 +534,7 @@ where
 			channel_id: msg.channel_id,
 			htlc_id: msg.htlc_id,
 			reason: failure.data,
+			attribution_data: failure.attribution_data,
 		}));
 	};
 

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -685,6 +685,7 @@ fn test_onion_failure() {
 			decoded_err_packet.hmac = Hmac::from_engine(hmac).to_byte_array();
 			let mut onion_error = OnionErrorPacket {
 				data: decoded_err_packet.encode(),
+				attribution_data: None,
 			};
 			onion_utils::test_crypt_failure_packet(
 				&onion_keys[1].shared_secret.as_ref(), &mut onion_error);
@@ -719,6 +720,7 @@ fn test_onion_failure() {
 			decoded_err_packet.hmac = Hmac::from_engine(hmac).to_byte_array();
 			let mut onion_error = OnionErrorPacket{
 				data: decoded_err_packet.encode(),
+				attribution_data: None,
 			};
 			onion_utils::test_crypt_failure_packet(
 				&onion_keys[0].shared_secret.as_ref(), &mut onion_error);
@@ -747,6 +749,7 @@ fn test_onion_failure() {
 			decoded_err_packet.hmac = Hmac::from_engine(hmac).to_byte_array();
 			let mut onion_error = OnionErrorPacket{
 				data: decoded_err_packet.encode(),
+				attribution_data: None,
 			};
 			onion_utils::test_crypt_failure_packet(
 				&onion_keys[1].shared_secret.as_ref(), &mut onion_error);

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -912,7 +912,7 @@ fn build_unencrypted_failure_packet(
 	hmac.input(&packet.encode()[32..]);
 	packet.hmac = Hmac::from_engine(hmac).to_byte_array();
 
-	OnionErrorPacket { data: packet.encode() }
+	OnionErrorPacket { data: packet.encode(), attribution_data: None }
 }
 
 pub(super) fn build_failure_packet(
@@ -1409,13 +1409,20 @@ impl Readable for HTLCFailReason {
 impl_writeable_tlv_based_enum!(HTLCFailReasonRepr,
 	(0, LightningError) => {
 		(0, data, (legacy, Vec<u8>, |us|
-			if let &HTLCFailReasonRepr::LightningError { err: msgs::OnionErrorPacket { ref data, .. } } = us {
+			if let &HTLCFailReasonRepr::LightningError { err: msgs::OnionErrorPacket { ref data, .. }, .. } = us {
 				Some(data)
 			} else {
 				None
 			})
 		),
-		(_unused, err, (static_value, msgs::OnionErrorPacket { data: data.ok_or(DecodeError::InvalidValue)? })),
+		(1, attribution_data, (legacy, AttributionData, |us|
+			if let &HTLCFailReasonRepr::LightningError { err: msgs::OnionErrorPacket { ref attribution_data, .. }, .. } = us {
+				attribution_data.as_ref()
+			} else {
+				None
+			})
+		),
+		(_unused, err, (static_value, msgs::OnionErrorPacket { data: data.ok_or(DecodeError::InvalidValue)?, attribution_data })),
 	},
 	(1, Reason) => {
 		(0, failure_code, required),
@@ -1473,7 +1480,10 @@ impl HTLCFailReason {
 
 	pub(super) fn from_msg(msg: &msgs::UpdateFailHTLC) -> Self {
 		Self(HTLCFailReasonRepr::LightningError {
-			err: OnionErrorPacket { data: msg.reason.clone() },
+			err: OnionErrorPacket {
+				data: msg.reason.clone(),
+				attribution_data: msg.attribution_data.clone(),
+			},
 		})
 	}
 
@@ -2105,6 +2115,31 @@ fn decode_next_hop<T, R: ReadableArgs<T>, N: NextPacketBytes>(
 	}
 }
 
+pub const HOLD_TIME_LEN: usize = 4;
+pub const MAX_HOPS: usize = 20;
+pub const HMAC_LEN: usize = 4;
+
+// Define the number of HMACs in the attributable data block. For the first node, there are 20 HMACs, and then for every
+// subsequent node, the number of HMACs decreases by 1. 20 + 19 + 18 + ... + 1 = 20 * 21 / 2 = 210.
+pub const HMAC_COUNT: usize = MAX_HOPS * (MAX_HOPS + 1) / 2;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct AttributionData {
+	pub hold_times: [u8; MAX_HOPS * HOLD_TIME_LEN],
+	pub hmacs: [u8; HMAC_LEN * HMAC_COUNT],
+}
+
+impl AttributionData {
+	pub fn new() -> Self {
+		Self { hold_times: [0; MAX_HOPS * HOLD_TIME_LEN], hmacs: [0; HMAC_LEN * HMAC_COUNT] }
+	}
+}
+
+impl_writeable!(AttributionData, {
+	hold_times,
+	hmacs
+});
+
 #[cfg(test)]
 mod tests {
 	use std::sync::Arc;
@@ -2567,8 +2602,10 @@ mod tests {
 			let outer_session_priv = SecretKey::from_slice(&[4; 32]).unwrap();
 
 			let error_packet_hex = "f8941a320b8fde4ad7b9b920c69cbf334114737497d93059d77e591eaa78d6334d3e2aeefcb0cc83402eaaf91d07d695cd895d9cad1018abdaf7d2a49d7657b1612729db7f393f0bb62b25afaaaa326d72a9214666025385033f2ec4605dcf1507467b5726d806da180ea224a7d8631cd31b0bdd08eead8bfe14fc8c7475e17768b1321b54dd4294aecc96da391efe0ca5bd267a45ee085c85a60cf9a9ac152fa4795fff8700a3ea4f848817f5e6943e855ab2e86f6929c9e885d8b20c49b14d2512c59ed21f10bd38691110b0d82c00d9fa48a20f10c7550358724c6e8e2b966e56a0aadf458695b273768062fa7c6e60eb72d4cdc67bf525c194e4a17fdcaa0e9d80480b586bf113f14eea530b6728a1c53fe5cee092e24a90f21f4b764015e7ed5e23";
-			let error_packet =
-				OnionErrorPacket { data: <Vec<u8>>::from_hex(error_packet_hex).unwrap() };
+			let error_packet = OnionErrorPacket {
+				data: <Vec<u8>>::from_hex(error_packet_hex).unwrap(),
+				attribution_data: None,
+			};
 			let decrypted_failure = process_onion_failure_inner(
 				&secp_ctx,
 				&logger,
@@ -2729,7 +2766,7 @@ mod tests {
 	fn test_non_attributable_failure_packet_onion() {
 		// Create a failure packet with bogus data.
 		let packet = vec![1u8; 292];
-		let onion_error_packet = OnionErrorPacket { data: packet };
+		let onion_error_packet = OnionErrorPacket { data: packet, attribution_data: None };
 
 		// In the current protocol, it is unfortunately not possible to identify the failure source.
 		let logger: TestLogger = TestLogger::new();
@@ -2758,7 +2795,8 @@ mod tests {
 		let hmac = Hmac::from_engine(hmac).to_byte_array();
 		packet[..32].copy_from_slice(&hmac);
 
-		let mut onion_error_packet = OnionErrorPacket { data: packet.to_vec() };
+		let mut onion_error_packet =
+			OnionErrorPacket { data: packet.to_vec(), attribution_data: None };
 		crypt_failure_packet(shared_secret, &mut onion_error_packet);
 
 		// For the unreadable failure, it is still expected that the failing channel can be identified.
@@ -2784,7 +2822,8 @@ mod tests {
 		hmac.input(&packet.encode()[32..]);
 		packet.hmac = Hmac::from_engine(hmac).to_byte_array();
 
-		let mut onion_error_packet = OnionErrorPacket { data: packet.encode() };
+		let mut onion_error_packet =
+			OnionErrorPacket { data: packet.encode(), attribution_data: None };
 		crypt_failure_packet(shared_secret, &mut onion_error_packet);
 
 		let logger = TestLogger::new();

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -52,7 +52,7 @@ pub(crate) struct OnionKeys {
 #[inline]
 pub(crate) fn gen_rho_from_shared_secret(shared_secret: &[u8]) -> [u8; 32] {
 	assert_eq!(shared_secret.len(), 32);
-	let mut hmac = HmacEngine::<Sha256>::new(&[0x72, 0x68, 0x6f]); // rho
+	let mut hmac = HmacEngine::<Sha256>::new(b"rho");
 	hmac.input(&shared_secret);
 	Hmac::from_engine(hmac).to_byte_array()
 }
@@ -74,7 +74,7 @@ pub(crate) fn gen_rho_mu_from_shared_secret(shared_secret: &[u8]) -> ([u8; 32], 
 #[inline]
 pub(super) fn gen_um_from_shared_secret(shared_secret: &[u8]) -> [u8; 32] {
 	assert_eq!(shared_secret.len(), 32);
-	let mut hmac = HmacEngine::<Sha256>::new(&[0x75, 0x6d]); // um
+	let mut hmac = HmacEngine::<Sha256>::new(b"um");
 	hmac.input(&shared_secret);
 	Hmac::from_engine(hmac).to_byte_array()
 }
@@ -82,7 +82,7 @@ pub(super) fn gen_um_from_shared_secret(shared_secret: &[u8]) -> [u8; 32] {
 #[inline]
 pub(super) fn gen_ammag_from_shared_secret(shared_secret: &[u8]) -> [u8; 32] {
 	assert_eq!(shared_secret.len(), 32);
-	let mut hmac = HmacEngine::<Sha256>::new(&[0x61, 0x6d, 0x6d, 0x61, 0x67]); // ammag
+	let mut hmac = HmacEngine::<Sha256>::new(b"ammag");
 	hmac.input(&shared_secret);
 	Hmac::from_engine(hmac).to_byte_array()
 }
@@ -91,7 +91,7 @@ pub(super) fn gen_ammag_from_shared_secret(shared_secret: &[u8]) -> [u8; 32] {
 #[inline]
 pub(super) fn gen_pad_from_shared_secret(shared_secret: &[u8]) -> [u8; 32] {
 	assert_eq!(shared_secret.len(), 32);
-	let mut hmac = HmacEngine::<Sha256>::new(&[0x70, 0x61, 0x64]); // pad
+	let mut hmac = HmacEngine::<Sha256>::new(b"pad");
 	hmac.input(&shared_secret);
 	Hmac::from_engine(hmac).to_byte_array()
 }

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -2163,11 +2163,11 @@ impl OutboundPayments {
 		#[cfg(any(test, feature = "_test_utils"))]
 		let DecodedOnionFailure {
 			network_update, short_channel_id, payment_failed_permanently, onion_error_code,
-			onion_error_data, failed_within_blinded_path
+			onion_error_data, failed_within_blinded_path, ..
 		} = onion_error.decode_onion_failure(secp_ctx, logger, &source);
 		#[cfg(not(any(test, feature = "_test_utils")))]
 		let DecodedOnionFailure {
-			network_update, short_channel_id, payment_failed_permanently, failed_within_blinded_path
+			network_update, short_channel_id, payment_failed_permanently, failed_within_blinded_path, ..
 		} = onion_error.decode_onion_failure(secp_ctx, logger, &source);
 
 		let payment_is_probe = payment_is_probe(payment_hash, &payment_id, probing_cookie_secret);

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -15,6 +15,7 @@
 
 use crate::io::{self, BufRead, Read, Write};
 use crate::io_extras::{copy, sink};
+use crate::ln::onion_utils::{HMAC_COUNT, HMAC_LEN, HOLD_TIME_LEN, MAX_HOPS};
 use crate::prelude::*;
 use crate::sync::{Mutex, RwLock};
 use core::cmp;
@@ -727,6 +728,10 @@ impl_array!(1300, u8); // for OnionPacket.hop_data
 
 impl_array!(8, u16);
 impl_array!(32, u16);
+
+// Implement array serialization for attribution_data.
+impl_array!(MAX_HOPS * HOLD_TIME_LEN, u8);
+impl_array!(HMAC_LEN * HMAC_COUNT, u8);
 
 /// A type for variable-length values within TLV record where the length is encoded as part of the record.
 /// Used to prevent encoding the length twice.


### PR DESCRIPTION
Implements https://github.com/lightning/bolts/pull/1044

This PR implements the `update_fail_htlc` optional `attribution_data` field as tlv type `101` rather than type `1` until interop with other node software is achieved.

Until that time, the feature bit doesn't need to be set either.