### PR TITLE
Remove unneeded allocation

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -1725,7 +1725,7 @@ impl<'de> Deserialize<'de> for Invoice {
 	fn deserialize<D>(deserializer: D) -> Result<Invoice, D::Error> where D: Deserializer<'de> {
 		let bolt11 = String::deserialize(deserializer)?
 			.parse::<Invoice>()
-			.map_err(|e| D::Error::custom(alloc::format!("{:?}", e)))?;
+			.map_err(|e| D::Error::custom(format_args!("{:?}", e)))?;
 
 		Ok(bolt11)
 	}


### PR DESCRIPTION
`<E as serde::de::Error>::custom()` accepts any `T: Display`, not just `String`. Therefore it accepts `Arguments<'_>` too so we can use `format_args!()` instead of `format!()`.

See https://github.com/lightningdevkit/rust-lightning/pull/2187#discussion_r1168781355