### PR TITLE
Prevent ChannelForceClosed monitor update error after detecting spend

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7756,6 +7756,8 @@ where
 
 		for (funding_txo, _) in args.channel_monitors.iter() {
 			if !funding_txo_set.contains(funding_txo) {
+				log_info!(args.logger, "Queueing monitor update to ensure missing channel {} is force closed",
+					log_bytes!(funding_txo.to_channel_id()));
 				let monitor_update = ChannelMonitorUpdate {
 					update_id: CLOSED_CHANNEL_UPDATE_ID,
 					updates: vec![ChannelMonitorUpdateStep::ChannelForceClosed { should_broadcast: true }],


### PR DESCRIPTION
If we detected a spend for a channel onchain prior to handling its `ChannelForceClosed` monitor update, we'd log a concerning error message and return an error unnecessarily. The channel has already been closed, so handling the `ChannelForceClosed` monitor update at this point should be a no-op.

Fixes #2263.