### PR TITLE
Mention lnd's SCB feature in the corresponding error message

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4092,7 +4092,7 @@ impl<Signer: WriteableEcdsaChannelSigner> Channel<Signer> {
 
 		if msg.next_local_commitment_number >= INITIAL_COMMITMENT_NUMBER || msg.next_remote_commitment_number >= INITIAL_COMMITMENT_NUMBER ||
 			msg.next_local_commitment_number == 0 {
-			return Err(ChannelError::Close("Peer sent a garbage channel_reestablish".to_owned()));
+			return Err(ChannelError::Close("Peer sent a garbage channel_reestablish (usually an lnd node with lost state asking us to force-close for them)".to_owned()));
 		}
 
 		if msg.next_remote_commitment_number > 0 {


### PR DESCRIPTION
It's a bit confusing when we see only "Peer sent a garbage channel_reestablish" when a peer uses lnd's SCB feature to ask us to broadcast the latest state. This updates the error message to be a bit clearer.