### PR TITLE
Make `lightning-transaction-sync` compat notice a bit more explicit

### DIFF
--- a/lightning-transaction-sync/src/lib.rs
+++ b/lightning-transaction-sync/src/lib.rs
@@ -13,7 +13,8 @@
 //!
 //! ## Version Compatibility
 //!
-//! Currently this crate is compatible with nodes that were created with LDK version 0.0.113 and above.
+//! Currently this crate is compatible with LDK version 0.0.114 and above using channels which were
+//! created on LDK version 0.0.113 and above.
 //!
 //! ## Usage Example:
 //!


### PR DESCRIPTION
Resolves #2254.

As `lightning-transaction-sync` was introduced with 0.0.114 and depended on prior changes in the same release cycle we deemed it reasonable to omit the implicitly limited backwards compatibility.

It however turns out this might be confusing to users copy/pasting the codebase. Here we therefore spell out the implicit dependency on 0.0.114 and above.