### PR TITLE
Fix large onion message packet generation

### DIFF
--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -324,7 +324,8 @@ fn construct_onion_packet_with_init_noise<HD: Writeable, P: Packet>(
 		chacha.process_in_place(packet_data);
 
 		if i == 0 {
-			packet_data[ONION_DATA_LEN - filler.len()..ONION_DATA_LEN].copy_from_slice(&filler[..]);
+			let onion_data_len = packet_data.len();
+			packet_data[onion_data_len - filler.len()..onion_data_len].copy_from_slice(&filler[..]);
 		}
 
 		let mut hmac = HmacEngine::<Sha256>::new(&keys.mu);

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -284,3 +284,20 @@ fn peer_buffer_full() {
 	let err = nodes[0].messenger.send_onion_message(&[], Destination::Node(nodes[1].get_node_pk()), OnionMessageContents::Custom(test_msg), None).unwrap_err();
 	assert_eq!(err, SendError::BufferFull);
 }
+
+#[test]
+fn many_hops() {
+	// Check we can send over a route with many hops. This will exercise our logic for onion messages
+	// of size [`crate::onion_message::packet::BIG_PACKET_HOP_DATA_LEN`].
+	let num_nodes: usize = 25;
+	let nodes = create_nodes(num_nodes as u8);
+	let test_msg = OnionMessageContents::Custom(TestCustomMessage {});
+
+	let mut intermediates = vec![];
+	for i in 1..(num_nodes-1) {
+		intermediates.push(nodes[i].get_node_pk());
+	}
+
+	nodes[0].messenger.send_onion_message(&intermediates, Destination::Node(nodes[num_nodes-1].get_node_pk()), test_msg, None).unwrap();
+	pass_along_path(&nodes);
+}

--- a/pending_changelog/big-om-error.txt
+++ b/pending_changelog/big-om-error.txt
@@ -1,0 +1,4 @@
+## Bug Fixes
+
+* Fixed sending large onion messages, which previously would result in an HMAC error on the second
+	hop (#2277).


### PR DESCRIPTION
Previously, if our onion message hop data was of size `onion_message::packet::BIG_PACKET_HOP_DATA_LEN`, we would construct an invalid onion packet due to a hardcoded assumption that the hop data would of length 1300. 

Also fix the OM test utils to no longer assert on logs. 

Pointed out by @tnull in #2271 