### PR TITLE
Use `MonotonicTime` as `Instant` shifted by 10 years forward

### DIFF
--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -239,7 +239,7 @@ impl Retry {
 			},
 			#[cfg(all(not(feature = "no-std"), not(test)))]
 			(Retry::Timeout(max_duration), PaymentAttempts { first_attempted_at, .. }) =>
-				*max_duration >= std::time::Instant::now().duration_since(*first_attempted_at),
+				*max_duration >= crate::util::time::MonotonicTime::now().duration_since(*first_attempted_at),
 			#[cfg(all(not(feature = "no-std"), test))]
 			(Retry::Timeout(max_duration), PaymentAttempts { first_attempted_at, .. }) =>
 				*max_duration >= SinceEpoch::now().duration_since(*first_attempted_at),
@@ -274,7 +274,7 @@ pub(crate) struct PaymentAttemptsUsingTime<T: Time> {
 }
 
 #[cfg(not(any(feature = "no-std", test)))]
-type ConfiguredTime = std::time::Instant;
+type ConfiguredTime = crate::util::time::MonotonicTime;
 #[cfg(feature = "no-std")]
 type ConfiguredTime = crate::util::time::Eternity;
 #[cfg(all(not(feature = "no-std"), test))]

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -325,7 +325,7 @@ impl ReadableArgs<u64> for FixedPenaltyScorer {
 }
 
 #[cfg(not(feature = "no-std"))]
-type ConfiguredTime = std::time::Instant;
+type ConfiguredTime = crate::util::time::MonotonicTime;
 #[cfg(feature = "no-std")]
 use crate::util::time::Eternity;
 #[cfg(feature = "no-std")]


### PR DESCRIPTION
Such implementation allows `MonotonicTime` to go backward up to 10 years on all platforms. On some platforms (e.g. iOS) `Instant` is represented as `u64` of nanoseconds since the boot of the system. Obviously such implementation does not allow to go backward before the time of the boot.
Fixes #2311.