### PR TITLE
Remove anchors config flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,6 @@ jobs:
           cargo check --no-default-features --features=no-std --release
           cargo check --no-default-features --features=futures --release
           cargo doc --release
-          RUSTDOCFLAGS="--cfg=anchors" cargo doc --release
       - name: Run cargo check for Taproot build.
         run: |
           cargo check --release
@@ -202,8 +201,8 @@ jobs:
           cargo check --no-default-features --features=futures --release
           cargo doc --release
         env:
-          RUSTFLAGS: '--cfg=anchors --cfg=taproot'
-          RUSTDOCFLAGS: '--cfg=anchors --cfg=taproot'
+          RUSTFLAGS: '--cfg=taproot'
+          RUSTDOCFLAGS: '--cfg=taproot'
 
   fuzz:
     runs-on: ubuntu-latest

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -101,9 +101,7 @@ if [ "$RUSTC_MINOR_VERSION" -gt 55 ]; then
 	popd
 fi
 
-echo -e "\n\nTest anchors builds"
-pushd lightning
-RUSTFLAGS="$RUSTFLAGS --cfg=anchors" cargo test --verbose --color always -p lightning
 echo -e "\n\nTest Taproot builds"
-RUSTFLAGS="$RUSTFLAGS --cfg=anchors --cfg=taproot" cargo test --verbose --color always -p lightning
+pushd lightning
+RUSTFLAGS="$RUSTFLAGS --cfg=taproot" cargo test --verbose --color always -p lightning
 popd

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -782,30 +782,13 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner, C: Deref, T: Deref, F: Deref, L
 	      L::Target: Logger,
 	      P::Target: Persist<ChannelSigner>,
 {
-	#[cfg(not(anchors))]
-	/// Processes [`SpendableOutputs`] events produced from each [`ChannelMonitor`] upon maturity.
-	///
-	/// An [`EventHandler`] may safely call back to the provider, though this shouldn't be needed in
-	/// order to handle these events.
-	///
-	/// [`SpendableOutputs`]: events::Event::SpendableOutputs
-	fn process_pending_events<H: Deref>(&self, handler: H) where H::Target: EventHandler {
-		let mut pending_events = Vec::new();
-		for monitor_state in self.monitors.read().unwrap().values() {
-			pending_events.append(&mut monitor_state.monitor.get_and_clear_pending_events());
-		}
-		for event in pending_events {
-			handler.handle_event(event);
-		}
-	}
-	#[cfg(anchors)]
 	/// Processes [`SpendableOutputs`] events produced from each [`ChannelMonitor`] upon maturity.
 	///
 	/// For channels featuring anchor outputs, this method will also process [`BumpTransaction`]
 	/// events produced from each [`ChannelMonitor`] while there is a balance to claim onchain
 	/// within each channel. As the confirmation of a commitment transaction may be critical to the
-	/// safety of funds, this method must be invoked frequently, ideally once for every chain tip
-	/// update (block connected or disconnected).
+	/// safety of funds, we recommend invoking this every 30 seconds, or lower if running in an
+	/// environment with spotty connections, like on mobile.
 	///
 	/// An [`EventHandler`] may safely call back to the provider, though this shouldn't be needed in
 	/// order to handle these events.

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -43,16 +43,13 @@ use crate::chain::{BestBlock, WatchedOutput};
 use crate::chain::chaininterface::{BroadcasterInterface, FeeEstimator, LowerBoundedFeeEstimator};
 use crate::chain::transaction::{OutPoint, TransactionData};
 use crate::sign::{SpendableOutputDescriptor, StaticPaymentOutputDescriptor, DelayedPaymentOutputDescriptor, WriteableEcdsaChannelSigner, SignerProvider, EntropySource};
-#[cfg(anchors)]
-use crate::chain::onchaintx::ClaimEvent;
-use crate::chain::onchaintx::OnchainTxHandler;
+use crate::chain::onchaintx::{ClaimEvent, OnchainTxHandler};
 use crate::chain::package::{CounterpartyOfferedHTLCOutput, CounterpartyReceivedHTLCOutput, HolderFundingOutput, HolderHTLCOutput, PackageSolvingData, PackageTemplate, RevokedOutput, RevokedHTLCOutput};
 use crate::chain::Filter;
 use crate::util::logger::Logger;
 use crate::util::ser::{Readable, ReadableArgs, RequiredWrapper, MaybeReadable, UpgradableRequired, Writer, Writeable, U48};
 use crate::util::byte_utils;
 use crate::events::Event;
-#[cfg(anchors)]
 use crate::events::bump_transaction::{AnchorDescriptor, HTLCDescriptor, BumpTransactionEvent};
 
 use crate::prelude::*;
@@ -268,7 +265,6 @@ impl_writeable_tlv_based!(HolderSignedTx, {
 	(14, htlc_outputs, vec_type)
 });
 
-#[cfg(anchors)]
 impl HolderSignedTx {
 	fn non_dust_htlcs(&self) -> Vec<HTLCOutputInCommitment> {
 		self.htlc_outputs.iter().filter_map(|(htlc, _, _)| {
@@ -2538,7 +2534,6 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 	pub fn get_and_clear_pending_events(&mut self) -> Vec<Event> {
 		let mut ret = Vec::new();
 		mem::swap(&mut ret, &mut self.pending_events);
-		#[cfg(anchors)]
 		for (claim_id, claim_event) in self.onchain_tx_handler.get_and_clear_pending_claim_events().drain(..) {
 			match claim_event {
 				ClaimEvent::BumpCommitment {

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -26,16 +26,13 @@ use crate::ln::chan_utils;
 use crate::ln::msgs::DecodeError;
 use crate::chain::chaininterface::{FeeEstimator, ConfirmationTarget, MIN_RELAY_FEE_SAT_PER_1000_WEIGHT};
 use crate::sign::WriteableEcdsaChannelSigner;
-#[cfg(anchors)]
-use crate::chain::onchaintx::ExternalHTLCClaim;
-use crate::chain::onchaintx::OnchainTxHandler;
+use crate::chain::onchaintx::{ExternalHTLCClaim, OnchainTxHandler};
 use crate::util::logger::Logger;
 use crate::util::ser::{Readable, Writer, Writeable, RequiredWrapper};
 
 use crate::io;
 use crate::prelude::*;
 use core::cmp;
-#[cfg(anchors)]
 use core::convert::TryInto;
 use core::mem;
 use core::ops::Deref;
@@ -866,7 +863,6 @@ impl PackageTemplate {
 		let output_weight = (8 + 1 + destination_script.len()) * WITNESS_SCALE_FACTOR;
 		inputs_weight + witnesses_weight + transaction_weight + output_weight
 	}
-	#[cfg(anchors)]
 	pub(crate) fn construct_malleable_package_with_external_funding<Signer: WriteableEcdsaChannelSigner>(
 		&self, onchain_handler: &mut OnchainTxHandler<Signer>,
 	) -> Option<Vec<ExternalHTLCClaim>> {
@@ -971,7 +967,6 @@ impl PackageTemplate {
 		None
 	}
 
-	#[cfg(anchors)]
 	/// Computes a feerate based on the given confirmation target. If a previous feerate was used,
 	/// the new feerate is below it, and `force_feerate_bump` is set, we'll use a 25% increase of
 	/// the previous feerate instead of the new feerate.

--- a/lightning/src/events/bump_transaction.rs
+++ b/lightning/src/events/bump_transaction.rs
@@ -14,16 +14,17 @@ use core::ops::Deref;
 
 use crate::chain::chaininterface::BroadcasterInterface;
 use crate::chain::ClaimId;
-use crate::sign::{ChannelSigner, EcdsaChannelSigner, SignerProvider};
+use crate::events::Event;
 use crate::io_extras::sink;
-use crate::ln::PaymentPreimage;
 use crate::ln::chan_utils;
 use crate::ln::chan_utils::{
 	ANCHOR_INPUT_WITNESS_WEIGHT, HTLC_SUCCESS_INPUT_ANCHOR_WITNESS_WEIGHT,
 	HTLC_TIMEOUT_INPUT_ANCHOR_WITNESS_WEIGHT, ChannelTransactionParameters, HTLCOutputInCommitment
 };
-use crate::events::Event;
-use crate::prelude::HashMap;
+use crate::ln::features::ChannelTypeFeatures;
+use crate::ln::PaymentPreimage;
+use crate::prelude::*;
+use crate::sign::{ChannelSigner, EcdsaChannelSigner, SignerProvider};
 use crate::sync::Mutex;
 use crate::util::logger::Logger;
 
@@ -33,7 +34,6 @@ use bitcoin::consensus::Encodable;
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use bitcoin::secp256k1::ecdsa::Signature;
-use crate::ln::features::ChannelTypeFeatures;
 
 const EMPTY_SCRIPT_SIG_WEIGHT: u64 = 1 /* empty script_sig */ * WITNESS_SCALE_FACTOR as u64;
 

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -14,10 +14,8 @@
 //! future, as well as generate and broadcast funding transactions handle payment preimages and a
 //! few other things.
 
-#[cfg(anchors)]
 pub mod bump_transaction;
 
-#[cfg(anchors)]
 pub use bump_transaction::BumpTransactionEvent;
 
 use crate::sign::SpendableOutputDescriptor;
@@ -832,7 +830,6 @@ pub enum Event {
 		/// Destination of the HTLC that failed to be processed.
 		failed_next_destination: HTLCDestination,
 	},
-	#[cfg(anchors)]
 	/// Indicates that a transaction originating from LDK needs to have its fee bumped. This event
 	/// requires confirmed external funds to be readily available to spend.
 	///
@@ -1029,7 +1026,6 @@ impl Writeable for Event {
 					(2, failed_next_destination, required),
 				})
 			},
-			#[cfg(anchors)]
 			&Event::BumpTransaction(ref event)=> {
 				27u8.write(writer)?;
 				match event {

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -829,7 +829,6 @@ pub fn get_anchor_redeemscript(funding_pubkey: &PublicKey) -> Script {
 		.into_script()
 }
 
-#[cfg(anchors)]
 /// Locates the output with an anchor script paying to `funding_pubkey` within `commitment_tx`.
 pub(crate) fn get_anchor_output<'a>(commitment_tx: &'a Transaction, funding_pubkey: &PublicKey) -> Option<(u32, &'a TxOut)> {
 	let anchor_script = chan_utils::get_anchor_redeemscript(funding_pubkey).to_v0_p2wsh();

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -5727,12 +5727,9 @@ impl<Signer: WriteableEcdsaChannelSigner> OutboundV1Channel<Signer> {
 		// Optionally, if the user would like to negotiate the `anchors_zero_fee_htlc_tx` option, we
 		// set it now. If they don't understand it, we'll fall back to our default of
 		// `only_static_remotekey`.
-		#[cfg(anchors)]
-		{ // Attributes are not allowed on if expressions on our current MSRV of 1.41.
-			if config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx &&
-				their_features.supports_anchors_zero_fee_htlc_tx() {
-				ret.set_anchors_zero_fee_htlc_tx_required();
-			}
+		if config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx &&
+			their_features.supports_anchors_zero_fee_htlc_tx() {
+			ret.set_anchors_zero_fee_htlc_tx_required();
 		}
 
 		ret
@@ -7379,7 +7376,6 @@ mod tests {
 	use hex;
 	use crate::ln::PaymentHash;
 	use crate::ln::channelmanager::{self, HTLCSource, PaymentId};
-	#[cfg(anchors)]
 	use crate::ln::channel::InitFeatures;
 	use crate::ln::channel::{Channel, InboundHTLCOutput, OutboundV1Channel, InboundV1Channel, OutboundHTLCOutput, InboundHTLCState, OutboundHTLCState, HTLCCandidate, HTLCInitiator, commit_tx_fee_msat};
 	use crate::ln::channel::{MAX_FUNDING_SATOSHIS_NO_WUMBO, TOTAL_BITCOIN_SUPPLY_SATOSHIS, MIN_THEIR_CHAN_RESERVE_SATOSHIS};
@@ -8703,7 +8699,6 @@ mod tests {
 		assert!(res.is_ok());
 	}
 
-	#[cfg(anchors)]
 	#[test]
 	fn test_supports_anchors_zero_htlc_tx_fee() {
 		// Tests that if both sides support and negotiate `anchors_zero_fee_htlc_tx`, it is the
@@ -8749,7 +8744,6 @@ mod tests {
 		assert_eq!(channel_b.context.channel_type, expected_channel_type);
 	}
 
-	#[cfg(anchors)]
 	#[test]
 	fn test_rejects_implicit_simple_anchors() {
 		// Tests that if `option_anchors` is being negotiated implicitly through the intersection of
@@ -8790,7 +8784,6 @@ mod tests {
 		assert!(channel_b.is_err());
 	}
 
-	#[cfg(anchors)]
 	#[test]
 	fn test_rejects_simple_anchors_channel_type() {
 		// Tests that if `option_anchors` is being negotiated through the `channel_type` feature,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7232,7 +7232,7 @@ pub(crate) fn provided_channel_type_features(config: &UserConfig) -> ChannelType
 
 /// Fetches the set of [`InitFeatures`] flags which are provided by or required by
 /// [`ChannelManager`].
-pub fn provided_init_features(_config: &UserConfig) -> InitFeatures {
+pub fn provided_init_features(config: &UserConfig) -> InitFeatures {
 	// Note that if new features are added here which other peers may (eventually) require, we
 	// should also add the corresponding (optional) bit to the [`ChannelMessageHandler`] impl for
 	// [`ErroringMessageHandler`].
@@ -7248,11 +7248,8 @@ pub fn provided_init_features(_config: &UserConfig) -> InitFeatures {
 	features.set_channel_type_optional();
 	features.set_scid_privacy_optional();
 	features.set_zero_conf_optional();
-	#[cfg(anchors)]
-	{ // Attributes are not allowed on if expressions on our current MSRV of 1.41.
-		if _config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx {
-			features.set_anchors_zero_fee_htlc_tx_optional();
-		}
+	if config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx {
+		features.set_anchors_zero_fee_htlc_tx_optional();
 	}
 	features
 }
@@ -9731,7 +9728,6 @@ mod tests {
 			sender_intended_amt_msat - extra_fee_msat, 42, None, true, Some(extra_fee_msat)).is_ok());
 	}
 
-	#[cfg(anchors)]
 	#[test]
 	fn test_anchors_zero_fee_htlc_tx_fallback() {
 		// Tests that if both nodes support anchors, but the remote node does not want to accept

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -36,7 +36,6 @@ use crate::util::transaction_utils;
 use crate::util::crypto::{hkdf_extract_expand_twice, sign, sign_with_aux_rand};
 use crate::util::ser::{Writeable, Writer, Readable, ReadableArgs};
 use crate::chain::transaction::OutPoint;
-#[cfg(anchors)]
 use crate::events::bump_transaction::HTLCDescriptor;
 use crate::ln::channel::ANCHOR_OUTPUT_VALUE_SATOSHI;
 use crate::ln::{chan_utils, PaymentPreimage};
@@ -489,7 +488,6 @@ pub trait EcdsaChannelSigner: ChannelSigner {
 	fn sign_justice_revoked_htlc(&self, justice_tx: &Transaction, input: usize, amount: u64,
 		per_commitment_key: &SecretKey, htlc: &HTLCOutputInCommitment,
 		secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()>;
-	#[cfg(anchors)]
 	/// Computes the signature for a commitment transaction's HTLC output used as an input within
 	/// `htlc_tx`, which spends the commitment transaction at index `input`. The signature returned
 	/// must be be computed using [`EcdsaSighashType::All`]. Note that this should only be used to
@@ -1028,7 +1026,6 @@ impl EcdsaChannelSigner for InMemorySigner {
 		return Ok(sign_with_aux_rand(secp_ctx, &sighash, &revocation_key, &self))
 	}
 
-	#[cfg(anchors)]
 	fn sign_holder_htlc_transaction(
 		&self, htlc_tx: &Transaction, input: usize, htlc_descriptor: &HTLCDescriptor,
 		secp_ctx: &Secp256k1<secp256k1::All>

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -149,11 +149,12 @@ pub struct ChannelHandshakeConfig {
 	/// Maximum value: 1,000,000, any values larger than 1 Million will be treated as 1 Million (or 100%)
 	///                instead, although channel negotiations will fail in that case.
 	pub their_channel_reserve_proportional_millionths: u32,
-	#[cfg(anchors)]
-	/// If set, we attempt to negotiate the `anchors_zero_fee_htlc_tx`option for outbound channels.
+	/// If set, we attempt to negotiate the `anchors_zero_fee_htlc_tx`option for all future
+	/// channels. This feature requires having a reserve of onchain funds readily available to bump
+	/// transactions in the event of a channel force close to avoid the possibility of losing funds.
 	///
 	/// If this option is set, channels may be created that will not be readable by LDK versions
-	/// prior to 0.0.114, causing [`ChannelManager`]'s read method to return a
+	/// prior to 0.0.116, causing [`ChannelManager`]'s read method to return a
 	/// [`DecodeError::InvalidValue`].
 	///
 	/// Note that setting this to true does *not* prevent us from opening channels with
@@ -196,7 +197,6 @@ impl Default for ChannelHandshakeConfig {
 			announced_channel: false,
 			commit_upfront_shutdown_pubkey: true,
 			their_channel_reserve_proportional_millionths: 10_000,
-			#[cfg(anchors)]
 			negotiate_anchors_zero_fee_htlc_tx: false,
 			our_max_accepted_htlcs: 50,
 		}

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -23,7 +23,6 @@ use bitcoin::util::sighash;
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::{SecretKey, PublicKey};
 use bitcoin::secp256k1::{Secp256k1, ecdsa::Signature};
-#[cfg(anchors)]
 use crate::events::bump_transaction::HTLCDescriptor;
 use crate::util::ser::{Writeable, Writer};
 use crate::io::Error;
@@ -206,7 +205,6 @@ impl EcdsaChannelSigner for EnforcingSigner {
 		Ok(self.inner.sign_justice_revoked_htlc(justice_tx, input, amount, per_commitment_key, htlc, secp_ctx).unwrap())
 	}
 
-	#[cfg(anchors)]
 	fn sign_holder_htlc_transaction(
 		&self, htlc_tx: &Transaction, input: usize, htlc_descriptor: &HTLCDescriptor,
 		secp_ctx: &Secp256k1<secp256k1::All>


### PR DESCRIPTION
Now that all of the core functionality for anchor outputs has landed, we're ready to remove the config flag that was temporarily hiding it from our API.

Depends on #2361.