### PR TITLE
Make lightning::sync public

### DIFF
--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -179,4 +179,4 @@ mod prelude {
 #[cfg(all(not(ldk_bench), feature = "backtrace", feature = "std", test))]
 extern crate backtrace;
 
-mod sync;
+pub mod sync;


### PR DESCRIPTION
I believe it might have always been the intention. I tested this 116-alpha1 fork out on Mutiny and sending / receiving seems to be working, just needed pub here.