### PR TITLE
Expose `DefaultMessageRouter`

### DIFF
--- a/lightning/src/onion_message/mod.rs
+++ b/lightning/src/onion_message/mod.rs
@@ -27,6 +27,6 @@ mod packet;
 mod functional_tests;
 
 // Re-export structs so they can be imported with just the `onion_message::` module prefix.
-pub use self::messenger::{CustomOnionMessageContents, CustomOnionMessageHandler, Destination, MessageRouter, OnionMessageContents, OnionMessagePath, OnionMessenger, SendError, SimpleArcOnionMessenger, SimpleRefOnionMessenger};
+pub use self::messenger::{CustomOnionMessageContents, CustomOnionMessageHandler, DefaultMessageRouter, Destination, MessageRouter, OnionMessageContents, OnionMessagePath, OnionMessenger, SendError, SimpleArcOnionMessenger, SimpleRefOnionMessenger};
 pub use self::offers::{OffersMessage, OffersMessageHandler};
 pub(crate) use self::packet::{ControlTlvs, Packet};


### PR DESCRIPTION
In #2384 we introduced a `DefaultMessageRouter` that can be given to `OnionMessenger`.

Except it can't as it's not exposed currently. Here, we fix this omission.

