### PR TITLE
Add `MempoolInterface` to add mempool scan

### DIFF
--- a/lightning/src/chain/mempoolinterface.rs
+++ b/lightning/src/chain/mempoolinterface.rs
@@ -1,0 +1,31 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Traits and utility impls which allow other parts of rust-lightning to
+//! interact with the mempool.
+//!
+//! Includes traits for monitoring and receiving notification for in-mempool
+//! descendants of a channel output.
+
+use crate::chain::transaction::OutPoint;
+
+use bitcoin::blockdata::transaction::Transaction;
+
+pub enum MempoolWatchStatus {
+	/// The in-mempool descendant of the watched outpoint.
+	DescendantTx(Transaction)
+	/// The watch outpoint has been reorged out of the chain.
+	Reorg,
+}
+
+/// An interface to monitor a local cacche of Bitcoin transacations waiting
+/// confirmations.
+pub trait MempoolInterface {
+	fn watch_outpoint(&self, funding_txo: OutPoint) -> MempoolWatchStatus;
+}


### PR DESCRIPTION
Local access to the mempool view enables routing hops and LSP to perfom more efficiently two tasks:
- passing backward HTLC preimage from the outbound edge to the inbound one (see `ChannelMonitor::get_pending_or_resolved_outbound_htlcs()`)
- detecting an unconfirmed dual-funding double spend and freeing up the locked UTXOS (cf. [liquidity griefing for 0-conf dual-funded txs](https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-May/003920.html))
 
For the first task, if a) our counterparty realizes a force-close and b) there are non-expired received HTLC outputs on the force-closed commitment transaction and c) our counterparty broadcast one or more HTLC-success transactions on those outputs, once those latest transactions are well-propagated on the network mempools, we can fetch the preimage and transmit it to the ChannelManager for pending off-chain inbound HTLCs resolution (i.e sending an `update_fulfill_htlc` to our counterparty on the inbound edge). Liquidity is therefore unlock faster on the inbound edge without having to wait on counterparty's commitment transaction confirmation.

For the second task, once we have dual-funding functional, we might accept counterparty's `TxAddInput` in the V2 channel establishment and commit some of our own inputs in the collaborative transaction for liquidity balanced channel opening. However, as long as the  channel is not confirmed, we're exposed to double-spend by our counterparty locking up our contributed UTXOs in a liquidity griefing, at the detrimental of others potential dual-funding flows we could enter into.

This PR implements #2341 by introducing a `MempoolInterface`. This interface has for now a single method `watch_outpoint()`, where the implementation should return any in-mempool descendant for the given `OutPoint`. This can be implemented given Bitcoin Core's `getmempooldescendant` (or I think a very similar rpc `getutxomempooldescendant` that I'll have to land there as  a first step).

Few integration approaches for a default `MempoolInterface` implementation can be considered:
- make it a new trait object in `ChainMonitor` ?
- make it a simple trait like `FeeEstimator` or `FeeEstimator` and defer implementation to downstream LDK users ?

The first option has the advantage to have a more robust and consistent integration if the mempool interface becomes
more complex in function of mempool evolution works on the Core side (e.g package policy or mempool clusters).

Other mempool scanning interfaces approaches can be considered before to make the necesary changes on the Core side to have a functional end-to-end mempool scanning for review.