### PR TITLE
Qualify BOLT 11/12 invoice and related types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
   check_commits:
     runs-on: ubuntu-latest
     env:
-      TOOLCHAIN: 1.57.0
+      TOOLCHAIN: stable
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/fuzz/src/bech32_parse.rs
+++ b/fuzz/src/bech32_parse.rs
@@ -9,7 +9,7 @@
 
 use crate::utils::test_logger;
 use core::convert::TryFrom;
-use lightning::offers::parse::{Bech32Encode, ParseError};
+use lightning::offers::parse::{Bech32Encode, Bolt12ParseError};
 
 #[inline]
 pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
@@ -35,8 +35,8 @@ impl AsRef<[u8]> for Bytes {
 }
 
 impl TryFrom<Vec<u8>> for Bytes {
-	type Error = ParseError;
-	fn try_from(data: Vec<u8>) -> Result<Self, ParseError> {
+	type Error = Bolt12ParseError;
+	fn try_from(data: Vec<u8>) -> Result<Self, Bolt12ParseError> {
 		Ok(Bytes(data))
 	}
 }

--- a/fuzz/src/invoice_deser.rs
+++ b/fuzz/src/invoice_deser.rs
@@ -8,13 +8,13 @@
 // licenses.
 
 use crate::utils::test_logger;
-use lightning::offers::invoice::Invoice;
+use lightning::offers::invoice::Bolt12Invoice;
 use lightning::util::ser::Writeable;
 use std::convert::TryFrom;
 
 #[inline]
 pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
-	if let Ok(invoice) = Invoice::try_from(data.to_vec()) {
+	if let Ok(invoice) = Bolt12Invoice::try_from(data.to_vec()) {
 		let mut bytes = Vec::with_capacity(data.len());
 		invoice.write(&mut bytes).unwrap();
 		assert_eq!(data, bytes);

--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -14,7 +14,7 @@ use lightning::blinded_path::BlindedPath;
 use lightning::sign::EntropySource;
 use lightning::ln::PaymentHash;
 use lightning::ln::features::BlindedHopFeatures;
-use lightning::offers::invoice::{BlindedPayInfo, UnsignedInvoice};
+use lightning::offers::invoice::{BlindedPayInfo, UnsignedBolt12Invoice};
 use lightning::offers::invoice_request::InvoiceRequest;
 use lightning::offers::parse::SemanticError;
 use lightning::util::ser::Writeable;
@@ -71,7 +71,7 @@ fn privkey(byte: u8) -> SecretKey {
 
 fn build_response<'a, T: secp256k1::Signing + secp256k1::Verification>(
 	invoice_request: &'a InvoiceRequest, secp_ctx: &Secp256k1<T>
-) -> Result<UnsignedInvoice<'a>, SemanticError> {
+) -> Result<UnsignedBolt12Invoice<'a>, SemanticError> {
 	let entropy_source = Randomness {};
 	let paths = vec![
 		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], &entropy_source, secp_ctx).unwrap(),

--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -16,7 +16,7 @@ use lightning::ln::PaymentHash;
 use lightning::ln::features::BlindedHopFeatures;
 use lightning::offers::invoice::{BlindedPayInfo, UnsignedBolt12Invoice};
 use lightning::offers::invoice_request::InvoiceRequest;
-use lightning::offers::parse::SemanticError;
+use lightning::offers::parse::Bolt12SemanticError;
 use lightning::util::ser::Writeable;
 
 #[inline]
@@ -71,7 +71,7 @@ fn privkey(byte: u8) -> SecretKey {
 
 fn build_response<'a, T: secp256k1::Signing + secp256k1::Verification>(
 	invoice_request: &'a InvoiceRequest, secp_ctx: &Secp256k1<T>
-) -> Result<UnsignedBolt12Invoice<'a>, SemanticError> {
+) -> Result<UnsignedBolt12Invoice<'a>, Bolt12SemanticError> {
 	let entropy_source = Randomness {};
 	let paths = vec![
 		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], &entropy_source, secp_ctx).unwrap(),

--- a/fuzz/src/offer_deser.rs
+++ b/fuzz/src/offer_deser.rs
@@ -12,7 +12,7 @@ use crate::utils::test_logger;
 use core::convert::{Infallible, TryFrom};
 use lightning::offers::invoice_request::UnsignedInvoiceRequest;
 use lightning::offers::offer::{Amount, Offer, Quantity};
-use lightning::offers::parse::SemanticError;
+use lightning::offers::parse::Bolt12SemanticError;
 use lightning::util::ser::Writeable;
 
 #[inline]
@@ -41,13 +41,13 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 
 fn build_response<'a>(
 	offer: &'a Offer, pubkey: PublicKey
-) -> Result<UnsignedInvoiceRequest<'a>, SemanticError> {
+) -> Result<UnsignedInvoiceRequest<'a>, Bolt12SemanticError> {
 	let mut builder = offer.request_invoice(vec![42; 64], pubkey)?;
 
 	builder = match offer.amount() {
 		None => builder.amount_msats(1000).unwrap(),
 		Some(Amount::Bitcoin { amount_msats }) => builder.amount_msats(amount_msats + 1)?,
-		Some(Amount::Currency { .. }) => return Err(SemanticError::UnsupportedCurrency),
+		Some(Amount::Currency { .. }) => return Err(Bolt12SemanticError::UnsupportedCurrency),
 	};
 
 	builder = match offer.supported_quantity() {

--- a/fuzz/src/refund_deser.rs
+++ b/fuzz/src/refund_deser.rs
@@ -15,7 +15,7 @@ use lightning::sign::EntropySource;
 use lightning::ln::PaymentHash;
 use lightning::ln::features::BlindedHopFeatures;
 use lightning::offers::invoice::{BlindedPayInfo, UnsignedBolt12Invoice};
-use lightning::offers::parse::SemanticError;
+use lightning::offers::parse::Bolt12SemanticError;
 use lightning::offers::refund::Refund;
 use lightning::util::ser::Writeable;
 
@@ -60,7 +60,7 @@ fn privkey(byte: u8) -> SecretKey {
 
 fn build_response<'a, T: secp256k1::Signing + secp256k1::Verification>(
 	refund: &'a Refund, signing_pubkey: PublicKey, secp_ctx: &Secp256k1<T>
-) -> Result<UnsignedBolt12Invoice<'a>, SemanticError> {
+) -> Result<UnsignedBolt12Invoice<'a>, Bolt12SemanticError> {
 	let entropy_source = Randomness {};
 	let paths = vec![
 		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], &entropy_source, secp_ctx).unwrap(),

--- a/fuzz/src/refund_deser.rs
+++ b/fuzz/src/refund_deser.rs
@@ -14,7 +14,7 @@ use lightning::blinded_path::BlindedPath;
 use lightning::sign::EntropySource;
 use lightning::ln::PaymentHash;
 use lightning::ln::features::BlindedHopFeatures;
-use lightning::offers::invoice::{BlindedPayInfo, UnsignedInvoice};
+use lightning::offers::invoice::{BlindedPayInfo, UnsignedBolt12Invoice};
 use lightning::offers::parse::SemanticError;
 use lightning::offers::refund::Refund;
 use lightning::util::ser::Writeable;
@@ -60,7 +60,7 @@ fn privkey(byte: u8) -> SecretKey {
 
 fn build_response<'a, T: secp256k1::Signing + secp256k1::Verification>(
 	refund: &'a Refund, signing_pubkey: PublicKey, secp_ctx: &Secp256k1<T>
-) -> Result<UnsignedInvoice<'a>, SemanticError> {
+) -> Result<UnsignedBolt12Invoice<'a>, SemanticError> {
 	let entropy_source = Randomness {};
 	let paths = vec![
 		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], &entropy_source, secp_ctx).unwrap(),

--- a/lightning-invoice/src/de.rs
+++ b/lightning-invoice/src/de.rs
@@ -24,7 +24,7 @@ use secp256k1::ecdsa::{RecoveryId, RecoverableSignature};
 use secp256k1::PublicKey;
 
 use super::{Bolt11Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
-	SemanticError, PrivateRoute, Bolt11ParseError, ParseOrSemanticError, Description, RawTaggedField, Currency, RawHrp, SiPrefix, RawBolt11Invoice,
+	Bolt11SemanticError, PrivateRoute, Bolt11ParseError, ParseOrSemanticError, Description, RawTaggedField, Currency, RawHrp, SiPrefix, RawBolt11Invoice,
 	constants, SignedRawBolt11Invoice, RawDataPart, InvoiceFeatures};
 
 use self::hrp_sm::parse_hrp;
@@ -715,8 +715,8 @@ impl From<Bolt11ParseError> for ParseOrSemanticError {
 	}
 }
 
-impl From<crate::SemanticError> for ParseOrSemanticError {
-	fn from(e: SemanticError) -> Self {
+impl From<crate::Bolt11SemanticError> for ParseOrSemanticError {
+	fn from(e: Bolt11SemanticError) -> Self {
 		ParseOrSemanticError::SemanticError(e)
 	}
 }

--- a/lightning-invoice/src/de.rs
+++ b/lightning-invoice/src/de.rs
@@ -23,7 +23,7 @@ use num_traits::{CheckedAdd, CheckedMul};
 use secp256k1::ecdsa::{RecoveryId, RecoverableSignature};
 use secp256k1::PublicKey;
 
-use super::{Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
+use super::{Bolt11Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
 	SemanticError, PrivateRoute, ParseError, ParseOrSemanticError, Description, RawTaggedField, Currency, RawHrp, SiPrefix, RawInvoice,
 	constants, SignedRawInvoice, RawDataPart, InvoiceFeatures};
 
@@ -210,7 +210,7 @@ impl FromStr for SiPrefix {
 }
 
 /// ```
-/// use lightning_invoice::Invoice;
+/// use lightning_invoice::Bolt11Invoice;
 ///
 ///
 /// let invoice = "lnbc100p1psj9jhxdqud3jxktt5w46x7unfv9kz6mn0v3jsnp4q0d3p2sfluzdx45tqcs\
@@ -225,14 +225,14 @@ impl FromStr for SiPrefix {
 /// 8s0gyuxjjgux34w75dnc6xp2l35j7es3jd4ugt3lu0xzre26yg5m7ke54n2d5sym4xcmxtl8238xxvw5h5h5\
 /// j5r6drg6k6zcqj0fcwg";
 ///
-/// assert!(invoice.parse::<Invoice>().is_ok());
+/// assert!(invoice.parse::<Bolt11Invoice>().is_ok());
 /// ```
-impl FromStr for Invoice {
+impl FromStr for Bolt11Invoice {
 	type Err = ParseOrSemanticError;
 
 	fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
 		let signed = s.parse::<SignedRawInvoice>()?;
-		Ok(Invoice::from_signed(signed)?)
+		Ok(Bolt11Invoice::from_signed(signed)?)
 	}
 }
 
@@ -251,10 +251,10 @@ impl FromStr for Invoice {
 /// 8s0gyuxjjgux34w75dnc6xp2l35j7es3jd4ugt3lu0xzre26yg5m7ke54n2d5sym4xcmxtl8238xxvw5h5h5\
 /// j5r6drg6k6zcqj0fcwg";
 ///
-/// let parsed_1 = invoice.parse::<Invoice>();
+/// let parsed_1 = invoice.parse::<Bolt11Invoice>();
 ///
 /// let parsed_2 = match invoice.parse::<SignedRawInvoice>() {
-/// 	Ok(signed) => match Invoice::from_signed(signed) {
+/// 	Ok(signed) => match Bolt11Invoice::from_signed(signed) {
 /// 		Ok(invoice) => Ok(invoice),
 /// 		Err(e) => Err(ParseOrSemanticError::SemanticError(e)),
 /// 	},

--- a/lightning-invoice/src/de.rs
+++ b/lightning-invoice/src/de.rs
@@ -25,7 +25,7 @@ use secp256k1::PublicKey;
 
 use super::{Bolt11Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
 	Bolt11SemanticError, PrivateRoute, Bolt11ParseError, ParseOrSemanticError, Description, RawTaggedField, Currency, RawHrp, SiPrefix, RawBolt11Invoice,
-	constants, SignedRawBolt11Invoice, RawDataPart, InvoiceFeatures};
+	constants, SignedRawBolt11Invoice, RawDataPart, Bolt11InvoiceFeatures};
 
 use self::hrp_sm::parse_hrp;
 
@@ -463,7 +463,7 @@ impl FromBase32 for TaggedField {
 			constants::TAG_PAYMENT_METADATA =>
 				Ok(TaggedField::PaymentMetadata(Vec::<u8>::from_base32(field_data)?)),
 			constants::TAG_FEATURES =>
-				Ok(TaggedField::Features(InvoiceFeatures::from_base32(field_data)?)),
+				Ok(TaggedField::Features(Bolt11InvoiceFeatures::from_base32(field_data)?)),
 			_ => {
 				// "A reader MUST skip over unknown fields"
 				Err(Bolt11ParseError::Skip)
@@ -969,14 +969,14 @@ mod test {
 
 	#[test]
 	fn test_payment_secret_and_features_de_and_ser() {
-		use lightning::ln::features::InvoiceFeatures;
+		use lightning::ln::features::Bolt11InvoiceFeatures;
 		use secp256k1::ecdsa::{RecoveryId, RecoverableSignature};
 		use crate::TaggedField::*;
 		use crate::{SiPrefix, SignedRawBolt11Invoice, InvoiceSignature, RawBolt11Invoice, RawHrp, RawDataPart,
 				 Currency, Sha256, PositiveTimestamp};
 
 		// Feature bits 9, 15, and 99 are set.
-		let expected_features = InvoiceFeatures::from_le_bytes(vec![0, 130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8]);
+		let expected_features = Bolt11InvoiceFeatures::from_le_bytes(vec![0, 130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8]);
 		let invoice_str = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqqqqqqqqqqqpqsq67gye39hfg3zd8rgc80k32tvy9xk2xunwm5lzexnvpx6fd77en8qaq424dxgt56cag2dpt359k3ssyhetktkpqh24jqnjyw6uqd08sgptq44qu";
 		let invoice = SignedRawBolt11Invoice {
 					raw_invoice: RawBolt11Invoice {

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -1148,7 +1148,7 @@ impl Invoice {
 		self.signed_invoice.hash
 	}
 
-	/// Transform the `Invoice` into it's unchecked version
+	/// Transform the `Invoice` into its unchecked version.
 	pub fn into_signed_raw(self) -> SignedRawInvoice {
 		self.signed_invoice
 	}

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -106,7 +106,7 @@ mod sync;
 /// reasons, but should generally result in an "invalid BOLT11 invoice" message for the user.
 #[allow(missing_docs)]
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum ParseError {
+pub enum Bolt11ParseError {
 	Bech32Error(bech32::Error),
 	ParseAmountError(ParseIntError),
 	MalformedSignature(secp256k1::Error),
@@ -136,7 +136,7 @@ pub enum ParseError {
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum ParseOrSemanticError {
 	/// The invoice couldn't be decoded
-	ParseError(ParseError),
+	ParseError(Bolt11ParseError),
 
 	/// The invoice could be decoded but violates the BOLT11 standard
 	SemanticError(crate::SemanticError),

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -288,7 +288,7 @@ pub struct SignedRawBolt11Invoice {
 	hash: [u8; 32],
 
 	/// signature of the payment request
-	signature: InvoiceSignature,
+	signature: Bolt11InvoiceSignature,
 }
 
 /// Represents an syntactically correct [`Bolt11Invoice`] for a payment on the lightning network,
@@ -499,15 +499,15 @@ pub enum Fallback {
 
 /// Recoverable signature
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
-pub struct InvoiceSignature(pub RecoverableSignature);
+pub struct Bolt11InvoiceSignature(pub RecoverableSignature);
 
-impl PartialOrd for InvoiceSignature {
+impl PartialOrd for Bolt11InvoiceSignature {
 	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
 		self.0.serialize_compact().1.partial_cmp(&other.0.serialize_compact().1)
 	}
 }
 
-impl Ord for InvoiceSignature {
+impl Ord for Bolt11InvoiceSignature {
 	fn cmp(&self, other: &Self) -> Ordering {
 		self.0.serialize_compact().1.cmp(&other.0.serialize_compact().1)
 	}
@@ -855,7 +855,7 @@ impl SignedRawBolt11Invoice {
 	///  1. raw invoice
 	///  2. hash of the raw invoice
 	///  3. signature
-	pub fn into_parts(self) -> (RawBolt11Invoice, [u8; 32], InvoiceSignature) {
+	pub fn into_parts(self) -> (RawBolt11Invoice, [u8; 32], Bolt11InvoiceSignature) {
 		(self.raw_invoice, self.hash, self.signature)
 	}
 
@@ -870,7 +870,7 @@ impl SignedRawBolt11Invoice {
 	}
 
 	/// Signature for the invoice.
-	pub fn signature(&self) -> &InvoiceSignature {
+	pub fn signature(&self) -> &Bolt11InvoiceSignature {
 		&self.signature
 	}
 
@@ -1004,7 +1004,7 @@ impl RawBolt11Invoice {
 		Ok(SignedRawBolt11Invoice {
 			raw_invoice: self,
 			hash: raw_hash,
-			signature: InvoiceSignature(signature),
+			signature: Bolt11InvoiceSignature(signature),
 		})
 	}
 
@@ -1591,7 +1591,7 @@ impl Deref for PrivateRoute {
 	}
 }
 
-impl Deref for InvoiceSignature {
+impl Deref for Bolt11InvoiceSignature {
 	type Target = RecoverableSignature;
 
 	fn deref(&self) -> &RecoverableSignature {
@@ -1797,7 +1797,7 @@ mod test {
 		use secp256k1::Secp256k1;
 		use secp256k1::ecdsa::{RecoveryId, RecoverableSignature};
 		use secp256k1::{SecretKey, PublicKey};
-		use crate::{SignedRawBolt11Invoice, InvoiceSignature, RawBolt11Invoice, RawHrp, RawDataPart, Currency, Sha256,
+		use crate::{SignedRawBolt11Invoice, Bolt11InvoiceSignature, RawBolt11Invoice, RawHrp, RawDataPart, Currency, Sha256,
 			 PositiveTimestamp};
 
 		let invoice = SignedRawBolt11Invoice {
@@ -1826,7 +1826,7 @@ mod test {
 				0x7b, 0x1d, 0x85, 0x8d, 0xb1, 0xd1, 0xf7, 0xab, 0x71, 0x37, 0xdc, 0xb7,
 				0x83, 0x5d, 0xb2, 0xec, 0xd5, 0x18, 0xe1, 0xc9
 			],
-			signature: InvoiceSignature(RecoverableSignature::from_compact(
+			signature: Bolt11InvoiceSignature(RecoverableSignature::from_compact(
 				& [
 					0x38u8, 0xec, 0x68, 0x91, 0x34, 0x5e, 0x20, 0x41, 0x45, 0xbe, 0x8a,
 					0x3a, 0x99, 0xde, 0x38, 0xe9, 0x8a, 0x39, 0xd6, 0xa5, 0x69, 0x43,

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -260,7 +260,7 @@ pub struct Bolt11Invoice {
 /// This is not exported to bindings users as we don't have a good way to map the reference lifetimes making this
 /// practically impossible to use safely in languages like C.
 #[derive(Eq, PartialEq, Debug, Clone, Ord, PartialOrd)]
-pub enum InvoiceDescription<'f> {
+pub enum Bolt11InvoiceDescription<'f> {
 	/// Reference to the directly supplied description in the invoice
 	Direct(&'f Description),
 
@@ -671,12 +671,12 @@ impl<H: tb::Bool, T: tb::Bool, C: tb::Bool, S: tb::Bool, M: tb::Bool> InvoiceBui
 	}
 
 	/// Set the description or description hash. This function is only available if no description (hash) was set.
-	pub fn invoice_description(self, description: InvoiceDescription) -> InvoiceBuilder<tb::True, H, T, C, S, M> {
+	pub fn invoice_description(self, description: Bolt11InvoiceDescription) -> InvoiceBuilder<tb::True, H, T, C, S, M> {
 		match description {
-			InvoiceDescription::Direct(desc) => {
+			Bolt11InvoiceDescription::Direct(desc) => {
 				self.description(desc.clone().into_inner())
 			}
-			InvoiceDescription::Hash(hash) => {
+			Bolt11InvoiceDescription::Hash(hash) => {
 				self.description_hash(hash.0)
 			}
 		}
@@ -1310,12 +1310,12 @@ impl Bolt11Invoice {
 
 	/// Return the description or a hash of it for longer ones
 	///
-	/// This is not exported to bindings users because we don't yet export InvoiceDescription
-	pub fn description(&self) -> InvoiceDescription {
+	/// This is not exported to bindings users because we don't yet export Bolt11InvoiceDescription
+	pub fn description(&self) -> Bolt11InvoiceDescription {
 		if let Some(direct) = self.signed_invoice.description() {
-			return InvoiceDescription::Direct(direct);
+			return Bolt11InvoiceDescription::Direct(direct);
 		} else if let Some(hash) = self.signed_invoice.description_hash() {
-			return InvoiceDescription::Hash(hash);
+			return Bolt11InvoiceDescription::Hash(hash);
 		}
 		unreachable!("ensured by constructor");
 	}
@@ -2142,7 +2142,7 @@ mod test {
 		assert_eq!(invoice.private_routes(), vec![&PrivateRoute(route_1), &PrivateRoute(route_2)]);
 		assert_eq!(
 			invoice.description(),
-			InvoiceDescription::Hash(&Sha256(sha256::Hash::from_slice(&[3;32][..]).unwrap()))
+			Bolt11InvoiceDescription::Hash(&Sha256(sha256::Hash::from_slice(&[3;32][..]).unwrap()))
 		);
 		assert_eq!(invoice.payment_hash(), &sha256::Hash::from_slice(&[21;32][..]).unwrap());
 		assert_eq!(invoice.payment_secret(), &PaymentSecret([42; 32]));

--- a/lightning-invoice/src/payment.rs
+++ b/lightning-invoice/src/payment.rs
@@ -9,7 +9,7 @@
 
 //! Convenient utilities for paying Lightning invoices and sending spontaneous payments.
 
-use crate::Invoice;
+use crate::Bolt11Invoice;
 
 use bitcoin_hashes::Hash;
 
@@ -25,15 +25,15 @@ use core::fmt::Debug;
 use core::ops::Deref;
 use core::time::Duration;
 
-/// Pays the given [`Invoice`], retrying if needed based on [`Retry`].
+/// Pays the given [`Bolt11Invoice`], retrying if needed based on [`Retry`].
 ///
-/// [`Invoice::payment_hash`] is used as the [`PaymentId`], which ensures idempotency as long
+/// [`Bolt11Invoice::payment_hash`] is used as the [`PaymentId`], which ensures idempotency as long
 /// as the payment is still pending. If the payment succeeds, you must ensure that a second payment
 /// with the same [`PaymentHash`] is never sent.
 ///
 /// If you wish to use a different payment idempotency token, see [`pay_invoice_with_id`].
 pub fn pay_invoice<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>(
-	invoice: &Invoice, retry_strategy: Retry,
+	invoice: &Bolt11Invoice, retry_strategy: Retry,
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>
 ) -> Result<PaymentId, PaymentError>
 where
@@ -51,17 +51,18 @@ where
 		.map(|()| payment_id)
 }
 
-/// Pays the given [`Invoice`] with a custom idempotency key, retrying if needed based on [`Retry`].
+/// Pays the given [`Bolt11Invoice`] with a custom idempotency key, retrying if needed based on
+/// [`Retry`].
 ///
 /// Note that idempotency is only guaranteed as long as the payment is still pending. Once the
 /// payment completes or fails, no idempotency guarantees are made.
 ///
-/// You should ensure that the [`Invoice::payment_hash`] is unique and the same [`PaymentHash`]
-/// has never been paid before.
+/// You should ensure that the [`Bolt11Invoice::payment_hash`] is unique and the same
+/// [`PaymentHash`] has never been paid before.
 ///
 /// See [`pay_invoice`] for a variant which uses the [`PaymentHash`] for the idempotency token.
 pub fn pay_invoice_with_id<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>(
-	invoice: &Invoice, payment_id: PaymentId, retry_strategy: Retry,
+	invoice: &Bolt11Invoice, payment_id: PaymentId, retry_strategy: Retry,
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>
 ) -> Result<(), PaymentError>
 where
@@ -78,17 +79,17 @@ where
 	pay_invoice_using_amount(invoice, amt_msat, payment_id, retry_strategy, channelmanager)
 }
 
-/// Pays the given zero-value [`Invoice`] using the given amount, retrying if needed based on
+/// Pays the given zero-value [`Bolt11Invoice`] using the given amount, retrying if needed based on
 /// [`Retry`].
 ///
-/// [`Invoice::payment_hash`] is used as the [`PaymentId`], which ensures idempotency as long
+/// [`Bolt11Invoice::payment_hash`] is used as the [`PaymentId`], which ensures idempotency as long
 /// as the payment is still pending. If the payment succeeds, you must ensure that a second payment
 /// with the same [`PaymentHash`] is never sent.
 ///
 /// If you wish to use a different payment idempotency token, see
 /// [`pay_zero_value_invoice_with_id`].
 pub fn pay_zero_value_invoice<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>(
-	invoice: &Invoice, amount_msats: u64, retry_strategy: Retry,
+	invoice: &Bolt11Invoice, amount_msats: u64, retry_strategy: Retry,
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>
 ) -> Result<PaymentId, PaymentError>
 where
@@ -107,19 +108,19 @@ where
 		.map(|()| payment_id)
 }
 
-/// Pays the given zero-value [`Invoice`] using the given amount and custom idempotency key,
+/// Pays the given zero-value [`Bolt11Invoice`] using the given amount and custom idempotency key,
 /// retrying if needed based on [`Retry`].
 ///
 /// Note that idempotency is only guaranteed as long as the payment is still pending. Once the
 /// payment completes or fails, no idempotency guarantees are made.
 ///
-/// You should ensure that the [`Invoice::payment_hash`] is unique and the same [`PaymentHash`]
-/// has never been paid before.
+/// You should ensure that the [`Bolt11Invoice::payment_hash`] is unique and the same
+/// [`PaymentHash`] has never been paid before.
 ///
 /// See [`pay_zero_value_invoice`] for a variant which uses the [`PaymentHash`] for the
 /// idempotency token.
 pub fn pay_zero_value_invoice_with_id<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>(
-	invoice: &Invoice, amount_msats: u64, payment_id: PaymentId, retry_strategy: Retry,
+	invoice: &Bolt11Invoice, amount_msats: u64, payment_id: PaymentId, retry_strategy: Retry,
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>
 ) -> Result<(), PaymentError>
 where
@@ -141,7 +142,7 @@ where
 }
 
 fn pay_invoice_using_amount<P: Deref>(
-	invoice: &Invoice, amount_msats: u64, payment_id: PaymentId, retry_strategy: Retry,
+	invoice: &Bolt11Invoice, amount_msats: u64, payment_id: PaymentId, retry_strategy: Retry,
 	payer: P
 ) -> Result<(), PaymentError> where P::Target: Payer {
 	let payment_hash = PaymentHash((*invoice.payment_hash()).into_inner());
@@ -164,20 +165,20 @@ fn pay_invoice_using_amount<P: Deref>(
 	payer.send_payment(payment_hash, recipient_onion, payment_id, route_params, retry_strategy)
 }
 
-fn expiry_time_from_unix_epoch(invoice: &Invoice) -> Duration {
+fn expiry_time_from_unix_epoch(invoice: &Bolt11Invoice) -> Duration {
 	invoice.signed_invoice.raw_invoice.data.timestamp.0 + invoice.expiry_time()
 }
 
 /// An error that may occur when making a payment.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PaymentError {
-	/// An error resulting from the provided [`Invoice`] or payment hash.
+	/// An error resulting from the provided [`Bolt11Invoice`] or payment hash.
 	Invoice(&'static str),
 	/// An error occurring when sending a payment.
 	Sending(RetryableSendFailure),
 }
 
-/// A trait defining behavior of an [`Invoice`] payer.
+/// A trait defining behavior of a [`Bolt11Invoice`] payer.
 ///
 /// Useful for unit testing internal methods.
 trait Payer {
@@ -283,7 +284,7 @@ mod tests {
 		duration_since_epoch
 	}
 
-	fn invoice(payment_preimage: PaymentPreimage) -> Invoice {
+	fn invoice(payment_preimage: PaymentPreimage) -> Bolt11Invoice {
 		let payment_hash = Sha256::hash(&payment_preimage.0);
 		let private_key = SecretKey::from_slice(&[42; 32]).unwrap();
 
@@ -300,7 +301,7 @@ mod tests {
 			.unwrap()
 	}
 
-	fn zero_value_invoice(payment_preimage: PaymentPreimage) -> Invoice {
+	fn zero_value_invoice(payment_preimage: PaymentPreimage) -> Bolt11Invoice {
 		let payment_hash = Sha256::hash(&payment_preimage.0);
 		let private_key = SecretKey::from_slice(&[42; 32]).unwrap();
 

--- a/lightning-invoice/src/ser.rs
+++ b/lightning-invoice/src/ser.rs
@@ -3,7 +3,7 @@ use core::fmt::{Display, Formatter};
 use bech32::{ToBase32, u5, WriteBase32, Base32Len};
 use crate::prelude::*;
 
-use super::{Bolt11Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
+use super::{Bolt11Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, Bolt11InvoiceSignature, PositiveTimestamp,
 	PrivateRoute, Description, RawTaggedField, Currency, RawHrp, SiPrefix, constants, SignedRawBolt11Invoice, RawDataPart};
 
 /// Converts a stream of bytes written to it to base32. On finalization the according padding will
@@ -456,7 +456,7 @@ impl ToBase32 for TaggedField {
 	}
 }
 
-impl ToBase32 for InvoiceSignature {
+impl ToBase32 for Bolt11InvoiceSignature {
 	fn write_base32<W: WriteBase32>(&self, writer: &mut W) -> Result<(), <W as WriteBase32>::Err> {
 		let mut converter = BytesToBase32::new(writer);
 		let (recovery_id, signature) = self.0.serialize_compact();

--- a/lightning-invoice/src/ser.rs
+++ b/lightning-invoice/src/ser.rs
@@ -4,7 +4,7 @@ use bech32::{ToBase32, u5, WriteBase32, Base32Len};
 use crate::prelude::*;
 
 use super::{Bolt11Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
-	PrivateRoute, Description, RawTaggedField, Currency, RawHrp, SiPrefix, constants, SignedRawInvoice, RawDataPart};
+	PrivateRoute, Description, RawTaggedField, Currency, RawHrp, SiPrefix, constants, SignedRawBolt11Invoice, RawDataPart};
 
 /// Converts a stream of bytes written to it to base32. On finalization the according padding will
 /// be applied. That means the results of writing two data blocks with one or two `BytesToBase32`
@@ -112,7 +112,7 @@ impl Display for Bolt11Invoice {
 	}
 }
 
-impl Display for SignedRawInvoice {
+impl Display for SignedRawBolt11Invoice {
 	fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
 		let hrp = self.raw_invoice.hrp.to_string();
 		let mut data  = self.raw_invoice.data.to_base32();

--- a/lightning-invoice/src/ser.rs
+++ b/lightning-invoice/src/ser.rs
@@ -3,7 +3,7 @@ use core::fmt::{Display, Formatter};
 use bech32::{ToBase32, u5, WriteBase32, Base32Len};
 use crate::prelude::*;
 
-use super::{Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
+use super::{Bolt11Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiryDelta, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
 	PrivateRoute, Description, RawTaggedField, Currency, RawHrp, SiPrefix, constants, SignedRawInvoice, RawDataPart};
 
 /// Converts a stream of bytes written to it to base32. On finalization the according padding will
@@ -106,7 +106,7 @@ fn bytes_size_to_base32_size(byte_size: usize) -> usize {
 	}
 }
 
-impl Display for Invoice {
+impl Display for Bolt11Invoice {
 	fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
 		self.signed_invoice.fmt(f)
 	}

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -1,6 +1,6 @@
 //! Convenient utilities to create an invoice.
 
-use crate::{CreationError, Currency, Invoice, InvoiceBuilder, SignOrCreationError};
+use crate::{Bolt11Invoice, CreationError, Currency, InvoiceBuilder, SignOrCreationError};
 
 use crate::{prelude::*, Description, InvoiceDescription, Sha256};
 use bech32::ToBase32;
@@ -64,7 +64,7 @@ pub fn create_phantom_invoice<ES: Deref, NS: Deref, L: Deref>(
 	amt_msat: Option<u64>, payment_hash: Option<PaymentHash>, description: String,
 	invoice_expiry_delta_secs: u32, phantom_route_hints: Vec<PhantomRouteHints>, entropy_source: ES,
 	node_signer: NS, logger: L, network: Currency, min_final_cltv_expiry_delta: Option<u16>, duration_since_epoch: Duration,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 where
 	ES::Target: EntropySource,
 	NS::Target: NodeSigner,
@@ -120,7 +120,7 @@ pub fn create_phantom_invoice_with_description_hash<ES: Deref, NS: Deref, L: Der
 	amt_msat: Option<u64>, payment_hash: Option<PaymentHash>, invoice_expiry_delta_secs: u32,
 	description_hash: Sha256, phantom_route_hints: Vec<PhantomRouteHints>, entropy_source: ES,
 	node_signer: NS, logger: L, network: Currency, min_final_cltv_expiry_delta: Option<u16>, duration_since_epoch: Duration,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 where
 	ES::Target: EntropySource,
 	NS::Target: NodeSigner,
@@ -139,7 +139,7 @@ fn _create_phantom_invoice<ES: Deref, NS: Deref, L: Deref>(
 	amt_msat: Option<u64>, payment_hash: Option<PaymentHash>, description: InvoiceDescription,
 	invoice_expiry_delta_secs: u32, phantom_route_hints: Vec<PhantomRouteHints>, entropy_source: ES,
 	node_signer: NS, logger: L, network: Currency, min_final_cltv_expiry_delta: Option<u16>, duration_since_epoch: Duration,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 where
 	ES::Target: EntropySource,
 	NS::Target: NodeSigner,
@@ -219,7 +219,7 @@ where
 	let data_without_signature = raw_invoice.data.to_base32();
 	let signed_raw_invoice = raw_invoice.sign(|_| node_signer.sign_invoice(hrp_bytes, &data_without_signature, Recipient::PhantomNode));
 	match signed_raw_invoice {
-		Ok(inv) => Ok(Invoice::from_signed(inv).unwrap()),
+		Ok(inv) => Ok(Bolt11Invoice::from_signed(inv).unwrap()),
 		Err(e) => Err(SignOrCreationError::SignError(e))
 	}
 }
@@ -333,7 +333,7 @@ pub fn create_invoice_from_channelmanager<M: Deref, T: Deref, ES: Deref, NS: Der
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
 	network: Currency, amt_msat: Option<u64>, description: String, invoice_expiry_delta_secs: u32,
 	min_final_cltv_expiry_delta: Option<u16>,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 where
 	M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
 	T::Target: BroadcasterInterface,
@@ -374,7 +374,7 @@ pub fn create_invoice_from_channelmanager_with_description_hash<M: Deref, T: Der
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
 	network: Currency, amt_msat: Option<u64>, description_hash: Sha256,
 	invoice_expiry_delta_secs: u32, min_final_cltv_expiry_delta: Option<u16>,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 where
 	M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
 	T::Target: BroadcasterInterface,
@@ -404,7 +404,7 @@ pub fn create_invoice_from_channelmanager_with_description_hash_and_duration_sin
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
 	network: Currency, amt_msat: Option<u64>, description_hash: Sha256,
 	duration_since_epoch: Duration, invoice_expiry_delta_secs: u32, min_final_cltv_expiry_delta: Option<u16>,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 		where
 			M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
 			T::Target: BroadcasterInterface,
@@ -429,7 +429,7 @@ pub fn create_invoice_from_channelmanager_and_duration_since_epoch<M: Deref, T: 
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
 	network: Currency, amt_msat: Option<u64>, description: String, duration_since_epoch: Duration,
 	invoice_expiry_delta_secs: u32, min_final_cltv_expiry_delta: Option<u16>,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 		where
 			M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
 			T::Target: BroadcasterInterface,
@@ -453,7 +453,7 @@ fn _create_invoice_from_channelmanager_and_duration_since_epoch<M: Deref, T: Der
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
 	network: Currency, amt_msat: Option<u64>, description: InvoiceDescription,
 	duration_since_epoch: Duration, invoice_expiry_delta_secs: u32, min_final_cltv_expiry_delta: Option<u16>,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 		where
 			M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
 			T::Target: BroadcasterInterface,
@@ -486,7 +486,7 @@ pub fn create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
 	network: Currency, amt_msat: Option<u64>, description: String, duration_since_epoch: Duration,
 	invoice_expiry_delta_secs: u32, payment_hash: PaymentHash, min_final_cltv_expiry_delta: Option<u16>,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 	where
 		M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
 		T::Target: BroadcasterInterface,
@@ -516,7 +516,7 @@ fn _create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_has
 	network: Currency, amt_msat: Option<u64>, description: InvoiceDescription, duration_since_epoch: Duration,
 	invoice_expiry_delta_secs: u32, payment_hash: PaymentHash, payment_secret: PaymentSecret,
 	min_final_cltv_expiry_delta: Option<u16>,
-) -> Result<Invoice, SignOrCreationError<()>>
+) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 	where
 		M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
 		T::Target: BroadcasterInterface,
@@ -571,7 +571,7 @@ fn _create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_has
 	let data_without_signature = raw_invoice.data.to_base32();
 	let signed_raw_invoice = raw_invoice.sign(|_| node_signer.sign_invoice(hrp_bytes, &data_without_signature, Recipient::Node));
 	match signed_raw_invoice {
-		Ok(inv) => Ok(Invoice::from_signed(inv).unwrap()),
+		Ok(inv) => Ok(Bolt11Invoice::from_signed(inv).unwrap()),
 		Err(e) => Err(SignOrCreationError::SignError(e))
 	}
 }

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -2,7 +2,7 @@
 
 use crate::{Bolt11Invoice, CreationError, Currency, InvoiceBuilder, SignOrCreationError};
 
-use crate::{prelude::*, Description, InvoiceDescription, Sha256};
+use crate::{prelude::*, Description, Bolt11InvoiceDescription, Sha256};
 use bech32::ToBase32;
 use bitcoin_hashes::Hash;
 use lightning::chain;
@@ -71,7 +71,7 @@ where
 	L::Target: Logger,
 {
 	let description = Description::new(description).map_err(SignOrCreationError::CreationError)?;
-	let description = InvoiceDescription::Direct(&description,);
+	let description = Bolt11InvoiceDescription::Direct(&description,);
 	_create_phantom_invoice::<ES, NS, L>(
 		amt_msat, payment_hash, description, invoice_expiry_delta_secs, phantom_route_hints,
 		entropy_source, node_signer, logger, network, min_final_cltv_expiry_delta, duration_since_epoch,
@@ -127,7 +127,7 @@ where
 	L::Target: Logger,
 {
 	_create_phantom_invoice::<ES, NS, L>(
-		amt_msat, payment_hash, InvoiceDescription::Hash(&description_hash),
+		amt_msat, payment_hash, Bolt11InvoiceDescription::Hash(&description_hash),
 		invoice_expiry_delta_secs, phantom_route_hints, entropy_source, node_signer, logger, network,
 		min_final_cltv_expiry_delta, duration_since_epoch,
 	)
@@ -136,7 +136,7 @@ where
 const MAX_CHANNEL_HINTS: usize = 3;
 
 fn _create_phantom_invoice<ES: Deref, NS: Deref, L: Deref>(
-	amt_msat: Option<u64>, payment_hash: Option<PaymentHash>, description: InvoiceDescription,
+	amt_msat: Option<u64>, payment_hash: Option<PaymentHash>, description: Bolt11InvoiceDescription,
 	invoice_expiry_delta_secs: u32, phantom_route_hints: Vec<PhantomRouteHints>, entropy_source: ES,
 	node_signer: NS, logger: L, network: Currency, min_final_cltv_expiry_delta: Option<u16>, duration_since_epoch: Duration,
 ) -> Result<Bolt11Invoice, SignOrCreationError<()>>
@@ -157,10 +157,10 @@ where
 	}
 
 	let invoice = match description {
-		InvoiceDescription::Direct(description) => {
+		Bolt11InvoiceDescription::Direct(description) => {
 			InvoiceBuilder::new(network).description(description.0.clone())
 		}
-		InvoiceDescription::Hash(hash) => InvoiceBuilder::new(network).description_hash(hash.0),
+		Bolt11InvoiceDescription::Hash(hash) => InvoiceBuilder::new(network).description_hash(hash.0),
 	};
 
 	// If we ever see performance here being too slow then we should probably take this ExpandedKey as a parameter instead.
@@ -417,7 +417,7 @@ pub fn create_invoice_from_channelmanager_with_description_hash_and_duration_sin
 {
 	_create_invoice_from_channelmanager_and_duration_since_epoch(
 		channelmanager, node_signer, logger, network, amt_msat,
-		InvoiceDescription::Hash(&description_hash),
+		Bolt11InvoiceDescription::Hash(&description_hash),
 		duration_since_epoch, invoice_expiry_delta_secs, min_final_cltv_expiry_delta,
 	)
 }
@@ -442,7 +442,7 @@ pub fn create_invoice_from_channelmanager_and_duration_since_epoch<M: Deref, T: 
 {
 	_create_invoice_from_channelmanager_and_duration_since_epoch(
 		channelmanager, node_signer, logger, network, amt_msat,
-		InvoiceDescription::Direct(
+		Bolt11InvoiceDescription::Direct(
 			&Description::new(description).map_err(SignOrCreationError::CreationError)?,
 		),
 		duration_since_epoch, invoice_expiry_delta_secs, min_final_cltv_expiry_delta,
@@ -451,7 +451,7 @@ pub fn create_invoice_from_channelmanager_and_duration_since_epoch<M: Deref, T: 
 
 fn _create_invoice_from_channelmanager_and_duration_since_epoch<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>(
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
-	network: Currency, amt_msat: Option<u64>, description: InvoiceDescription,
+	network: Currency, amt_msat: Option<u64>, description: Bolt11InvoiceDescription,
 	duration_since_epoch: Duration, invoice_expiry_delta_secs: u32, min_final_cltv_expiry_delta: Option<u16>,
 ) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 		where
@@ -503,7 +503,7 @@ pub fn create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_
 		.map_err(|()| SignOrCreationError::CreationError(CreationError::InvalidAmount))?;
 	_create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_hash(
 		channelmanager, node_signer, logger, network, amt_msat,
-		InvoiceDescription::Direct(
+		Bolt11InvoiceDescription::Direct(
 			&Description::new(description).map_err(SignOrCreationError::CreationError)?,
 		),
 		duration_since_epoch, invoice_expiry_delta_secs, payment_hash, payment_secret,
@@ -513,9 +513,9 @@ pub fn create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_
 
 fn _create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_hash<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>(
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
-	network: Currency, amt_msat: Option<u64>, description: InvoiceDescription, duration_since_epoch: Duration,
-	invoice_expiry_delta_secs: u32, payment_hash: PaymentHash, payment_secret: PaymentSecret,
-	min_final_cltv_expiry_delta: Option<u16>,
+	network: Currency, amt_msat: Option<u64>, description: Bolt11InvoiceDescription,
+	duration_since_epoch: Duration, invoice_expiry_delta_secs: u32, payment_hash: PaymentHash,
+	payment_secret: PaymentSecret, min_final_cltv_expiry_delta: Option<u16>,
 ) -> Result<Bolt11Invoice, SignOrCreationError<()>>
 	where
 		M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
@@ -537,10 +537,10 @@ fn _create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_has
 	log_trace!(logger, "Creating invoice with payment hash {}", log_bytes!(payment_hash.0));
 
 	let invoice = match description {
-		InvoiceDescription::Direct(description) => {
+		Bolt11InvoiceDescription::Direct(description) => {
 			InvoiceBuilder::new(network).description(description.0.clone())
 		}
-		InvoiceDescription::Hash(hash) => InvoiceBuilder::new(network).description_hash(hash.0),
+		Bolt11InvoiceDescription::Hash(hash) => InvoiceBuilder::new(network).description_hash(hash.0),
 	};
 
 	let mut invoice = invoice
@@ -794,7 +794,7 @@ fn prefer_current_channel(min_inbound_capacity_msat: Option<u64>, current_channe
 mod test {
 	use core::cell::RefCell;
 	use core::time::Duration;
-	use crate::{Currency, Description, InvoiceDescription, SignOrCreationError, CreationError};
+	use crate::{Currency, Description, Bolt11InvoiceDescription, SignOrCreationError, CreationError};
 	use bitcoin_hashes::{Hash, sha256};
 	use bitcoin_hashes::sha256::Hash as Sha256;
 	use lightning::sign::PhantomKeysManager;
@@ -852,7 +852,7 @@ mod test {
 		assert_eq!(invoice.amount_pico_btc(), Some(100_000));
 		// If no `min_final_cltv_expiry_delta` is specified, then it should be `MIN_FINAL_CLTV_EXPIRY_DELTA`.
 		assert_eq!(invoice.min_final_cltv_expiry_delta(), MIN_FINAL_CLTV_EXPIRY_DELTA as u64);
-		assert_eq!(invoice.description(), InvoiceDescription::Direct(&Description("test".to_string())));
+		assert_eq!(invoice.description(), Bolt11InvoiceDescription::Direct(&Description("test".to_string())));
 		assert_eq!(invoice.expiry_time(), Duration::from_secs(non_default_invoice_expiry_secs.into()));
 
 		// Invoice SCIDs should always use inbound SCID aliases over the real channel ID, if one is
@@ -948,7 +948,7 @@ mod test {
 		).unwrap();
 		assert_eq!(invoice.amount_pico_btc(), Some(100_000));
 		assert_eq!(invoice.min_final_cltv_expiry_delta(), MIN_FINAL_CLTV_EXPIRY_DELTA as u64);
-		assert_eq!(invoice.description(), InvoiceDescription::Hash(&crate::Sha256(Sha256::hash("Testing description_hash".as_bytes()))));
+		assert_eq!(invoice.description(), Bolt11InvoiceDescription::Hash(&crate::Sha256(Sha256::hash("Testing description_hash".as_bytes()))));
 	}
 
 	#[test]
@@ -965,7 +965,7 @@ mod test {
 		).unwrap();
 		assert_eq!(invoice.amount_pico_btc(), Some(100_000));
 		assert_eq!(invoice.min_final_cltv_expiry_delta(), MIN_FINAL_CLTV_EXPIRY_DELTA as u64);
-		assert_eq!(invoice.description(), InvoiceDescription::Direct(&Description("test".to_string())));
+		assert_eq!(invoice.description(), Bolt11InvoiceDescription::Direct(&Description("test".to_string())));
 		assert_eq!(invoice.payment_hash(), &sha256::Hash::from_slice(&payment_hash.0[..]).unwrap());
 	}
 
@@ -1317,7 +1317,7 @@ mod test {
 		};
 
 		assert_eq!(invoice.min_final_cltv_expiry_delta(), MIN_FINAL_CLTV_EXPIRY_DELTA as u64);
-		assert_eq!(invoice.description(), InvoiceDescription::Direct(&Description("test".to_string())));
+		assert_eq!(invoice.description(), Bolt11InvoiceDescription::Direct(&Description("test".to_string())));
 		assert_eq!(invoice.route_hints().len(), 2);
 		assert_eq!(invoice.expiry_time(), Duration::from_secs(non_default_invoice_expiry_secs.into()));
 		assert!(!invoice.features().unwrap().supports_basic_mpp());
@@ -1455,7 +1455,7 @@ mod test {
 		assert_eq!(invoice.amount_pico_btc(), Some(200_000));
 		assert_eq!(invoice.min_final_cltv_expiry_delta(), MIN_FINAL_CLTV_EXPIRY_DELTA as u64);
 		assert_eq!(invoice.expiry_time(), Duration::from_secs(non_default_invoice_expiry_secs.into()));
-		assert_eq!(invoice.description(), InvoiceDescription::Hash(&crate::Sha256(Sha256::hash("Description hash phantom invoice".as_bytes()))));
+		assert_eq!(invoice.description(), Bolt11InvoiceDescription::Hash(&crate::Sha256(Sha256::hash("Description hash phantom invoice".as_bytes()))));
 	}
 
 	#[test]

--- a/lightning-invoice/tests/ser_de.rs
+++ b/lightning-invoice/tests/ser_de.rs
@@ -421,7 +421,7 @@ fn test_bolt_invalid_invoices() {
 	// Tests the BOLT 11 invalid invoice test vectors
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqqsgqtqyx5vggfcsll4wu246hz02kp85x4katwsk9639we5n5yngc3yhqkm35jnjw4len8vrnqnf5ejh0mzj9n3vz2px97evektfm2l6wqccp3y7372"
-		), Err(ParseOrSemanticError::SemanticError(SemanticError::InvalidFeatures)));
+		), Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::InvalidFeatures)));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrnt"
 		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(bech32::Error::InvalidChecksum))));
@@ -433,7 +433,7 @@ fn test_bolt_invalid_invoices() {
 		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(bech32::Error::MixedCase))));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgqwgt7mcn5yqw3yx0w94pswkpq6j9uh6xfqqqtsk4tnarugeektd4hg5975x9am52rz4qskukxdmjemg92vvqz8nvmsye63r5ykel43pgz7zq0g2"
-		), Err(ParseOrSemanticError::SemanticError(SemanticError::InvalidSignature)));
+		), Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::InvalidSignature)));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6na6hlh"
 		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::TooShortDataPart)));
@@ -442,5 +442,5 @@ fn test_bolt_invalid_invoices() {
 		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::UnknownSiPrefix)));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500000001p1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgq0lzc236j96a95uv0m3umg28gclm5lqxtqqwk32uuk4k6673k6n5kfvx3d2h8s295fad45fdhmusm8sjudfhlf6dcsxmfvkeywmjdkxcp99202x"
-		), Err(ParseOrSemanticError::SemanticError(SemanticError::ImpreciseAmount)));
+		), Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::ImpreciseAmount)));
 }

--- a/lightning-invoice/tests/ser_de.rs
+++ b/lightning-invoice/tests/ser_de.rs
@@ -424,22 +424,22 @@ fn test_bolt_invalid_invoices() {
 		), Err(ParseOrSemanticError::SemanticError(SemanticError::InvalidFeatures)));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrnt"
-		), Err(ParseOrSemanticError::ParseError(ParseError::Bech32Error(bech32::Error::InvalidChecksum))));
+		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(bech32::Error::InvalidChecksum))));
 	assert_eq!(Bolt11Invoice::from_str(
 		"pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrny"
-		), Err(ParseOrSemanticError::ParseError(ParseError::Bech32Error(bech32::Error::MissingSeparator))));
+		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(bech32::Error::MissingSeparator))));
 	assert_eq!(Bolt11Invoice::from_str(
 		"LNBC2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrny"
-		), Err(ParseOrSemanticError::ParseError(ParseError::Bech32Error(bech32::Error::MixedCase))));
+		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(bech32::Error::MixedCase))));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgqwgt7mcn5yqw3yx0w94pswkpq6j9uh6xfqqqtsk4tnarugeektd4hg5975x9am52rz4qskukxdmjemg92vvqz8nvmsye63r5ykel43pgz7zq0g2"
 		), Err(ParseOrSemanticError::SemanticError(SemanticError::InvalidSignature)));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6na6hlh"
-		), Err(ParseOrSemanticError::ParseError(ParseError::TooShortDataPart)));
+		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::TooShortDataPart)));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500x1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgqrrzc4cvfue4zp3hggxp47ag7xnrlr8vgcmkjxk3j5jqethnumgkpqp23z9jclu3v0a7e0aruz366e9wqdykw6dxhdzcjjhldxq0w6wgqcnu43j"
-		), Err(ParseOrSemanticError::ParseError(ParseError::UnknownSiPrefix)));
+		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::UnknownSiPrefix)));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500000001p1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgq0lzc236j96a95uv0m3umg28gclm5lqxtqqwk32uuk4k6673k6n5kfvx3d2h8s295fad45fdhmusm8sjudfhlf6dcsxmfvkeywmjdkxcp99202x"
 		), Err(ParseOrSemanticError::SemanticError(SemanticError::ImpreciseAmount)));

--- a/lightning-invoice/tests/ser_de.rs
+++ b/lightning-invoice/tests/ser_de.rs
@@ -412,35 +412,35 @@ fn invoice_deserialize() {
 		}
 		assert_eq!(deserialized_hunks, parsed_hunks);
 
-		Invoice::from_signed(serialized.parse::<SignedRawInvoice>().unwrap()).unwrap();
+		Bolt11Invoice::from_signed(serialized.parse::<SignedRawInvoice>().unwrap()).unwrap();
 	}
 }
 
 #[test]
 fn test_bolt_invalid_invoices() {
 	// Tests the BOLT 11 invalid invoice test vectors
-	assert_eq!(Invoice::from_str(
+	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqqsgqtqyx5vggfcsll4wu246hz02kp85x4katwsk9639we5n5yngc3yhqkm35jnjw4len8vrnqnf5ejh0mzj9n3vz2px97evektfm2l6wqccp3y7372"
 		), Err(ParseOrSemanticError::SemanticError(SemanticError::InvalidFeatures)));
-	assert_eq!(Invoice::from_str(
+	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrnt"
 		), Err(ParseOrSemanticError::ParseError(ParseError::Bech32Error(bech32::Error::InvalidChecksum))));
-	assert_eq!(Invoice::from_str(
+	assert_eq!(Bolt11Invoice::from_str(
 		"pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrny"
 		), Err(ParseOrSemanticError::ParseError(ParseError::Bech32Error(bech32::Error::MissingSeparator))));
-	assert_eq!(Invoice::from_str(
+	assert_eq!(Bolt11Invoice::from_str(
 		"LNBC2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrny"
 		), Err(ParseOrSemanticError::ParseError(ParseError::Bech32Error(bech32::Error::MixedCase))));
-	assert_eq!(Invoice::from_str(
+	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgqwgt7mcn5yqw3yx0w94pswkpq6j9uh6xfqqqtsk4tnarugeektd4hg5975x9am52rz4qskukxdmjemg92vvqz8nvmsye63r5ykel43pgz7zq0g2"
 		), Err(ParseOrSemanticError::SemanticError(SemanticError::InvalidSignature)));
-	assert_eq!(Invoice::from_str(
+	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6na6hlh"
 		), Err(ParseOrSemanticError::ParseError(ParseError::TooShortDataPart)));
-	assert_eq!(Invoice::from_str(
+	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500x1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgqrrzc4cvfue4zp3hggxp47ag7xnrlr8vgcmkjxk3j5jqethnumgkpqp23z9jclu3v0a7e0aruz366e9wqdykw6dxhdzcjjhldxq0w6wgqcnu43j"
 		), Err(ParseOrSemanticError::ParseError(ParseError::UnknownSiPrefix)));
-	assert_eq!(Invoice::from_str(
+	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500000001p1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgq0lzc236j96a95uv0m3umg28gclm5lqxtqqwk32uuk4k6673k6n5kfvx3d2h8s295fad45fdhmusm8sjudfhlf6dcsxmfvkeywmjdkxcp99202x"
 		), Err(ParseOrSemanticError::SemanticError(SemanticError::ImpreciseAmount)));
 }

--- a/lightning-invoice/tests/ser_de.rs
+++ b/lightning-invoice/tests/ser_de.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 use std::time::Duration;
 use std::str::FromStr;
 
-fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
+fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 	vec![
 		(
 			"lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq9qrsgq357wnc5r2ueh7ck6q93dj32dlqnls087fxdwk8qakdyafkq3yap9us6v52vjjsrvywa6rt52cm9r9zqt8r2t7mlcwspyetp5h2tztugp9lfyql".to_owned(),
@@ -389,7 +389,7 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, bool, bool)> {
 fn invoice_deserialize() {
 	for (serialized, deserialized, ignore_feature_diff, ignore_unknown_fields) in get_test_tuples() {
 		eprintln!("Testing invoice {}...", serialized);
-		let parsed = serialized.parse::<SignedRawInvoice>().unwrap();
+		let parsed = serialized.parse::<SignedRawBolt11Invoice>().unwrap();
 
 		let (parsed_invoice, _, parsed_sig) = parsed.into_parts();
 		let (deserialized_invoice, _, deserialized_sig) = deserialized.into_parts();
@@ -412,7 +412,7 @@ fn invoice_deserialize() {
 		}
 		assert_eq!(deserialized_hunks, parsed_hunks);
 
-		Bolt11Invoice::from_signed(serialized.parse::<SignedRawInvoice>().unwrap()).unwrap();
+		Bolt11Invoice::from_signed(serialized.parse::<SignedRawBolt11Invoice>().unwrap()).unwrap();
 	}
 }
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -43,7 +43,7 @@ use crate::ln::{inbound_payment, PaymentHash, PaymentPreimage, PaymentSecret};
 use crate::ln::channel::{Channel, ChannelContext, ChannelError, ChannelUpdateStatus, ShutdownResult, UpdateFulfillCommitFetch, OutboundV1Channel, InboundV1Channel};
 use crate::ln::features::{ChannelFeatures, ChannelTypeFeatures, InitFeatures, NodeFeatures};
 #[cfg(any(feature = "_test_utils", test))]
-use crate::ln::features::InvoiceFeatures;
+use crate::ln::features::Bolt11InvoiceFeatures;
 use crate::routing::gossip::NetworkGraph;
 use crate::routing::router::{BlindedTail, DefaultRouter, InFlightHtlcs, Path, Payee, PaymentParameters, Route, RouteParameters, Router};
 use crate::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters};
@@ -6928,13 +6928,13 @@ where
 		provided_node_features(&self.default_configuration)
 	}
 
-	/// Fetches the set of [`InvoiceFeatures`] flags which are provided by or required by
+	/// Fetches the set of [`Bolt11InvoiceFeatures`] flags which are provided by or required by
 	/// [`ChannelManager`].
 	///
 	/// Note that the invoice feature flags can vary depending on if the invoice is a "phantom invoice"
 	/// or not. Thus, this method is not public.
 	#[cfg(any(feature = "_test_utils", test))]
-	pub fn invoice_features(&self) -> InvoiceFeatures {
+	pub fn invoice_features(&self) -> Bolt11InvoiceFeatures {
 		provided_invoice_features(&self.default_configuration)
 	}
 
@@ -7366,13 +7366,13 @@ pub(crate) fn provided_node_features(config: &UserConfig) -> NodeFeatures {
 	provided_init_features(config).to_context()
 }
 
-/// Fetches the set of [`InvoiceFeatures`] flags which are provided by or required by
+/// Fetches the set of [`Bolt11InvoiceFeatures`] flags which are provided by or required by
 /// [`ChannelManager`].
 ///
 /// Note that the invoice feature flags can vary depending on if the invoice is a "phantom invoice"
 /// or not. Thus, this method is not public.
 #[cfg(any(feature = "_test_utils", test))]
-pub(crate) fn provided_invoice_features(config: &UserConfig) -> InvoiceFeatures {
+pub(crate) fn provided_invoice_features(config: &UserConfig) -> Bolt11InvoiceFeatures {
 	provided_init_features(config).to_context()
 }
 

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -20,7 +20,7 @@ use crate::ln::channelmanager::{HTLCForwardInfo, FailureCode, CLTV_FAR_FAR_AWAY,
 use crate::ln::onion_utils;
 use crate::routing::gossip::{NetworkUpdate, RoutingFees};
 use crate::routing::router::{get_route, PaymentParameters, Route, RouteHint, RouteHintHop};
-use crate::ln::features::{InitFeatures, InvoiceFeatures};
+use crate::ln::features::{InitFeatures, Bolt11InvoiceFeatures};
 use crate::ln::msgs;
 use crate::ln::msgs::{ChannelMessageHandler, ChannelUpdate};
 use crate::ln::wire::Encode;
@@ -862,7 +862,7 @@ fn test_always_create_tlv_format_onion_payloads() {
 	create_announced_chan_between_nodes(&nodes, 1, 2);
 
 	let payment_params = PaymentParameters::from_node_id(nodes[2].node.get_our_node_id(), TEST_FINAL_CLTV)
-		.with_bolt11_features(InvoiceFeatures::empty()).unwrap();
+		.with_bolt11_features(Bolt11InvoiceFeatures::empty()).unwrap();
 	let (route, _payment_hash, _payment_preimage, _payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[2], payment_params, 40000);
 
 	let hops = &route.paths[0].hops;

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -18,7 +18,7 @@ use crate::chain::transaction::OutPoint;
 use crate::events::{ClosureReason, Event, HTLCDestination, MessageSendEvent, MessageSendEventsProvider, PathFailure, PaymentFailureReason};
 use crate::ln::channel::EXPIRE_PREV_CONFIG_TICKS;
 use crate::ln::channelmanager::{BREAKDOWN_TIMEOUT, ChannelManager, MPP_TIMEOUT_TICKS, MIN_CLTV_EXPIRY_DELTA, PaymentId, PaymentSendFailure, IDEMPOTENCY_TIMEOUT_TICKS, RecentPaymentDetails, RecipientOnionFields, HTLCForwardInfo, PendingHTLCRouting, PendingAddHTLCInfo};
-use crate::ln::features::InvoiceFeatures;
+use crate::ln::features::Bolt11InvoiceFeatures;
 use crate::ln::{msgs, PaymentSecret, PaymentPreimage};
 use crate::ln::msgs::ChannelMessageHandler;
 use crate::ln::outbound_payment::Retry;
@@ -1903,7 +1903,7 @@ fn do_automatic_retries(test: AutoRetry) {
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
 	let amt_msat = 1000;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();
@@ -2122,7 +2122,7 @@ fn auto_retry_partial_failure() {
 	let payment_expiry_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() + 60 * 60;
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();
@@ -2334,7 +2334,7 @@ fn auto_retry_zero_attempts_send_error() {
 	let payment_expiry_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() + 60 * 60;
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();
@@ -2374,7 +2374,7 @@ fn fails_paying_after_rejected_by_payee() {
 	let payment_expiry_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() + 60 * 60;
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();
@@ -2421,7 +2421,7 @@ fn retry_multi_path_single_failed_payment() {
 	let payment_expiry_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() + 60 * 60;
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();
@@ -2514,7 +2514,7 @@ fn immediate_retry_on_failure() {
 	let payment_expiry_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() + 60 * 60;
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();
@@ -2602,7 +2602,7 @@ fn no_extra_retries_on_back_to_back_fail() {
 	let payment_expiry_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() + 60 * 60;
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();
@@ -2804,7 +2804,7 @@ fn test_simple_partial_retry() {
 	let payment_expiry_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() + 60 * 60;
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();
@@ -2970,7 +2970,7 @@ fn test_threaded_payment_retries() {
 	let payment_expiry_secs = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_secs() + 60 * 60;
 	#[cfg(not(feature = "std"))]
 	let payment_expiry_secs = 60 * 60;
-	let mut invoice_features = InvoiceFeatures::empty();
+	let mut invoice_features = Bolt11InvoiceFeatures::empty();
 	invoice_features.set_variable_length_onion_required();
 	invoice_features.set_payment_secret_required();
 	invoice_features.set_basic_mpp_optional();

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -330,8 +330,8 @@ impl<'a, S: SigningPubkeyStrategy> InvoiceBuilder<'a, S> {
 
 impl<'a> InvoiceBuilder<'a, ExplicitSigningPubkey> {
 	/// Builds an unsigned [`Bolt12Invoice`] after checking for valid semantics. It can be signed by
-	/// [`UnsignedInvoice::sign`].
-	pub fn build(self) -> Result<UnsignedInvoice<'a>, SemanticError> {
+	/// [`UnsignedBolt12Invoice::sign`].
+	pub fn build(self) -> Result<UnsignedBolt12Invoice<'a>, SemanticError> {
 		#[cfg(feature = "std")] {
 			if self.invoice.is_offer_or_refund_expired() {
 				return Err(SemanticError::AlreadyExpired);
@@ -339,7 +339,7 @@ impl<'a> InvoiceBuilder<'a, ExplicitSigningPubkey> {
 		}
 
 		let InvoiceBuilder { invreq_bytes, invoice, .. } = self;
-		Ok(UnsignedInvoice { invreq_bytes, invoice })
+		Ok(UnsignedBolt12Invoice { invreq_bytes, invoice })
 	}
 }
 
@@ -355,7 +355,7 @@ impl<'a> InvoiceBuilder<'a, DerivedSigningPubkey> {
 		}
 
 		let InvoiceBuilder { invreq_bytes, invoice, keys, .. } = self;
-		let unsigned_invoice = UnsignedInvoice { invreq_bytes, invoice };
+		let unsigned_invoice = UnsignedBolt12Invoice { invreq_bytes, invoice };
 
 		let keys = keys.unwrap();
 		let invoice = unsigned_invoice
@@ -366,12 +366,12 @@ impl<'a> InvoiceBuilder<'a, DerivedSigningPubkey> {
 }
 
 /// A semantically valid [`Bolt12Invoice`] that hasn't been signed.
-pub struct UnsignedInvoice<'a> {
+pub struct UnsignedBolt12Invoice<'a> {
 	invreq_bytes: &'a Vec<u8>,
 	invoice: InvoiceContents,
 }
 
-impl<'a> UnsignedInvoice<'a> {
+impl<'a> UnsignedBolt12Invoice<'a> {
 	/// The public key corresponding to the key needed to sign the invoice.
 	pub fn signing_pubkey(&self) -> PublicKey {
 		self.invoice.fields().signing_pubkey

--- a/lightning/src/offers/invoice_error.rs
+++ b/lightning/src/offers/invoice_error.rs
@@ -17,27 +17,27 @@ use crate::util::string::UntrustedString;
 
 use crate::prelude::*;
 
-/// An error in response to an [`InvoiceRequest`] or an [`Invoice`].
+/// An error in response to an [`InvoiceRequest`] or an [`Bolt12Invoice`].
 ///
 /// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
-/// [`Invoice`]: crate::offers::invoice::Invoice
+/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct InvoiceError {
-	/// The field in the [`InvoiceRequest`] or the [`Invoice`] that contained an error.
+	/// The field in the [`InvoiceRequest`] or the [`Bolt12Invoice`] that contained an error.
 	///
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
-	/// [`Invoice`]: crate::offers::invoice::Invoice
+	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	pub erroneous_field: Option<ErroneousField>,
 
 	/// An explanation of the error.
 	pub message: UntrustedString,
 }
 
-/// The field in the [`InvoiceRequest`] or the [`Invoice`] that contained an error.
+/// The field in the [`InvoiceRequest`] or the [`Bolt12Invoice`] that contained an error.
 ///
 /// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
-/// [`Invoice`]: crate::offers::invoice::Invoice
+/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ErroneousField {

--- a/lightning/src/offers/invoice_error.rs
+++ b/lightning/src/offers/invoice_error.rs
@@ -11,7 +11,7 @@
 
 use crate::io;
 use crate::ln::msgs::DecodeError;
-use crate::offers::parse::SemanticError;
+use crate::offers::parse::Bolt12SemanticError;
 use crate::util::ser::{HighZeroBytesDroppedBigSize, Readable, WithoutLength, Writeable, Writer};
 use crate::util::string::UntrustedString;
 
@@ -93,8 +93,8 @@ impl Readable for InvoiceError {
 	}
 }
 
-impl From<SemanticError> for InvoiceError {
-	fn from(error: SemanticError) -> Self {
+impl From<Bolt12SemanticError> for InvoiceError {
+	fn from(error: Bolt12SemanticError) -> Self {
 		InvoiceError {
 			erroneous_field: None,
 			message: UntrustedString(format!("{:?}", error)),

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -319,8 +319,8 @@ impl<'a, M: MetadataStrategy, T: secp256k1::Signing> OfferBuilder<'a, M, T> {
 /// An `Offer` is a potentially long-lived proposal for payment of a good or service.
 ///
 /// An offer is a precursor to an [`InvoiceRequest`]. A merchant publishes an offer from which a
-/// customer may request an [`Invoice`] for a specific quantity and using an amount sufficient to
-/// cover that quantity (i.e., at least `quantity * amount`). See [`Offer::amount`].
+/// customer may request an [`Bolt12Invoice`] for a specific quantity and using an amount sufficient
+/// to cover that quantity (i.e., at least `quantity * amount`). See [`Offer::amount`].
 ///
 /// Offers may be denominated in currency other than bitcoin but are ultimately paid using the
 /// latter.
@@ -328,7 +328,7 @@ impl<'a, M: MetadataStrategy, T: secp256k1::Signing> OfferBuilder<'a, M, T> {
 /// Through the use of [`BlindedPath`]s, offers provide recipient privacy.
 ///
 /// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
-/// [`Invoice`]: crate::offers::invoice::Invoice
+/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Offer {
@@ -338,10 +338,11 @@ pub struct Offer {
 	pub(super) contents: OfferContents,
 }
 
-/// The contents of an [`Offer`], which may be shared with an [`InvoiceRequest`] or an [`Invoice`].
+/// The contents of an [`Offer`], which may be shared with an [`InvoiceRequest`] or a
+/// [`Bolt12Invoice`].
 ///
 /// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
-/// [`Invoice`]: crate::offers::invoice::Invoice
+/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub(super) struct OfferContents {
@@ -451,8 +452,8 @@ impl Offer {
 	/// - derives the [`InvoiceRequest::payer_id`] such that a different key can be used for each
 	///   request, and
 	/// - sets the [`InvoiceRequest::metadata`] when [`InvoiceRequestBuilder::build`] is called such
-	///   that it can be used by [`Invoice::verify`] to determine if the invoice was requested using
-	///   a base [`ExpandedKey`] from which the payer id was derived.
+	///   that it can be used by [`Bolt12Invoice::verify`] to determine if the invoice was requested
+	///   using a base [`ExpandedKey`] from which the payer id was derived.
 	///
 	/// Useful to protect the sender's privacy.
 	///
@@ -460,7 +461,7 @@ impl Offer {
 	///
 	/// [`InvoiceRequest::payer_id`]: crate::offers::invoice_request::InvoiceRequest::payer_id
 	/// [`InvoiceRequest::metadata`]: crate::offers::invoice_request::InvoiceRequest::metadata
-	/// [`Invoice::verify`]: crate::offers::invoice::Invoice::verify
+	/// [`Bolt12Invoice::verify`]: crate::offers::invoice::Bolt12Invoice::verify
 	/// [`ExpandedKey`]: crate::ln::inbound_payment::ExpandedKey
 	pub fn request_invoice_deriving_payer_id<'a, 'b, ES: Deref, T: secp256k1::Signing>(
 		&'a self, expanded_key: &ExpandedKey, entropy_source: ES, secp_ctx: &'b Secp256k1<T>
@@ -497,7 +498,7 @@ impl Offer {
 	}
 
 	/// Creates an [`InvoiceRequestBuilder`] for the offer with the given `metadata` and `payer_id`,
-	/// which will be reflected in the `Invoice` response.
+	/// which will be reflected in the `Bolt12Invoice` response.
 	///
 	/// The `metadata` is useful for including information about the derivation of `payer_id` such
 	/// that invoice response handling can be stateless. Also serves as payer-provided entropy while

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -29,24 +29,24 @@ mod sealed {
 	use bitcoin::bech32::{FromBase32, ToBase32};
 	use core::convert::TryFrom;
 	use core::fmt;
-	use super::ParseError;
+	use super::Bolt12ParseError;
 
 	use crate::prelude::*;
 
 	/// Indicates a message can be encoded using bech32.
-	pub trait Bech32Encode: AsRef<[u8]> + TryFrom<Vec<u8>, Error=ParseError> {
+	pub trait Bech32Encode: AsRef<[u8]> + TryFrom<Vec<u8>, Error=Bolt12ParseError> {
 		/// Human readable part of the message's bech32 encoding.
 		const BECH32_HRP: &'static str;
 
 		/// Parses a bech32-encoded message into a TLV stream.
-		fn from_bech32_str(s: &str) -> Result<Self, ParseError> {
+		fn from_bech32_str(s: &str) -> Result<Self, Bolt12ParseError> {
 			// Offer encoding may be split by '+' followed by optional whitespace.
 			let encoded = match s.split('+').skip(1).next() {
 				Some(_) => {
 					for chunk in s.split('+') {
 						let chunk = chunk.trim_start();
 						if chunk.is_empty() || chunk.contains(char::is_whitespace) {
-							return Err(ParseError::InvalidContinuation);
+							return Err(Bolt12ParseError::InvalidContinuation);
 						}
 					}
 
@@ -59,7 +59,7 @@ mod sealed {
 			let (hrp, data) = bech32::decode_without_checksum(encoded.as_ref())?;
 
 			if hrp != Self::BECH32_HRP {
-				return Err(ParseError::InvalidBech32Hrp);
+				return Err(Bolt12ParseError::InvalidBech32Hrp);
 			}
 
 			let data = Vec::<u8>::from_base32(&data)?;
@@ -116,10 +116,8 @@ impl<T: SeekReadable> TryFrom<Vec<u8>> for ParsedMessage<T> {
 }
 
 /// Error when parsing a bech32 encoded message using [`str::parse`].
-///
-/// This is not exported to bindings users as its name conflicts with the BOLT 11 ParseError type.
 #[derive(Debug, PartialEq)]
-pub enum ParseError {
+pub enum Bolt12ParseError {
 	/// The bech32 encoding does not conform to the BOLT 12 requirements for continuing messages
 	/// across multiple parts (i.e., '+' followed by whitespace).
 	InvalidContinuation,
@@ -195,25 +193,25 @@ pub enum SemanticError {
 	MissingSignature,
 }
 
-impl From<bech32::Error> for ParseError {
+impl From<bech32::Error> for Bolt12ParseError {
 	fn from(error: bech32::Error) -> Self {
 		Self::Bech32(error)
 	}
 }
 
-impl From<DecodeError> for ParseError {
+impl From<DecodeError> for Bolt12ParseError {
 	fn from(error: DecodeError) -> Self {
 		Self::Decode(error)
 	}
 }
 
-impl From<SemanticError> for ParseError {
+impl From<SemanticError> for Bolt12ParseError {
 	fn from(error: SemanticError) -> Self {
 		Self::InvalidSemantics(error)
 	}
 }
 
-impl From<secp256k1::Error> for ParseError {
+impl From<secp256k1::Error> for Bolt12ParseError {
 	fn from(error: secp256k1::Error) -> Self {
 		Self::InvalidSignature(error)
 	}

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -129,16 +129,14 @@ pub enum Bolt12ParseError {
 	/// The bech32 decoded string could not be decoded as the expected message type.
 	Decode(DecodeError),
 	/// The parsed message has invalid semantics.
-	InvalidSemantics(SemanticError),
+	InvalidSemantics(Bolt12SemanticError),
 	/// The parsed message has an invalid signature.
 	InvalidSignature(secp256k1::Error),
 }
 
 /// Error when interpreting a TLV stream as a specific type.
-///
-/// This is not exported to bindings users as its name conflicts with the BOLT 11 SemanticError type.
 #[derive(Debug, PartialEq)]
-pub enum SemanticError {
+pub enum Bolt12SemanticError {
 	/// The current [`std::time::SystemTime`] is past the offer or invoice's expiration.
 	AlreadyExpired,
 	/// The provided chain hash does not correspond to a supported chain.
@@ -205,8 +203,8 @@ impl From<DecodeError> for Bolt12ParseError {
 	}
 }
 
-impl From<SemanticError> for Bolt12ParseError {
-	fn from(error: SemanticError) -> Self {
+impl From<Bolt12SemanticError> for Bolt12ParseError {
+	fn from(error: Bolt12SemanticError) -> Self {
 		Self::InvalidSemantics(error)
 	}
 }

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -28,7 +28,7 @@
 //!
 //! use bitcoin::network::constants::Network;
 //! use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, SecretKey};
-//! use lightning::offers::parse::ParseError;
+//! use lightning::offers::parse::Bolt12ParseError;
 //! use lightning::offers::refund::{Refund, RefundBuilder};
 //! use lightning::util::ser::{Readable, Writeable};
 //!
@@ -40,7 +40,7 @@
 //! # fn create_another_blinded_path() -> BlindedPath { unimplemented!() }
 //! #
 //! # #[cfg(feature = "std")]
-//! # fn build() -> Result<(), ParseError> {
+//! # fn build() -> Result<(), Bolt12ParseError> {
 //! let secp_ctx = Secp256k1::new();
 //! let keys = KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 //! let pubkey = PublicKey::from(keys);
@@ -88,7 +88,7 @@ use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
 use crate::offers::invoice::{BlindedPayInfo, DerivedSigningPubkey, ExplicitSigningPubkey, InvoiceBuilder};
 use crate::offers::invoice_request::{InvoiceRequestTlvStream, InvoiceRequestTlvStreamRef};
 use crate::offers::offer::{OfferTlvStream, OfferTlvStreamRef};
-use crate::offers::parse::{Bech32Encode, ParseError, ParsedMessage, SemanticError};
+use crate::offers::parse::{Bech32Encode, Bolt12ParseError, ParsedMessage, SemanticError};
 use crate::offers::payer::{PayerContents, PayerTlvStream, PayerTlvStreamRef};
 use crate::offers::signer::{Metadata, MetadataMaterial, self};
 use crate::util::ser::{SeekReadable, WithoutLength, Writeable, Writer};
@@ -606,7 +606,7 @@ impl Bech32Encode for Refund {
 }
 
 impl FromStr for Refund {
-	type Err = ParseError;
+	type Err = Bolt12ParseError;
 
 	fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
 		Refund::from_bech32_str(s)
@@ -614,7 +614,7 @@ impl FromStr for Refund {
 }
 
 impl TryFrom<Vec<u8>> for Refund {
-	type Error = ParseError;
+	type Error = Bolt12ParseError;
 
 	fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
 		let refund = ParsedMessage::<RefundTlvStream>::try_from(bytes)?;
@@ -718,7 +718,7 @@ mod tests {
 	use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
 	use crate::offers::invoice_request::InvoiceRequestTlvStreamRef;
 	use crate::offers::offer::OfferTlvStreamRef;
-	use crate::offers::parse::{ParseError, SemanticError};
+	use crate::offers::parse::{Bolt12ParseError, SemanticError};
 	use crate::offers::payer::PayerTlvStreamRef;
 	use crate::offers::test_utils::*;
 	use crate::util::ser::{BigSize, Writeable};
@@ -1082,7 +1082,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::MissingPayerMetadata));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::MissingPayerMetadata));
 			},
 		}
 	}
@@ -1101,7 +1101,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::MissingDescription));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::MissingDescription));
 			},
 		}
 	}
@@ -1120,7 +1120,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::MissingAmount));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::MissingAmount));
 			},
 		}
 
@@ -1130,7 +1130,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::InvalidAmount));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::InvalidAmount));
 			},
 		}
 	}
@@ -1149,7 +1149,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::MissingPayerId));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::MissingPayerId));
 			},
 		}
 	}
@@ -1218,7 +1218,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::UnexpectedMetadata));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::UnexpectedMetadata));
 			},
 		}
 
@@ -1229,7 +1229,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::UnexpectedChain));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::UnexpectedChain));
 			},
 		}
 
@@ -1240,7 +1240,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::UnexpectedAmount));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::UnexpectedAmount));
 			},
 		}
 
@@ -1251,7 +1251,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::UnexpectedFeatures));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::UnexpectedFeatures));
 			},
 		}
 
@@ -1261,7 +1261,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::UnexpectedQuantity));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::UnexpectedQuantity));
 			},
 		}
 
@@ -1272,7 +1272,7 @@ mod tests {
 		match Refund::try_from(tlv_stream.to_bytes()) {
 			Ok(_) => panic!("expected error"),
 			Err(e) => {
-				assert_eq!(e, ParseError::InvalidSemantics(SemanticError::UnexpectedSigningPubkey));
+				assert_eq!(e, Bolt12ParseError::InvalidSemantics(SemanticError::UnexpectedSigningPubkey));
 			},
 		}
 	}
@@ -1292,7 +1292,7 @@ mod tests {
 
 		match Refund::try_from(encoded_refund) {
 			Ok(_) => panic!("expected error"),
-			Err(e) => assert_eq!(e, ParseError::Decode(DecodeError::InvalidValue)),
+			Err(e) => assert_eq!(e, Bolt12ParseError::Decode(DecodeError::InvalidValue)),
 		}
 	}
 }

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -10,11 +10,11 @@
 //! Data structures and encoding for refunds.
 //!
 //! A [`Refund`] is an "offer for money" and is typically constructed by a merchant and presented
-//! directly to the customer. The recipient responds with an [`Invoice`] to be paid.
+//! directly to the customer. The recipient responds with a [`Bolt12Invoice`] to be paid.
 //!
 //! This is an [`InvoiceRequest`] produced *not* in response to an [`Offer`].
 //!
-//! [`Invoice`]: crate::offers::invoice::Invoice
+//! [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 //! [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 //! [`Offer`]: crate::offers::offer::Offer
 //!
@@ -207,12 +207,12 @@ impl<'a, T: secp256k1::Signing> RefundBuilder<'a, T> {
 	}
 
 	/// Sets [`Refund::quantity`] of items. This is purely for informational purposes. It is useful
-	/// when the refund pertains to an [`Invoice`] that paid for more than one item from an
+	/// when the refund pertains to a [`Bolt12Invoice`] that paid for more than one item from an
 	/// [`Offer`] as specified by [`InvoiceRequest::quantity`].
 	///
 	/// Successive calls to this method will override the previous setting.
 	///
-	/// [`Invoice`]: crate::offers::invoice::Invoice
+	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	/// [`InvoiceRequest::quantity`]: crate::offers::invoice_request::InvoiceRequest::quantity
 	/// [`Offer`]: crate::offers::offer::Offer
 	pub fn quantity(mut self, quantity: u64) -> Self {
@@ -234,7 +234,7 @@ impl<'a, T: secp256k1::Signing> RefundBuilder<'a, T> {
 			self.refund.chain = None;
 		}
 
-		// Create the metadata for stateless verification of an Invoice.
+		// Create the metadata for stateless verification of a Bolt12Invoice.
 		if self.refund.payer.0.has_derivation_material() {
 			let mut metadata = core::mem::take(&mut self.refund.payer.0);
 
@@ -272,13 +272,13 @@ impl<'a, T: secp256k1::Signing> RefundBuilder<'a, T> {
 	}
 }
 
-/// A `Refund` is a request to send an [`Invoice`] without a preceding [`Offer`].
+/// A `Refund` is a request to send an [`Bolt12Invoice`] without a preceding [`Offer`].
 ///
 /// Typically, after an invoice is paid, the recipient may publish a refund allowing the sender to
 /// recoup their funds. A refund may be used more generally as an "offer for money", such as with a
 /// bitcoin ATM.
 ///
-/// [`Invoice`]: crate::offers::invoice::Invoice
+/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 /// [`Offer`]: crate::offers::offer::Offer
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -287,9 +287,9 @@ pub struct Refund {
 	pub(super) contents: RefundContents,
 }
 
-/// The contents of a [`Refund`], which may be shared with an [`Invoice`].
+/// The contents of a [`Refund`], which may be shared with an [`Bolt12Invoice`].
 ///
-/// [`Invoice`]: crate::offers::invoice::Invoice
+/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub(super) struct RefundContents {
@@ -407,8 +407,8 @@ impl Refund {
 	/// Creates an [`InvoiceBuilder`] for the refund with the given required fields.
 	///
 	/// Unless [`InvoiceBuilder::relative_expiry`] is set, the invoice will expire two hours after
-	/// `created_at`, which is used to set [`Invoice::created_at`]. Useful for `no-std` builds where
-	/// [`std::time::SystemTime`] is not available.
+	/// `created_at`, which is used to set [`Bolt12Invoice::created_at`]. Useful for `no-std` builds
+	/// where [`std::time::SystemTime`] is not available.
 	///
 	/// The caller is expected to remember the preimage of `payment_hash` in order to
 	/// claim a payment for the invoice.
@@ -425,7 +425,7 @@ impl Refund {
 	///
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
-	/// [`Invoice::created_at`]: crate::offers::invoice::Invoice::created_at
+	/// [`Bolt12Invoice::created_at`]: crate::offers::invoice::Bolt12Invoice::created_at
 	pub fn respond_with_no_std(
 		&self, payment_paths: Vec<(BlindedPayInfo, BlindedPath)>, payment_hash: PaymentHash,
 		signing_pubkey: PublicKey, created_at: Duration
@@ -438,13 +438,13 @@ impl Refund {
 	}
 
 	/// Creates an [`InvoiceBuilder`] for the refund using the given required fields and that uses
-	/// derived signing keys to sign the [`Invoice`].
+	/// derived signing keys to sign the [`Bolt12Invoice`].
 	///
 	/// See [`Refund::respond_with`] for further details.
 	///
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
-	/// [`Invoice`]: crate::offers::invoice::Invoice
+	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	#[cfg(feature = "std")]
 	pub fn respond_using_derived_keys<ES: Deref>(
 		&self, payment_paths: Vec<(BlindedPayInfo, BlindedPath)>, payment_hash: PaymentHash,
@@ -463,13 +463,13 @@ impl Refund {
 	}
 
 	/// Creates an [`InvoiceBuilder`] for the refund using the given required fields and that uses
-	/// derived signing keys to sign the [`Invoice`].
+	/// derived signing keys to sign the [`Bolt12Invoice`].
 	///
 	/// See [`Refund::respond_with_no_std`] for further details.
 	///
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
-	/// [`Invoice`]: crate::offers::invoice::Invoice
+	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	pub fn respond_using_derived_keys_no_std<ES: Deref>(
 		&self, payment_paths: Vec<(BlindedPayInfo, BlindedPath)>, payment_hash: PaymentHash,
 		created_at: core::time::Duration, expanded_key: &ExpandedKey, entropy_source: ES

--- a/lightning/src/onion_message/offers.rs
+++ b/lightning/src/onion_message/offers.rs
@@ -14,7 +14,7 @@ use crate::io::{self, Read};
 use crate::ln::msgs::DecodeError;
 use crate::offers::invoice_error::InvoiceError;
 use crate::offers::invoice_request::InvoiceRequest;
-use crate::offers::invoice::Invoice;
+use crate::offers::invoice::Bolt12Invoice;
 use crate::offers::parse::ParseError;
 use crate::util::logger::Logger;
 use crate::util::ser::{Readable, ReadableArgs, Writeable, Writer};
@@ -30,8 +30,8 @@ const INVOICE_ERROR_TLV_TYPE: u64 = 68;
 ///
 /// [`OnionMessage`]: crate::ln::msgs::OnionMessage
 pub trait OffersMessageHandler {
-	/// Handles the given message by either responding with an [`Invoice`], sending a payment, or
-	/// replying with an error.
+	/// Handles the given message by either responding with an [`Bolt12Invoice`], sending a payment,
+	/// or replying with an error.
 	fn handle_message(&self, message: OffersMessage) -> Option<OffersMessage>;
 }
 
@@ -40,15 +40,15 @@ pub trait OffersMessageHandler {
 /// [`OnionMessage`]: crate::ln::msgs::OnionMessage
 #[derive(Debug)]
 pub enum OffersMessage {
-	/// A request for an [`Invoice`] for a particular [`Offer`].
+	/// A request for a [`Bolt12Invoice`] for a particular [`Offer`].
 	///
 	/// [`Offer`]: crate::offers::offer::Offer
 	InvoiceRequest(InvoiceRequest),
 
-	/// An [`Invoice`] sent in response to an [`InvoiceRequest`] or a [`Refund`].
+	/// A [`Bolt12Invoice`] sent in response to an [`InvoiceRequest`] or a [`Refund`].
 	///
 	/// [`Refund`]: crate::offers::refund::Refund
-	Invoice(Invoice),
+	Invoice(Bolt12Invoice),
 
 	/// An error from handling an [`OffersMessage`].
 	InvoiceError(InvoiceError),
@@ -75,7 +75,7 @@ impl OffersMessage {
 	fn parse(tlv_type: u64, bytes: Vec<u8>) -> Result<Self, ParseError> {
 		match tlv_type {
 			INVOICE_REQUEST_TLV_TYPE => Ok(Self::InvoiceRequest(InvoiceRequest::try_from(bytes)?)),
-			INVOICE_TLV_TYPE => Ok(Self::Invoice(Invoice::try_from(bytes)?)),
+			INVOICE_TLV_TYPE => Ok(Self::Invoice(Bolt12Invoice::try_from(bytes)?)),
 			_ => Err(ParseError::Decode(DecodeError::InvalidValue)),
 		}
 	}

--- a/lightning/src/onion_message/offers.rs
+++ b/lightning/src/onion_message/offers.rs
@@ -15,7 +15,7 @@ use crate::ln::msgs::DecodeError;
 use crate::offers::invoice_error::InvoiceError;
 use crate::offers::invoice_request::InvoiceRequest;
 use crate::offers::invoice::Bolt12Invoice;
-use crate::offers::parse::ParseError;
+use crate::offers::parse::Bolt12ParseError;
 use crate::util::logger::Logger;
 use crate::util::ser::{Readable, ReadableArgs, Writeable, Writer};
 
@@ -72,11 +72,11 @@ impl OffersMessage {
 		}
 	}
 
-	fn parse(tlv_type: u64, bytes: Vec<u8>) -> Result<Self, ParseError> {
+	fn parse(tlv_type: u64, bytes: Vec<u8>) -> Result<Self, Bolt12ParseError> {
 		match tlv_type {
 			INVOICE_REQUEST_TLV_TYPE => Ok(Self::InvoiceRequest(InvoiceRequest::try_from(bytes)?)),
 			INVOICE_TLV_TYPE => Ok(Self::Invoice(Bolt12Invoice::try_from(bytes)?)),
-			_ => Err(ParseError::Decode(DecodeError::InvalidValue)),
+			_ => Err(Bolt12ParseError::Decode(DecodeError::InvalidValue)),
 		}
 	}
 }
@@ -103,12 +103,12 @@ impl<L: Logger + ?Sized> ReadableArgs<(u64, &L)> for OffersMessage {
 
 		match Self::parse(tlv_type, bytes) {
 			Ok(message) => Ok(message),
-			Err(ParseError::Decode(e)) => Err(e),
-			Err(ParseError::InvalidSemantics(e)) => {
+			Err(Bolt12ParseError::Decode(e)) => Err(e),
+			Err(Bolt12ParseError::InvalidSemantics(e)) => {
 				log_trace!(logger, "Invalid semantics for TLV type {}: {:?}", tlv_type, e);
 				Err(DecodeError::InvalidValue)
 			},
-			Err(ParseError::InvalidSignature(e)) => {
+			Err(Bolt12ParseError::InvalidSignature(e)) => {
 				log_trace!(logger, "Invalid signature for TLV type {}: {:?}", tlv_type, e);
 				Err(DecodeError::InvalidValue)
 			},

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -16,7 +16,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use crate::blinded_path::{BlindedHop, BlindedPath};
 use crate::ln::PaymentHash;
 use crate::ln::channelmanager::{ChannelDetails, PaymentId};
-use crate::ln::features::{Bolt12InvoiceFeatures, ChannelFeatures, InvoiceFeatures, NodeFeatures};
+use crate::ln::features::{Bolt11InvoiceFeatures, Bolt12InvoiceFeatures, ChannelFeatures, NodeFeatures};
 use crate::ln::msgs::{DecodeError, ErrorAction, LightningError, MAX_VALUE_MSAT};
 use crate::offers::invoice::{BlindedPayInfo, Bolt12Invoice};
 use crate::routing::gossip::{DirectedChannelInfo, EffectiveCapacity, ReadOnlyNetworkGraph, NetworkGraph, NodeId, RoutingFees};
@@ -640,7 +640,7 @@ impl PaymentParameters {
 	/// [`RecipientOnionFields::secret_only`]: crate::ln::channelmanager::RecipientOnionFields::secret_only
 	pub fn for_keysend(payee_pubkey: PublicKey, final_cltv_expiry_delta: u32, allow_mpp: bool) -> Self {
 		Self::from_node_id(payee_pubkey, final_cltv_expiry_delta)
-			.with_bolt11_features(InvoiceFeatures::for_keysend(allow_mpp))
+			.with_bolt11_features(Bolt11InvoiceFeatures::for_keysend(allow_mpp))
 			.expect("PaymentParameters::from_node_id should always initialize the payee as unblinded")
 	}
 
@@ -680,7 +680,7 @@ impl PaymentParameters {
 	/// [`PaymentParameters::from_bolt12_invoice`].
 	///
 	/// This is not exported to bindings users since bindings don't support move semantics
-	pub fn with_bolt11_features(self, features: InvoiceFeatures) -> Result<Self, ()> {
+	pub fn with_bolt11_features(self, features: Bolt11InvoiceFeatures) -> Result<Self, ()> {
 		match self.payee {
 			Payee::Blinded { .. } => Err(()),
 			Payee::Clear { route_hints, node_id, final_cltv_expiry_delta, .. } =>
@@ -766,7 +766,7 @@ pub enum Payee {
 		/// does not contain any features.
 		///
 		/// [`for_keysend`]: PaymentParameters::for_keysend
-		features: Option<InvoiceFeatures>,
+		features: Option<Bolt11InvoiceFeatures>,
 		/// The minimum CLTV delta at the end of the route. This value must not be zero.
 		final_cltv_expiry_delta: u32,
 	},
@@ -819,11 +819,11 @@ impl Payee {
 }
 
 enum FeaturesRef<'a> {
-	Bolt11(&'a InvoiceFeatures),
+	Bolt11(&'a Bolt11InvoiceFeatures),
 	Bolt12(&'a Bolt12InvoiceFeatures),
 }
 enum Features {
-	Bolt11(InvoiceFeatures),
+	Bolt11(Bolt11InvoiceFeatures),
 	Bolt12(Bolt12InvoiceFeatures),
 }
 
@@ -834,7 +834,7 @@ impl Features {
 			_ => None,
 		}
 	}
-	fn bolt11(self) -> Option<InvoiceFeatures> {
+	fn bolt11(self) -> Option<Bolt11InvoiceFeatures> {
 		match self {
 			Self::Bolt11(f) => Some(f),
 			_ => None,
@@ -6104,7 +6104,7 @@ mod tests {
 
 		let params = ProbabilisticScoringFeeParameters::default();
 		let mut scorer = ProbabilisticScorer::new(ProbabilisticScoringDecayParameters::default(), &graph, &logger);
-		let features = super::InvoiceFeatures::empty();
+		let features = super::Bolt11InvoiceFeatures::empty();
 
 		super::bench_utils::generate_test_routes(&graph, &mut scorer, &params, features, random_init_seed(), 0, 2);
 	}
@@ -6680,7 +6680,7 @@ pub(crate) mod bench_utils {
 	use crate::chain::transaction::OutPoint;
 	use crate::sign::{EntropySource, KeysManager};
 	use crate::ln::channelmanager::{self, ChannelCounterparty, ChannelDetails};
-	use crate::ln::features::InvoiceFeatures;
+	use crate::ln::features::Bolt11InvoiceFeatures;
 	use crate::routing::gossip::NetworkGraph;
 	use crate::util::config::UserConfig;
 	use crate::util::ser::ReadableArgs;
@@ -6772,7 +6772,7 @@ pub(crate) mod bench_utils {
 	}
 
 	pub(crate) fn generate_test_routes<S: Score>(graph: &NetworkGraph<&TestLogger>, scorer: &mut S,
-		score_params: &S::ScoreParams, features: InvoiceFeatures, mut seed: u64,
+		score_params: &S::ScoreParams, features: Bolt11InvoiceFeatures, mut seed: u64,
 		starting_amount: u64, route_count: usize,
 	) -> Vec<(ChannelDetails, PaymentParameters, u64)> {
 		let payer = payer_pubkey();
@@ -6853,7 +6853,7 @@ pub mod benches {
 	use super::*;
 	use crate::sign::{EntropySource, KeysManager};
 	use crate::ln::channelmanager;
-	use crate::ln::features::InvoiceFeatures;
+	use crate::ln::features::Bolt11InvoiceFeatures;
 	use crate::routing::gossip::NetworkGraph;
 	use crate::routing::scoring::{FixedPenaltyScorer, ProbabilisticScorer, ProbabilisticScoringFeeParameters, ProbabilisticScoringDecayParameters};
 	use crate::util::config::UserConfig;
@@ -6871,7 +6871,7 @@ pub mod benches {
 		let logger = TestLogger::new();
 		let network_graph = bench_utils::read_network_graph(&logger).unwrap();
 		let scorer = FixedPenaltyScorer::with_penalty(0);
-		generate_routes(bench, &network_graph, scorer, &(), InvoiceFeatures::empty(), 0,
+		generate_routes(bench, &network_graph, scorer, &(), Bolt11InvoiceFeatures::empty(), 0,
 			"generate_routes_with_zero_penalty_scorer");
 	}
 
@@ -6889,7 +6889,7 @@ pub mod benches {
 		let network_graph = bench_utils::read_network_graph(&logger).unwrap();
 		let params = ProbabilisticScoringFeeParameters::default();
 		let scorer = ProbabilisticScorer::new(ProbabilisticScoringDecayParameters::default(), &network_graph, &logger);
-		generate_routes(bench, &network_graph, scorer, &params, InvoiceFeatures::empty(), 0,
+		generate_routes(bench, &network_graph, scorer, &params, Bolt11InvoiceFeatures::empty(), 0,
 			"generate_routes_with_probabilistic_scorer");
 	}
 
@@ -6915,7 +6915,7 @@ pub mod benches {
 
 	fn generate_routes<S: Score>(
 		bench: &mut Criterion, graph: &NetworkGraph<&TestLogger>, mut scorer: S,
-		score_params: &S::ScoreParams, features: InvoiceFeatures, starting_amount: u64,
+		score_params: &S::ScoreParams, features: Bolt11InvoiceFeatures, starting_amount: u64,
 		bench_name: &'static str,
 	) {
 		let payer = bench_utils::payer_pubkey();

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -18,7 +18,7 @@ use crate::ln::PaymentHash;
 use crate::ln::channelmanager::{ChannelDetails, PaymentId};
 use crate::ln::features::{Bolt12InvoiceFeatures, ChannelFeatures, InvoiceFeatures, NodeFeatures};
 use crate::ln::msgs::{DecodeError, ErrorAction, LightningError, MAX_VALUE_MSAT};
-use crate::offers::invoice::{BlindedPayInfo, Invoice as Bolt12Invoice};
+use crate::offers::invoice::{BlindedPayInfo, Bolt12Invoice};
 use crate::routing::gossip::{DirectedChannelInfo, EffectiveCapacity, ReadOnlyNetworkGraph, NetworkGraph, NodeId, RoutingFees};
 use crate::routing::scoring::{ChannelUsage, LockableScore, Score};
 use crate::util::ser::{Writeable, Readable, ReadableArgs, Writer};
@@ -271,9 +271,9 @@ impl_writeable_tlv_based!(RouteHop, {
 });
 
 /// The blinded portion of a [`Path`], if we're routing to a recipient who provided blinded paths in
-/// their BOLT12 [`Invoice`].
+/// their [`Bolt12Invoice`].
 ///
-/// [`Invoice`]: crate::offers::invoice::Invoice
+/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct BlindedTail {
 	/// The hops of the [`BlindedPath`] provided by the recipient.


### PR DESCRIPTION
Qualifies BOLT 11/12 types such that there are no conflicts in bindings. This includes public types like `Invoice` and similar types (e.g., `RawInvoice`, `SignedRawInvoice`, and `UnsignedInvoice`) and error types (`ParseError` and `SemanticError`). However, it does not include types like `InvoiceRequest`, `InvoiceDescription`, `InvoiceSignature`, etc. nor types like `ParseOrSemanticError`, though there may be an argument for renaming some of these types, too.

Private types were not renamed. `InvoiceBuilder` types have not been renamed yet since they are not exported for bindings. Though they probably should be for consistency with the `Invoice` rename. Open to doing that in this PR.