### PR TITLE
Support signing BOLT 12 messages in `NodeSigner`

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -44,6 +44,8 @@ use lightning::ln::channel::FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE;
 use lightning::ln::msgs::{self, CommitmentUpdate, ChannelMessageHandler, DecodeError, UpdateAddHTLC, Init};
 use lightning::ln::script::ShutdownScript;
 use lightning::ln::functional_test_utils::*;
+use lightning::offers::invoice::UnsignedBolt12Invoice;
+use lightning::offers::invoice_request::UnsignedInvoiceRequest;
 use lightning::util::enforcing_trait_impls::{EnforcingSigner, EnforcementState};
 use lightning::util::errors::APIError;
 use lightning::util::logger::Logger;
@@ -57,6 +59,7 @@ use crate::utils::test_persister::TestPersister;
 use bitcoin::secp256k1::{Message, PublicKey, SecretKey, Scalar, Secp256k1};
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::{RecoverableSignature, Signature};
+use bitcoin::secp256k1::schnorr;
 
 use std::mem;
 use std::cmp::{self, Ordering};
@@ -208,6 +211,18 @@ impl NodeSigner for KeyProvider {
 	}
 
 	fn sign_invoice(&self, _hrp_bytes: &[u8], _invoice_data: &[u5], _recipient: Recipient) -> Result<RecoverableSignature, ()> {
+		unreachable!()
+	}
+
+	fn sign_bolt12_invoice_request(
+		&self, _invoice_request: &UnsignedInvoiceRequest
+	) -> Result<schnorr::Signature, ()> {
+		unreachable!()
+	}
+
+	fn sign_bolt12_invoice(
+		&self, _invoice: &UnsignedBolt12Invoice,
+	) -> Result<schnorr::Signature, ()> {
 		unreachable!()
 	}
 

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -40,6 +40,8 @@ use lightning::ln::peer_handler::{MessageHandler,PeerManager,SocketDescriptor,Ig
 use lightning::ln::msgs::{self, DecodeError};
 use lightning::ln::script::ShutdownScript;
 use lightning::ln::functional_test_utils::*;
+use lightning::offers::invoice::UnsignedBolt12Invoice;
+use lightning::offers::invoice_request::UnsignedInvoiceRequest;
 use lightning::routing::gossip::{P2PGossipSync, NetworkGraph};
 use lightning::routing::utxo::UtxoLookup;
 use lightning::routing::router::{InFlightHtlcs, PaymentParameters, Route, RouteParameters, Router};
@@ -55,6 +57,7 @@ use crate::utils::test_persister::TestPersister;
 use bitcoin::secp256k1::{Message, PublicKey, SecretKey, Scalar, Secp256k1};
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::{RecoverableSignature, Signature};
+use bitcoin::secp256k1::schnorr;
 
 use std::cell::RefCell;
 use hashbrown::{HashMap, hash_map};
@@ -313,6 +316,18 @@ impl NodeSigner for KeyProvider {
 	}
 
 	fn sign_invoice(&self, _hrp_bytes: &[u8], _invoice_data: &[u5], _recipient: Recipient) -> Result<RecoverableSignature, ()> {
+		unreachable!()
+	}
+
+	fn sign_bolt12_invoice_request(
+		&self, _invoice_request: &UnsignedInvoiceRequest
+	) -> Result<schnorr::Signature, ()> {
+		unreachable!()
+	}
+
+	fn sign_bolt12_invoice(
+		&self, _invoice: &UnsignedBolt12Invoice,
+	) -> Result<schnorr::Signature, ()> {
 		unreachable!()
 	}
 

--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -38,7 +38,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 			if signing_pubkey == odd_pubkey || signing_pubkey == even_pubkey {
 				unsigned_invoice
 					.sign::<_, Infallible>(
-						|digest| Ok(secp_ctx.sign_schnorr_no_aux_rand(digest, &keys))
+						|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
 					)
 					.unwrap()
 					.write(&mut buffer)
@@ -46,7 +46,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 			} else {
 				unsigned_invoice
 					.sign::<_, Infallible>(
-						|digest| Ok(secp_ctx.sign_schnorr_no_aux_rand(digest, &keys))
+						|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
 					)
 					.unwrap_err();
 			}
@@ -69,9 +69,9 @@ fn privkey(byte: u8) -> SecretKey {
 	SecretKey::from_slice(&[byte; 32]).unwrap()
 }
 
-fn build_response<'a, T: secp256k1::Signing + secp256k1::Verification>(
-	invoice_request: &'a InvoiceRequest, secp_ctx: &Secp256k1<T>
-) -> Result<UnsignedBolt12Invoice<'a>, Bolt12SemanticError> {
+fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
+	invoice_request: &InvoiceRequest, secp_ctx: &Secp256k1<T>
+) -> Result<UnsignedBolt12Invoice, Bolt12SemanticError> {
 	let entropy_source = Randomness {};
 	let paths = vec![
 		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], &entropy_source, secp_ctx).unwrap(),

--- a/fuzz/src/offer_deser.rs
+++ b/fuzz/src/offer_deser.rs
@@ -30,7 +30,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 		if let Ok(invoice_request) = build_response(&offer, pubkey) {
 			invoice_request
 				.sign::<_, Infallible>(
-					|digest| Ok(secp_ctx.sign_schnorr_no_aux_rand(digest, &keys))
+					|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
 				)
 				.unwrap()
 				.write(&mut buffer)
@@ -39,9 +39,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	}
 }
 
-fn build_response<'a>(
-	offer: &'a Offer, pubkey: PublicKey
-) -> Result<UnsignedInvoiceRequest<'a>, Bolt12SemanticError> {
+fn build_response(
+	offer: &Offer, pubkey: PublicKey
+) -> Result<UnsignedInvoiceRequest, Bolt12SemanticError> {
 	let mut builder = offer.request_invoice(vec![42; 64], pubkey)?;
 
 	builder = match offer.amount() {

--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -4,10 +4,13 @@ use bitcoin::blockdata::script::Script;
 use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey};
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::RecoverableSignature;
+use bitcoin::secp256k1::schnorr;
 
 use lightning::sign::{Recipient, KeyMaterial, EntropySource, NodeSigner, SignerProvider};
 use lightning::ln::msgs::{self, DecodeError, OnionMessageHandler};
 use lightning::ln::script::ShutdownScript;
+use lightning::offers::invoice::UnsignedBolt12Invoice;
+use lightning::offers::invoice_request::UnsignedInvoiceRequest;
 use lightning::util::enforcing_trait_impls::EnforcingSigner;
 use lightning::util::logger::Logger;
 use lightning::util::ser::{Readable, Writeable, Writer};
@@ -150,6 +153,18 @@ impl NodeSigner for KeyProvider {
 	fn get_inbound_payment_key_material(&self) -> KeyMaterial { unreachable!() }
 
 	fn sign_invoice(&self, _hrp_bytes: &[u8], _invoice_data: &[u5], _recipient: Recipient) -> Result<RecoverableSignature, ()> {
+		unreachable!()
+	}
+
+	fn sign_bolt12_invoice_request(
+		&self, _invoice_request: &UnsignedInvoiceRequest
+	) -> Result<schnorr::Signature, ()> {
+		unreachable!()
+	}
+
+	fn sign_bolt12_invoice(
+		&self, _invoice: &UnsignedBolt12Invoice,
+	) -> Result<schnorr::Signature, ()> {
 		unreachable!()
 	}
 

--- a/fuzz/src/refund_deser.rs
+++ b/fuzz/src/refund_deser.rs
@@ -34,7 +34,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 		if let Ok(invoice) = build_response(&refund, pubkey, &secp_ctx) {
 			invoice
 				.sign::<_, Infallible>(
-					|digest| Ok(secp_ctx.sign_schnorr_no_aux_rand(digest, &keys))
+					|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
 				)
 				.unwrap()
 				.write(&mut buffer)
@@ -58,9 +58,9 @@ fn privkey(byte: u8) -> SecretKey {
 	SecretKey::from_slice(&[byte; 32]).unwrap()
 }
 
-fn build_response<'a, T: secp256k1::Signing + secp256k1::Verification>(
-	refund: &'a Refund, signing_pubkey: PublicKey, secp_ctx: &Secp256k1<T>
-) -> Result<UnsignedBolt12Invoice<'a>, Bolt12SemanticError> {
+fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
+	refund: &Refund, signing_pubkey: PublicKey, secp_ctx: &Secp256k1<T>
+) -> Result<UnsignedBolt12Invoice, Bolt12SemanticError> {
 	let entropy_source = Randomness {};
 	let paths = vec![
 		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], &entropy_source, secp_ctx).unwrap(),

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -397,6 +397,11 @@ impl UnsignedBolt12Invoice {
 		Self { bytes, contents, tagged_hash }
 	}
 
+	/// Returns the [`TaggedHash`] of the invoice to sign.
+	pub fn tagged_hash(&self) -> &TaggedHash {
+		&self.tagged_hash
+	}
+
 	/// Signs the [`TaggedHash`] of the invoice using the given function.
 	///
 	/// Note: The hash computation may have included unknown, odd TLV records.

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -635,15 +635,15 @@ impl InvoiceRequestContents {
 		self.inner.chain()
 	}
 
-	fn amount_msats(&self) -> Option<u64> {
+	pub(super) fn amount_msats(&self) -> Option<u64> {
 		self.inner.amount_msats
 	}
 
-	fn features(&self) -> &InvoiceRequestFeatures {
+	pub(super) fn features(&self) -> &InvoiceRequestFeatures {
 		&self.inner.features
 	}
 
-	fn quantity(&self) -> Option<u64> {
+	pub(super) fn quantity(&self) -> Option<u64> {
 		self.inner.quantity
 	}
 
@@ -651,7 +651,7 @@ impl InvoiceRequestContents {
 		self.payer_id
 	}
 
-	fn payer_note(&self) -> Option<PrintableString> {
+	pub(super) fn payer_note(&self) -> Option<PrintableString> {
 		self.inner.payer_note.as_ref()
 			.map(|payer_note| PrintableString(payer_note.as_str()))
 	}

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -372,6 +372,11 @@ impl UnsignedInvoiceRequest {
 		Self { bytes, contents, tagged_hash }
 	}
 
+	/// Returns the [`TaggedHash`] of the invoice to sign.
+	pub fn tagged_hash(&self) -> &TaggedHash {
+		&self.tagged_hash
+	}
+
 	/// Signs the [`TaggedHash`] of the invoice request using the given function.
 	///
 	/// Note: The hash computation may have included unknown, odd TLV records.

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -460,29 +460,28 @@ impl InvoiceRequest {
 	///
 	/// [`chain`]: Self::chain
 	pub fn amount_msats(&self) -> Option<u64> {
-		self.contents.inner.amount_msats
+		self.contents.amount_msats()
 	}
 
 	/// Features pertaining to requesting an invoice.
 	pub fn features(&self) -> &InvoiceRequestFeatures {
-		&self.contents.inner.features
+		&self.contents.features()
 	}
 
 	/// The quantity of the offer's item conforming to [`Offer::is_valid_quantity`].
 	pub fn quantity(&self) -> Option<u64> {
-		self.contents.inner.quantity
+		self.contents.quantity()
 	}
 
 	/// A possibly transient pubkey used to sign the invoice request.
 	pub fn payer_id(&self) -> PublicKey {
-		self.contents.payer_id
+		self.contents.payer_id()
 	}
 
 	/// A payer-provided note which will be seen by the recipient and reflected back in the invoice
 	/// response.
 	pub fn payer_note(&self) -> Option<PrintableString> {
-		self.contents.inner.payer_note.as_ref()
-			.map(|payer_note| PrintableString(payer_note.as_str()))
+		self.contents.payer_note()
 	}
 
 	/// Signature of the invoice request using [`payer_id`].
@@ -626,8 +625,25 @@ impl InvoiceRequestContents {
 		self.inner.chain()
 	}
 
+	fn amount_msats(&self) -> Option<u64> {
+		self.inner.amount_msats
+	}
+
+	fn features(&self) -> &InvoiceRequestFeatures {
+		&self.inner.features
+	}
+
+	fn quantity(&self) -> Option<u64> {
+		self.inner.quantity
+	}
+
 	pub(super) fn payer_id(&self) -> PublicKey {
 		self.payer_id
+	}
+
+	fn payer_note(&self) -> Option<PrintableString> {
+		self.inner.payer_note.as_ref()
+			.map(|payer_note| PrintableString(payer_note.as_str()))
 	}
 
 	pub(super) fn as_tlv_stream(&self) -> PartialInvoiceRequestTlvStreamRef {

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -88,17 +88,15 @@ where
 	Ok(signature)
 }
 
-/// Verifies the signature with a pubkey over the given bytes using a tagged hash as the message
+/// Verifies the signature with a pubkey over the given message using a tagged hash as the message
 /// digest.
-///
-/// Panics if `bytes` is not a well-formed TLV stream containing at least one TLV record.
 pub(super) fn verify_signature(
-	signature: &Signature, tag: &str, bytes: &[u8], pubkey: PublicKey,
+	signature: &Signature, message: TaggedHash, pubkey: PublicKey,
 ) -> Result<(), secp256k1::Error> {
-	let digest = message_digest(tag, bytes);
+	let digest = message.as_digest();
 	let pubkey = pubkey.into();
 	let secp_ctx = Secp256k1::verification_only();
-	secp_ctx.verify_schnorr(signature, &digest, &pubkey)
+	secp_ctx.verify_schnorr(signature, digest, &pubkey)
 }
 
 pub(super) fn message_digest(tag: &str, bytes: &[u8]) -> Message {

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -30,6 +30,7 @@ tlv_stream!(SignatureTlvStream, SignatureTlvStreamRef, SIGNATURE_TYPES, {
 ///
 /// [BIP 340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 /// [BOLT 12]: https://github.com/rustyrussell/lightning-rfc/blob/guilt/offers/12-offer-encoding.md#signature-calculation
+#[derive(Debug, PartialEq)]
 pub struct TaggedHash(Message);
 
 impl TaggedHash {

--- a/lightning/src/offers/mod.rs
+++ b/lightning/src/offers/mod.rs
@@ -15,7 +15,7 @@
 pub mod invoice;
 pub mod invoice_error;
 pub mod invoice_request;
-mod merkle;
+pub mod merkle;
 pub mod offer;
 pub mod parse;
 mod payer;

--- a/lightning/src/offers/mod.rs
+++ b/lightning/src/offers/mod.rs
@@ -12,11 +12,13 @@
 //!
 //! Offers are a flexible protocol for Lightning payments.
 
+#[macro_use]
+pub mod offer;
+
 pub mod invoice;
 pub mod invoice_error;
 pub mod invoice_request;
 pub mod merkle;
-pub mod offer;
 pub mod parse;
 mod payer;
 pub mod refund;

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -398,14 +398,14 @@ impl Offer {
 
 	/// Features pertaining to the offer.
 	pub fn features(&self) -> &OfferFeatures {
-		&self.contents.features
+		&self.contents.features()
 	}
 
 	/// Duration since the Unix epoch when an invoice should no longer be requested.
 	///
 	/// If `None`, the offer does not expire.
 	pub fn absolute_expiry(&self) -> Option<Duration> {
-		self.contents.absolute_expiry
+		self.contents.absolute_expiry()
 	}
 
 	/// Whether the offer has expired.
@@ -417,13 +417,13 @@ impl Offer {
 	/// The issuer of the offer, possibly beginning with `user@domain` or `domain`. Intended to be
 	/// displayed to the user but with the caveat that it has not been verified in any way.
 	pub fn issuer(&self) -> Option<PrintableString> {
-		self.contents.issuer.as_ref().map(|issuer| PrintableString(issuer.as_str()))
+		self.contents.issuer()
 	}
 
 	/// Paths to the recipient originating from publicly reachable nodes. Blinded paths provide
 	/// recipient privacy by obfuscating its node id.
 	pub fn paths(&self) -> &[BlindedPath] {
-		self.contents.paths.as_ref().map(|paths| paths.as_slice()).unwrap_or(&[])
+		self.contents.paths()
 	}
 
 	/// The quantity of items supported.
@@ -551,8 +551,20 @@ impl OfferContents {
 		self.metadata.as_ref().and_then(|metadata| metadata.as_bytes())
 	}
 
+	pub fn amount(&self) -> Option<&Amount> {
+		self.amount.as_ref()
+	}
+
 	pub fn description(&self) -> PrintableString {
 		PrintableString(&self.description)
+	}
+
+	pub fn features(&self) -> &OfferFeatures {
+		&self.features
+	}
+
+	pub fn absolute_expiry(&self) -> Option<Duration> {
+		self.absolute_expiry
 	}
 
 	#[cfg(feature = "std")]
@@ -566,8 +578,12 @@ impl OfferContents {
 		}
 	}
 
-	pub fn amount(&self) -> Option<&Amount> {
-		self.amount.as_ref()
+	pub fn issuer(&self) -> Option<PrintableString> {
+		self.issuer.as_ref().map(|issuer| PrintableString(issuer.as_str()))
+	}
+
+	pub fn paths(&self) -> &[BlindedPath] {
+		self.paths.as_ref().map(|paths| paths.as_slice()).unwrap_or(&[])
 	}
 
 	pub(super) fn check_amount_msats_for_quantity(

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -455,16 +455,16 @@ impl Offer {
 	/// Similar to [`Offer::request_invoice`] except it:
 	/// - derives the [`InvoiceRequest::payer_id`] such that a different key can be used for each
 	///   request, and
-	/// - sets the [`InvoiceRequest::metadata`] when [`InvoiceRequestBuilder::build`] is called such
-	///   that it can be used by [`Bolt12Invoice::verify`] to determine if the invoice was requested
-	///   using a base [`ExpandedKey`] from which the payer id was derived.
+	/// - sets the [`InvoiceRequest::payer_metadata`] when [`InvoiceRequestBuilder::build`] is
+	///   called such that it can be used by [`Bolt12Invoice::verify`] to determine if the invoice
+	///   was requested using a base [`ExpandedKey`] from which the payer id was derived.
 	///
 	/// Useful to protect the sender's privacy.
 	///
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// [`InvoiceRequest::payer_id`]: crate::offers::invoice_request::InvoiceRequest::payer_id
-	/// [`InvoiceRequest::metadata`]: crate::offers::invoice_request::InvoiceRequest::metadata
+	/// [`InvoiceRequest::payer_metadata`]: crate::offers::invoice_request::InvoiceRequest::payer_metadata
 	/// [`Bolt12Invoice::verify`]: crate::offers::invoice::Bolt12Invoice::verify
 	/// [`ExpandedKey`]: crate::ln::inbound_payment::ExpandedKey
 	pub fn request_invoice_deriving_payer_id<'a, 'b, ES: Deref, T: secp256k1::Signing>(

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -358,16 +358,72 @@ pub(super) struct OfferContents {
 	signing_pubkey: PublicKey,
 }
 
-impl Offer {
+macro_rules! offer_accessors { ($self: ident, $contents: expr) => {
 	// TODO: Return a slice once ChainHash has constants.
 	// - https://github.com/rust-bitcoin/rust-bitcoin/pull/1283
 	// - https://github.com/rust-bitcoin/rust-bitcoin/pull/1286
 	/// The chains that may be used when paying a requested invoice (e.g., bitcoin mainnet).
 	/// Payments must be denominated in units of the minimal lightning-payable unit (e.g., msats)
 	/// for the selected chain.
-	pub fn chains(&self) -> Vec<ChainHash> {
-		self.contents.chains()
+	pub fn chains(&$self) -> Vec<$crate::bitcoin::blockdata::constants::ChainHash> {
+		$contents.chains()
 	}
+
+	// TODO: Link to corresponding method in `InvoiceRequest`.
+	/// Opaque bytes set by the originator. Useful for authentication and validating fields since it
+	/// is reflected in `invoice_request` messages along with all the other fields from the `offer`.
+	pub fn metadata(&$self) -> Option<&Vec<u8>> {
+		$contents.metadata()
+	}
+
+	/// The minimum amount required for a successful payment of a single item.
+	pub fn amount(&$self) -> Option<&$crate::offers::offer::Amount> {
+		$contents.amount()
+	}
+
+	/// A complete description of the purpose of the payment. Intended to be displayed to the user
+	/// but with the caveat that it has not been verified in any way.
+	pub fn description(&$self) -> $crate::util::string::PrintableString {
+		$contents.description()
+	}
+
+	/// Features pertaining to the offer.
+	pub fn offer_features(&$self) -> &$crate::ln::features::OfferFeatures {
+		&$contents.features()
+	}
+
+	/// Duration since the Unix epoch when an invoice should no longer be requested.
+	///
+	/// If `None`, the offer does not expire.
+	pub fn absolute_expiry(&$self) -> Option<core::time::Duration> {
+		$contents.absolute_expiry()
+	}
+
+	/// The issuer of the offer, possibly beginning with `user@domain` or `domain`. Intended to be
+	/// displayed to the user but with the caveat that it has not been verified in any way.
+	pub fn issuer(&$self) -> Option<$crate::util::string::PrintableString> {
+		$contents.issuer()
+	}
+
+	/// Paths to the recipient originating from publicly reachable nodes. Blinded paths provide
+	/// recipient privacy by obfuscating its node id.
+	pub fn paths(&$self) -> &[$crate::blinded_path::BlindedPath] {
+		$contents.paths()
+	}
+
+	/// The quantity of items supported.
+	pub fn supported_quantity(&$self) -> $crate::offers::offer::Quantity {
+		$contents.supported_quantity()
+	}
+
+	/// The public key used by the recipient to sign invoices.
+	pub fn signing_pubkey(&$self) -> $crate::bitcoin::secp256k1::PublicKey {
+		$contents.signing_pubkey()
+	}
+} }
+
+impl Offer {
+	offer_accessors!(self, self.contents);
 
 	pub(super) fn implied_chain(&self) -> ChainHash {
 		self.contents.implied_chain()
@@ -378,57 +434,10 @@ impl Offer {
 		self.contents.supports_chain(chain)
 	}
 
-	// TODO: Link to corresponding method in `InvoiceRequest`.
-	/// Opaque bytes set by the originator. Useful for authentication and validating fields since it
-	/// is reflected in `invoice_request` messages along with all the other fields from the `offer`.
-	pub fn metadata(&self) -> Option<&Vec<u8>> {
-		self.contents.metadata()
-	}
-
-	/// The minimum amount required for a successful payment of a single item.
-	pub fn amount(&self) -> Option<&Amount> {
-		self.contents.amount()
-	}
-
-	/// A complete description of the purpose of the payment. Intended to be displayed to the user
-	/// but with the caveat that it has not been verified in any way.
-	pub fn description(&self) -> PrintableString {
-		self.contents.description()
-	}
-
-	/// Features pertaining to the offer.
-	pub fn features(&self) -> &OfferFeatures {
-		&self.contents.features()
-	}
-
-	/// Duration since the Unix epoch when an invoice should no longer be requested.
-	///
-	/// If `None`, the offer does not expire.
-	pub fn absolute_expiry(&self) -> Option<Duration> {
-		self.contents.absolute_expiry()
-	}
-
 	/// Whether the offer has expired.
 	#[cfg(feature = "std")]
 	pub fn is_expired(&self) -> bool {
 		self.contents.is_expired()
-	}
-
-	/// The issuer of the offer, possibly beginning with `user@domain` or `domain`. Intended to be
-	/// displayed to the user but with the caveat that it has not been verified in any way.
-	pub fn issuer(&self) -> Option<PrintableString> {
-		self.contents.issuer()
-	}
-
-	/// Paths to the recipient originating from publicly reachable nodes. Blinded paths provide
-	/// recipient privacy by obfuscating its node id.
-	pub fn paths(&self) -> &[BlindedPath] {
-		self.contents.paths()
-	}
-
-	/// The quantity of items supported.
-	pub fn supported_quantity(&self) -> Quantity {
-		self.contents.supported_quantity()
 	}
 
 	/// Returns whether the given quantity is valid for the offer.
@@ -441,11 +450,6 @@ impl Offer {
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	pub fn expects_quantity(&self) -> bool {
 		self.contents.expects_quantity()
-	}
-
-	/// The public key used by the recipient to sign invoices.
-	pub fn signing_pubkey(&self) -> PublicKey {
-		self.contents.signing_pubkey()
 	}
 
 	/// Similar to [`Offer::request_invoice`] except it:
@@ -469,7 +473,7 @@ impl Offer {
 	where
 		ES::Target: EntropySource,
 	{
-		if self.features().requires_unknown_bits() {
+		if self.offer_features().requires_unknown_bits() {
 			return Err(Bolt12SemanticError::UnknownRequiredFeatures);
 		}
 
@@ -490,7 +494,7 @@ impl Offer {
 	where
 		ES::Target: EntropySource,
 	{
-		if self.features().requires_unknown_bits() {
+		if self.offer_features().requires_unknown_bits() {
 			return Err(Bolt12SemanticError::UnknownRequiredFeatures);
 		}
 
@@ -515,7 +519,7 @@ impl Offer {
 	pub fn request_invoice(
 		&self, metadata: Vec<u8>, payer_id: PublicKey
 	) -> Result<InvoiceRequestBuilder<ExplicitPayerId, secp256k1::SignOnly>, Bolt12SemanticError> {
-		if self.features().requires_unknown_bits() {
+		if self.offer_features().requires_unknown_bits() {
 			return Err(Bolt12SemanticError::UnknownRequiredFeatures);
 		}
 
@@ -890,7 +894,7 @@ mod tests {
 		assert_eq!(offer.metadata(), None);
 		assert_eq!(offer.amount(), None);
 		assert_eq!(offer.description(), PrintableString("foo"));
-		assert_eq!(offer.features(), &OfferFeatures::empty());
+		assert_eq!(offer.offer_features(), &OfferFeatures::empty());
 		assert_eq!(offer.absolute_expiry(), None);
 		#[cfg(feature = "std")]
 		assert!(!offer.is_expired());
@@ -1131,7 +1135,7 @@ mod tests {
 			.features_unchecked(OfferFeatures::unknown())
 			.build()
 			.unwrap();
-		assert_eq!(offer.features(), &OfferFeatures::unknown());
+		assert_eq!(offer.offer_features(), &OfferFeatures::unknown());
 		assert_eq!(offer.as_tlv_stream().features, Some(&OfferFeatures::unknown()));
 
 		let offer = OfferBuilder::new("foo".into(), pubkey(42))
@@ -1139,7 +1143,7 @@ mod tests {
 			.features_unchecked(OfferFeatures::empty())
 			.build()
 			.unwrap();
-		assert_eq!(offer.features(), &OfferFeatures::empty());
+		assert_eq!(offer.offer_features(), &OfferFeatures::empty());
 		assert_eq!(offer.as_tlv_stream().features, None);
 	}
 

--- a/lightning/src/offers/payer.rs
+++ b/lightning/src/offers/payer.rs
@@ -22,9 +22,9 @@ use crate::prelude::*;
 #[cfg_attr(test, derive(PartialEq))]
 pub(super) struct PayerContents(pub Metadata);
 
-/// TLV record type for [`InvoiceRequest::metadata`] and [`Refund::metadata`].
+/// TLV record type for [`InvoiceRequest::payer_metadata`] and [`Refund::metadata`].
 ///
-/// [`InvoiceRequest::metadata`]: crate::offers::invoice_request::InvoiceRequest::metadata
+/// [`InvoiceRequest::payer_metadata`]: crate::offers::invoice_request::InvoiceRequest::payer_metadata
 /// [`Refund::metadata`]: crate::offers::refund::Refund::metadata
 pub(super) const PAYER_METADATA_TYPE: u64 = 0;
 

--- a/lightning/src/offers/payer.rs
+++ b/lightning/src/offers/payer.rs
@@ -22,10 +22,10 @@ use crate::prelude::*;
 #[cfg_attr(test, derive(PartialEq))]
 pub(super) struct PayerContents(pub Metadata);
 
-/// TLV record type for [`InvoiceRequest::payer_metadata`] and [`Refund::metadata`].
+/// TLV record type for [`InvoiceRequest::payer_metadata`] and [`Refund::payer_metadata`].
 ///
 /// [`InvoiceRequest::payer_metadata`]: crate::offers::invoice_request::InvoiceRequest::payer_metadata
-/// [`Refund::metadata`]: crate::offers::refund::Refund::metadata
+/// [`Refund::payer_metadata`]: crate::offers::refund::Refund::payer_metadata
 pub(super) const PAYER_METADATA_TYPE: u64 = 0;
 
 tlv_stream!(PayerTlvStream, PayerTlvStreamRef, 0..1, {

--- a/lightning/src/offers/test_utils.rs
+++ b/lightning/src/offers/test_utils.rs
@@ -9,25 +9,26 @@
 
 //! Utilities for testing BOLT 12 Offers interfaces
 
-use bitcoin::secp256k1::{KeyPair, Message, PublicKey, Secp256k1, SecretKey};
+use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, SecretKey};
 use bitcoin::secp256k1::schnorr::Signature;
-use core::convert::Infallible;
+use core::convert::{AsRef, Infallible};
 use core::time::Duration;
 use crate::blinded_path::{BlindedHop, BlindedPath};
 use crate::sign::EntropySource;
 use crate::ln::PaymentHash;
 use crate::ln::features::BlindedHopFeatures;
 use crate::offers::invoice::BlindedPayInfo;
+use crate::offers::merkle::TaggedHash;
 
 pub(super) fn payer_keys() -> KeyPair {
 	let secp_ctx = Secp256k1::new();
 	KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap())
 }
 
-pub(super) fn payer_sign(digest: &Message) -> Result<Signature, Infallible> {
+pub(super) fn payer_sign<T: AsRef<TaggedHash>>(message: &T) -> Result<Signature, Infallible> {
 	let secp_ctx = Secp256k1::new();
 	let keys = KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
-	Ok(secp_ctx.sign_schnorr_no_aux_rand(digest, &keys))
+	Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
 }
 
 pub(super) fn payer_pubkey() -> PublicKey {
@@ -39,10 +40,10 @@ pub(super) fn recipient_keys() -> KeyPair {
 	KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[43; 32]).unwrap())
 }
 
-pub(super) fn recipient_sign(digest: &Message) -> Result<Signature, Infallible> {
+pub(super) fn recipient_sign<T: AsRef<TaggedHash>>(message: &T) -> Result<Signature, Infallible> {
 	let secp_ctx = Secp256k1::new();
 	let keys = KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[43; 32]).unwrap());
-	Ok(secp_ctx.sign_schnorr_no_aux_rand(digest, &keys))
+	Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
 }
 
 pub(super) fn recipient_pubkey() -> PublicKey {

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -652,7 +652,7 @@ impl PaymentParameters {
 	/// [`PaymentParameters::expiry_time`].
 	pub fn from_bolt12_invoice(invoice: &Bolt12Invoice) -> Self {
 		Self::blinded(invoice.payment_paths().to_vec())
-			.with_bolt12_features(invoice.features().clone()).unwrap()
+			.with_bolt12_features(invoice.invoice_features().clone()).unwrap()
 			.with_expiry_time(invoice.created_at().as_secs().saturating_add(invoice.relative_expiry().as_secs()))
 	}
 

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -26,10 +26,9 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::hash_types::WPubkeyHash;
 
-use bitcoin::secp256k1::{SecretKey, PublicKey, Scalar};
-use bitcoin::secp256k1::{Secp256k1, ecdsa::Signature, Signing};
+use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey, Signing};
 use bitcoin::secp256k1::ecdh::SharedSecret;
-use bitcoin::secp256k1::ecdsa::RecoverableSignature;
+use bitcoin::secp256k1::ecdsa::{RecoverableSignature, Signature};
 use bitcoin::{PackedLockTime, secp256k1, Sequence, Witness};
 
 use crate::util::transaction_utils;

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -44,9 +44,9 @@ use bitcoin::network::constants::Network;
 use bitcoin::hash_types::{BlockHash, Txid};
 use bitcoin::util::sighash::SighashCache;
 
-use bitcoin::secp256k1::{SecretKey, PublicKey, Secp256k1, ecdsa::Signature, Scalar};
+use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey};
 use bitcoin::secp256k1::ecdh::SharedSecret;
-use bitcoin::secp256k1::ecdsa::RecoverableSignature;
+use bitcoin::secp256k1::ecdsa::{RecoverableSignature, Signature};
 
 #[cfg(any(test, feature = "_test_utils"))]
 use regex;

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -24,6 +24,8 @@ use crate::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 use crate::ln::{msgs, wire};
 use crate::ln::msgs::LightningError;
 use crate::ln::script::ShutdownScript;
+use crate::offers::invoice::UnsignedBolt12Invoice;
+use crate::offers::invoice_request::UnsignedInvoiceRequest;
 use crate::routing::gossip::{EffectiveCapacity, NetworkGraph, NodeId};
 use crate::routing::utxo::{UtxoLookup, UtxoLookupError, UtxoResult};
 use crate::routing::router::{find_route, InFlightHtlcs, Path, Route, RouteParameters, Router, ScorerAccountingForInFlightHtlcs};
@@ -47,6 +49,7 @@ use bitcoin::util::sighash::SighashCache;
 use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey};
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::{RecoverableSignature, Signature};
+use bitcoin::secp256k1::schnorr;
 
 #[cfg(any(test, feature = "_test_utils"))]
 use regex;
@@ -800,6 +803,18 @@ impl NodeSigner for TestNodeSigner {
 		unreachable!()
 	}
 
+	fn sign_bolt12_invoice_request(
+		&self, _invoice_request: &UnsignedInvoiceRequest
+	) -> Result<schnorr::Signature, ()> {
+		unreachable!()
+	}
+
+	fn sign_bolt12_invoice(
+		&self, _invoice: &UnsignedBolt12Invoice,
+	) -> Result<schnorr::Signature, ()> {
+		unreachable!()
+	}
+
 	fn sign_gossip_message(&self, _msg: msgs::UnsignedGossipMessage) -> Result<Signature, ()> {
 		unreachable!()
 	}
@@ -838,6 +853,18 @@ impl NodeSigner for TestKeysInterface {
 
 	fn sign_invoice(&self, hrp_bytes: &[u8], invoice_data: &[u5], recipient: Recipient) -> Result<RecoverableSignature, ()> {
 		self.backing.sign_invoice(hrp_bytes, invoice_data, recipient)
+	}
+
+	fn sign_bolt12_invoice_request(
+		&self, invoice_request: &UnsignedInvoiceRequest
+	) -> Result<schnorr::Signature, ()> {
+		self.backing.sign_bolt12_invoice_request(invoice_request)
+	}
+
+	fn sign_bolt12_invoice(
+		&self, invoice: &UnsignedBolt12Invoice,
+	) -> Result<schnorr::Signature, ()> {
+		self.backing.sign_bolt12_invoice(invoice)
 	}
 
 	fn sign_gossip_message(&self, msg: msgs::UnsignedGossipMessage) -> Result<Signature, ()> {


### PR DESCRIPTION
BOLT 12 messages need to be signed in the following scenarios:
- constructing an `InvoiceRequest` after scanning an `Offer`,
- constructing an `Invoice` after scanning a `Refund`, and
- constructing an `Invoice` when handling an `InvoiceRequest`.

Extend the `NodeSigner` trait to support signing BOLT 12 messages such that it can be used in these contexts. The method could be used then in an `OffersMessageHandler` when keys aren't derived from the offer or payer metadata.

Taken from #2371.