### PR TITLE
Clarify `cargo bench` sample prompt

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,6 +1,6 @@
 This crate uses criterion to benchmark various LDK functions.
 
-It can be run as `RUSTFLAGS=--cfg=ldk_bench cargo bench`.
+It can be run as `RUSTFLAGS=--cfg=ldk_bench cargo bench --features=criterion`.
 
 For routing or other HashMap-bottlenecked functions, the `hashbrown` feature
 should also be benchmarked.


### PR DESCRIPTION
Criterion will only be found if the `criterion` feature is enabled. We therefore add it to the sample prompt given in the readme.