### PR TITLE
Add fee-bumping reserves recommendations for anchor channels

### DIFF
--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -152,6 +152,7 @@ pub struct ChannelHandshakeConfig {
 	/// If set, we attempt to negotiate the `anchors_zero_fee_htlc_tx`option for all future
 	/// channels. This feature requires having a reserve of onchain funds readily available to bump
 	/// transactions in the event of a channel force close to avoid the possibility of losing funds.
+	/// The level of reserve maintained might follow the recommendations in [`bump_transaction`].
 	///
 	/// Note that if you wish accept inbound channels with anchor outputs, you must enable
 	/// [`UserConfig::manually_accept_inbound_channels`] and manually accept them with


### PR DESCRIPTION
This PR introduces recommendations for the fee-bumping reserves that a LDK user using anchor outputs channels is required to maintain in a future where `update_fee` as a fee-updating mechanism is deprecated, or its impact reduced.

The recommendations are given on an indicative title only, and in no way are compulsive. Recommendations are conservative for the worst-case of the routing hop, one might have to envision lower level of thresholds if the channels are with “semi-trusted” peers, HTLC forwarding is blocked or fee-bumping is relied on a blessed third-party (e.g a LSP).

While the soundest recommendations might be translated in code default in the future, I think (and hope) this documentation will be always hopeful for LDK users integrating their own wallets with our fee-bumping traits like `CoinSelectionSource` or `WalletSource`.