### PR TITLE
Expose more intercepted htlc details

### DIFF
--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -1623,7 +1623,7 @@ fn do_test_intercepted_payment(test: InterceptTest) {
 	assert_eq!(events.len(), 1);
 	let (intercept_id, expected_outbound_amount_msat) = match events[0] {
 		crate::events::Event::HTLCIntercepted {
-			intercept_id, expected_outbound_amount_msat, payment_hash: pmt_hash, inbound_amount_msat, requested_next_hop_scid: short_channel_id
+			intercept_id, expected_outbound_amount_msat, payment_hash: pmt_hash, inbound_amount_msat, requested_next_hop_scid: short_channel_id, ..
 		} => {
 			assert_eq!(pmt_hash, payment_hash);
 			assert_eq!(inbound_amount_msat, route.get_total_amount() + route.get_total_fees());


### PR DESCRIPTION
This exposes the onion packet and outgoing_cltv for intercepted HTLCs.  The latest LSPS4 proposal requires the LSP have access to this information so it can forward it to the client out-of-band of the normal update_add_htlc flow.

See this section for more details: https://github.com/BitcoinAndLightningLayerSpecs/lsp/blob/8a3ad1d4c8e6c0f1849fa6e59163e48c431ae74a/LSPS4/README.md#3-pending-payment-part-notification