### PR TITLE
(Minor) Remove an unused import (ChannelSigner)

### DIFF
--- a/lightning/src/events/bump_transaction.rs
+++ b/lightning/src/events/bump_transaction.rs
@@ -26,7 +26,7 @@ use crate::ln::chan_utils::{
 use crate::ln::features::ChannelTypeFeatures;
 use crate::ln::PaymentPreimage;
 use crate::prelude::*;
-use crate::sign::{ChannelSigner, EcdsaChannelSigner, SignerProvider, WriteableEcdsaChannelSigner};
+use crate::sign::{EcdsaChannelSigner, SignerProvider, WriteableEcdsaChannelSigner};
 use crate::sync::Mutex;
 use crate::util::logger::Logger;
 


### PR DESCRIPTION
One-liner fix for an unused import warning.
Remove unused import `sign::ChannelSigner`.

Rids the following compiler warning:
```
warning: unused import: `ChannelSigner`
  --> lightning/src/events/bump_transaction.rs:29:19
   |
29 | use crate::sign::{ChannelSigner, EcdsaChannelSigner, SignerProvider, WriteableEcdsaChannelSigner};
   |                   ^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```
