### PR TITLE
Flip keysend feature bit on

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7426,7 +7426,9 @@ where
 /// Fetches the set of [`NodeFeatures`] flags which are provided by or required by
 /// [`ChannelManager`].
 pub(crate) fn provided_node_features(config: &UserConfig) -> NodeFeatures {
-	provided_init_features(config).to_context()
+	let mut node_features = provided_init_features(config).to_context();
+	node_features.set_keysend_optional();
+	node_features
 }
 
 /// Fetches the set of [`Bolt11InvoiceFeatures`] flags which are provided by or required by


### PR DESCRIPTION
Keysend seems to be the only feature bit that's in the node context and not the init context, so whenever we switched to providing the default init feature bits as our node feature bits, we must've left out keysend!