### PR TITLE
Fix keysend not being sent in `OutboundPayment::send_payment_internal`

### DIFF
--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -684,7 +684,7 @@ impl OutboundPayments {
 			Some(route_params.payment_params.clone()), entropy_source, best_block_height)
 			.map_err(|_| RetryableSendFailure::DuplicatePayment)?;
 
-		let res = self.pay_route_internal(&route, payment_hash, recipient_onion, None, payment_id, None,
+		let res = self.pay_route_internal(&route, payment_hash, recipient_onion, keysend_preimage, payment_id, None,
 			onion_session_privs, node_signer, best_block_height, &send_payment_along_path);
 		log_info!(logger, "Result sending payment with id {}: {:?}", log_bytes!(payment_id.0), res);
 		if let Err(e) = res {

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -237,6 +237,73 @@ fn mpp_receive_timeout() {
 }
 
 #[test]
+fn test_keysend_payments_to_public_node() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let _chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 10001);
+	let network_graph = nodes[0].network_graph.clone();
+	let payer_pubkey = nodes[0].node.get_our_node_id();
+	let payee_pubkey = nodes[1].node.get_our_node_id();
+	let route_params = RouteParameters {
+		payment_params: PaymentParameters::for_keysend(payee_pubkey, 40, false),
+		final_value_msat: 10000,
+	};
+	let scorer = test_utils::TestScorer::new();
+	let random_seed_bytes = chanmon_cfgs[1].keys_manager.get_secure_random_bytes();
+	let route = find_route(&payer_pubkey, &route_params, &network_graph, None, nodes[0].logger, &scorer, &(), &random_seed_bytes).unwrap();
+
+	let test_preimage = PaymentPreimage([42; 32]);
+	let payment_hash = nodes[0].node.send_spontaneous_payment(&route, Some(test_preimage),
+		RecipientOnionFields::spontaneous_empty(), PaymentId(test_preimage.0)).unwrap();
+	check_added_monitors!(nodes[0], 1);
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let event = events.pop().unwrap();
+	let path = vec![&nodes[1]];
+	pass_along_path(&nodes[0], &path, 10000, payment_hash, None, event, true, Some(test_preimage));
+	claim_payment(&nodes[0], &path, test_preimage);
+}
+
+#[test]
+fn test_keysend_payments_to_private_node() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let payer_pubkey = nodes[0].node.get_our_node_id();
+	let payee_pubkey = nodes[1].node.get_our_node_id();
+
+	let _chan = create_chan_between_nodes(&nodes[0], &nodes[1]);
+	let route_params = RouteParameters {
+		payment_params: PaymentParameters::for_keysend(payee_pubkey, 40, false),
+		final_value_msat: 10000,
+	};
+	let network_graph = nodes[0].network_graph.clone();
+	let first_hops = nodes[0].node.list_usable_channels();
+	let scorer = test_utils::TestScorer::new();
+	let random_seed_bytes = chanmon_cfgs[1].keys_manager.get_secure_random_bytes();
+	let route = find_route(
+		&payer_pubkey, &route_params, &network_graph, Some(&first_hops.iter().collect::<Vec<_>>()),
+		nodes[0].logger, &scorer, &(), &random_seed_bytes
+	).unwrap();
+
+	let test_preimage = PaymentPreimage([42; 32]);
+	let payment_hash = nodes[0].node.send_spontaneous_payment(&route, Some(test_preimage),
+		RecipientOnionFields::spontaneous_empty(), PaymentId(test_preimage.0)).unwrap();
+	check_added_monitors!(nodes[0], 1);
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let event = events.pop().unwrap();
+	let path = vec![&nodes[1]];
+	pass_along_path(&nodes[0], &path, 10000, payment_hash, None, event, true, Some(test_preimage));
+	claim_payment(&nodes[0], &path, test_preimage);
+}
+
+#[test]
 fn test_mpp_keysend() {
 	let mut mpp_keysend_config = test_default_channel_config();
 	mpp_keysend_config.accept_mpp_keysend = true;


### PR DESCRIPTION
Following up on #2465. I kept thinking that it doesn't make sense that we'd reject a keysend payment based on our feature bit not being set. After some digging, I found the issue was that we weren't sending the preimage.