### PR TITLE
Make `Time` public

### DIFF
--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -21,6 +21,7 @@ pub mod message_signing;
 pub mod invoice;
 pub mod persist;
 pub mod string;
+pub mod time;
 pub mod wakers;
 
 pub(crate) mod atomic_counter;
@@ -35,7 +36,6 @@ pub(crate) mod poly1305;
 pub(crate) mod chacha20poly1305rfc;
 pub(crate) mod transaction_utils;
 pub(crate) mod scid_utils;
-pub(crate) mod time;
 
 pub mod indexed_map;
 

--- a/lightning/src/util/time.rs
+++ b/lightning/src/util/time.rs
@@ -60,6 +60,7 @@ impl Sub<Duration> for Eternity {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg(not(feature = "no-std"))]
+/// Tracts time monotonically, but may go backwards in time if the system clock is adjusted.
 pub struct MonotonicTime(std::time::Instant);
 
 /// The amount of time to shift `Instant` forward to prevent overflow when subtracting a `Duration`


### PR DESCRIPTION
If we make `Time` public, this allows for other libraries to implement the handling of time themselves. This could be nice for things like wasm where we can't use the standard library to get the time, but we sitll have access to the time through other libraries.