### PR TITLE
[minor] Fix wrong msg type in SendTxAbort, typo

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -1667,7 +1667,7 @@ pub enum MessageSendEvent {
 		/// The node_id of the node which should receive this message
 		node_id: PublicKey,
 		/// The message which should be sent.
-		msg: msgs::TxAddInput,
+		msg: msgs::TxAbort,
 	},
 	/// Used to indicate that a channel_ready message should be sent to the peer with the given node_id.
 	SendChannelReady {

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -1229,7 +1229,7 @@ pub trait ChannelMessageHandler : MessageSendEventsProvider {
 	/// Handle an incoming `channel_ready` message from the given peer.
 	fn handle_channel_ready(&self, their_node_id: &PublicKey, msg: &ChannelReady);
 
-	// Channl close:
+	// Channel close:
 	/// Handle an incoming `shutdown` message from the given peer.
 	fn handle_shutdown(&self, their_node_id: &PublicKey, msg: &Shutdown);
 	/// Handle an incoming `closing_signed` message from the given peer.


### PR DESCRIPTION
Fix obvious typo -- `TxAddInput` instead of `TxAbort` -- in the not-yet-used `SendTxAbort` struct.