### PR TITLE
Downgrade log message "Channel Monitor sync is still in progress" from info to debug

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -772,7 +772,7 @@ where C::Target: chain::Filter,
 					monitor_state.last_chain_persist_height.load(Ordering::Acquire) + LATENCY_GRACE_PERIOD_BLOCKS as usize
 						> self.highest_chain_height.load(Ordering::Acquire)
 			{
-				log_info!(self.logger, "A Channel Monitor sync is still in progress, refusing to provide monitor events!");
+				log_debug!(self.logger, "A Channel Monitor sync is still in progress, refusing to provide monitor events!");
 			} else {
 				if monitor_state.channel_perm_failed.load(Ordering::Acquire) {
 					// If a `UpdateOrigin::ChainSync` persistence failed with `PermanantFailure`,


### PR DESCRIPTION
I'm persisting ChannelMonitors asynchronously to a distributed database and returning ChannelMonitorUpdateStatus::InProgress until the data is committed. The update only takes a few milliseconds and in that time I can see two occurrences of the message "A Channel Monitor sync is still in progress, refusing to provide monitor events!" in the logs. It's being triggered by the async background processor calling process_pending_events on the chain monitor and channel manager.

Everything appears to be working as expected so it seems to me this log message can be downgraded to debug given it is normal behavior. It is not necessary to print it twice every time there is a channel update.