### PR TITLE
Disable use of SystemTime when in wasm32

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -43,7 +43,7 @@ extern crate core;
 #[cfg(feature = "serde")]
 extern crate serde;
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 use std::time::SystemTime;
 
 use bech32::u5;
@@ -693,7 +693,7 @@ impl<D: tb::Bool, T: tb::Bool, C: tb::Bool, S: tb::Bool, M: tb::Bool> InvoiceBui
 
 impl<D: tb::Bool, H: tb::Bool, C: tb::Bool, S: tb::Bool, M: tb::Bool> InvoiceBuilder<D, H, tb::False, C, S, M> {
 	/// Sets the timestamp to a specific [`SystemTime`].
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn timestamp(mut self, time: SystemTime) -> InvoiceBuilder<D, H, tb::True, C, S, M> {
 		match PositiveTimestamp::from_system_time(time) {
 			Ok(t) => self.timestamp = Some(t),
@@ -715,7 +715,7 @@ impl<D: tb::Bool, H: tb::Bool, C: tb::Bool, S: tb::Bool, M: tb::Bool> InvoiceBui
 	}
 
 	/// Sets the timestamp to the current system time.
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn current_timestamp(mut self) -> InvoiceBuilder<D, H, tb::True, C, S, M> {
 		let now = PositiveTimestamp::from_system_time(SystemTime::now());
 		self.timestamp = Some(now.expect("for the foreseeable future this shouldn't happen"));
@@ -1101,7 +1101,7 @@ impl PositiveTimestamp {
 	/// Note that the subsecond part is dropped as it is not representable in BOLT 11 invoices.
 	///
 	/// Otherwise, returns a [`CreationError::TimestampOutOfBounds`].
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn from_system_time(time: SystemTime) -> Result<Self, CreationError> {
 		time.duration_since(SystemTime::UNIX_EPOCH)
 			.map(Self::from_duration_since_epoch)
@@ -1129,13 +1129,13 @@ impl PositiveTimestamp {
 	}
 
 	/// Returns the [`SystemTime`] representing the stored time
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn as_time(&self) -> SystemTime {
 		SystemTime::UNIX_EPOCH + self.0
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 impl From<PositiveTimestamp> for SystemTime {
 	fn from(val: PositiveTimestamp) -> Self {
 		SystemTime::UNIX_EPOCH + val.0
@@ -1285,7 +1285,7 @@ impl Bolt11Invoice {
 	}
 
 	/// Returns the `Bolt11Invoice`'s timestamp (should equal its creation time)
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn timestamp(&self) -> SystemTime {
 		self.signed_invoice.raw_invoice().data.timestamp.as_time()
 	}
@@ -1359,13 +1359,13 @@ impl Bolt11Invoice {
 	}
 
 	/// Returns whether the invoice has expired.
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn is_expired(&self) -> bool {
 		Self::is_expired_from_epoch(&self.timestamp(), self.expiry_time())
 	}
 
 	/// Returns whether the expiry time from the given epoch has passed.
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub(crate) fn is_expired_from_epoch(epoch: &SystemTime, expiry_time: Duration) -> bool {
 		match epoch.elapsed() {
 			Ok(elapsed) => elapsed > expiry_time,
@@ -1374,7 +1374,7 @@ impl Bolt11Invoice {
 	}
 
 	/// Returns the Duration remaining until the invoice expires.
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn duration_until_expiry(&self) -> Duration {
 		SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)
 			.map(|now| self.expiration_remaining_from_epoch(now))

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -313,7 +313,6 @@ fn rotate_through_iterators<T, I: Iterator<Item = T>>(mut vecs: Vec<I>) -> impl 
 	})
 }
 
-#[cfg(feature = "std")]
 /// Utility to construct an invoice. Generally, unless you want to do something like a custom
 /// cltv_expiry, this is what you should be using to create an invoice. The reason being, this
 /// method stores the invoice's payment secret and preimage in `ChannelManager`, so (a) the user
@@ -329,6 +328,7 @@ fn rotate_through_iterators<T, I: Iterator<Item = T>>(mut vecs: Vec<I>) -> impl 
 /// confirmations during routing.
 ///
 /// [`MIN_FINAL_CLTV_EXPIRY_DETLA`]: lightning::ln::channelmanager::MIN_FINAL_CLTV_EXPIRY_DELTA
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 pub fn create_invoice_from_channelmanager<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>(
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
 	network: Currency, amt_msat: Option<u64>, description: String, invoice_expiry_delta_secs: u32,
@@ -353,7 +353,6 @@ where
 	)
 }
 
-#[cfg(feature = "std")]
 /// Utility to construct an invoice. Generally, unless you want to do something like a custom
 /// cltv_expiry, this is what you should be using to create an invoice. The reason being, this
 /// method stores the invoice's payment secret and preimage in `ChannelManager`, so (a) the user
@@ -370,6 +369,7 @@ where
 /// confirmations during routing.
 ///
 /// [`MIN_FINAL_CLTV_EXPIRY_DETLA`]: lightning::ln::channelmanager::MIN_FINAL_CLTV_EXPIRY_DELTA
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 pub fn create_invoice_from_channelmanager_with_description_hash<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>(
 	channelmanager: &ChannelManager<M, T, ES, NS, SP, F, R, L>, node_signer: NS, logger: L,
 	network: Currency, amt_msat: Option<u64>, description_hash: Sha256,

--- a/lightning-rapid-gossip-sync/src/lib.rs
+++ b/lightning-rapid-gossip-sync/src/lib.rs
@@ -115,7 +115,7 @@ impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L
 	///
 	/// `sync_path`: Path to the file where the gossip update data is located
 	///
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn sync_network_graph_with_file_path(
 		&self,
 		sync_path: &str,
@@ -128,7 +128,7 @@ impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L
 	/// Returns the last sync timestamp to be used the next time rapid sync data is queried.
 	///
 	/// `update_data`: `&[u8]` binary stream that comprises the update data
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn update_network_graph(&self, update_data: &[u8]) -> Result<u32, GraphSyncError> {
 		let mut read_cursor = io::Cursor::new(update_data);
 		self.update_network_graph_from_byte_stream(&mut read_cursor)

--- a/lightning-rapid-gossip-sync/src/processing.rs
+++ b/lightning-rapid-gossip-sync/src/processing.rs
@@ -17,7 +17,7 @@ use lightning::io;
 use crate::error::GraphSyncError;
 use crate::RapidGossipSync;
 
-#[cfg(all(feature = "std", not(test)))]
+#[cfg(all(feature = "std", not(target_arch = "wasm32"), not(test)))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(not(feature = "std"))]
@@ -38,7 +38,7 @@ const MAX_INITIAL_NODE_ID_VECTOR_CAPACITY: u32 = 50_000;
 const STALE_RGS_UPDATE_AGE_LIMIT_SECS: u64 = 60 * 60 * 24 * 14;
 
 impl<NG: Deref<Target=NetworkGraph<L>>, L: Deref> RapidGossipSync<NG, L> where L::Target: Logger {
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub(crate) fn update_network_graph_from_byte_stream<R: io::Read>(
 		&self,
 		read_cursor: &mut R,

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -126,7 +126,7 @@ use crate::util::string::PrintableString;
 
 use crate::prelude::*;
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 use std::time::SystemTime;
 
 pub(crate) const DEFAULT_RELATIVE_EXPIRY: Duration = Duration::from_secs(7200);
@@ -333,7 +333,7 @@ impl<'a> InvoiceBuilder<'a, ExplicitSigningPubkey> {
 	/// Builds an unsigned [`Bolt12Invoice`] after checking for valid semantics. It can be signed by
 	/// [`UnsignedBolt12Invoice::sign`].
 	pub fn build(self) -> Result<UnsignedBolt12Invoice, Bolt12SemanticError> {
-		#[cfg(feature = "std")] {
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))] {
 			if self.invoice.is_offer_or_refund_expired() {
 				return Err(Bolt12SemanticError::AlreadyExpired);
 			}
@@ -349,7 +349,7 @@ impl<'a> InvoiceBuilder<'a, DerivedSigningPubkey> {
 	pub fn build_and_sign<T: secp256k1::Signing>(
 		self, secp_ctx: &Secp256k1<T>
 	) -> Result<Bolt12Invoice, Bolt12SemanticError> {
-		#[cfg(feature = "std")] {
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))] {
 			if self.invoice.is_offer_or_refund_expired() {
 				return Err(Bolt12SemanticError::AlreadyExpired);
 			}
@@ -647,7 +647,7 @@ macro_rules! invoice_accessors { ($self: ident, $contents: expr) => {
 	}
 
 	/// Whether the invoice has expired.
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn is_expired(&$self) -> bool {
 		$contents.is_expired()
 	}
@@ -718,7 +718,7 @@ impl Bolt12Invoice {
 
 impl InvoiceContents {
 	/// Whether the original offer or refund has expired.
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	fn is_offer_or_refund_expired(&self) -> bool {
 		match self {
 			InvoiceContents::ForOffer { invoice_request, .. } =>
@@ -859,7 +859,7 @@ impl InvoiceContents {
 		self.fields().relative_expiry.unwrap_or(DEFAULT_RELATIVE_EXPIRY)
 	}
 
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	fn is_expired(&self) -> bool {
 		let absolute_expiry = self.created_at().checked_add(self.relative_expiry());
 		match absolute_expiry {
@@ -1356,7 +1356,7 @@ mod tests {
 		assert_eq!(unsigned_invoice.payment_paths(), payment_paths.as_slice());
 		assert_eq!(unsigned_invoice.created_at(), now);
 		assert_eq!(unsigned_invoice.relative_expiry(), DEFAULT_RELATIVE_EXPIRY);
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(!unsigned_invoice.is_expired());
 		assert_eq!(unsigned_invoice.payment_hash(), payment_hash);
 		assert_eq!(unsigned_invoice.amount_msats(), 1000);
@@ -1398,7 +1398,7 @@ mod tests {
 		assert_eq!(invoice.payment_paths(), payment_paths.as_slice());
 		assert_eq!(invoice.created_at(), now);
 		assert_eq!(invoice.relative_expiry(), DEFAULT_RELATIVE_EXPIRY);
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(!invoice.is_expired());
 		assert_eq!(invoice.payment_hash(), payment_hash);
 		assert_eq!(invoice.amount_msats(), 1000);
@@ -1495,7 +1495,7 @@ mod tests {
 		assert_eq!(invoice.payment_paths(), payment_paths.as_slice());
 		assert_eq!(invoice.created_at(), now);
 		assert_eq!(invoice.relative_expiry(), DEFAULT_RELATIVE_EXPIRY);
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(!invoice.is_expired());
 		assert_eq!(invoice.payment_hash(), payment_hash);
 		assert_eq!(invoice.amount_msats(), 1000);
@@ -1707,7 +1707,7 @@ mod tests {
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 		let (_, _, _, tlv_stream, _) = invoice.as_tlv_stream();
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(!invoice.is_expired());
 		assert_eq!(invoice.relative_expiry(), one_hour);
 		assert_eq!(tlv_stream.relative_expiry, Some(one_hour.as_secs() as u32));
@@ -1723,7 +1723,7 @@ mod tests {
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 		let (_, _, _, tlv_stream, _) = invoice.as_tlv_stream();
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(invoice.is_expired());
 		assert_eq!(invoice.relative_expiry(), one_hour - Duration::from_secs(1));
 		assert_eq!(tlv_stream.relative_expiry, Some(one_hour.as_secs() as u32 - 1));

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -225,7 +225,7 @@ impl<'a, 'b, P: PayerIdStrategy, T: secp256k1::Signing> InvoiceRequestBuilder<'a
 		(UnsignedInvoiceRequest, Option<KeyPair>, Option<&'b Secp256k1<T>>),
 		Bolt12SemanticError
 	> {
-		#[cfg(feature = "std")] {
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))] {
 			if self.offer.is_expired() {
 				return Err(Bolt12SemanticError::AlreadyExpired);
 			}
@@ -538,7 +538,7 @@ impl InvoiceRequest {
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// [`Duration`]: core::time::Duration
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn respond_with(
 		&self, payment_paths: Vec<(BlindedPayInfo, BlindedPath)>, payment_hash: PaymentHash
 	) -> Result<InvoiceBuilder<ExplicitSigningPubkey>, Bolt12SemanticError> {
@@ -623,7 +623,7 @@ impl VerifiedInvoiceRequest {
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// [`Duration`]: core::time::Duration
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn respond_with(
 		&self, payment_paths: Vec<(BlindedPayInfo, BlindedPath)>, payment_hash: PaymentHash
 	) -> Result<InvoiceBuilder<ExplicitSigningPubkey>, Bolt12SemanticError> {
@@ -651,7 +651,7 @@ impl VerifiedInvoiceRequest {
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn respond_using_derived_keys(
 		&self, payment_paths: Vec<(BlindedPayInfo, BlindedPath)>, payment_hash: PaymentHash
 	) -> Result<InvoiceBuilder<DerivedSigningPubkey>, Bolt12SemanticError> {

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -90,7 +90,7 @@ use crate::util::string::PrintableString;
 
 use crate::prelude::*;
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 use std::time::SystemTime;
 
 pub(super) const IV_BYTES: &[u8; IV_LEN] = b"LDK Offer ~~~~~~";
@@ -436,7 +436,7 @@ impl Offer {
 	}
 
 	/// Whether the offer has expired.
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn is_expired(&self) -> bool {
 		self.contents.is_expired()
 	}
@@ -580,7 +580,7 @@ impl OfferContents {
 		self.absolute_expiry
 	}
 
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub(super) fn is_expired(&self) -> bool {
 		match self.absolute_expiry {
 			Some(seconds_from_epoch) => match SystemTime::UNIX_EPOCH.elapsed() {
@@ -907,7 +907,7 @@ mod tests {
 		assert_eq!(offer.description(), PrintableString("foo"));
 		assert_eq!(offer.offer_features(), &OfferFeatures::empty());
 		assert_eq!(offer.absolute_expiry(), None);
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(!offer.is_expired());
 		assert_eq!(offer.paths(), &[]);
 		assert_eq!(offer.issuer(), None);
@@ -1167,7 +1167,7 @@ mod tests {
 			.absolute_expiry(future_expiry)
 			.build()
 			.unwrap();
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(!offer.is_expired());
 		assert_eq!(offer.absolute_expiry(), Some(future_expiry));
 		assert_eq!(offer.as_tlv_stream().absolute_expiry, Some(future_expiry.as_secs()));
@@ -1177,7 +1177,7 @@ mod tests {
 			.absolute_expiry(past_expiry)
 			.build()
 			.unwrap();
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(offer.is_expired());
 		assert_eq!(offer.absolute_expiry(), Some(past_expiry));
 		assert_eq!(offer.as_tlv_stream().absolute_expiry, Some(past_expiry.as_secs()));

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -97,7 +97,7 @@ use crate::util::string::PrintableString;
 
 use crate::prelude::*;
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 use std::time::SystemTime;
 
 pub(super) const IV_BYTES: &[u8; IV_LEN] = b"LDK Refund ~~~~~";
@@ -328,7 +328,7 @@ impl Refund {
 	}
 
 	/// Whether the refund has expired.
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn is_expired(&self) -> bool {
 		self.contents.is_expired()
 	}
@@ -397,7 +397,7 @@ impl Refund {
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// [`Duration`]: core::time::Duration
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn respond_with(
 		&self, payment_paths: Vec<(BlindedPayInfo, BlindedPath)>, payment_hash: PaymentHash,
 		signing_pubkey: PublicKey,
@@ -450,7 +450,7 @@ impl Refund {
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn respond_using_derived_keys<ES: Deref>(
 		&self, payment_paths: Vec<(BlindedPayInfo, BlindedPath)>, payment_hash: PaymentHash,
 		expanded_key: &ExpandedKey, entropy_source: ES
@@ -512,7 +512,7 @@ impl RefundContents {
 		self.absolute_expiry
 	}
 
-	#[cfg(feature = "std")]
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub(super) fn is_expired(&self) -> bool {
 		match self.absolute_expiry {
 			Some(seconds_from_epoch) => match SystemTime::UNIX_EPOCH.elapsed() {
@@ -789,7 +789,7 @@ mod tests {
 		assert_eq!(refund.payer_metadata(), &[1; 32]);
 		assert_eq!(refund.description(), PrintableString("foo"));
 		assert_eq!(refund.absolute_expiry(), None);
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(!refund.is_expired());
 		assert_eq!(refund.paths(), &[]);
 		assert_eq!(refund.issuer(), None);
@@ -970,7 +970,7 @@ mod tests {
 			.build()
 			.unwrap();
 		let (_, tlv_stream, _) = refund.as_tlv_stream();
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(!refund.is_expired());
 		assert_eq!(refund.absolute_expiry(), Some(future_expiry));
 		assert_eq!(tlv_stream.absolute_expiry, Some(future_expiry.as_secs()));
@@ -981,7 +981,7 @@ mod tests {
 			.build()
 			.unwrap();
 		let (_, tlv_stream, _) = refund.as_tlv_stream();
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		assert!(refund.is_expired());
 		assert_eq!(refund.absolute_expiry(), Some(past_expiry));
 		assert_eq!(tlv_stream.absolute_expiry, Some(past_expiry.as_secs()));
@@ -1239,7 +1239,7 @@ mod tests {
 		match refund.to_string().parse::<Refund>() {
 			Ok(refund) => {
 				assert_eq!(refund.absolute_expiry(), Some(past_expiry));
-				#[cfg(feature = "std")]
+				#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 				assert!(refund.is_expired());
 				assert_eq!(refund.paths(), &paths[..]);
 				assert_eq!(refund.issuer(), Some(PrintableString("bar")));

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -48,7 +48,7 @@ use crate::sync::Mutex;
 use core::ops::{Bound, Deref};
 use core::str::FromStr;
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// We remove stale channel directional info two weeks after the last update, per BOLT 7's
@@ -567,7 +567,7 @@ where U::Target: UtxoLookup, L::Target: Logger
 		// For no-std builds, we bury our head in the sand and do a full sync on each connection.
 		#[allow(unused_mut, unused_assignments)]
 		let mut gossip_start_time = 0;
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		{
 			gossip_start_time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time must be > 1970").as_secs();
 			if self.should_request_full_sync(&their_node_id) {
@@ -1665,7 +1665,7 @@ impl<L: Deref> NetworkGraph<L> where L::Target: Logger {
 
 		#[allow(unused_mut, unused_assignments)]
 		let mut announcement_received_time = 0;
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		{
 			announcement_received_time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time must be > 1970").as_secs();
 		}
@@ -1692,9 +1692,9 @@ impl<L: Deref> NetworkGraph<L> where L::Target: Logger {
 	///
 	/// The channel and any node for which this was their last channel are removed from the graph.
 	pub fn channel_failed_permanent(&self, short_channel_id: u64) {
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		let current_time_unix = Some(SystemTime::now().duration_since(UNIX_EPOCH).expect("Time must be > 1970").as_secs());
-		#[cfg(not(feature = "std"))]
+		#[cfg(any(not(feature = "std"), target_arch = "wasm32"))]
 		let current_time_unix = None;
 
 		self.channel_failed_permanent_with_time(short_channel_id, current_time_unix)
@@ -1715,9 +1715,9 @@ impl<L: Deref> NetworkGraph<L> where L::Target: Logger {
 	/// Marks a node in the graph as permanently failed, effectively removing it and its channels
 	/// from local storage.
 	pub fn node_failed_permanent(&self, node_id: &PublicKey) {
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		let current_time_unix = Some(SystemTime::now().duration_since(UNIX_EPOCH).expect("Time must be > 1970").as_secs());
-		#[cfg(not(feature = "std"))]
+		#[cfg(any(not(feature = "std"), target_arch = "wasm32"))]
 		let current_time_unix = None;
 
 		let node_id = NodeId::from_pubkey(node_id);
@@ -1745,7 +1745,6 @@ impl<L: Deref> NetworkGraph<L> where L::Target: Logger {
 		}
 	}
 
-	#[cfg(feature = "std")]
 	/// Removes information about channels that we haven't heard any updates about in some time.
 	/// This can be used regularly to prune the network graph of channels that likely no longer
 	/// exist.
@@ -1762,6 +1761,7 @@ impl<L: Deref> NetworkGraph<L> where L::Target: Logger {
 	///
 	/// This method is only available with the `std` feature. See
 	/// [`NetworkGraph::remove_stale_channels_and_tracking_with_time`] for `no-std` use.
+	#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 	pub fn remove_stale_channels_and_tracking(&self) {
 		let time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time must be > 1970").as_secs();
 		self.remove_stale_channels_and_tracking_with_time(time);
@@ -1875,11 +1875,11 @@ impl<L: Deref> NetworkGraph<L> where L::Target: Logger {
 			});
 		}
 
-		#[cfg(all(feature = "std", not(test), not(feature = "_test_utils")))]
+		#[cfg(all(feature = "std", not(target_arch="wasm32"), not(test), not(feature = "_test_utils")))]
 		{
 			// Note that many tests rely on being able to set arbitrarily old timestamps, thus we
 			// disable this check during tests!
-			let time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time must be > 1970").as_secs();
+			let time = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).expect("Time must be > 1970").as_secs();
 			if (msg.timestamp as u64) < time - STALE_CHANNEL_UPDATE_AGE_LIMIT_SECS {
 				return Err(LightningError{err: "channel_update is older than two weeks old".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)});
 			}
@@ -2321,7 +2321,7 @@ pub(crate) mod tests {
 			Err(e) => assert_eq!(e.err, "Already have chain-validated channel")
 		};
 
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		{
 			use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -383,12 +383,10 @@ impl ReadableArgs<u64> for FixedPenaltyScorer {
 	}
 }
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(not(any(feature = "no-std", target_arch="wasm32")))]
 type ConfiguredTime = crate::util::time::MonotonicTime;
-#[cfg(feature = "no-std")]
-use crate::util::time::Eternity;
-#[cfg(feature = "no-std")]
-type ConfiguredTime = Eternity;
+#[cfg(any(feature = "no-std", target_arch="wasm32"))]
+type ConfiguredTime = crate::util::time::Eternity;
 
 /// [`ScoreLookUp`] implementation using channel success probability distributions.
 ///

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -70,7 +70,7 @@ use core::mem;
 use bitcoin::bech32::u5;
 use crate::sign::{InMemorySigner, Recipient, EntropySource, NodeSigner, SignerProvider};
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 use std::time::{SystemTime, UNIX_EPOCH};
 use bitcoin::Sequence;
 
@@ -840,7 +840,7 @@ impl msgs::RoutingMessageHandler for TestRoutingMessageHandler {
 
 		#[allow(unused_mut, unused_assignments)]
 		let mut gossip_start_time = 0;
-		#[cfg(feature = "std")]
+		#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 		{
 			gossip_start_time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time must be > 1970").as_secs();
 			if self.request_full_sync.load(Ordering::Acquire) {

--- a/lightning/src/util/time.rs
+++ b/lightning/src/util/time.rs
@@ -59,15 +59,15 @@ impl Sub<Duration> for Eternity {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg(not(feature = "no-std"))]
+#[cfg(all(not(feature = "no-std"), not(target_arch = "wasm32")))]
 pub struct MonotonicTime(std::time::Instant);
 
 /// The amount of time to shift `Instant` forward to prevent overflow when subtracting a `Duration`
 /// from `Instant::now` on some operating systems (e.g., iOS representing `Instance` as `u64`).
-#[cfg(not(feature = "no-std"))]
+#[cfg(all(not(feature = "no-std"), not(target_arch = "wasm32")))]
 const SHIFT: Duration = Duration::from_secs(10 * 365 * 24 * 60 * 60); // 10 years.
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(all(not(feature = "no-std"), not(target_arch = "wasm32")))]
 impl Time for MonotonicTime {
 	fn now() -> Self {
 		let instant = std::time::Instant::now().checked_add(SHIFT).expect("Overflow on MonotonicTime instantiation");
@@ -93,7 +93,7 @@ impl Time for MonotonicTime {
 	}
 }
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(all(not(feature = "no-std"), not(target_arch = "wasm32")))]
 impl Sub<Duration> for MonotonicTime {
 	type Output = Self;
 


### PR DESCRIPTION
I think this shoulda allow a std version of ldk to be used in wasm32. Before the only reason we switched over to no-std is because of the calls to the system clock. This should make it so those calls won't happen when built for wasm.