### PR TITLE
Avoid unnecessarily cloning unsigned Transaction when broadcasting

### DIFF
--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -1123,8 +1123,8 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner> OnchainTxHandler<ChannelSigner>
 		ret
 	}
 
-	pub(crate) fn get_unsigned_holder_commitment_tx(&self) -> Transaction {
-		self.holder_commitment.trust().built_transaction().transaction.clone()
+	pub(crate) fn get_unsigned_holder_commitment_tx(&self) -> &Transaction {
+		&self.holder_commitment.trust().built_transaction().transaction
 	}
 
 	//TODO: getting lastest holder transactions should be infallible and result in us "force-closing the channel", but we may

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -982,7 +982,7 @@ pub struct DirectedChannelTransactionParameters<'a> {
 
 impl<'a> DirectedChannelTransactionParameters<'a> {
 	/// Get the channel pubkeys for the broadcaster
-	pub fn broadcaster_pubkeys(&self) -> &ChannelPublicKeys {
+	pub fn broadcaster_pubkeys(&self) -> &'a ChannelPublicKeys {
 		if self.holder_is_broadcaster {
 			&self.inner.holder_pubkeys
 		} else {
@@ -991,7 +991,7 @@ impl<'a> DirectedChannelTransactionParameters<'a> {
 	}
 
 	/// Get the channel pubkeys for the countersignatory
-	pub fn countersignatory_pubkeys(&self) -> &ChannelPublicKeys {
+	pub fn countersignatory_pubkeys(&self) -> &'a ChannelPublicKeys {
 		if self.holder_is_broadcaster {
 			&self.inner.counterparty_parameters.as_ref().unwrap().pubkeys
 		} else {
@@ -1020,7 +1020,7 @@ impl<'a> DirectedChannelTransactionParameters<'a> {
 	}
 
 	/// Whether to use anchors for this channel
-	pub fn channel_type_features(&self) -> &ChannelTypeFeatures {
+	pub fn channel_type_features(&self) -> &'a ChannelTypeFeatures {
 		&self.inner.channel_type_features
 	}
 }
@@ -1279,7 +1279,7 @@ impl<'a> Deref for TrustedClosingTransaction<'a> {
 
 impl<'a> TrustedClosingTransaction<'a> {
 	/// The pre-built Bitcoin commitment transaction
-	pub fn built_transaction(&self) -> &Transaction {
+	pub fn built_transaction(&self) -> &'a Transaction {
 		&self.inner.built
 	}
 
@@ -1668,17 +1668,17 @@ impl<'a> TrustedCommitmentTransaction<'a> {
 	}
 
 	/// The pre-built Bitcoin commitment transaction
-	pub fn built_transaction(&self) -> &BuiltCommitmentTransaction {
+	pub fn built_transaction(&self) -> &'a BuiltCommitmentTransaction {
 		&self.inner.built
 	}
 
 	/// The pre-calculated transaction creation public keys.
-	pub fn keys(&self) -> &TxCreationKeys {
+	pub fn keys(&self) -> &'a TxCreationKeys {
 		&self.inner.keys
 	}
 
 	/// Should anchors be used.
-	pub fn channel_type_features(&self) -> &ChannelTypeFeatures {
+	pub fn channel_type_features(&self) -> &'a ChannelTypeFeatures {
 		&self.inner.channel_type_features
 	}
 


### PR DESCRIPTION
Our `Trusted*` wrappers in `chan_utils` expose additional inner
fields by reference. However, because they were not explicitly
marked as returning a reference with the wrapped struct's
lifetimes, rustc was considering them to return a reference with
the wrapper struct's lifetime.

This is unnecessarily restrictive, and resulted in the addition of
a clone in 9850c58 which we remove
here.