### PR TITLE
Correct syn pinning on cargo 1.48

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
         include:
           - toolchain: stable
             platform: ubuntu-latest
-            coverage: true
           # 1.48.0 is the MSRV for all crates except lightning-transaction-sync and Win/Mac
           - toolchain: 1.48.0
             platform: ubuntu-latest
@@ -50,46 +49,31 @@ jobs:
         run: |
           sudo apt-get -y install shellcheck
           shellcheck ci/ci-tests.sh
-      - name: Run CI script with coverage generation
-        if: matrix.coverage
-        shell: bash # Default on Winblows is powershell
-        run: LDK_COVERAGE_BUILD=true ./ci/ci-tests.sh
       - name: Run CI script
-        if: "!matrix.coverage"
         shell: bash # Default on Winblows is powershell
         run: ./ci/ci-tests.sh
-      - name: Install deps for kcov
-        if: matrix.coverage
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev
-      - name: Install kcov
-        if: matrix.coverage
-        run: |
-          wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
-          tar xzf master.tar.gz
-          cd kcov-master && mkdir build && cd build
-          cmake ..
-          make
-          make install DESTDIR=../../kcov-build
-          cd ../.. && rm -rf kcov-master master.tar.gz
-      - name: Generate coverage report
-        if: matrix.coverage
-        run: |
-          for file in target/debug/deps/lightning*; do
-            [ -x "${file}" ] || continue;
-            mkdir -p "target/cov/$(basename $file)";
-            ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file";
-          done
-      - name: Upload coverage
-        if: matrix.coverage
-        uses: codecov/codecov-action@v3
+
+  coverage:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
         with:
+          fetch-depth: 0
+      - name: Install Rust stable toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal
+      - name: Run tests with coverage generation
+        run: |
+          cargo install cargo-llvm-cov
+          export RUSTFLAGS="-Clink-dead-code -Coverflow-checks=off"
+          cargo llvm-cov --features rest-client,rpc-client,tokio,futures,serde --codecov --hide-instantiations --output-path=target/codecov.json
           # Could you use this to fake the coverage report for your PR? Sure.
           # Will anyone be impressed by your amazing coverage? No
           # Maybe if codecov wasn't broken we wouldn't need to do this...
-          token: f421b687-4dc2-4387-ac3d-dc3b2528af57
-          fail_ci_if_error: true
+          bash <(curl -s https://codecov.io/bash) -f target/codecov.json -t "f421b687-4dc2-4387-ac3d-dc3b2528af57"
 
   benchmark:
     runs-on: ubuntu-latest

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -30,7 +30,10 @@ PIN_RELEASE_DEPS # pin the release dependencies in our main workspace
 [ "$RUSTC_MINOR_VERSION" -lt 56 ] && cargo update -p quote --precise "1.0.30" --verbose
 
 # The syn crate depends on too-new proc-macro2 starting with v2.0.33, i.e., has MSRV of 1.56
-[ "$RUSTC_MINOR_VERSION" -lt 56 ] && cargo update -p syn:2.0.33 --precise "2.0.32" --verbose
+if [ "$RUSTC_MINOR_VERSION" -lt 56 ]; then
+	SYN_2_DEP=$(grep -o '"syn 2.*' Cargo.lock | tr -d '",' | tr ' ' ':')
+	cargo update -p "$SYN_2_DEP" --precise "2.0.32" --verbose
+fi
 
 # The proc-macro2 crate switched to Rust edition 2021 starting with v1.0.66, i.e., has MSRV of 1.56
 [ "$RUSTC_MINOR_VERSION" -lt 56 ] && cargo update -p proc-macro2 --precise "1.0.65" --verbose

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -41,8 +41,6 @@ fi
 # The memchr crate switched to an MSRV of 1.60 starting with v2.6.0
 [ "$RUSTC_MINOR_VERSION" -lt 60 ] && cargo update -p memchr --precise "2.5.0" --verbose
 
-[ "$LDK_COVERAGE_BUILD" != "" ] && export RUSTFLAGS="-C link-dead-code"
-
 export RUST_BACKTRACE=1
 
 echo -e "\n\nBuilding and testing all workspace crates..."

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -45,29 +45,29 @@ export RUST_BACKTRACE=1
 
 echo -e "\n\nBuilding and testing all workspace crates..."
 cargo test --verbose --color always
-cargo build --verbose --color always
+cargo check --verbose --color always
 
 echo -e "\n\nBuilding and testing Block Sync Clients with features"
 pushd lightning-block-sync
 cargo test --verbose --color always --features rest-client
-cargo build --verbose --color always --features rest-client
+cargo check --verbose --color always --features rest-client
 cargo test --verbose --color always --features rpc-client
-cargo build --verbose --color always --features rpc-client
+cargo check --verbose --color always --features rpc-client
 cargo test --verbose --color always --features rpc-client,rest-client
-cargo build --verbose --color always --features rpc-client,rest-client
+cargo check --verbose --color always --features rpc-client,rest-client
 cargo test --verbose --color always --features rpc-client,rest-client,tokio
-cargo build --verbose --color always --features rpc-client,rest-client,tokio
+cargo check --verbose --color always --features rpc-client,rest-client,tokio
 popd
 
 if [[ $RUSTC_MINOR_VERSION -gt 67 && "$HOST_PLATFORM" != *windows* ]]; then
 	echo -e "\n\nBuilding and testing Transaction Sync Clients with features"
 	pushd lightning-transaction-sync
 	cargo test --verbose --color always --features esplora-blocking
-	cargo build --verbose --color always --features esplora-blocking
+	cargo check --verbose --color always --features esplora-blocking
 	cargo test --verbose --color always --features esplora-async
-	cargo build --verbose --color always --features esplora-async
+	cargo check --verbose --color always --features esplora-async
 	cargo test --verbose --color always --features esplora-async-https
-	cargo build --verbose --color always --features esplora-async-https
+	cargo check --verbose --color always --features esplora-async-https
 	popd
 fi
 
@@ -93,7 +93,7 @@ fi
 echo -e "\n\nBuilding with all Log-Limiting features"
 pushd lightning
 grep '^max_level_' Cargo.toml | awk '{ print $1 }'| while read -r FEATURE; do
-	cargo build --verbose --color always --features "$FEATURE"
+	cargo check --verbose --color always --features "$FEATURE"
 done
 popd
 


### PR DESCRIPTION
Sadly the pinning introduced in 050f5a90297678f2cad36feee9a1db2367e was brittle in the face of any further syn updates, and has already broken.

Here we fix it by looking up the actual version of syn to pin.

Note that this dependency is somewhat nonsense as its actually only a `criterion` dependency, pulled in even though we haven't set the bench flag (as we aren't yet using `resolver = 2`).