### PR TITLE
Use `Default::default()` to construct `()` as a test scoring param

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -10190,7 +10190,7 @@ mod tests {
 			TEST_FINAL_CLTV, false), 100_000);
 		let route = find_route(
 			&nodes[0].node.get_our_node_id(), &route_params, &nodes[0].network_graph,
-			None, nodes[0].logger, &scorer, &(), &random_seed_bytes
+			None, nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes
 		).unwrap();
 		nodes[0].node.send_spontaneous_payment(&route, Some(payment_preimage),
 			RecipientOnionFields::spontaneous_empty(), PaymentId(payment_preimage.0)).unwrap();
@@ -10224,7 +10224,7 @@ mod tests {
 		let payment_preimage = PaymentPreimage([42; 32]);
 		let route = find_route(
 			&nodes[0].node.get_our_node_id(), &route_params, &nodes[0].network_graph,
-			None, nodes[0].logger, &scorer, &(), &random_seed_bytes
+			None, nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes
 		).unwrap();
 		let payment_hash = nodes[0].node.send_spontaneous_payment(&route, Some(payment_preimage),
 			RecipientOnionFields::spontaneous_empty(), PaymentId(payment_preimage.0)).unwrap();
@@ -10281,7 +10281,7 @@ mod tests {
 		);
 		let route = find_route(
 			&nodes[0].node.get_our_node_id(), &route_params, &nodes[0].network_graph,
-			None, nodes[0].logger, &scorer, &(), &random_seed_bytes
+			None, nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes
 		).unwrap();
 		let payment_id_2 = PaymentId([45; 32]);
 		nodes[0].node.send_spontaneous_payment(&route, Some(payment_preimage),
@@ -10332,7 +10332,7 @@ mod tests {
 		let random_seed_bytes = chanmon_cfgs[1].keys_manager.get_secure_random_bytes();
 		let route = find_route(
 			&payer_pubkey, &route_params, &network_graph, Some(&first_hops.iter().collect::<Vec<_>>()),
-			nodes[0].logger, &scorer, &(), &random_seed_bytes
+			nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes
 		).unwrap();
 
 		let test_preimage = PaymentPreimage([42; 32]);
@@ -10377,7 +10377,7 @@ mod tests {
 		let random_seed_bytes = chanmon_cfgs[1].keys_manager.get_secure_random_bytes();
 		let route = find_route(
 			&payer_pubkey, &route_params, &network_graph, Some(&first_hops.iter().collect::<Vec<_>>()),
-			nodes[0].logger, &scorer, &(), &random_seed_bytes
+			nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes
 		).unwrap();
 
 		let test_preimage = PaymentPreimage([42; 32]);

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1854,7 +1854,7 @@ pub fn get_route(send_node: &Node, route_params: &RouteParameters) -> Result<Rou
 	router::get_route(
 		&send_node.node.get_our_node_id(), route_params, &send_node.network_graph.read_only(),
 		Some(&send_node.node.list_usable_channels().iter().collect::<Vec<_>>()),
-		send_node.logger, &scorer, &(), &random_seed_bytes
+		send_node.logger, &scorer, &Default::default(), &random_seed_bytes
 	)
 }
 
@@ -2506,7 +2506,7 @@ pub fn route_over_limit<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_rou
 	let keys_manager = test_utils::TestKeysInterface::new(&seed, Network::Testnet);
 	let random_seed_bytes = keys_manager.get_secure_random_bytes();
 	let route = router::get_route(&origin_node.node.get_our_node_id(), &route_params, &network_graph,
-		None, origin_node.logger, &scorer, &(), &random_seed_bytes).unwrap();
+		None, origin_node.logger, &scorer, &Default::default(), &random_seed_bytes).unwrap();
 	assert_eq!(route.paths.len(), 1);
 	assert_eq!(route.paths[0].hops.len(), expected_route.len());
 	for (node, hop) in expected_route.iter().zip(route.paths[0].hops.iter()) {

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -7231,7 +7231,7 @@ fn test_check_htlc_underpaying() {
 		TEST_FINAL_CLTV).with_bolt11_features(nodes[1].node.invoice_features()).unwrap();
 	let route_params = RouteParameters::from_payment_params_and_value(payment_params, 10_000);
 	let route = get_route(&nodes[0].node.get_our_node_id(), &route_params, &nodes[0].network_graph.read_only(),
-		None, nodes[0].logger, &scorer, &(), &random_seed_bytes).unwrap();
+		None, nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes).unwrap();
 	let (_, our_payment_hash, _) = get_payment_preimage_hash!(nodes[0]);
 	let our_payment_secret = nodes[1].node.create_inbound_payment_for_hash(our_payment_hash, Some(100_000), 7200, None).unwrap();
 	nodes[0].node.send_payment_with_route(&route, our_payment_hash,
@@ -7489,12 +7489,12 @@ fn test_bump_penalty_txn_on_revoked_htlcs() {
 	let random_seed_bytes = chanmon_cfgs[1].keys_manager.get_secure_random_bytes();
 	let route_params = RouteParameters::from_payment_params_and_value(payment_params, 3_000_000);
 	let route = get_route(&nodes[0].node.get_our_node_id(), &route_params, &nodes[0].network_graph.read_only(), None,
-		nodes[0].logger, &scorer, &(), &random_seed_bytes).unwrap();
+		nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes).unwrap();
 	let payment_preimage = send_along_route(&nodes[0], route, &[&nodes[1]], 3_000_000).0;
 	let payment_params = PaymentParameters::from_node_id(nodes[0].node.get_our_node_id(), 50).with_bolt11_features(nodes[0].node.invoice_features()).unwrap();
 	let route_params = RouteParameters::from_payment_params_and_value(payment_params, 3_000_000);
 	let route = get_route(&nodes[1].node.get_our_node_id(), &route_params, &nodes[1].network_graph.read_only(), None,
-		nodes[0].logger, &scorer, &(), &random_seed_bytes).unwrap();
+		nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes).unwrap();
 	send_along_route(&nodes[1], route, &[&nodes[0]], 3_000_000);
 
 	let revoked_local_txn = get_local_commitment_txn!(nodes[1], chan.2);

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -1052,7 +1052,7 @@ macro_rules! get_phantom_route {
 		(get_route(
 			&$nodes[0].node.get_our_node_id(), &route_params, &network_graph,
 			Some(&$nodes[0].node.list_usable_channels().iter().collect::<Vec<_>>()),
-			$nodes[0].logger, &scorer, &(), &[0u8; 32]
+			$nodes[0].logger, &scorer, &Default::default(), &[0u8; 32]
 		).unwrap(), phantom_route_hint.phantom_scid)
 	}
 }}

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -267,7 +267,7 @@ fn do_test_keysend_payments(public_node: bool, with_retry: bool) {
 	let random_seed_bytes = chanmon_cfgs[1].keys_manager.get_secure_random_bytes();
 	let route = find_route(
 		&payer_pubkey, &route_params, &network_graph, first_hops,
-		nodes[0].logger, &scorer, &(), &random_seed_bytes
+		nodes[0].logger, &scorer, &Default::default(), &random_seed_bytes
 	).unwrap();
 
 	{
@@ -320,7 +320,7 @@ fn test_mpp_keysend() {
 	let scorer = test_utils::TestScorer::new();
 	let random_seed_bytes = chanmon_cfgs[0].keys_manager.get_secure_random_bytes();
 	let route = find_route(&payer_pubkey, &route_params, &network_graph, None, nodes[0].logger,
-		&scorer, &(), &random_seed_bytes).unwrap();
+		&scorer, &Default::default(), &random_seed_bytes).unwrap();
 
 	let payment_preimage = PaymentPreimage([42; 32]);
 	let payment_secret = PaymentSecret(payment_preimage.0);
@@ -1106,7 +1106,7 @@ fn get_ldk_payment_preimage() {
 	let route = get_route( &nodes[0].node.get_our_node_id(), &route_params,
 		&nodes[0].network_graph.read_only(),
 		Some(&nodes[0].node.list_usable_channels().iter().collect::<Vec<_>>()), nodes[0].logger,
-		&scorer, &(), &random_seed_bytes).unwrap();
+		&scorer, &Default::default(), &random_seed_bytes).unwrap();
 	nodes[0].node.send_payment_with_route(&route, payment_hash,
 		RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
 	check_added_monitors!(nodes[0], 1);
@@ -1750,9 +1750,9 @@ fn do_test_intercepted_payment(test: InterceptTest) {
 		]).unwrap()
 		.with_bolt11_features(nodes[2].node.invoice_features()).unwrap();
 	let route_params = RouteParameters::from_payment_params_and_value(payment_params, amt_msat,);
-	let route = get_route( &nodes[0].node.get_our_node_id(), &route_params,
-		&nodes[0].network_graph.read_only(), None, nodes[0].logger, &scorer, &(),
-		&random_seed_bytes,).unwrap();
+	let route = get_route(&nodes[0].node.get_our_node_id(), &route_params,
+		&nodes[0].network_graph.read_only(), None, nodes[0].logger, &scorer, &Default::default(),
+		&random_seed_bytes).unwrap();
 
 	let (payment_hash, payment_secret) = nodes[2].node.create_inbound_payment(Some(amt_msat), 60 * 60, None).unwrap();
 	nodes[0].node.send_payment_with_route(&route, payment_hash,

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -315,12 +315,12 @@ fn updates_shutdown_wait() {
 	let payment_params_1 = PaymentParameters::from_node_id(nodes[1].node.get_our_node_id(), TEST_FINAL_CLTV).with_bolt11_features(nodes[1].node.invoice_features()).unwrap();
 	let route_params = RouteParameters::from_payment_params_and_value(payment_params_1, 100_000);
 	let route_1 = get_route(&nodes[0].node.get_our_node_id(), &route_params,
-		&nodes[0].network_graph.read_only(), None, &logger, &scorer, &(), &random_seed_bytes).unwrap();
+		&nodes[0].network_graph.read_only(), None, &logger, &scorer, &Default::default(), &random_seed_bytes).unwrap();
 	let payment_params_2 = PaymentParameters::from_node_id(nodes[0].node.get_our_node_id(),
 		TEST_FINAL_CLTV).with_bolt11_features(nodes[0].node.invoice_features()).unwrap();
 	let route_params = RouteParameters::from_payment_params_and_value(payment_params_2, 100_000);
 	let route_2 = get_route(&nodes[1].node.get_our_node_id(), &route_params,
-		&nodes[1].network_graph.read_only(), None, &logger, &scorer, &(), &random_seed_bytes).unwrap();
+		&nodes[1].network_graph.read_only(), None, &logger, &scorer, &Default::default(), &random_seed_bytes).unwrap();
 	unwrap_send_err!(nodes[0].node.send_payment_with_route(&route_1, payment_hash,
 			RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)
 		), true, APIError::ChannelUnavailable {..}, {});


### PR DESCRIPTION
In bindings, we can't use unbounded generic types, and thus have to rip out the `ScoreParams` and replace them with static `ProbabilisticScoringFeeParams` universally. To make this easier, using `Default::default()` everywhere allows the type to change out from under the test without the test needing to change.