### PR TITLE
Fix two issues in `Balance` generation

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1748,6 +1748,12 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 					debug_assert!(holder_delayed_output_pending.is_none());
 					holder_delayed_output_pending = Some(event.confirmation_threshold());
 				},
+				OnchainEvent::MaturingOutput {
+					descriptor: SpendableOutputDescriptor::DelayedPaymentOutput(ref descriptor) }
+				if descriptor.outpoint.into_bitcoin_outpoint() == htlc_output_to_spend => {
+					debug_assert!(holder_delayed_output_pending.is_none());
+					holder_delayed_output_pending = Some(event.confirmation_threshold());
+				},
 				_ => {},
 			}
 		}


### PR DESCRIPTION
The second issue I hit in prod on my node - an anchor HTLC timeout transaction confirmed but the output on the HTLC transaction was still locked for another few hundred blocks. During this time, we don't generate a corresponding `Balance` at all, which is a potentially dangerous situation. While fixing it, I noticed the first issue - we shouldn't be deciding if an HTLC is confirming based on the output index in the HTLC transaction matching the output index in the commitment transaction.

Sadly I don't have time to write tests here (or real commit messages). The second should be trivial to test, the first shouldn't be too hard, I think if we swap around some of the amounts in the existing balances tests it'll swap the output order and the old code will break.