### PR TITLE
Expose `parse_onion_address` publicly in `no-std`

### DIFF
--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -39,10 +39,12 @@ use crate::onion_message;
 use crate::sign::{NodeSigner, Recipient};
 
 use crate::prelude::*;
+#[cfg(feature = "std")]
 use core::convert::TryFrom;
 use core::fmt;
 use core::fmt::Debug;
 use core::ops::Deref;
+#[cfg(feature = "std")]
 use core::str::FromStr;
 use crate::io::{self, Cursor, Read};
 use crate::io_extras::read_to_end;
@@ -956,7 +958,10 @@ impl From<std::net::SocketAddr> for SocketAddress {
 		}
 }
 
-fn parse_onion_address(host: &str, port: u16) -> Result<SocketAddress, SocketAddressParseError> {
+/// Parses an OnionV3 host and port into a [`SocketAddress::OnionV3`].
+///
+/// The host part must end with ".onion".
+pub fn parse_onion_address(host: &str, port: u16) -> Result<SocketAddress, SocketAddressParseError> {
 	if host.ends_with(".onion") {
 		let domain = &host[..host.len() - ".onion".len()];
 		if domain.len() != 56 {


### PR DESCRIPTION
The reason for having a separate `parse_onion_address` from `FromStr` is to have an onion parsing function in `no-std`, but when we added it we forgot to make it public. We do this here, as well as fix a few compilation warnings in `no-std`.