### PR TITLE
Make `InMemorySigner::channel_value_satoshis` pub

### DIFF
--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -797,7 +797,7 @@ pub struct InMemorySigner {
 	/// Counterparty public keys and counterparty/holder `selected_contest_delay`, populated on channel acceptance.
 	channel_parameters: Option<ChannelTransactionParameters>,
 	/// The total value of this channel.
-	channel_value_satoshis: u64,
+	pub channel_value_satoshis: u64,
 	/// Key derivation parameters.
 	channel_keys_id: [u8; 32],
 	/// Seed from which all randomness produced is derived from.


### PR DESCRIPTION
For splicing / dual funding, we prefer not to use the `InMemorySigner` constructor, because it re-derives the pubkeys.  We would like to keep just one copy of the keys and create RBF-candidate specific keys by cloning.  To enable this, we would like the channel value to be `pub` so we can set it to the relevant value for the candidate.

