### PR TITLE
Make clippy shut up about `PartialOrd` and `Ord` both impl'd

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -504,7 +504,7 @@ pub struct Bolt11InvoiceSignature(pub RecoverableSignature);
 
 impl PartialOrd for Bolt11InvoiceSignature {
 	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		self.0.serialize_compact().1.partial_cmp(&other.0.serialize_compact().1)
+		Some(self.cmp(other))
 	}
 }
 


### PR DESCRIPTION
Clippy gets mad that we have an implementation of `ParialOrd` and `Ord` separately, even though both are identical. Making `ParitalOrd` call `Ord` makes clippy shut up.