### PR TITLE
Support async get_per_commitment_point, release_commitment_secret

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -914,7 +914,7 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 						_ => if out.may_fail.load(atomic::Ordering::Acquire) {
 							return;
 						} else {
-							panic!("Unhandled message event {:?}", event)
+							panic!("Unhandled message event on node {}, {:?}", $node, event)
 						},
 					}
 					if $limit_events != ProcessMessages::AllMessages {
@@ -1407,7 +1407,7 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 				// after we resolve all pending events.
 				// First make sure there are no pending monitor updates, resetting the error state
 				// and calling force_channel_monitor_updated for each monitor.
-				out.locked_write(format!("Restoring monitors...\n").as_bytes());
+				out.locked_write(b"Restoring monitors...\n");
 				if let Some((id, _)) = monitor_a.latest_monitors.lock().unwrap().get(&chan_1_funding) {
 					monitor_a.chain_monitor.force_channel_monitor_updated(chan_1_funding, *id);
 					nodes[0].process_monitor_events();
@@ -1426,10 +1426,10 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 				}
 
 				// Next, make sure peers are all connected to each other
-				out.locked_write(format!("Reconnecting peers...\n").as_bytes());
+				out.locked_write(b"Reconnecting peers...\n");
 
 				if chan_a_disconnected {
-					out.locked_write(format!("Reconnecting node 0 and node 1...\n").as_bytes());
+					out.locked_write(b"Reconnecting node 0 and node 1...\n");
 					nodes[0].peer_connected(&nodes[1].get_our_node_id(), &Init {
 						features: nodes[1].init_features(), networks: None, remote_network_address: None
 					}, true).unwrap();
@@ -1439,7 +1439,7 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 					chan_a_disconnected = false;
 				}
 				if chan_b_disconnected {
-					out.locked_write(format!("Reconnecting node 1 and node 2...\n").as_bytes());
+					out.locked_write(b"Reconnecting node 1 and node 2...\n");
 					nodes[1].peer_connected(&nodes[2].get_our_node_id(), &Init {
 						features: nodes[2].init_features(), networks: None, remote_network_address: None
 					}, true).unwrap();
@@ -1449,7 +1449,7 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 					chan_b_disconnected = false;
 				}
 
-				out.locked_write(format!("Restoring signers...\n").as_bytes());
+				out.locked_write(b"Restoring signers...\n");
 
 				*monitor_a.persister.update_ret.lock().unwrap() = ChannelMonitorUpdateStatus::Completed;
 				*monitor_b.persister.update_ret.lock().unwrap() = ChannelMonitorUpdateStatus::Completed;
@@ -1471,7 +1471,7 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 					nodes[2].signer_unblocked(None);
 				}
 
-				out.locked_write(format!("Running event queues to quiescence...\n").as_bytes());
+				out.locked_write(b"Running event queues to quiescence...\n");
 
 				for i in 0..std::usize::MAX {
 					if i == 100 { panic!("It may take may iterations to settle the state, but it should not take forever"); }
@@ -1488,20 +1488,20 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 					break;
 				}
 
-				out.locked_write(format!("All channels restored to normal operation.\n").as_bytes());
+				out.locked_write(b"All channels restored to normal operation.\n");
 
 				// Finally, make sure that at least one end of each channel can make a substantial payment
 				assert!(
 					send_payment(&nodes[0], &nodes[1], chan_a, 10_000_000, &mut payment_id, &mut payment_idx) ||
 					send_payment(&nodes[1], &nodes[0], chan_a, 10_000_000, &mut payment_id, &mut payment_idx));
-				out.locked_write(format!("Successfully sent a payment between node 0 and node 1.\n").as_bytes());
+				out.locked_write(b"Successfully sent a payment between node 0 and node 1.\n");
 
 				assert!(
 					send_payment(&nodes[1], &nodes[2], chan_b, 10_000_000, &mut payment_id, &mut payment_idx) ||
 					send_payment(&nodes[2], &nodes[1], chan_b, 10_000_000, &mut payment_id, &mut payment_idx));
-				out.locked_write(format!("Successfully sent a payment between node 1 and node 2.\n").as_bytes());
+				out.locked_write(b"Successfully sent a payment between node 1 and node 2.\n");
 
-				out.locked_write(format!("Flushing pending messages.\n").as_bytes());
+				out.locked_write(b"Flushing pending messages.\n");
 				for i in 0..std::usize::MAX {
 					if i == 100 { panic!("It may take may iterations to settle the state, but it should not take forever"); }
 

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -2944,9 +2944,7 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 							},
 							commitment_txid: htlc.commitment_txid,
 							per_commitment_number: htlc.per_commitment_number,
-							per_commitment_point: self.onchain_tx_handler.signer.get_per_commitment_point(
-								htlc.per_commitment_number, &self.onchain_tx_handler.secp_ctx,
-							),
+							per_commitment_point: htlc.per_commitment_point,
 							feerate_per_kw: 0,
 							htlc: htlc.htlc,
 							preimage: htlc.preimage,

--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -178,6 +178,7 @@ pub(crate) struct ExternalHTLCClaim {
 	pub(crate) htlc: HTLCOutputInCommitment,
 	pub(crate) preimage: Option<PaymentPreimage>,
 	pub(crate) counterparty_sig: Signature,
+	pub(crate) per_commitment_point: bitcoin::secp256k1::PublicKey,
 }
 
 // Represents the different types of claims for which events are yielded externally to satisfy said
@@ -1177,9 +1178,11 @@ impl<ChannelSigner: WriteableEcdsaChannelSigner> OnchainTxHandler<ChannelSigner>
 				})
 				.map(|(htlc_idx, htlc)| {
 					let counterparty_htlc_sig = holder_commitment.counterparty_htlc_sigs[htlc_idx];
+
 					ExternalHTLCClaim {
 						commitment_txid: trusted_tx.txid(),
 						per_commitment_number: trusted_tx.commitment_number(),
+						per_commitment_point: trusted_tx.per_commitment_point(),
 						htlc: htlc.clone(),
 						preimage: *preimage,
 						counterparty_sig: counterparty_htlc_sig,

--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -1404,14 +1404,14 @@ fn dont_elide_channely_ready_from_state_1() {
 		true);
 	nodes[0].node.signer_unblocked(None);
 
-	{
-		let events = nodes[0].node.get_and_clear_pending_msg_events();
-		assert_eq!(events.len(), 2, "Expected 2 events, got {}: {:?}", events.len(), events);
-		match (&events[0], &events[1]) {
-			(MessageSendEvent::SendChannelReestablish { .. }, MessageSendEvent::SendChannelReady { .. }) => (),
-			(a, b) => panic!("Expected SendChannelReestablish and SendChannelReady, not {:?} and {:?}", a, b)
-		}
-	}
+	let events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 3, "Expected 2 events, got {}: {:?}", events.len(), events);
+	match (&events[0], &events[1], &events[2]) {
+		(MessageSendEvent::SendChannelReestablish { .. },
+		 MessageSendEvent::SendChannelReady { .. },
+		 MessageSendEvent::UpdateHTLCs { .. }) => (),
+		(a, b, c) => panic!("Expected SendChannelReestablish SendChannelReady UpdateHTLCs, not {:?} {:?} {:?}", a, b, c)
+	};
 }
 
 #[test]
@@ -1502,14 +1502,104 @@ fn dont_lose_commitment_update() {
 		true);
 	nodes[0].node.signer_unblocked(None);
 
+	let events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 3, "Expected 3 events, got {}: {:?}", events.len(), events);
+	match (&events[0], &events[1], &events[2]) {
+		(MessageSendEvent::SendChannelReestablish { .. },
+		 MessageSendEvent::SendChannelReady { .. },
+		 MessageSendEvent::UpdateHTLCs { .. }) => (),
+		(a, b, c) => panic!("Expected SendChannelReestablish SendChannelReady UpdateHTLCs; not {:?} {:?} {:?}", a, b, c)
+	}
+}
+
+#[test]
+fn dont_lose_commitment_update_redux() {
+	// - ~a0~ Disable A's signer.
+	// - ~60~ Send a payment from A to B for 1,000 msats.
+	// - ~2c~ Disconnect A and B, then restart A.
+	// - ~0e~ Reconnect A and B.
+	// - ~a3~ Unblock A's signer ~sign_counterparty_commitment~.
+	// - ~19~ Process all messages on B.
+	// - ~ff~ Reset.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let persister;
+	let new_chain_monitor;
+
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let alice_deserialized;
+
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, channel_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	// Turn off Alice's signer.
+	eprintln!("disabling alice's signer");
+	nodes[0].set_channel_signer_ops_available(
+		&nodes[1].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET | ops::SIGN_COUNTERPARTY_COMMITMENT,
+		false);
+
+	eprintln!("sending payment from alice to bob");
+	let (route, payment_hash, _payment_preimage, payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[1], 1_000_000);
+	nodes[0].node.send_payment_with_route(&route, payment_hash,
+		RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+
+	check_added_monitors!(nodes[0], 1);
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+
+	// Disconnect Bob and restart Alice
+	eprintln!("disconnecting bob");
+	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id());
+
+	eprintln!("restarting alice");
 	{
-		let events = nodes[0].node.get_and_clear_pending_msg_events();
-		assert_eq!(events.len(), 3, "Expected 3 events, got {}: {:?}", events.len(), events);
-		match (&events[0], &events[1], &events[2]) {
-			(MessageSendEvent::SendChannelReestablish { .. },
-			 MessageSendEvent::UpdateHTLCs { .. },
-			 MessageSendEvent::SendChannelReady { .. }) => (),
-			(a, b, c) => panic!("Expected SendChannelReestablish, UpdateHTLCs, SendChannelReady; not {:?}, {:?}, {:?}", a, b, c)
+		let alice_serialized = nodes[0].node.encode();
+		let alice_monitor_serialized = get_monitor!(nodes[0], channel_id).encode();
+		reload_node!(nodes[0], *nodes[0].node.get_current_default_configuration(), &alice_serialized, &[&alice_monitor_serialized], persister, new_chain_monitor, alice_deserialized);
+	}
+
+	// Reconnect Alice and Bob.
+	eprintln!("reconnecting alice and bob");
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init {
+		features: nodes[1].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init {
+		features: nodes[0].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	// Bob should have sent Alice a channel_reestablish. Alice should not have done anything.
+	assert!(get_chan_reestablish_msgs!(nodes[0], nodes[1]).is_empty());
+	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
+	assert_eq!(reestablish_2.len(), 1);
+
+	// Unblock alice for sign_counterparty_commitment.
+	eprintln!("unblocking alice's signer for sign_counterparty_commitment");
+	nodes[0].set_channel_signer_ops_available(&nodes[1].node.get_our_node_id(), &channel_id, ops::SIGN_COUNTERPARTY_COMMITMENT, true);
+	nodes[0].node.signer_unblocked(None);
+	assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
+
+	nodes[0].node.handle_channel_reestablish(&nodes[1].node.get_our_node_id(), &reestablish_2[0]);
+	match handle_chan_reestablish_msgs!(nodes[0], nodes[1]) {
+		(None, None, None, _) => (),
+		(channel_ready, revoke_and_ack, commitment_update, order) => {
+			panic!("got channel_ready={:?} revoke_and_ack={:?} commitment_update={:?} order={:?}",
+						 channel_ready, revoke_and_ack, commitment_update, order);
 		}
+	};
+
+	// Unblock alice for get_per_commitment_point and release_commitment_secret
+	eprintln!("unblocking alice's signer for get_per_commitment_point and release_commitment_secret");
+	nodes[0].set_channel_signer_ops_available(&nodes[1].node.get_our_node_id(), &channel_id, ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET, true);
+	nodes[0].node.signer_unblocked(None);
+
+	let events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 3, "Expected 3 events, got {}: {:?}", events.len(), events);
+	match (&events[0], &events[1], &events[2]) {
+		(MessageSendEvent::SendChannelReestablish { .. },
+		 MessageSendEvent::SendChannelReady { .. },
+		 MessageSendEvent::UpdateHTLCs { .. }) => (),
+		(a, b, c) => panic!("Expected SendChannelReestablish SendChannelReady UpdateHTLCs; not {:?} {:?} {:?}", a, b, c)
 	}
 }

--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -10,13 +10,47 @@
 //! Tests for asynchronous signing. These tests verify that the channel state machine behaves
 //! properly with a signer implementation that asynchronously derives signatures.
 
+use bitcoin::secp256k1::PublicKey;
 use crate::events::{Event, MessageSendEvent, MessageSendEventsProvider};
+use crate::ln::ChannelId;
 use crate::ln::functional_test_utils::*;
+use crate::ln::msgs;
 use crate::ln::msgs::ChannelMessageHandler;
-use crate::ln::channelmanager::{PaymentId, RecipientOnionFields};
+use crate::ln::channelmanager::{PaymentId, RAACommitmentOrder, RecipientOnionFields};
+use crate::util::ser::Writeable;
+use crate::util::test_channel_signer::ops;
+use crate::util::test_utils;
 
-#[test]
-fn test_async_commitment_signature_for_funding_created() {
+/// Helper to run operations with a simulated asynchronous signer.
+///
+/// Disables the signer for the specified channel and then runs `do_fn`, then re-enables the signer
+/// and calls `signer_unblocked`.
+#[cfg(test)]
+pub fn with_async_signer<'a, DoFn, T>(node: &Node, peer_id: &PublicKey, channel_id: &ChannelId, masks: &Vec<u32>, do_fn: &'a DoFn) -> T
+	where DoFn: Fn() -> T
+{
+	let mask = masks.iter().fold(0, |acc, m| (acc | m));
+	eprintln!("disabling {}", ops::string_from(mask));
+	node.set_channel_signer_ops_available(peer_id, channel_id, mask, false);
+	let res = do_fn();
+
+	// Recompute the channel ID just in case the original ID was temporary.
+	let new_channel_id = {
+		let channels = node.node.list_channels();
+		assert_eq!(channels.len(), 1, "expected one channel, not {}", channels.len());
+		channels[0].channel_id
+	};
+
+	for mask in masks {
+		eprintln!("enabling {} and calling signer_unblocked", ops::string_from(*mask));
+		node.set_channel_signer_ops_available(peer_id, &new_channel_id, *mask, true);
+		node.node.signer_unblocked(Some((*peer_id, new_channel_id)));
+	}
+	res
+}
+
+#[cfg(test)]
+fn do_test_funding_created(masks: &Vec<u32>) {
 	// Simulate acquiring the signature for `funding_created` asynchronously.
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
@@ -37,22 +71,11 @@ fn test_async_commitment_signature_for_funding_created() {
 	// But! Let's make node[0]'s signer be unavailable: we should *not* broadcast a funding_created
 	// message...
 	let (temporary_channel_id, tx, _) = create_funding_transaction(&nodes[0], &nodes[1].node.get_our_node_id(), 100000, 42);
-	nodes[0].set_channel_signer_available(&nodes[1].node.get_our_node_id(), &temporary_channel_id, false);
-	nodes[0].node.funding_transaction_generated(&temporary_channel_id, &nodes[1].node.get_our_node_id(), tx.clone()).unwrap();
-	check_added_monitors(&nodes[0], 0);
-
-	assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
-
-	// Now re-enable the signer and simulate a retry. The temporary_channel_id won't work anymore so
-	// we have to dig out the real channel ID.
-	let chan_id = {
-		let channels = nodes[0].node.list_channels();
-		assert_eq!(channels.len(), 1, "expected one channel, not {}", channels.len());
-		channels[0].channel_id
-	};
-
-	nodes[0].set_channel_signer_available(&nodes[1].node.get_our_node_id(), &chan_id, true);
-	nodes[0].node.signer_unblocked(Some((nodes[1].node.get_our_node_id(), chan_id)));
+	with_async_signer(&nodes[0], &nodes[1].node.get_our_node_id(), &temporary_channel_id, masks, &|| {
+		nodes[0].node.funding_transaction_generated(&temporary_channel_id, &nodes[1].node.get_our_node_id(), tx.clone()).unwrap();
+		check_added_monitors(&nodes[0], 0);
+		assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
+	});
 
 	let mut funding_created_msg = get_event_msg!(nodes[0], MessageSendEvent::SendFundingCreated, nodes[1].node.get_our_node_id());
 	nodes[1].node.handle_funding_created(&nodes[0].node.get_our_node_id(), &funding_created_msg);
@@ -67,7 +90,38 @@ fn test_async_commitment_signature_for_funding_created() {
 }
 
 #[test]
-fn test_async_commitment_signature_for_funding_signed() {
+fn test_funding_created_grs() {
+	do_test_funding_created(&vec![ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_funding_created_gsr() {
+	do_test_funding_created(&vec![ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+#[test]
+fn test_funding_created_rsg() {
+	do_test_funding_created(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_funding_created_rgs() {
+	do_test_funding_created(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_funding_created_srg() {
+	do_test_funding_created(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_funding_created_sgr() {
+	do_test_funding_created(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+
+#[cfg(test)]
+fn do_test_funding_signed(masks: &Vec<u32>) {
 	// Simulate acquiring the signature for `funding_signed` asynchronously.
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
@@ -92,21 +146,11 @@ fn test_async_commitment_signature_for_funding_signed() {
 
 	// Now let's make node[1]'s signer be unavailable while handling the `funding_created`. It should
 	// *not* broadcast a `funding_signed`...
-	nodes[1].set_channel_signer_available(&nodes[0].node.get_our_node_id(), &temporary_channel_id, false);
-	nodes[1].node.handle_funding_created(&nodes[0].node.get_our_node_id(), &funding_created_msg);
-	check_added_monitors(&nodes[1], 1);
-
-	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
-
-	// Now re-enable the signer and simulate a retry. The temporary_channel_id won't work anymore so
-	// we have to dig out the real channel ID.
-	let chan_id = {
-		let channels = nodes[0].node.list_channels();
-		assert_eq!(channels.len(), 1, "expected one channel, not {}", channels.len());
-		channels[0].channel_id
-	};
-	nodes[1].set_channel_signer_available(&nodes[0].node.get_our_node_id(), &chan_id, true);
-	nodes[1].node.signer_unblocked(Some((nodes[0].node.get_our_node_id(), chan_id)));
+	with_async_signer(&nodes[1], &nodes[0].node.get_our_node_id(), &temporary_channel_id, masks, &|| {
+		nodes[1].node.handle_funding_created(&nodes[0].node.get_our_node_id(), &funding_created_msg);
+		check_added_monitors(&nodes[1], 1);
+		assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
+	});
 
 	expect_channel_pending_event(&nodes[1], &nodes[0].node.get_our_node_id());
 
@@ -118,7 +162,38 @@ fn test_async_commitment_signature_for_funding_signed() {
 }
 
 #[test]
-fn test_async_commitment_signature_for_commitment_signed() {
+fn test_funding_signed_grs() {
+	do_test_funding_signed(&vec![ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_funding_signed_gsr() {
+	do_test_funding_signed(&vec![ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+#[test]
+fn test_funding_signed_rsg() {
+	do_test_funding_signed(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_funding_signed_rgs() {
+	do_test_funding_signed(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_funding_signed_srg() {
+	do_test_funding_signed(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_funding_signed_sgr() {
+	do_test_funding_signed(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+
+#[cfg(test)]
+fn do_test_commitment_signed(masks: &Vec<u32>) {
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
@@ -144,29 +219,50 @@ fn test_async_commitment_signature_for_commitment_signed() {
 
 	dst.node.handle_update_add_htlc(&src.node.get_our_node_id(), &payment_event.msgs[0]);
 
-	// Mark dst's signer as unavailable and handle src's commitment_signed: while dst won't yet have a
-	// `commitment_signed` of its own to offer, it should publish a `revoke_and_ack`.
-	dst.set_channel_signer_available(&src.node.get_our_node_id(), &chan_id, false);
-	dst.node.handle_commitment_signed(&src.node.get_our_node_id(), &payment_event.commitment_msg);
-	check_added_monitors(dst, 1);
+	// Mark dst's signer as unavailable and handle src's commitment_signed. If dst's signer is
+	// offline, it oughtn't yet respond with any updates.
+	with_async_signer(dst, &src.node.get_our_node_id(), &chan_id, masks, &|| {
+		dst.node.handle_commitment_signed(&src.node.get_our_node_id(), &payment_event.commitment_msg);
+		check_added_monitors(dst, 1);
+		assert!(dst.node.get_and_clear_pending_msg_events().is_empty());
+	});
 
-	get_event_msg!(dst, MessageSendEvent::SendRevokeAndACK, src.node.get_our_node_id());
-
-	// Mark dst's signer as available and retry: we now expect to see dst's `commitment_signed`.
-	dst.set_channel_signer_available(&src.node.get_our_node_id(), &chan_id, true);
-	dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
-
-	let events = dst.node.get_and_clear_pending_msg_events();
-	assert_eq!(events.len(), 1, "expected one message, got {}", events.len());
-	if let MessageSendEvent::UpdateHTLCs { ref node_id, .. } = events[0] {
-		assert_eq!(node_id, &src.node.get_our_node_id());
-	} else {
-		panic!("expected UpdateHTLCs message, not {:?}", events[0]);
-	};
+	get_revoke_commit_msgs(&dst, &src.node.get_our_node_id());
 }
 
 #[test]
-fn test_async_commitment_signature_for_funding_signed_0conf() {
+fn test_commitment_signed_grs() {
+	do_test_commitment_signed(&vec![ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_commitment_signed_gsr() {
+	do_test_commitment_signed(&vec![ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+#[test]
+fn test_commitment_signed_rsg() {
+	do_test_commitment_signed(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_commitment_signed_rgs() {
+	do_test_commitment_signed(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_commitment_signed_srg() {
+	do_test_commitment_signed(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_commitment_signed_sgr() {
+	do_test_commitment_signed(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+
+#[cfg(test)]
+fn do_test_funding_signed_0conf(masks: &Vec<u32>) {
 	// Simulate acquiring the signature for `funding_signed` asynchronously for a zero-conf channel.
 	let mut manually_accept_config = test_default_channel_config();
 	manually_accept_config.manually_accept_inbound_channels = true;
@@ -184,7 +280,6 @@ fn test_async_commitment_signature_for_funding_signed_0conf() {
 
 	{
 		let events = nodes[1].node.get_and_clear_pending_events();
-		assert_eq!(events.len(), 1, "Expected one event, got {}", events.len());
 		match &events[0] {
 			Event::OpenChannelRequest { temporary_channel_id, .. } => {
 				nodes[1].node.accept_inbound_channel_from_trusted_peer_0conf(
@@ -193,6 +288,7 @@ fn test_async_commitment_signature_for_funding_signed_0conf() {
 			},
 			ev => panic!("Expected OpenChannelRequest, not {:?}", ev)
 		}
+		assert_eq!(events.len(), 1, "Expected one event, got {}", events.len());
 	}
 
 	// nodes[0] <-- accept_channel --- nodes[1]
@@ -209,27 +305,15 @@ fn test_async_commitment_signature_for_funding_signed_0conf() {
 
 	// Now let's make node[1]'s signer be unavailable while handling the `funding_created`. It should
 	// *not* broadcast a `funding_signed`...
-	nodes[1].set_channel_signer_available(&nodes[0].node.get_our_node_id(), &temporary_channel_id, false);
-	nodes[1].node.handle_funding_created(&nodes[0].node.get_our_node_id(), &funding_created_msg);
-	check_added_monitors(&nodes[1], 1);
-
-	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
-
-	// Now re-enable the signer and simulate a retry. The temporary_channel_id won't work anymore so
-	// we have to dig out the real channel ID.
-	let chan_id = {
-		let channels = nodes[0].node.list_channels();
-		assert_eq!(channels.len(), 1, "expected one channel, not {}", channels.len());
-		channels[0].channel_id
-	};
+	with_async_signer(&nodes[1], &nodes[0].node.get_our_node_id(), &temporary_channel_id, masks, &|| {
+		nodes[1].node.handle_funding_created(&nodes[0].node.get_our_node_id(), &funding_created_msg);
+		check_added_monitors(&nodes[1], 1);
+		assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
+	});
 
 	// At this point, we basically expect the channel to open like a normal zero-conf channel.
-	nodes[1].set_channel_signer_available(&nodes[0].node.get_our_node_id(), &chan_id, true);
-	nodes[1].node.signer_unblocked(Some((nodes[0].node.get_our_node_id(), chan_id)));
-
 	let (funding_signed, channel_ready_1) = {
 		let events = nodes[1].node.get_and_clear_pending_msg_events();
-		assert_eq!(events.len(), 2);
 		let funding_signed = match &events[0] {
 			MessageSendEvent::SendFundingSigned { msg, .. } => msg.clone(),
 			ev => panic!("Expected SendFundingSigned, not {:?}", ev)
@@ -265,7 +349,229 @@ fn test_async_commitment_signature_for_funding_signed_0conf() {
 }
 
 #[test]
-fn test_async_commitment_signature_for_peer_disconnect() {
+fn test_funding_signed_0conf_grs() {
+	do_test_funding_signed_0conf(&vec![ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_funding_signed_0conf_gsr() {
+	do_test_funding_signed_0conf(&vec![ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+#[test]
+fn test_funding_signed_0conf_rsg() {
+	do_test_funding_signed_0conf(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_funding_signed_0conf_rgs() {
+	do_test_funding_signed_0conf(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_funding_signed_0conf_srg() {
+	do_test_funding_signed_0conf(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_funding_signed_0conf_sgr() {
+	do_test_funding_signed_0conf(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+
+#[cfg(test)]
+fn do_test_payment(masks: &Vec<u32>) {
+	// This runs through a one-hop payment from start to finish, simulating an asynchronous signer at
+	// each step.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_up1, _up2, channel_id, _tx) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	let alice = &nodes[0];
+	let bob = &nodes[1];
+
+	let (route, payment_hash, payment_preimage, payment_secret) = get_route_and_payment_hash!(alice, bob, 8_000_000);
+
+	with_async_signer(&alice, &bob.node.get_our_node_id(), &channel_id, masks, &|| {
+		alice.node.send_payment_with_route(&route, payment_hash,
+			RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+		check_added_monitors!(alice, 1);
+		let events = alice.node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 0, "expected 0 events, got {}", events.len());
+	});
+
+	let payment_event = {
+		let mut events = alice.node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		SendEvent::from_event(events.remove(0))
+	};
+	assert_eq!(payment_event.node_id, bob.node.get_our_node_id());
+	assert_eq!(payment_event.msgs.len(), 1);
+
+	// alice --[update_add_htlc]--> bob
+	// alice --[commitment_signed]--> bob
+	with_async_signer(&bob, &alice.node.get_our_node_id(), &channel_id, masks, &|| {
+		bob.node.handle_update_add_htlc(&alice.node.get_our_node_id(), &payment_event.msgs[0]);
+		bob.node.handle_commitment_signed(&alice.node.get_our_node_id(), &payment_event.commitment_msg);
+		check_added_monitors(bob, 1);
+	});
+
+	// alice <--[revoke_and_ack]-- bob
+	// alice <--[commitment_signed]-- bob
+	{
+		let (raa, cu) = {
+			let events = bob.node.get_and_clear_pending_msg_events();
+			assert_eq!(events.len(), 2, "expected 2 messages, got {}", events.len());
+			match (&events[0], &events[1]) {
+				(MessageSendEvent::SendRevokeAndACK { msg: raa, .. }, MessageSendEvent::UpdateHTLCs { updates: cu, .. }) => {
+					assert_eq!(cu.update_add_htlcs.len(), 0, "expected 0 update_add_htlcs, got {}", cu.update_add_htlcs.len());
+					(raa.clone(), cu.clone())
+				}
+				(a, b) => panic!("expected SendRevokeAndAck and UpdateHTLCs, not {:?} and {:?}", a, b)
+			}
+		};
+
+		// TODO: run this with_async_signer once validate_counterparty_revocation supports it.
+		alice.node.handle_revoke_and_ack(&bob.node.get_our_node_id(), &raa);
+		check_added_monitors(alice, 1);
+
+		with_async_signer(&alice, &bob.node.get_our_node_id(), &channel_id, masks, &|| {
+			alice.node.handle_commitment_signed(&bob.node.get_our_node_id(), &cu.commitment_signed);
+			check_added_monitors(alice, 1);
+		});
+	}
+
+	// alice --[revoke_and_ack]--> bob
+	// TODO: run this with_async_signer once validate_counterparty_revocation supports it.
+	let raa = get_event_msg!(alice, MessageSendEvent::SendRevokeAndACK, bob.node.get_our_node_id());
+	bob.node.handle_revoke_and_ack(&alice.node.get_our_node_id(), &raa);
+	check_added_monitors(bob, 1);
+
+	expect_pending_htlcs_forwardable!(bob);
+
+	// Bob generates a PaymentClaimable to user code.
+	{
+		let events = bob.node.get_and_clear_pending_events();
+		assert_eq!(events.len(), 1, "expected 1 event, got {}", events.len());
+		match &events[0] {
+			Event::PaymentClaimable { .. } => {
+				bob.node.claim_funds(payment_preimage);
+			}
+			ev => panic!("Expected PaymentClaimable, got {:?}", ev)
+		}
+		check_added_monitors(bob, 1);
+	}
+
+	// Bob generates a PaymentClaimed event to user code.
+	{
+		let events = bob.node.get_and_clear_pending_events();
+		assert_eq!(events.len(), 1, "expected 1 event, got {}", events.len());
+		match &events[0] {
+			Event::PaymentClaimed { .. } => (),
+			ev => panic!("Expected PaymentClaimed, got {:?}", ev),
+		}
+	}
+
+	// alice <--[update_fulfill_htlcs]-- bob
+	// alice <--[commitment_signed]-- bob
+	{
+		let cu = {
+			let events = bob.node.get_and_clear_pending_msg_events();
+			assert_eq!(events.len(), 1, "expected 1 events, got {}", events.len());
+			match &events[0] {
+				MessageSendEvent::UpdateHTLCs { updates, .. } => {
+					assert_eq!(updates.update_fulfill_htlcs.len(), 1, "expected 1 update_fulfill_htlcs, got {}", updates.update_fulfill_htlcs.len());
+					updates.clone()
+				}
+				ev => panic!("Expected UpdateHTLCs, got {:?}", ev)
+			}
+		};
+
+		with_async_signer(&alice, &bob.node.get_our_node_id(), &channel_id, masks, &|| {
+			alice.node.handle_update_fulfill_htlc(&bob.node.get_our_node_id(), &cu.update_fulfill_htlcs[0]);
+			alice.node.handle_commitment_signed(&bob.node.get_our_node_id(), &cu.commitment_signed);
+			check_added_monitors(alice, 1);
+		});
+	}
+
+	// alice --[revoke_and_ack]--> bob
+	// alice --[commitment_signed]--> bob
+	{
+		let (raa, cu) = {
+			let events = alice.node.get_and_clear_pending_msg_events();
+			assert_eq!(events.len(), 2, "expected 2 messages, got {}", events.len());
+			match (&events[0], &events[1]) {
+				(MessageSendEvent::SendRevokeAndACK { msg: raa, .. }, MessageSendEvent::UpdateHTLCs { updates: cu, .. }) => {
+					assert_eq!(cu.update_fulfill_htlcs.len(), 0, "expected 0 update_fulfill_htlcs, got {}", cu.update_fulfill_htlcs.len());
+					(raa.clone(), cu.clone())
+				}
+				(a, b) => panic!("expected SendRevokeAndAck and UpdateHTLCs, not {:?} and {:?}", a, b)
+			}
+		};
+
+		// TODO: run with async once validate_counterparty_revocation supports it.
+		bob.node.handle_revoke_and_ack(&alice.node.get_our_node_id(), &raa);
+		check_added_monitors(bob, 1);
+
+		with_async_signer(&bob, &alice.node.get_our_node_id(), &channel_id, masks, &|| {
+			bob.node.handle_commitment_signed(&alice.node.get_our_node_id(), &cu.commitment_signed);
+			check_added_monitors(bob, 1);
+		});
+	}
+
+	// alice <--[revoke_and_ack]-- bob
+	// TODO: run with async once validate_counterparty_revocation supports it.
+	let raa = get_event_msg!(bob, MessageSendEvent::SendRevokeAndACK, alice.node.get_our_node_id());
+	alice.node.handle_revoke_and_ack(&bob.node.get_our_node_id(), &raa);
+	check_added_monitors(alice, 0);
+
+	// Alice generates PaymentSent and PaymentPathSuccessful events to user code.
+	{
+		let events = alice.node.get_and_clear_pending_events();
+		assert_eq!(events.len(), 2, "expected 2 event, got {}", events.len());
+		match (&events[0], &events[1]) {
+			(Event::PaymentSent { .. }, Event::PaymentPathSuccessful { .. }) => (),
+			(a, b) => panic!("Expected PaymentSent and PaymentPathSuccessful, got {:?} and {:?}", a, b)
+		}
+
+		check_added_monitors(alice, 1);  // why? would have expected this after handling RAA...
+	}
+}
+
+#[test]
+fn test_payment_grs() {
+	do_test_payment(&vec![ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_payment_gsr() {
+	do_test_payment(&vec![ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+#[test]
+fn test_payment_rsg() {
+	do_test_payment(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_payment_rgs() {
+	do_test_payment(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_payment_srg() {
+	do_test_payment(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_payment_sgr() {
+	do_test_payment(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+#[cfg(test)]
+fn do_test_peer_reconnect(masks: &Vec<u32>) {
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
@@ -273,51 +579,550 @@ fn test_async_commitment_signature_for_peer_disconnect() {
 	let (_, _, chan_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
 
 	// Send a payment.
-	let src = &nodes[0];
-	let dst = &nodes[1];
-	let (route, our_payment_hash, _our_payment_preimage, our_payment_secret) = get_route_and_payment_hash!(src, dst, 8000000);
-	src.node.send_payment_with_route(&route, our_payment_hash,
-		RecipientOnionFields::secret_only(our_payment_secret), PaymentId(our_payment_hash.0)).unwrap();
-	check_added_monitors!(src, 1);
+	let alice = &nodes[0];
+	let bob = &nodes[1];
+	let (route, payment_hash, payment_preimage, payment_secret) = get_route_and_payment_hash!(alice, bob, 8_000_000);
 
-	// Pass the payment along the route.
+	with_async_signer(&alice, &bob.node.get_our_node_id(), &chan_id, masks, &|| {
+		alice.node.send_payment_with_route(&route, payment_hash,
+			RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+		check_added_monitors!(alice, 1);
+		let events = alice.node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 0, "expected 0 events, got {}", events.len());
+
+		alice.node.peer_disconnected(&bob.node.get_our_node_id());
+		bob.node.peer_disconnected(&alice.node.get_our_node_id());
+	});
+
+	with_async_signer(&alice, &bob.node.get_our_node_id(), &chan_id, masks, &|| {
+		let mut reconnect_args = ReconnectArgs::new(alice, bob);
+		reconnect_args.send_channel_ready = (true, true);  // ...since this will be state 1.
+		reconnect_nodes(reconnect_args);
+	});
+
 	let payment_event = {
-		let mut events = src.node.get_and_clear_pending_msg_events();
+		let mut events = alice.node.get_and_clear_pending_msg_events();
 		assert_eq!(events.len(), 1);
 		SendEvent::from_event(events.remove(0))
 	};
-	assert_eq!(payment_event.node_id, dst.node.get_our_node_id());
+	assert_eq!(payment_event.node_id, bob.node.get_our_node_id());
 	assert_eq!(payment_event.msgs.len(), 1);
 
-	dst.node.handle_update_add_htlc(&src.node.get_our_node_id(), &payment_event.msgs[0]);
+	// alice --[update_add_htlc]--> bob
+	// alice --[commitment_signed]--> bob
+	with_async_signer(&bob, &alice.node.get_our_node_id(), &chan_id, masks, &|| {
+		bob.node.handle_update_add_htlc(&alice.node.get_our_node_id(), &payment_event.msgs[0]);
+		bob.node.handle_commitment_signed(&alice.node.get_our_node_id(), &payment_event.commitment_msg);
+		check_added_monitors(bob, 1);
 
-	// Mark dst's signer as unavailable and handle src's commitment_signed: while dst won't yet have a
-	// `commitment_signed` of its own to offer, it should publish a `revoke_and_ack`.
-	dst.set_channel_signer_available(&src.node.get_our_node_id(), &chan_id, false);
-	dst.node.handle_commitment_signed(&src.node.get_our_node_id(), &payment_event.commitment_msg);
-	check_added_monitors(dst, 1);
+		alice.node.peer_disconnected(&bob.node.get_our_node_id());
+		bob.node.peer_disconnected(&alice.node.get_our_node_id());
+	});
 
-	get_event_msg!(dst, MessageSendEvent::SendRevokeAndACK, src.node.get_our_node_id());
+	let (alice_reestablish, bob_reestablish) = with_async_signer(&alice, &bob.node.get_our_node_id(), &chan_id, masks, &|| {
+		alice.node.peer_connected(&bob.node.get_our_node_id(), &msgs::Init {
+			features: bob.node.init_features(), networks: None, remote_network_address: None
+		}, true).expect("peer_connected failed for alice");
+		let alice_msgs = get_chan_reestablish_msgs!(alice, bob);
+		assert_eq!(alice_msgs.len(), 1, "expected 1 message, got {}", alice_msgs.len());
+		bob.node.peer_connected(&alice.node.get_our_node_id(), &msgs::Init {
+			features: alice.node.init_features(), networks: None, remote_network_address: None
+		}, false).expect("peer_connected failed for bob");
+		let bob_msgs = get_chan_reestablish_msgs!(bob, alice);
+		assert_eq!(bob_msgs.len(), 1, "expected 1 message, got {}", bob_msgs.len());
+		(alice_msgs[0].clone(), bob_msgs[0].clone())
+	});
 
-	// Now disconnect and reconnect the peers.
-	src.node.peer_disconnected(&dst.node.get_our_node_id());
-	dst.node.peer_disconnected(&src.node.get_our_node_id());
-	let mut reconnect_args = ReconnectArgs::new(&nodes[0], &nodes[1]);
-	reconnect_args.send_channel_ready = (false, false);
-	reconnect_args.pending_raa = (true, false);
-	reconnect_nodes(reconnect_args);
+	with_async_signer(&bob, &alice.node.get_our_node_id(), &chan_id, masks, &|| {
+		bob.node.handle_channel_reestablish(&alice.node.get_our_node_id(), &alice_reestablish);
+	});
 
-	// Mark dst's signer as available and retry: we now expect to see dst's `commitment_signed`.
-	dst.set_channel_signer_available(&src.node.get_our_node_id(), &chan_id, true);
-	dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
+	let (raa, cu) = match handle_chan_reestablish_msgs!(bob, alice) {
+		(None, Some(raa), Some(cu), RAACommitmentOrder::RevokeAndACKFirst) => (raa, cu),
+		(channel_ready, raa, cu, order) => {
+			panic!("bob: channel_ready={:?} raa={:?} cu={:?} order={:?}", channel_ready, raa, cu, order);
+		}
+	};
+
+	with_async_signer(&alice, &bob.node.get_our_node_id(), &chan_id, masks, &|| {
+		alice.node.handle_channel_reestablish(&bob.node.get_our_node_id(), &bob_reestablish);
+	});
+
+	match handle_chan_reestablish_msgs!(alice, bob) {
+		(None, None, None, _) => (),
+		(channel_ready, raa, cu, order) => {
+			panic!("alice: channel_ready={:?} raa={:?} cu={:?} order={:?}", channel_ready, raa, cu, order);
+		}
+	};
+
+	with_async_signer(&alice, &bob.node.get_our_node_id(), &chan_id, masks, &|| {
+		alice.node.handle_revoke_and_ack(&bob.node.get_our_node_id(), &raa);
+		check_added_monitors(alice, 1);
+	});
+
+	// Disconnect?
+
+	with_async_signer(&alice, &bob.node.get_our_node_id(), &chan_id, masks, &|| {
+		alice.node.handle_commitment_signed(&bob.node.get_our_node_id(), &cu.commitment_signed);
+		check_added_monitors(alice, 1);
+	});
+
+	// Disconnect?
+
+	let raa = get_event_msg!(alice, MessageSendEvent::SendRevokeAndACK, bob.node.get_our_node_id());
+	with_async_signer(&bob, &alice.node.get_our_node_id(), &chan_id, masks, &|| {
+		bob.node.handle_revoke_and_ack(&alice.node.get_our_node_id(), &raa);
+		check_added_monitors(bob, 1);
+	});
+
+	expect_pending_htlcs_forwardable!(bob);
 
 	{
-		let events = dst.node.get_and_clear_pending_msg_events();
-		assert_eq!(events.len(), 1, "expected one message, got {}", events.len());
-		if let MessageSendEvent::UpdateHTLCs { ref node_id, .. } = events[0] {
-			assert_eq!(node_id, &src.node.get_our_node_id());
-		} else {
-			panic!("expected UpdateHTLCs message, not {:?}", events[0]);
-		};
+		let events = bob.node.get_and_clear_pending_events();
+		assert_eq!(events.len(), 1, "expected 1 event, got {}", events.len());
+		match &events[0] {
+			Event::PaymentClaimable { .. } => (),
+			ev => panic!("Expected PaymentClaimable, got {:?}", ev),
+		}
 	}
+
+	with_async_signer(&bob, &alice.node.get_our_node_id(), &chan_id, masks, &|| {
+		bob.node.claim_funds(payment_preimage);
+		check_added_monitors(bob, 1);
+	});
+
+	let _cu = {
+		let events = bob.node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1, "expected 1 message, got {}", events.len());
+		match &events[0] {
+			MessageSendEvent::UpdateHTLCs { ref updates, .. } => updates.clone(),
+			ev => panic!("expected UpdateHTLCs, got {:?}", ev),
+		}
+	};
+
+	{
+		let events = bob.node.get_and_clear_pending_events();
+		assert_eq!(events.len(), 1, "expected 1 event, got {}", events.len());
+		match &events[0] {
+			Event::PaymentClaimed { .. } => (),
+			ev => panic!("Expected PaymentClaimed, got {:?}", ev),
+		}
+	}
+
+	// Blah blah blah... send cu to alice, probably sprinkle some reconnects above.
+}
+
+#[test]
+fn test_peer_reconnect_grs() {
+	do_test_peer_reconnect(&vec![ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_peer_reconnect_gsr() {
+	do_test_peer_reconnect(&vec![ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+#[test]
+fn test_peer_reconnect_rsg() {
+	do_test_peer_reconnect(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_peer_reconnect_rgs() {
+	do_test_peer_reconnect(&vec![ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT, ops::SIGN_COUNTERPARTY_COMMITMENT]);
+}
+
+#[test]
+fn test_peer_reconnect_srg() {
+	do_test_peer_reconnect(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::RELEASE_COMMITMENT_SECRET, ops::GET_PER_COMMITMENT_POINT]);
+}
+
+#[test]
+fn test_peer_reconnect_sgr() {
+	do_test_payment(&vec![ops::SIGN_COUNTERPARTY_COMMITMENT, ops::GET_PER_COMMITMENT_POINT, ops::RELEASE_COMMITMENT_SECRET]);
+}
+
+#[test]
+fn channel_update_fee_test() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, chan_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	let alice = &nodes[0];
+	let bob = &nodes[1];
+
+	// Balance
+	send_payment(alice, &vec!(bob)[..], 8_000_000);
+
+	// Send a payment from Bob to Alice: this requires Alice to acquire a new commitment point from
+	// the signer. Make the signer be unavailable, and then trigger a situation that requires Alice to
+	// request fee update. Alice should be able to generate the fee update without crashing: she needs
+	// to be able to get the statistics about the new transaction, but doesn't actually need the
+	// signed transaction itself.
+	let (route, payment_hash, _payment_preimage, payment_secret) = get_route_and_payment_hash!(bob, alice, 2_000_000);
+	bob.node.send_payment_with_route(
+		&route, payment_hash,
+		RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+	check_added_monitors!(bob, 1);
+
+	let payment_event = {
+		let mut events = bob.node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		SendEvent::from_event(events.remove(0))
+	};
+
+	alice.set_channel_signer_ops_available(
+		&bob.node.get_our_node_id(), &chan_id, ops::GET_PER_COMMITMENT_POINT, false);
+
+	alice.node.handle_update_add_htlc(&bob.node.get_our_node_id(), &payment_event.msgs[0]);
+	alice.node.handle_commitment_signed(&bob.node.get_our_node_id(), &payment_event.commitment_msg);
+	check_added_monitors!(alice, 1);
+
+	// Force alice to generate an update_fee
+	{
+		let mut feerate_lock = chanmon_cfgs[0].fee_estimator.sat_per_kw.lock().unwrap();
+		*feerate_lock += 20;
+	}
+
+	alice.node.timer_tick_occurred();
+
+	assert!(alice.node.get_and_clear_pending_msg_events().is_empty());
+
+	alice.set_channel_signer_ops_available(
+		&bob.node.get_our_node_id(), &chan_id, ops::GET_PER_COMMITMENT_POINT, true);
+	alice.node.signer_unblocked(None);
+
+	let events = alice.node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 2);
+	match (&events[0], &events[1]) {
+		(MessageSendEvent::SendRevokeAndACK { .. }, MessageSendEvent::UpdateHTLCs { .. }) => {
+			// TODO(waterson) we'd kind of expect to see an update_fee here, but we actually don't because
+			// signer_maybe_unblocked doesn't create that. It probably should.
+		}
+		(a, b) => {
+			panic!("Expected SendRevokeAndACK and UpdateHTLCs, got {:?} and {:?}", a, b);
+		}
+	}
+}
+
+#[test]
+fn monitor_honors_commitment_raa_order() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, chan_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	let alice = &nodes[0];
+	let bob = &nodes[1];
+
+	let (route, payment_hash, _, payment_secret) = get_route_and_payment_hash!(alice, bob, 8_000_000);
+
+	alice.node.send_payment_with_route(&route, payment_hash,
+		RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+	check_added_monitors!(alice, 1);
+
+	let payment_event = {
+		let mut events = alice.node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		SendEvent::from_event(events.remove(0))
+	};
+
+	// Make the commitment secret be unavailable. The expectation here is that Bob should send the
+	// revoke-and-ack first. So even though he can generate a commitment update, he should hold onto
+	// that until he's ready to revoke.
+	bob.set_channel_signer_ops_available(&alice.node.get_our_node_id(),  &chan_id, ops::RELEASE_COMMITMENT_SECRET, false);
+
+	bob.node.handle_update_add_htlc(&alice.node.get_our_node_id(), &payment_event.msgs[0]);
+	bob.node.handle_commitment_signed(&alice.node.get_our_node_id(), &payment_event.commitment_msg);
+	check_added_monitors(bob, 1);
+
+	assert!(bob.node.get_and_clear_pending_msg_events().is_empty());
+
+	// Now make the commitment secret available and restart the channel.
+	bob.set_channel_signer_ops_available(&alice.node.get_our_node_id(),  &chan_id, ops::RELEASE_COMMITMENT_SECRET, true);
+	bob.node.signer_unblocked(None);
+
+	get_revoke_commit_msgs(bob, &alice.node.get_our_node_id());
+}
+
+#[test]
+fn reconnect_while_awaiting_commitment_point() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, channel_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	let alice = &nodes[0];
+	let bob = &nodes[1];
+
+	let (route, payment_hash, _payment_preimage, payment_secret) = get_route_and_payment_hash!(alice, bob, 8_000_000);
+	alice.node.send_payment_with_route(&route, payment_hash,
+		RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+	check_added_monitors!(alice, 1);
+	let payment_event = {
+		let mut events = alice.node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		SendEvent::from_event(events.remove(0))
+	};
+	assert_eq!(payment_event.node_id, bob.node.get_our_node_id());
+	assert_eq!(payment_event.msgs.len(), 1);
+
+	// Don't let Bob fetch the commitment point right now.
+	bob.set_channel_signer_ops_available(
+		&alice.node.get_our_node_id(), &channel_id, ops::GET_PER_COMMITMENT_POINT, false);
+
+	// alice --[update_add_htlc]--> bob
+	// alice --[commitment_signed]--> bob
+	bob.node.handle_update_add_htlc(&alice.node.get_our_node_id(), &payment_event.msgs[0]);
+	bob.node.handle_commitment_signed(&alice.node.get_our_node_id(), &payment_event.commitment_msg);
+	check_added_monitors(bob, 1);
+
+	// Bob should not have responded with any messages since he's blocked on the signer yielding the
+	// commitment point.
+	assert!(bob.node.get_and_clear_pending_msg_events().is_empty());
+
+	// Disconnect Alice and Bob...
+	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id());
+	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id());
+
+	// ...and now reconnect them. Bob still should not have the commitment point, and so we'll unpack
+	// the sequence by hand here.
+	alice.node.peer_connected(&bob.node.get_our_node_id(), &msgs::Init {
+		features: bob.node.init_features(), networks: None, remote_network_address: None
+	}, true).unwrap();
+	let reestablish_1 = get_chan_reestablish_msgs!(alice, bob);
+
+	// Alice should have sent Bob a channel_reestablish.
+	assert_eq!(reestablish_1.len(), 1);
+
+	bob.node.peer_connected(&alice.node.get_our_node_id(), &msgs::Init {
+		features: alice.node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	// But Bob should _not_ have sent Alice one, since he's waiting on the signer to provide the
+	// commitment point.
+	assert!(get_chan_reestablish_msgs!(bob, alice).is_empty());
+
+	// Make Bob handle Alice's channel_reestablish. This should cause Bob to generate a
+	// channel_announcement and a channel_update, but nothing more.
+	{
+		bob.node.handle_channel_reestablish(&alice.node.get_our_node_id(), &reestablish_1[0]);
+		match handle_chan_reestablish_msgs!(bob, alice) {
+			(None, None, None, _) => (),
+			(channel_ready, revoke_and_ack, commitment_update, order) => {
+				panic!("got channel_ready={:?} revoke_and_ack={:?} commitment_update={:?} order={:?}",
+					channel_ready, revoke_and_ack, commitment_update, order);
+			}
+		}
+	}
+
+	// Provide the commitment points and unblock Bob's signer. This should result in Bob sending a
+	// channel_reestablish, an RAA and a new commitment_update.
+	bob.set_channel_signer_ops_available(
+		&alice.node.get_our_node_id(), &channel_id, ops::GET_PER_COMMITMENT_POINT, true);
+	bob.node.signer_unblocked(None);
+
+	let events = bob.node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 3, "Expected 3 events, got {:?}", events);
+	let reestablish_2 = match (&events[0], &events[1], &events[2]) {
+		(MessageSendEvent::SendChannelReestablish { msg: channel_reestablish, .. },
+		 MessageSendEvent::SendRevokeAndACK { msg: revoke_and_ack, .. },
+		 MessageSendEvent::UpdateHTLCs { updates, .. }) => {
+			(channel_reestablish, revoke_and_ack, updates)
+		}
+		(a, b, c) => panic!("Expected SendChannelReestablish, SendRevokeAndACK, UpdateHTLCs; got {:?} {:?} {:?}", a, b, c)
+	};
+
+	{
+		alice.node.handle_channel_reestablish(&bob.node.get_our_node_id(), &reestablish_2.0);
+		match handle_chan_reestablish_msgs!(alice, bob) {
+			(None, None, None, _) => (),
+			(channel_ready, revoke_and_ack, commitment_update, order) => {
+				panic!("got channel_ready={:?} revoke_and_ack={:?} commitment_update={:?} order={:?}",
+					channel_ready, revoke_and_ack, commitment_update, order);
+			}
+		}
+	}
+}
+
+#[test]
+fn peer_restart_with_blocked_signer() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let persister;
+	let new_chain_monitor;
+
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let alice_deserialized;
+
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, channel_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	// Disconnect Bob and restart Alice
+	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id());
+
+	{
+		let alice_serialized = nodes[0].node.encode();
+		let alice_monitor_serialized = get_monitor!(nodes[0], channel_id).encode();
+		reload_node!(nodes[0], *nodes[0].node.get_current_default_configuration(), &alice_serialized, &[&alice_monitor_serialized], persister, new_chain_monitor, alice_deserialized);
+	}
+
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
+
+	// Turn off Alice's signer.
+	nodes[0].set_channel_signer_ops_available(
+		&nodes[1].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET | ops::SIGN_COUNTERPARTY_COMMITMENT,
+		false);
+
+	let node1_id = nodes[1].node.get_our_node_id();
+	nodes[0].forget_signer_material(&node1_id, &channel_id);
+
+	// Reconnect Alice and Bob.
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init {
+		features: nodes[1].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init {
+		features: nodes[0].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	// Bob should have sent a channel_reestablish, but Alice should not have since her signer is
+	// offline.
+	assert!(get_chan_reestablish_msgs!(nodes[0], nodes[1]).is_empty());
+	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
+	assert_eq!(reestablish_2.len(), 1);
+
+	nodes[0].node.handle_channel_reestablish(&nodes[1].node.get_our_node_id(), &reestablish_2[0]);
+	match handle_chan_reestablish_msgs!(nodes[0], nodes[1]) {
+		(None, None, None, _) => (),
+		(channel_ready, revoke_and_ack, commitment_update, order) => {
+			panic!("got channel_ready={:?} revoke_and_ack={:?} commitment_update={:?} order={:?}",
+						 channel_ready, revoke_and_ack, commitment_update, order);
+		}
+	};
+
+	// Re-enable and unblock Alice's signer.
+	nodes[0].set_channel_signer_ops_available(
+		&nodes[1].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET | ops::SIGN_COUNTERPARTY_COMMITMENT,
+		true);
+
+	nodes[0].node.signer_unblocked(None);
+
+	// N.B. that we can't just use `get_chan_reestablish_msgs` here, because we'll be expecting _both_
+	// the channel_reestablish and the channel_ready that will have been generated from being sent the
+	// channel_reestablish from our counterparty.
+	let events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 2, "Expected two events, got {:?}", events);
+	match (&events[0], &events[1]) {
+		(MessageSendEvent::SendChannelReestablish { .. }, MessageSendEvent::SendChannelReady { .. }) => (),
+		(a, b) => panic!("Expected channel_reestablish and channel_ready, got {:?} and {:?}", a, b),
+	};
+}
+
+#[test]
+fn peer_restart_with_blocked_signer_and_pending_payment() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let persister;
+	let new_chain_monitor;
+
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let alice_deserialized;
+
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, channel_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	let (route, payment_hash, _payment_preimage, payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[1], 1_000_000);
+	nodes[0].node.send_payment_with_route(&route, payment_hash,
+		RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+
+	check_added_monitors!(nodes[0], 1);
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+
+	// Deliver the update_add_htlc and commitment_signed to Bob.
+	{
+		let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 1);
+		let payment_event = SendEvent::from_event(events.remove(0));
+		assert_eq!(payment_event.node_id, nodes[1].node.get_our_node_id());
+		assert_eq!(payment_event.msgs.len(), 1);
+		nodes[1].node.handle_update_add_htlc(&nodes[0].node.get_our_node_id(), &payment_event.msgs[0]);
+		nodes[1].node.handle_commitment_signed(&nodes[0].node.get_our_node_id(), &payment_event.commitment_msg);
+	}
+
+	// Disconnect Bob and restart Alice
+	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id());
+
+	{
+		let alice_serialized = nodes[0].node.encode();
+		let alice_monitor_serialized = get_monitor!(nodes[0], channel_id).encode();
+		reload_node!(nodes[0], *nodes[0].node.get_current_default_configuration(), &alice_serialized, &[&alice_monitor_serialized], persister, new_chain_monitor, alice_deserialized);
+	}
+
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+
+	// Turn off Bob's signer.
+	nodes[1].set_channel_signer_ops_available(
+		&nodes[0].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET | ops::SIGN_COUNTERPARTY_COMMITMENT,
+		false);
+
+	// Reconnect Alice and Bob.
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init {
+		features: nodes[1].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init {
+		features: nodes[0].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	// Alice should have sent Bob a channel_reestablish and vice versa.
+	let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
+	assert_eq!(reestablish_1.len(), 1);
+	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
+	assert_eq!(reestablish_2.len(), 1);
+
+	{
+		nodes[1].node.handle_channel_reestablish(&nodes[0].node.get_our_node_id(), &reestablish_1[0]);
+		match handle_chan_reestablish_msgs!(nodes[1], nodes[0]) {
+			(None, None, None, _) => (),
+			(channel_ready, revoke_and_ack, commitment_update, order) => {
+				panic!("got channel_ready={:?} revoke_and_ack={:?} commitment_update={:?} order={:?}",
+					channel_ready, revoke_and_ack, commitment_update, order);
+			}
+		}
+	}
+
+	{
+		nodes[0].node.handle_channel_reestablish(&nodes[1].node.get_our_node_id(), &reestablish_2[0]);
+		match handle_chan_reestablish_msgs!(nodes[0], nodes[1]) {
+			(None, None, None, _) => (),
+			(channel_ready, revoke_and_ack, commitment_update, order) => {
+				panic!("got channel_ready={:?} revoke_and_ack={:?} commitment_update={:?} order={:?}",
+					channel_ready, revoke_and_ack, commitment_update, order);
+			}
+		}
+	};
+
+	// Re-enable and unblock Bob's signer.
+	nodes[1].set_channel_signer_ops_available(
+		&nodes[0].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET | ops::SIGN_COUNTERPARTY_COMMITMENT,
+		true);
+
+	nodes[1].node.signer_unblocked(None);
+
+	// At this point we should provide Alice with the revoke_and_ack and commitment_signed.
+	get_revoke_commit_msgs(&nodes[1], &nodes[0].node.get_our_node_id());
+	check_added_monitors!(nodes[1], 1);
 }

--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -1309,3 +1309,207 @@ fn no_stray_channel_reestablish() {
 	let events = nodes[0].node.get_and_clear_pending_msg_events();
 	assert!(events.is_empty(), "Expected no events from Alice, got {:?}", events);
 }
+
+#[test]
+fn dont_elide_channely_ready_from_state_1() {
+	// 1. Disable Alice's signer.
+	// 2. Send a payment from Alice to Bob.
+	// 3. Disconnect Alice and Bob. Reload Alice.
+	// 4. Reconnect Alice and Bob.
+	// 5. Process messages on Bob, which should generate a `channel_reestablish`.
+	// 6. Process messages on Alice, which should *not* send anything, in particular an
+	//    `update_add_htlc` because Alice must send a `channel_ready` (that she can't create
+	//    without her signer) first.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let persister;
+	let new_chain_monitor;
+
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let alice_deserialized;
+
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, channel_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	// Turn off Alice's signer.
+	eprintln!("disabling alice's signer");
+	nodes[0].set_channel_signer_ops_available(
+		&nodes[1].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET | ops::SIGN_COUNTERPARTY_COMMITMENT,
+		false);
+
+	eprintln!("sending payment from alice to bob");
+	let (route, payment_hash, _payment_preimage, payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[1], 1_000_000);
+	nodes[0].node.send_payment_with_route(&route, payment_hash,
+		RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+
+	check_added_monitors!(nodes[0], 1);
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+
+	// Disconnect Bob and restart Alice
+	eprintln!("disconnecting bob");
+	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id());
+
+	eprintln!("restarting alice");
+	{
+		let alice_serialized = nodes[0].node.encode();
+		let alice_monitor_serialized = get_monitor!(nodes[0], channel_id).encode();
+		reload_node!(nodes[0], *nodes[0].node.get_current_default_configuration(), &alice_serialized, &[&alice_monitor_serialized], persister, new_chain_monitor, alice_deserialized);
+	}
+
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+
+	eprintln!("unblocking alice's signer with commmitment signed");
+	nodes[0].set_channel_signer_ops_available(
+		&nodes[1].node.get_our_node_id(), &channel_id,
+		ops::SIGN_COUNTERPARTY_COMMITMENT,
+		true);
+	nodes[0].node.signer_unblocked(None);
+
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+
+	// Reconnect Alice and Bob.
+	eprintln!("reconnecting alice and bob");
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init {
+		features: nodes[1].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init {
+		features: nodes[0].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	// Bob should have sent Alice a channel_reestablish. Alice should not have done anything.
+	assert!(get_chan_reestablish_msgs!(nodes[0], nodes[1]).is_empty());
+	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
+	assert_eq!(reestablish_2.len(), 1);
+
+	// When Alice handle's the channel_reestablish, she should _still_ do nothing, in particular,
+	// because she doesn't have the channel ready available.
+	nodes[0].node.handle_channel_reestablish(&nodes[1].node.get_our_node_id(), &reestablish_2[0]);
+	match handle_chan_reestablish_msgs!(nodes[0], nodes[1]) {
+		(None, None, None, _) => (),
+		(channel_ready, revoke_and_ack, commitment_update, order) => {
+			panic!("got channel_ready={:?} revoke_and_ack={:?} commitment_update={:?} order={:?}",
+						 channel_ready, revoke_and_ack, commitment_update, order);
+		}
+	};
+
+	// Now provide the commitment point and Alice should send her channel_reestablish.
+	nodes[0].set_channel_signer_ops_available(
+		&nodes[1].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT,
+		true);
+	nodes[0].node.signer_unblocked(None);
+
+	{
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 2, "Expected 2 events, got {}: {:?}", events.len(), events);
+		match (&events[0], &events[1]) {
+			(MessageSendEvent::SendChannelReestablish { .. }, MessageSendEvent::SendChannelReady { .. }) => (),
+			(a, b) => panic!("Expected SendChannelReestablish and SendChannelReady, not {:?} and {:?}", a, b)
+		}
+	}
+}
+
+#[test]
+fn dont_lose_commitment_update() {
+	// 1. Send a payment from Alice to Bob.
+	// 2. Disable signing on Alice.
+	// 3. Disconnect Alice and Bob. Reload Alice.
+	// 4. Reconnect Alice and Bob.
+	// 5. Process messages on Bob, which should generate a `channel_reestablish`.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let persister;
+	let new_chain_monitor;
+
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let alice_deserialized;
+
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, channel_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	eprintln!("sending payment from alice to bob");
+	let (route, payment_hash, _payment_preimage, payment_secret) = get_route_and_payment_hash!(nodes[0], nodes[1], 1_000_000);
+	nodes[0].node.send_payment_with_route(&route, payment_hash,
+		RecipientOnionFields::secret_only(payment_secret), PaymentId(payment_hash.0)).unwrap();
+
+	// Turn off Alice's signer.
+	eprintln!("disabling alice's signer");
+	nodes[0].set_channel_signer_ops_available(
+		&nodes[1].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET | ops::SIGN_COUNTERPARTY_COMMITMENT,
+		false);
+
+	check_added_monitors!(nodes[0], 1);
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+
+	// Disconnect Bob and restart Alice
+	eprintln!("disconnecting bob");
+	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id());
+
+	eprintln!("restarting alice");
+	{
+		let alice_serialized = nodes[0].node.encode();
+		let alice_monitor_serialized = get_monitor!(nodes[0], channel_id).encode();
+		reload_node!(nodes[0], *nodes[0].node.get_current_default_configuration(), &alice_serialized, &[&alice_monitor_serialized], persister, new_chain_monitor, alice_deserialized);
+	}
+
+	// Reconnect Alice and Bob.
+	eprintln!("reconnecting alice and bob");
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init {
+		features: nodes[1].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init {
+		features: nodes[0].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+
+	// Bob should have sent Alice a channel_reestablish. Alice should not have done anything.
+	assert!(get_chan_reestablish_msgs!(nodes[0], nodes[1]).is_empty());
+	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
+	assert_eq!(reestablish_2.len(), 1);
+
+	// When Alice handle's the channel_reestablish, she should _still_ do nothing, in particular,
+	// because she doesn't have the channel ready available.
+	nodes[0].node.handle_channel_reestablish(&nodes[1].node.get_our_node_id(), &reestablish_2[0]);
+	match handle_chan_reestablish_msgs!(nodes[0], nodes[1]) {
+		(None, None, None, _) => (),
+		(channel_ready, revoke_and_ack, commitment_update, order) => {
+			panic!("got channel_ready={:?} revoke_and_ack={:?} commitment_update={:?} order={:?}",
+						 channel_ready, revoke_and_ack, commitment_update, order);
+		}
+	};
+
+	{
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		assert!(events.is_empty(), "expected no events, got {:?}", events);
+	}
+
+	{
+		let events = nodes[1].node.get_and_clear_pending_msg_events();
+		assert!(events.is_empty(), "expected no events, got {:?}", events);
+	}
+
+	eprintln!("unblocking alice's signer");
+	nodes[0].set_channel_signer_ops_available(
+		&nodes[1].node.get_our_node_id(), &channel_id,
+		ops::GET_PER_COMMITMENT_POINT | ops::RELEASE_COMMITMENT_SECRET | ops::SIGN_COUNTERPARTY_COMMITMENT,
+		true);
+	nodes[0].node.signer_unblocked(None);
+
+	{
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), 3, "Expected 3 events, got {}: {:?}", events.len(), events);
+		match (&events[0], &events[1], &events[2]) {
+			(MessageSendEvent::SendChannelReestablish { .. },
+			 MessageSendEvent::UpdateHTLCs { .. },
+			 MessageSendEvent::SendChannelReady { .. }) => (),
+			(a, b, c) => panic!("Expected SendChannelReestablish, UpdateHTLCs, SendChannelReady; not {:?}, {:?}, {:?}", a, b, c)
+		}
+	}
+}

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -32,6 +32,8 @@ use crate::util::config::{UserConfig, MaxDustHTLCExposure};
 use crate::util::ser::{ReadableArgs, Writeable};
 #[cfg(test)]
 use crate::util::logger::Logger;
+#[cfg(test)]
+use crate::util::test_channel_signer::ops;
 
 use bitcoin::blockdata::block::{Block, Header, Version};
 use bitcoin::blockdata::locktime::absolute::LockTime;
@@ -446,14 +448,14 @@ impl<'a, 'b, 'c> Node<'a, 'b, 'c> {
 	pub fn get_block_header(&self, height: u32) -> Header {
 		self.blocks.lock().unwrap()[height as usize].0.header
 	}
+
 	/// Changes the channel signer's availability for the specified peer and channel.
 	///
 	/// When `available` is set to `true`, the channel signer will behave normally. When set to
 	/// `false`, the channel signer will act like an off-line remote signer and will return `Err` for
-	/// several of the signing methods. Currently, only `get_per_commitment_point` and
-	/// `release_commitment_secret` are affected by this setting.
+	/// several of the signing methods.
 	#[cfg(test)]
-	pub fn set_channel_signer_available(&self, peer_id: &PublicKey, chan_id: &ChannelId, available: bool) {
+	pub fn set_channel_signer_ops_available(&self, peer_id: &PublicKey, chan_id: &ChannelId, mask: u32, available: bool) {
 		let per_peer_state = self.node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(peer_id).unwrap().lock().unwrap();
 		let signer = (|| {
@@ -462,8 +464,21 @@ impl<'a, 'b, 'c> Node<'a, 'b, 'c> {
 				None => panic!("Couldn't find a channel with id {}", chan_id),
 			}
 		})();
-		log_debug!(self.logger, "Setting channel signer for {} as available={}", chan_id, available);
-		signer.as_ecdsa().unwrap().set_available(available);
+		log_debug!(self.logger, "Setting channel signer for {} as {}available for {} (mask={})",
+			chan_id, if available { "" } else { "un" }, ops::string_from(mask), mask);
+		signer.as_ecdsa().unwrap().set_ops_available(mask, available);
+	}
+
+	/// Removes signature material from the channel context.
+	#[cfg(test)]
+	pub fn forget_signer_material(&mut self, peer_id: &PublicKey, chan_id: &ChannelId) {
+		let mut per_peer_state = self.node.per_peer_state.write().unwrap();
+		let mut chan_lock = per_peer_state.get_mut(peer_id).unwrap().lock().unwrap();
+		match chan_lock.channel_by_id.get_mut(chan_id) {
+			Some(ref mut phase) => phase.context_mut().forget_signer_material(),
+			None => panic!("Couldn't find a channel with id {}", chan_id),
+		}
+		log_debug!(self.logger, "Forgetting signing material for {}", chan_id);
 	}
 }
 
@@ -3164,7 +3179,7 @@ macro_rules! get_chan_reestablish_msgs {
 					assert_eq!(*node_id, $dst_node.node.get_our_node_id());
 					announcements.insert(msg.contents.short_channel_id);
 				} else {
-					panic!("Unexpected event")
+					panic!("Unexpected event re-establishing channel, {:?}", msg)
 				}
 			}
 			assert!(announcements.is_empty());
@@ -3219,6 +3234,13 @@ macro_rules! handle_chan_reestablish_msgs {
 			} else {
 				RAACommitmentOrder::CommitmentFirst
 			};
+
+			if let Some(&MessageSendEvent::SendChannelUpdate { ref node_id, .. }) = msg_events.get(idx) {
+				assert_eq!(*node_id, $dst_node.node.get_our_node_id());
+				idx += 1;
+				assert!(!had_channel_update);
+				had_channel_update = true;
+			}
 
 			if let Some(ev) = msg_events.get(idx) {
 				match ev {
@@ -3370,7 +3392,7 @@ pub fn reconnect_nodes<'a, 'b, 'c, 'd>(args: ReconnectArgs<'a, 'b, 'c, 'd>) {
 				} else { panic!("Unexpected event! {:?}", announcement_event[0]); }
 			}
 		} else {
-			assert!(chan_msgs.0.is_none());
+			assert!(chan_msgs.0.is_none(), "did not expect to have a ChannelReady for node 1");
 		}
 		if pending_raa.0 {
 			assert!(chan_msgs.3 == RAACommitmentOrder::RevokeAndACKFirst);
@@ -3378,7 +3400,7 @@ pub fn reconnect_nodes<'a, 'b, 'c, 'd>(args: ReconnectArgs<'a, 'b, 'c, 'd>) {
 			assert!(node_a.node.get_and_clear_pending_msg_events().is_empty());
 			check_added_monitors!(node_a, 1);
 		} else {
-			assert!(chan_msgs.1.is_none());
+			assert!(chan_msgs.1.is_none(), "did not expect to have a RevokeAndACK for node 1");
 		}
 		if pending_htlc_adds.0 != 0 || pending_htlc_claims.0 != 0 || pending_htlc_fails.0 != 0 ||
 			pending_cell_htlc_claims.0 != 0 || pending_cell_htlc_fails.0 != 0 ||
@@ -3411,7 +3433,7 @@ pub fn reconnect_nodes<'a, 'b, 'c, 'd>(args: ReconnectArgs<'a, 'b, 'c, 'd>) {
 				check_added_monitors!(node_b, if pending_responding_commitment_signed_dup_monitor.0 { 0 } else { 1 });
 			}
 		} else {
-			assert!(chan_msgs.2.is_none());
+			assert!(chan_msgs.2.is_none(), "did not expect to have commitment updates for node 1");
 		}
 	}
 
@@ -3428,7 +3450,7 @@ pub fn reconnect_nodes<'a, 'b, 'c, 'd>(args: ReconnectArgs<'a, 'b, 'c, 'd>) {
 				}
 			}
 		} else {
-			assert!(chan_msgs.0.is_none());
+			assert!(chan_msgs.0.is_none(), "did not expect to have a ChannelReady for node 2");
 		}
 		if pending_raa.1 {
 			assert!(chan_msgs.3 == RAACommitmentOrder::RevokeAndACKFirst);
@@ -3436,7 +3458,7 @@ pub fn reconnect_nodes<'a, 'b, 'c, 'd>(args: ReconnectArgs<'a, 'b, 'c, 'd>) {
 			assert!(node_b.node.get_and_clear_pending_msg_events().is_empty());
 			check_added_monitors!(node_b, 1);
 		} else {
-			assert!(chan_msgs.1.is_none());
+			assert!(chan_msgs.1.is_none(), "did not expect to have a RevokeAndACK for node 2");
 		}
 		if pending_htlc_adds.1 != 0 || pending_htlc_claims.1 != 0 || pending_htlc_fails.1 != 0 ||
 			pending_cell_htlc_claims.1 != 0 || pending_cell_htlc_fails.1 != 0 ||
@@ -3469,7 +3491,7 @@ pub fn reconnect_nodes<'a, 'b, 'c, 'd>(args: ReconnectArgs<'a, 'b, 'c, 'd>) {
 				check_added_monitors!(node_a, if pending_responding_commitment_signed_dup_monitor.1 { 0 } else { 1 });
 			}
 		} else {
-			assert!(chan_msgs.2.is_none());
+			assert!(chan_msgs.2.is_none(), "did not expect to have commitment updates for node 2");
 		}
 	}
 }

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -720,7 +720,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
-		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx),
+		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx).unwrap(),
 		 pubkeys.funding_pubkey)
 	};
 
@@ -1442,8 +1442,8 @@ fn test_fee_spike_violation_fails_htlc() {
 
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
-		 chan_signer.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER),
-		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 2, &secp_ctx),
+		 chan_signer.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER).unwrap(),
+		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 2, &secp_ctx).unwrap(),
 		 chan_signer.as_ref().pubkeys().funding_pubkey)
 	};
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
@@ -1455,7 +1455,7 @@ fn test_fee_spike_violation_fails_htlc() {
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
-		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx),
+		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx).unwrap(),
 		 chan_signer.as_ref().pubkeys().funding_pubkey)
 	};
 
@@ -7795,15 +7795,15 @@ fn test_counterparty_raa_skip_no_crash() {
 
 		// Make signer believe we got a counterparty signature, so that it allows the revocation
 		keys.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
-		per_commitment_secret = keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER);
+		per_commitment_secret = keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER).unwrap();
 
 		// Must revoke without gaps
 		keys.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
-		keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 1);
+		keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 1).expect("unable to release commitment secret");
 
 		keys.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
 		next_per_commitment_point = PublicKey::from_secret_key(&Secp256k1::new(),
-			&SecretKey::from_slice(&keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 2)).unwrap());
+			&SecretKey::from_slice(&keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 2).unwrap()).unwrap());
 	}
 
 	nodes[1].node.handle_revoke_and_ack(&nodes[0].node.get_our_node_id(),

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -68,9 +68,51 @@ pub struct TestChannelSigner {
 	/// Channel state used for policy enforcement
 	pub state: Arc<Mutex<EnforcementState>>,
 	pub disable_revocation_policy_check: bool,
-	/// When `true` (the default), the signer will respond immediately with signatures. When `false`,
-	/// the signer will return an error indicating that it is unavailable.
-	pub available: Arc<Mutex<bool>>,
+}
+
+/// Channel signer operations that can be individually enabled and disabled. If a particular value
+/// is set in the `TestChannelSigner::unavailable` bitmask, then that operation will return an
+/// error.
+pub mod ops {
+	pub const GET_PER_COMMITMENT_POINT: u32                  = 1 << 0;
+	pub const RELEASE_COMMITMENT_SECRET: u32                 = 1 << 1;
+	pub const VALIDATE_HOLDER_COMMITMENT: u32                = 1 << 2;
+	pub const SIGN_COUNTERPARTY_COMMITMENT: u32              = 1 << 3;
+	pub const VALIDATE_COUNTERPARTY_REVOCATION: u32          = 1 << 4;
+	pub const SIGN_HOLDER_COMMITMENT_AND_HTLCS: u32          = 1 << 5;
+	pub const SIGN_JUSTICE_REVOKED_OUTPUT: u32               = 1 << 6;
+	pub const SIGN_JUSTICE_REVOKED_HTLC: u32                 = 1 << 7;
+	pub const SIGN_HOLDER_HTLC_TRANSACTION: u32              = 1 << 8;
+	pub const SIGN_COUNTERPARTY_HTLC_TRANSATION: u32         = 1 << 9;
+	pub const SIGN_CLOSING_TRANSACTION: u32                  = 1 << 10;
+	pub const SIGN_HOLDER_ANCHOR_INPUT: u32                  = 1 << 11;
+	pub const SIGN_CHANNEL_ANNOUNCMENT_WITH_FUNDING_KEY: u32 = 1 << 12;
+
+	#[cfg(test)]
+	pub fn string_from(mask: u32) -> String {
+		if mask == 0 {
+			return "nothing".to_owned();
+		}
+		if mask == !(0 as u32) {
+			return "everything".to_owned();
+		}
+
+		vec![
+			if (mask & GET_PER_COMMITMENT_POINT) != 0 { Some("get_per_commitment_point") } else { None },
+			if (mask & RELEASE_COMMITMENT_SECRET) != 0 { Some("release_commitment_secret") } else { None },
+			if (mask & VALIDATE_HOLDER_COMMITMENT) != 0 { Some("validate_holder_commitment") } else { None },
+			if (mask & SIGN_COUNTERPARTY_COMMITMENT) != 0 { Some("sign_counterparty_commitment") } else { None },
+			if (mask & VALIDATE_COUNTERPARTY_REVOCATION) != 0 { Some("validate_counterparty_revocation") } else { None },
+			if (mask & SIGN_HOLDER_COMMITMENT_AND_HTLCS) != 0 { Some("sign_holder_commitment_and_htlcs") } else { None },
+			if (mask & SIGN_JUSTICE_REVOKED_OUTPUT) != 0 { Some("sign_justice_revoked_output") } else { None },
+			if (mask & SIGN_JUSTICE_REVOKED_HTLC) != 0 { Some("sign_justice_revoked_htlc") } else { None },
+			if (mask & SIGN_HOLDER_HTLC_TRANSACTION) != 0 { Some("sign_holder_htlc_transaction") } else { None },
+			if (mask & SIGN_COUNTERPARTY_HTLC_TRANSATION) != 0 { Some("sign_counterparty_htlc_transation") } else { None },
+			if (mask & SIGN_CLOSING_TRANSACTION) != 0 { Some("sign_closing_transaction") } else { None },
+			if (mask & SIGN_HOLDER_ANCHOR_INPUT) != 0 { Some("sign_holder_anchor_input") } else { None },
+			if (mask & SIGN_CHANNEL_ANNOUNCMENT_WITH_FUNDING_KEY) != 0 { Some("sign_channel_announcment_with_funding_key") } else { None },
+		].iter().flatten().map(|s| s.to_string()).collect::<Vec<_>>().join(", ")
+	}
 }
 
 impl PartialEq for TestChannelSigner {
@@ -87,7 +129,6 @@ impl TestChannelSigner {
 			inner,
 			state,
 			disable_revocation_policy_check: false,
-			available: Arc::new(Mutex::new(true)),
 		}
 	}
 
@@ -101,7 +142,6 @@ impl TestChannelSigner {
 			inner,
 			state,
 			disable_revocation_policy_check,
-			available: Arc::new(Mutex::new(true)),
 		}
 	}
 
@@ -113,22 +153,33 @@ impl TestChannelSigner {
 	}
 
 	/// Marks the signer's availability.
-	///
-	/// When `true`, methods are forwarded to the underlying signer as normal. When `false`, some
-	/// methods will return `Err` indicating that the signer is unavailable. Intended to be used for
-	/// testing asynchronous signing.
 	#[cfg(test)]
-	pub fn set_available(&self, available: bool) {
-		*self.available.lock().unwrap() = available;
+	pub fn set_ops_available(&self, mask: u32, available: bool) {
+		let mut state = self.get_enforcement_state();
+		if available {
+			state.unavailable_signer_ops &= !mask;  // clear the bits that are now available
+		} else {
+			state.unavailable_signer_ops |= mask;   // set the bits that are now unavailable
+		}
+	}
+
+	fn is_signer_available(&self, ops_mask: u32) -> bool {
+		self.state.lock().unwrap().is_signer_available(ops_mask)
 	}
 }
 
 impl ChannelSigner for TestChannelSigner {
-	fn get_per_commitment_point(&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>) -> PublicKey {
+	fn get_per_commitment_point(&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<PublicKey, ()> {
+		if !self.is_signer_available(ops::GET_PER_COMMITMENT_POINT) {
+			return Err(());
+		}
 		self.inner.get_per_commitment_point(idx, secp_ctx)
 	}
 
-	fn release_commitment_secret(&self, idx: u64) -> [u8; 32] {
+	fn release_commitment_secret(&self, idx: u64) -> Result<[u8; 32], ()> {
+		if !self.is_signer_available(ops::RELEASE_COMMITMENT_SECRET) {
+			return Err(());
+		}
 		{
 			let mut state = self.state.lock().unwrap();
 			assert!(idx == state.last_holder_revoked_commitment || idx == state.last_holder_revoked_commitment - 1, "can only revoke the current or next unrevoked commitment - trying {}, last revoked {}", idx, state.last_holder_revoked_commitment);
@@ -139,6 +190,9 @@ impl ChannelSigner for TestChannelSigner {
 	}
 
 	fn validate_holder_commitment(&self, holder_tx: &HolderCommitmentTransaction, _outbound_htlc_preimages: Vec<PaymentPreimage>) -> Result<(), ()> {
+		if !self.is_signer_available(ops::VALIDATE_HOLDER_COMMITMENT) {
+			return Err(());
+		}
 		let mut state = self.state.lock().unwrap();
 		let idx = holder_tx.commitment_number();
 		assert!(idx == state.last_holder_commitment || idx == state.last_holder_commitment - 1, "expecting to validate the current or next holder commitment - trying {}, current {}", idx, state.last_holder_commitment);
@@ -147,7 +201,7 @@ impl ChannelSigner for TestChannelSigner {
 	}
 
 	fn validate_counterparty_revocation(&self, idx: u64, _secret: &SecretKey) -> Result<(), ()> {
-		if !*self.available.lock().unwrap() {
+		if !self.is_signer_available(ops::VALIDATE_COUNTERPARTY_REVOCATION) {
 			return Err(());
 		}
 		let mut state = self.state.lock().unwrap();
@@ -170,7 +224,7 @@ impl EcdsaChannelSigner for TestChannelSigner {
 		self.verify_counterparty_commitment_tx(commitment_tx, secp_ctx);
 
 		{
-			if !*self.available.lock().unwrap() {
+			if !self.is_signer_available(ops::SIGN_COUNTERPARTY_COMMITMENT) {
 				return Err(());
 			}
 			let mut state = self.state.lock().unwrap();
@@ -189,7 +243,7 @@ impl EcdsaChannelSigner for TestChannelSigner {
 	}
 
 	fn sign_holder_commitment(&self, commitment_tx: &HolderCommitmentTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
-		if !*self.available.lock().unwrap() {
+		if !self.is_signer_available(ops::SIGN_HOLDER_COMMITMENT_AND_HTLCS) {
 			return Err(());
 		}
 		let trusted_tx = self.verify_holder_commitment_tx(commitment_tx, secp_ctx);
@@ -362,6 +416,10 @@ pub struct EnforcementState {
 	pub last_holder_revoked_commitment: u64,
 	/// The last validated holder commitment number, backwards counting
 	pub last_holder_commitment: u64,
+	/// A flag array that indicates which signing operations are currently *not* available in the
+	/// channel. When a method's bit is set, then the signer will act as if the signature is
+	/// unavailable and return an error result.
+	pub unavailable_signer_ops: u32,
 }
 
 impl EnforcementState {
@@ -372,6 +430,19 @@ impl EnforcementState {
 			last_counterparty_revoked_commitment: INITIAL_REVOKED_COMMITMENT_NUMBER,
 			last_holder_revoked_commitment: INITIAL_REVOKED_COMMITMENT_NUMBER,
 			last_holder_commitment: INITIAL_REVOKED_COMMITMENT_NUMBER,
+			unavailable_signer_ops: 0,
 		}
+	}
+
+	pub fn set_signer_available(&mut self, ops_mask: u32) {
+		self.unavailable_signer_ops &= !ops_mask;  // clear the bits that are now available
+	}
+
+	pub fn set_signer_unavailable(&mut self, ops_mask: u32) {
+		self.unavailable_signer_ops |= ops_mask;   // set the bits that are now unavailable
+	}
+
+	pub fn is_signer_available(&self, ops_mask: u32) -> bool {
+		(self.unavailable_signer_ops & ops_mask) == 0
 	}
 }


### PR DESCRIPTION
Apologies in advance for the hair-ball. Mostly just wanted to get a 50,000 foot overview to see if things were headed in the right direction. If things look okay, I can take a step back and chop this into more modestly-sized PRs.

In general, this PR adds state to the context to allow a `ChannelSigner` implementation to respond asynchronously to the `get_per_commitment_point`, `release_commitment_secret`, and `sign_counterparty_commitment` methods, which are the main signer methods that are called during channel setup and normal operation.

These changes seem to work as advertised during normal channel operation (creation and payment exchange), and do not obviously fail during channel re-establishment or across node restart. That said, there are a lot more test scenarios to evaluate here.

The details are below.

Adds the RevokeAndAck and RAACommitemnt ordering to the `SignerResumeUpdates` struct that is returned from `signer_maybe_unblocked`.

Adds `signer_maybe_unblocked` for both inbound and outbound unfunded channel states. We need these now because `get_per_commitment_point` is asynchronous -- and necessary for us to proceed out of the unfunded state into normal
operation. Adds appropriate `SignerResumeUpdates` classes for both inbound and outbound unfunded states.

Maintains `cur_holder_commitment_point` and `prev_holder_commitment_secret` on the channel context. By making these part of the context state, we can access them at any point we need them without requiring a signer call to regenerate. These are updated appropriately throughout the channel state machine by calling a new context method `update_holder_per_commitment`.

Add several flags to indicate messages that may now be pending the remote signer unblocking:

- `signer_pending_revoke_and_ack`, set when we're waiting to send the   revoke-and-ack to the counterparty. This might _not_ just be us waiting on the signer; for example, if the commitment order requires sending the RAA after the commitment update, then even though we _might_ be able to generate the RAA (e.g., because we have the secret), we will not do so while the commitment update is pending (e.g., because we're missing the latest point or do not have a signed counterparty commitment).

- `signer_pending_channel_ready`, set when we're waiting to send the channel-ready to the counterparty.

- `signer_pending_commitment_point`, set when we're waiting for the signer to return us the commitment point for the current state.

- `signer_pending_released_secret`, set when we're waiting for the signer to release the commitment secret for the previous state.

This state (current commitment point, previous secret, flags) is persisted in the channel monitor, and restored when the channel is unpickled.

When a monitor update completes, we may still be pending results from the remote signer. If that is the case, we ensure that we correctly maintain the above state flags before the channel state is resumed. For example, if the _monitor_ is pending a commitment signed, but we were not able to retrieve the commitment update from the signer, then we ensure that `signer_pending_commitment_update` is set.

When unblocking the signer, we need to ensure that we honor message ordering constraints. For the commitment update and revoke-and-ack, ensure that we can honor the context's current `resend_order`. For example, assume we must send
the RAA before the CU, and could potentially send a CU because we have the commitment point and a signed counterparty commitment transaction. _But_, we have not yet received the previous state's commitment secret. In this case, we
ensure that no messages are emitted until the commitment secret is released, at which point the signer-unblocked call will emit both messages.

A similar situation exists with the `channel_ready` message and the `funding_signed` / `funding_created` messages at channel startup: we make sure that we don't emit `channel_ready` before the funding message.

There is at least one unsolved problem here: during channel re-establishment, we need to request an _arbitrary_ commitment point from the signer in order to verify that the counterparty's giving us a legitimate secret. For the time
being, I've simply commented out this check; however, this is not a viable solution. There are a few options to consider here:

1. We could require that an asynchronous signer _cache_ the previous commitment points, so that any such request must necessarily succeed synchronously.
   
2. We could attempt to factor this method as to admit an asynchronous response that would restart the channel re-establish once the commitment point has been provided by the signer and the counterparty's secret can be verified.

The former places some additional burden on a remote signer (albeit minimal) and seems reasonable to me.

As for testing...

For testing asynchronous channel signing, replaces the simple boolean ("everything is on, or everything is off") with flags that let us toggle different signing methods on and off. This lets us (sort of) simulate the signer returning responses in an arbitrary order.

Adds a fully-exploded "send a one-hop payment" test to the async test suite. At each step, simulate the async signer being unavailable, and then unblocking. Vary the order to check all possible orderings of `get_per_commitment_point`, `release_commitment_secret`, and `sign_counterparty_commitment` being provided by the signer.

But there is a lot more to be done here. Many of the odd-ball cases in the PR _aren't_ covered by unit tests and were instead uncovered by running the code in situ with an LND counterparty. So there are a lot more tests to write here.
