### PR TITLE
Fix race between outbound messages and peer disconnection

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -1870,15 +1870,13 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, OM: Deref, L: Deref, CM
 			let flush_read_disabled = self.gossip_processing_backlog_lifted.swap(false, Ordering::Relaxed);
 
 			let mut peers_to_disconnect = HashMap::new();
-			let mut events_generated = self.message_handler.chan_handler.get_and_clear_pending_msg_events();
-			events_generated.append(&mut self.message_handler.route_handler.get_and_clear_pending_msg_events());
 
 			{
-				// TODO: There are some DoS attacks here where you can flood someone's outbound send
-				// buffer by doing things like announcing channels on another node. We should be willing to
-				// drop optional-ish messages when send buffers get full!
-
 				let peers_lock = self.peers.read().unwrap();
+
+				let mut events_generated = self.message_handler.chan_handler.get_and_clear_pending_msg_events();
+				events_generated.append(&mut self.message_handler.route_handler.get_and_clear_pending_msg_events());
+
 				let peers = &*peers_lock;
 				macro_rules! get_peer_for_forwarding {
 					($node_id: expr) => {


### PR DESCRIPTION
Previously, outbound messages held in `process_events` could race
with peer disconnection, allowing a message intended for a peer
before disconnection to be sent to the same peer after
disconnection.

The fix is simple - hold the peers read lock while we fetch
pending messages from peers (as we disconnect with the write lock).