### PR TITLE
Reduce disk usage in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           shellcheck ci/ci-tests.sh
       - name: Run CI script
         shell: bash # Default on Winblows is powershell
-        run: ./ci/ci-tests.sh
+        run: CI_MINIMIZE_DISK_USAGE=1 ./ci/ci-tests.sh
 
   coverage:
     strategy:

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -80,6 +80,7 @@ if [ "$RUSTC_MINOR_VERSION" -gt 55 ]; then
 	echo -e "\n\nTest Custom Message Macros"
 	pushd lightning-custom-message
 	cargo test --verbose --color always
+	[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 	popd
 fi
 
@@ -130,17 +131,20 @@ else
 	[ "$RUSTC_MINOR_VERSION" -lt 60 ] && cargo update -p memchr --precise "2.5.0" --verbose
 	cargo check --verbose --color always
 fi
+[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 popd
 
 # Test that we can build downstream code with only the "release pins".
 pushd msrv-no-dev-deps-check
 PIN_RELEASE_DEPS
 cargo check
+[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 popd
 
 if [ -f "$(which arm-none-eabi-gcc)" ]; then
 	pushd no-std-check
 	cargo build --target=thumbv7m-none-eabi
+	[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 	popd
 fi
 


### PR DESCRIPTION
Recently github appears to have reduced the available free disk space in actions runs, causing CI to fail with out of space errors. Here we simply run `cargo clean` a few times in CI to reduce our disk usage somewhat.