### PR TITLE
Make test log lines somewhat more eye-scannable

### DIFF
--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -969,8 +969,10 @@ impl Logger for TestLogger {
 	fn log(&self, record: &Record) {
 		*self.lines.lock().unwrap().entry((record.module_path.to_string(), format!("{}", record.args))).or_insert(0) += 1;
 		if record.level >= self.level {
-			#[cfg(all(not(ldk_bench), feature = "std"))]
-			println!("{:<5} {} [{} : {}, {}] {}", record.level.to_string(), self.id, record.module_path, record.file, record.line, record.args);
+			#[cfg(all(not(ldk_bench), feature = "std"))] {
+				let pfx = format!("{} {} [{}:{}]", self.id, record.level.to_string(), record.module_path, record.line);
+				println!("{:<55}{}", pfx, record.args);
+			}
 		}
 	}
 }


### PR DESCRIPTION
When running tests, our log output should be reasonably readable by developers, but currently it repeats the module twice (via the module and file name), and then starts the log line at a variable location.

Instead, we only print the module and then align the start of the log lines so that the output is much more scannable.