### PR TITLE
Update docs on `MonitorEvent::HolderForceClosed`

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -132,7 +132,8 @@ pub enum MonitorEvent {
 	/// A monitor event containing an HTLCUpdate.
 	HTLCEvent(HTLCUpdate),
 
-	/// A monitor event that the Channel's commitment transaction was confirmed.
+	/// Indicates we broadcasted the channel's latest commitment transaction and thus closed the
+	/// channel.
 	HolderForceClosed(OutPoint),
 
 	/// Indicates a [`ChannelMonitor`] update has completed. See


### PR DESCRIPTION
In a96e2fe144383ea6fd670153fb895ee07a3245ef we renamed `MonitorEvent::CommitmentTxConfirmed` to `HolderForceClosed` to better document what actually happened. However, we failed to update the documentation on the type, which we do here.

Pointed out by @yellowred.