### PR TITLE
Add serde serialization support for Offer

### DIFF
--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -48,10 +48,12 @@ regex = { version = "1.5.6", optional = true }
 backtrace = { version = "0.3", optional = true }
 
 core2 = { version = "0.3.0", optional = true, default-features = false }
+serde = { version = "1.0.118", optional = true }
 
 [dev-dependencies]
 hex = "0.4"
 regex = "1.5.6"
+serde_json = { version = "1"}
 
 [dev-dependencies.bitcoin]
 version = "0.29.0"

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -6343,7 +6343,7 @@ mod tests {
 		let route = get_route(&our_id, &route_params, &network_graph, None, Arc::clone(&logger),
 			&scorer, &Default::default(), &random_seed_bytes).unwrap();
 		let path = route.paths[0].hops.iter().map(|hop| hop.short_channel_id).collect::<Vec<_>>();
-		assert!(path.len() == MAX_PATH_LENGTH_ESTIMATE.into());
+		assert!(path.len() == MAX_PATH_LENGTH_ESTIMATE as usize);
 
 		// But we can't create a path surpassing the MAX_PATH_LENGTH_ESTIMATE limit.
 		let fail_payment_params = PaymentParameters::from_node_id(nodes[19], 0);


### PR DESCRIPTION
Fixes #2683 .

Serializes as the bech32 string. `Invoice` already has similar support. `serde` dep/feature had to be added to `lightning` crate.