### PR TITLE
`ChannelManager` documentation refresh

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1135,6 +1135,22 @@ where
 /// Thus, [`ChannelManager`] is typically used to parameterize a [`MessageHandler`] and an
 /// [`OnionMessenger`]. The latter is required to support BOLT 12 functionality.
 ///
+/// # `ChannelManager` vs `ChannelMonitor`
+///
+/// It's important to distinguish between the *off-chain* management and *on-chain* enforcement of
+/// lightning channels. [`ChannelManager`] exchanges messages with peers to manage the off-chain
+/// state of each channel. During this process, it generates a [`ChannelMonitor`] for each channel
+/// and a [`ChannelMonitorUpdate`] for each relevant change, notifying its parameterized
+/// [`chain::Watch`] of them.
+///
+/// An implementation of [`chain::Watch`], such as [`ChainMonitor`], is responsible for aggregating
+/// these [`ChannelMonitor`]s and applying any [`ChannelMonitorUpdate`]s to them. It then monitors
+/// for any pertinent on-chain activity, enforcing claims as needed.
+///
+/// This division of off-chain management and on-chain enforcement allows for interesting node
+/// setups. For instance, on-chain enforcement could be moved to a separate host or have added
+/// redundancy, possibly as a watchtower. See [`chain::Watch`] for the relevant interface.
+///
 /// # Persistence
 ///
 /// Implements [`Writeable`] to write out all channel state to disk. Implies [`peer_disconnected`] for

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1115,6 +1115,8 @@ where
 /// Implements [`ChannelMessageHandler`], handling the multi-channel parts and passing things through
 /// to individual Channels.
 ///
+/// # Persistence
+///
 /// Implements [`Writeable`] to write out all channel state to disk. Implies [`peer_disconnected`] for
 /// all peers during write/read (though does not modify this instance, only the instance being
 /// serialized). This will result in any channels which have not yet exchanged [`funding_created`] (i.e.,
@@ -1134,11 +1136,15 @@ where
 /// tells you the last block hash which was connected. You should get the best block tip before using the manager.
 /// See [`chain::Listen`] and [`chain::Confirm`] for more details.
 ///
+/// # `ChannelUpdate` Messages
+///
 /// Note that `ChannelManager` is responsible for tracking liveness of its channels and generating
 /// [`ChannelUpdate`] messages informing peers that the channel is temporarily disabled. To avoid
 /// spam due to quick disconnection/reconnection, updates are not sent until the channel has been
 /// offline for a full minute. In order to track this, you must call
 /// [`timer_tick_occurred`] roughly once per minute, though it doesn't have to be perfect.
+///
+/// # DoS Mitigation
 ///
 /// To avoid trivial DoS issues, `ChannelManager` limits the number of inbound connections and
 /// inbound channels without confirmed funding transactions. This may result in nodes which we do
@@ -1148,6 +1154,8 @@ where
 /// Because it is an indication of trust, inbound channels which we've accepted as 0conf are
 /// exempted from the count of unfunded channels. Similarly, outbound channels and connections are
 /// never limited. Please ensure you limit the count of such channels yourself.
+///
+/// # Type Aliases
 ///
 /// Rather than using a plain `ChannelManager`, it is preferable to use either a [`SimpleArcChannelManager`]
 /// a [`SimpleRefChannelManager`], for conciseness. See their documentation for more details, but

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -459,6 +459,16 @@ for OfferWithDerivedMetadataBuilder<'a> {
 	}
 }
 
+#[cfg(c_bindings)]
+impl<'a> From<OfferWithDerivedMetadataBuilder<'a>>
+for OfferBuilder<'a, DerivedMetadata, secp256k1::All> {
+	fn from(builder: OfferWithDerivedMetadataBuilder<'a>) -> Self {
+		let OfferWithDerivedMetadataBuilder { offer, metadata_strategy, secp_ctx } = builder;
+
+		Self { offer, metadata_strategy, secp_ctx }
+	}
+}
+
 /// An `Offer` is a potentially long-lived proposal for payment of a good or service.
 ///
 /// An offer is a precursor to an [`InvoiceRequest`]. A merchant publishes an offer from which a

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -375,6 +375,16 @@ for RefundMaybeWithDerivedMetadataBuilder<'a> {
 	}
 }
 
+#[cfg(c_bindings)]
+impl<'a> From<RefundMaybeWithDerivedMetadataBuilder<'a>>
+for RefundBuilder<'a, secp256k1::All> {
+	fn from(builder: RefundMaybeWithDerivedMetadataBuilder<'a>) -> Self {
+		let RefundMaybeWithDerivedMetadataBuilder { refund, secp_ctx } = builder;
+
+		Self { refund, secp_ctx }
+	}
+}
+
 /// A `Refund` is a request to send an [`Bolt12Invoice`] without a preceding [`Offer`].
 ///
 /// Typically, after an invoice is paid, the recipient may publish a refund allowing the sender to

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -736,6 +736,19 @@ pub trait NodeSigner {
 	fn sign_gossip_message(&self, msg: UnsignedGossipMessage) -> Result<Signature, ()>;
 }
 
+// Primarily needed in doctests because of https://github.com/rust-lang/rust/issues/67295
+/// A dynamic [`SignerProvider`] temporarily needed for doc tests.
+#[cfg(taproot)]
+#[doc(hidden)]
+#[deprecated(note = "Remove once taproot cfg is removed")]
+pub type DynSignerProvider = dyn SignerProvider<EcdsaSigner = InMemorySigner, TaprootSigner = InMemorySigner>;
+
+/// A dynamic [`SignerProvider`] temporarily needed for doc tests.
+#[cfg(not(taproot))]
+#[doc(hidden)]
+#[deprecated(note = "Remove once taproot cfg is removed")]
+pub type DynSignerProvider = dyn SignerProvider<EcdsaSigner = InMemorySigner>;
+
 /// A trait that can return signer instances for individual channels.
 pub trait SignerProvider {
 	/// A type which implements [`WriteableEcdsaChannelSigner`] which will be returned by [`Self::derive_channel_signer`].


### PR DESCRIPTION
`ChannelManager`'s documentation could use a little love. It needs:
- a clear explanation of its purpose and use
- how it can be parameterized
- how it relates to other components (e.g. `ChainMonitor` / `ChannelMonitors`)
- operational requirements
- example usage

All this needs to be organized in a way that is approachable, discoverable, and doesn't overwhelm the user. Some documentation may need to be consolidated or placed at a higher-level so it is not missed.

This PR re-writes `ChannelManager`'s summary, adds sections to delineate the existing docs, and proposes new sections. It still has a ways to go. One consideration is how to split the documentation between `ChannelManager`, its methods, the higher-level `channelmanager` module docs (yet to be re-written), and even higher-level modules. Or if the module layout should be flattened a bit to foster better discovery.

Feedback encouraged!