### PR TITLE
Introduce check for is peer is disconnected

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2415,6 +2415,11 @@ where
 			.ok_or_else(|| APIError::APIMisuseError{ err: format!("Not connected to node: {}", their_network_key) })?;
 
 		let mut peer_state = peer_state_mutex.lock().unwrap();
+
+		if !peer_state.is_connected {
+			return Err(APIError::APIMisuseError { err: format!("Disconnected from the node: {}", their_network_key) });
+		}
+
 		let channel = {
 			let outbound_scid_alias = self.create_and_insert_outbound_scid_alias();
 			let their_features = &peer_state.latest_features;


### PR DESCRIPTION
resolves #2437

- This PR introduces a check for if the peer is disconnected.
- Use this check to fail early in `create_channel` function.