### PR TITLE
Impl Default for ChannelDetails

### DIFF
--- a/lightning/src/ln/channel_id.rs
+++ b/lightning/src/ln/channel_id.rs
@@ -33,6 +33,12 @@ use core::ops::Deref;
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ChannelId(pub [u8; 32]);
 
+impl Default for ChannelId {
+	fn default() -> Self {
+		Self::new_zero()
+	}
+}
+
 impl ChannelId {
 	/// Create _v1_ channel ID based on a funding TX ID and output index
 	pub fn v1_from_funding_txid(txid: &[u8; 32], output_index: u16) -> Self {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1491,8 +1491,21 @@ pub struct ChannelCounterparty {
 	pub outbound_htlc_maximum_msat: Option<u64>,
 }
 
+impl Default for ChannelCounterparty {
+	fn default() -> Self {
+		Self {
+			node_id: PublicKey::from_slice(&[2; 33]).unwrap(), // dummy value
+			features: InitFeatures::empty(),
+			unspendable_punishment_reserve: 0,
+			forwarding_info: None,
+			outbound_htlc_minimum_msat: None,
+			outbound_htlc_maximum_msat: None,
+		}
+	}
+}
+
 /// Details of a channel, as returned by [`ChannelManager::list_channels`] and [`ChannelManager::list_usable_channels`]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct ChannelDetails {
 	/// The channel's ID (prior to funding transaction generation, this is a random 32 bytes,
 	/// thereafter this is the txid of the funding transaction xor the funding transaction output).


### PR DESCRIPTION
This is useful for testing in downstream projects, makes it so we don't need to specify every single field.

Main question is if the dummy public key for `ChannelCounterparty` is okay