### PR TITLE
Group channel funding transaction fields (small refactor) [splicing]

### DIFF
--- a/lightning/src/ln/priv_short_conf_tests.rs
+++ b/lightning/src/ln/priv_short_conf_tests.rs
@@ -860,12 +860,12 @@ fn test_0conf_channel_reorg() {
 	// support simply un-setting the SCID and waiting until the channel gets re-confirmed, but for
 	// now we force-close the channel here.
 	check_closed_event!(&nodes[0], 1, ClosureReason::ProcessingError {
-		err: "Funding transaction was un-confirmed. Locked at 0 confs, now have 0 confs.".to_owned()
+		err: "Funding transaction was un-confirmed. Locked at 0 confs, now have Unconfirmed confs.".to_owned()
 	}, [nodes[1].node.get_our_node_id()], 100000);
 	check_closed_broadcast!(nodes[0], true);
 	check_added_monitors(&nodes[0], 1);
 	check_closed_event!(&nodes[1], 1, ClosureReason::ProcessingError {
-		err: "Funding transaction was un-confirmed. Locked at 0 confs, now have 0 confs.".to_owned()
+		err: "Funding transaction was un-confirmed. Locked at 0 confs, now have Unconfirmed confs.".to_owned()
 	}, [nodes[0].node.get_our_node_id()], 100000);
 	check_closed_broadcast!(nodes[1], true);
 	check_added_monitors(&nodes[1], 1);

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -348,9 +348,9 @@ fn do_test_unconf_chan(reload_node: bool, reorg_after_reload: bool, use_funding_
 	*nodes[0].chain_monitor.expect_channel_force_closed.lock().unwrap() = Some((chan.2, true));
 	nodes[0].node.test_process_background_events(); // Required to free the pending background monitor update
 	check_added_monitors!(nodes[0], 1);
-	let expected_err = "Funding transaction was un-confirmed. Locked at 6 confs, now have 0 confs.";
+	let expected_err = "Funding transaction was un-confirmed. Locked at 6 confs, now have Unconfirmed confs.";
 	if reorg_after_reload || !reload_node {
-		handle_announce_close_broadcast_events(&nodes, 0, 1, true, "Channel closed because of an exception: Funding transaction was un-confirmed. Locked at 6 confs, now have 0 confs.");
+		handle_announce_close_broadcast_events(&nodes, 0, 1, true, "Channel closed because of an exception: Funding transaction was un-confirmed. Locked at 6 confs, now have Unconfirmed confs.");
 		check_added_monitors!(nodes[1], 1);
 		check_closed_event!(nodes[1], 1, ClosureReason::CounterpartyForceClosed { peer_msg: UntrustedString(format!("Channel closed because of an exception: {}", expected_err)) }
 			, [nodes[0].node.get_our_node_id()], 100000);


### PR DESCRIPTION
Groups three `Channel` fields storing funding transaction status into a separate structure `TransactionConfirmation`. This is a small refactor with very minimal code logic change.

Motivation:

- In the upcoming Splicing feature, there is a need to keep info about multiple funding transactions (e.g. while the new spliced tx is being confirmed, both the new and old must be kept around). With the current structure of multiple fields this is cumbersome.
- In Dual Funding, in case of RBF multiple funding transaction candidates have to be kept. 
- Group together the several fields that relate to the funding transaction state (`funding_transaction`, `funding_tx_confirmed_in`, `funding_tx_confirmation_height`).

Changes:

- New `TransactionConfirmation` struct, with fields for `transaction`, `confirmed_in`, and `confirmation_height`
- convenience method for computing confirmation depth, handling special cases

Note: The serialization format is untouched.
See also #2743 .
