### PR TITLE
Add `channel_keys_id` to `SpendableOutputDescriptor::StaticOutput`

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -4082,6 +4082,7 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 				spendable_outputs.push(SpendableOutputDescriptor::StaticOutput {
 					outpoint: OutPoint { txid: tx.txid(), index: i as u16 },
 					output: outp.clone(),
+					channel_keys_id: Some(self.channel_keys_id),
 				});
 			}
 			if let Some(ref broadcasted_holder_revokable_script) = self.broadcasted_holder_revokable_script {
@@ -4110,6 +4111,7 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 				spendable_outputs.push(SpendableOutputDescriptor::StaticOutput {
 					outpoint: OutPoint { txid: tx.txid(), index: i as u16 },
 					output: outp.clone(),
+					channel_keys_id: Some(self.channel_keys_id),
 				});
 			}
 		}


### PR DESCRIPTION
In 7f0fd868ad4e8072440f1eb79e78894de1629157, `channel_keys_id` was added as an argument to `SignerProvider::get_destination_script`, allowing implementors to generate a new script for each channel.

This is great, however users then have no way to re-derive the corresponding private key when they ultimately receive a `SpendableOutputDescriptor::StaticOutput`. Instead, they have to track all the addresses as they derive them separately. In many cases this is fine, but we should support both deployments, which we do here by simply including the missing `channel_keys_id` for the user.