### PR TITLE
Serialize Trampoline payloads in outbound onions.

### DIFF
--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -66,6 +66,8 @@
 //!      for more info).
 //! - `Keysend` - send funds to a node without an invoice
 //!     (see the [`Keysend` feature assignment proposal](https://github.com/lightning/bolts/issues/605#issuecomment-606679798) for more information).
+//! - `Trampoline` - supports receiving and forwarding Trampoline payments
+//!     (see the [`Trampoline` feature proposal](https://github.com/lightning/bolts/pull/836) for more information).
 //!
 //! LDK knows about the following features, but does not support them:
 //! - `AnchorsNonzeroFeeHtlcTx` - the initial version of anchor outputs, which was later found to be
@@ -152,6 +154,8 @@ mod sealed {
 		ChannelType | SCIDPrivacy,
 		// Byte 6
 		ZeroConf,
+		// Byte 7
+		Trampoline,
 	]);
 	define_context!(NodeContext, [
 		// Byte 0
@@ -168,6 +172,8 @@ mod sealed {
 		ChannelType | SCIDPrivacy,
 		// Byte 6
 		ZeroConf | Keysend,
+		// Byte 7
+		Trampoline,
 	]);
 	define_context!(ChannelContext, []);
 	define_context!(Bolt11InvoiceContext, [
@@ -185,6 +191,8 @@ mod sealed {
 		,
 		// Byte 6
 		PaymentMetadata,
+		// Byte 7
+		Trampoline,
 	]);
 	define_context!(OfferContext, []);
 	define_context!(InvoiceRequestContext, []);
@@ -420,6 +428,9 @@ mod sealed {
 	define_feature!(55, Keysend, [NodeContext],
 		"Feature flags for keysend payments.", set_keysend_optional, set_keysend_required,
 		supports_keysend, requires_keysend);
+	define_feature!(57, Trampoline, [InitContext, NodeContext, Bolt11InvoiceContext],
+		"Feature flags for Trampoline routing.", set_trampoline_routing_optional, set_trampoline_routing_required,
+		supports_trampoline_routing, requires_trampoline_routing);
 	// Note: update the module-level docs when a new feature bit is added!
 
 	#[cfg(test)]


### PR DESCRIPTION
This PR alters the outbound onion payload to optionally accommodate a Trampoline packet.

Additionally, we add the Trampoline support feature flag.