### PR TITLE
simplify GossipVerifier types using APeerManager

### DIFF
--- a/lightning-block-sync/src/gossip.rs
+++ b/lightning-block-sync/src/gossip.rs
@@ -9,10 +9,7 @@ use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::blockdata::transaction::{TxOut, OutPoint};
 use bitcoin::hash_types::BlockHash;
 
-use lightning::sign::NodeSigner;
-
-use lightning::ln::peer_handler::{CustomMessageHandler, PeerManager, SocketDescriptor};
-use lightning::ln::msgs::{ChannelMessageHandler, OnionMessageHandler};
+use lightning::ln::peer_handler::APeerManager;
 
 use lightning::routing::gossip::{NetworkGraph, P2PGossipSync};
 use lightning::routing::utxo::{UtxoFuture, UtxoLookup, UtxoResult, UtxoLookupError};
@@ -135,21 +132,14 @@ impl<
 pub struct GossipVerifier<S: FutureSpawner,
 	Blocks: Deref + Send + Sync + 'static + Clone,
 	L: Deref + Send + Sync + 'static,
-	Descriptor: SocketDescriptor + Send + Sync + 'static,
-	CM: Deref + Send + Sync + 'static,
-	OM: Deref + Send + Sync + 'static,
-	CMH: Deref + Send + Sync + 'static,
-	NS: Deref + Send + Sync + 'static,
+	APM: Deref + Send + Sync + 'static + Clone,
 > where
 	Blocks::Target: UtxoSource,
 	L::Target: Logger,
-	CM::Target: ChannelMessageHandler,
-	OM::Target: OnionMessageHandler,
-	CMH::Target: CustomMessageHandler,
-	NS::Target: NodeSigner,
+	APM::Target: APeerManager,
 {
 	source: Blocks,
-	peer_manager: Arc<PeerManager<Descriptor, CM, Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Self, L>>, OM, L, CMH, NS>>,
+	peer_manager: APM,
 	gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Self, L>>,
 	spawn: S,
 	block_cache: Arc<Mutex<VecDeque<(u32, Block)>>>,
@@ -160,24 +150,17 @@ const BLOCK_CACHE_SIZE: usize = 5;
 impl<S: FutureSpawner,
 	Blocks: Deref + Send + Sync + Clone,
 	L: Deref + Send + Sync,
-	Descriptor: SocketDescriptor + Send + Sync,
-	CM: Deref + Send + Sync,
-	OM: Deref + Send + Sync,
-	CMH: Deref + Send + Sync,
-	NS: Deref + Send + Sync,
-> GossipVerifier<S, Blocks, L, Descriptor, CM, OM, CMH, NS> where
+	APM: Deref + Send + Sync + Clone,
+> GossipVerifier<S, Blocks, L, APM> where
 	Blocks::Target: UtxoSource,
 	L::Target: Logger,
-	CM::Target: ChannelMessageHandler,
-	OM::Target: OnionMessageHandler,
-	CMH::Target: CustomMessageHandler,
-	NS::Target: NodeSigner,
+	APM::Target: APeerManager,
 {
 	/// Constructs a new [`GossipVerifier`].
 	///
 	/// This is expected to be given to a [`P2PGossipSync`] (initially constructed with `None` for
 	/// the UTXO lookup) via [`P2PGossipSync::add_utxo_lookup`].
-	pub fn new(source: Blocks, spawn: S, gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Self, L>>, peer_manager: Arc<PeerManager<Descriptor, CM, Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Self, L>>, OM, L, CMH, NS>>) -> Self {
+	pub fn new(source: Blocks, spawn: S, gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Self, L>>, peer_manager: APM) -> Self {
 		Self {
 			source, spawn, gossiper, peer_manager,
 			block_cache: Arc::new(Mutex::new(VecDeque::with_capacity(BLOCK_CACHE_SIZE))),
@@ -269,18 +252,11 @@ impl<S: FutureSpawner,
 impl<S: FutureSpawner,
 	Blocks: Deref + Send + Sync + Clone,
 	L: Deref + Send + Sync,
-	Descriptor: SocketDescriptor + Send + Sync,
-	CM: Deref + Send + Sync,
-	OM: Deref + Send + Sync,
-	CMH: Deref + Send + Sync,
-	NS: Deref + Send + Sync,
-> Deref for GossipVerifier<S, Blocks, L, Descriptor, CM, OM, CMH, NS> where
+	APM: Deref + Send + Sync + Clone,
+> Deref for GossipVerifier<S, Blocks, L, APM> where
 	Blocks::Target: UtxoSource,
 	L::Target: Logger,
-	CM::Target: ChannelMessageHandler,
-	OM::Target: OnionMessageHandler,
-	CMH::Target: CustomMessageHandler,
-	NS::Target: NodeSigner,
+	APM::Target: APeerManager,
 {
 	type Target = Self;
 	fn deref(&self) -> &Self { self }
@@ -290,18 +266,11 @@ impl<S: FutureSpawner,
 impl<S: FutureSpawner,
 	Blocks: Deref + Send + Sync + Clone,
 	L: Deref + Send + Sync,
-	Descriptor: SocketDescriptor + Send + Sync,
-	CM: Deref + Send + Sync,
-	OM: Deref + Send + Sync,
-	CMH: Deref + Send + Sync,
-	NS: Deref + Send + Sync,
-> UtxoLookup for GossipVerifier<S, Blocks, L, Descriptor, CM, OM, CMH, NS> where
+	APM: Deref + Send + Sync + Clone,
+> UtxoLookup for GossipVerifier<S, Blocks, L, APM> where
 	Blocks::Target: UtxoSource,
 	L::Target: Logger,
-	CM::Target: ChannelMessageHandler,
-	OM::Target: OnionMessageHandler,
-	CMH::Target: CustomMessageHandler,
-	NS::Target: NodeSigner,
+	APM::Target: APeerManager,
 {
 	fn get_utxo(&self, _chain_hash: &ChainHash, short_channel_id: u64) -> UtxoResult {
 		let res = UtxoFuture::new();
@@ -309,11 +278,11 @@ impl<S: FutureSpawner,
 		let source = self.source.clone();
 		let gossiper = Arc::clone(&self.gossiper);
 		let block_cache = Arc::clone(&self.block_cache);
-		let pm = Arc::clone(&self.peer_manager);
+		let pm = self.peer_manager.clone();
 		self.spawn.spawn(async move {
 			let res = Self::retrieve_utxo(source, block_cache, short_channel_id).await;
 			fut.resolve(gossiper.network_graph(), &*gossiper, res);
-			pm.process_events();
+			pm.as_ref().process_events();
 		});
 		UtxoResult::Async(res)
 	}


### PR DESCRIPTION
This simplifies the types but also allows an end-user (RGS in this case) to use a PeerManager that does not use P2PGossipSync as their `RoutingMessageHandler`.