### PR TITLE
Relax `OnionMessenger::peer_disconnected` assertion

### DIFF
--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -914,7 +914,8 @@ where
 	fn peer_disconnected(&self, their_node_id: &PublicKey) {
 		match self.message_recipients.lock().unwrap().remove(their_node_id) {
 			Some(OnionMessageRecipient::ConnectedPeer(..)) => {},
-			_ => debug_assert!(false),
+			Some(_) => debug_assert!(false),
+			None => {},
 		}
 	}
 


### PR DESCRIPTION
When a peer is connected, `OnionMessenger` tracks it only if it supports onion messages. On disconnect, we `debug_assert` that the peer was in a state `ConnectedPeer`, failing when it is in the `PendingConnection` state. However, we were mistakenly asserting for peers that we were not tracking (i.e., that don't support onion messages). Relax the check to not fail on the latter.

Reported by @tnull 