### PR TITLE
cfg-gate async signing logic

### DIFF
--- a/ci/check-cfg-flags.py
+++ b/ci/check-cfg-flags.py
@@ -86,6 +86,8 @@ def check_cfg_tag(cfg):
         pass
     elif cfg == "taproot":
         pass
+    elif cfg == "async_signing":
+        pass
     elif cfg == "require_route_graph_test":
         pass
     else:

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -171,7 +171,6 @@ if [ -f "$(which arm-none-eabi-gcc)" ]; then
 	popd
 fi
 
-echo -e "\n\nTest Taproot builds"
-pushd lightning
+echo -e "\n\nTest cfg-flag builds"
 RUSTFLAGS="$RUSTFLAGS --cfg=taproot" cargo test --verbose --color always -p lightning
-popd
+RUSTFLAGS="$RUSTFLAGS --cfg=async_signing" cargo test --verbose --color always -p lightning

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7322,8 +7322,7 @@ where
 	/// attempted in every channel, or in the specifically provided channel.
 	///
 	/// [`ChannelSigner`]: crate::sign::ChannelSigner
-	#[cfg(test)] // This is only implemented for one signer method, and should be private until we
-	             // actually finish implementing it fully.
+	#[cfg(async_signing)]
 	pub fn signer_unblocked(&self, channel_opt: Option<(PublicKey, ChannelId)>) {
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -76,7 +76,7 @@ mod monitor_tests;
 #[cfg(test)]
 #[allow(unused_mut)]
 mod shutdown_tests;
-#[cfg(test)]
+#[cfg(all(test, async_signing))]
 #[allow(unused_mut)]
 mod async_signer_tests;
 


### PR DESCRIPTION
We are intending to release without having completed our async signing logic, which sadly means we need to cfg-gate it to ensure we restore the previous state of panicking on signer errors, rather than putting us in a stuck state with no way to recover.

Here we add a new `async_signing` cfg flag and use it to gate all the new logic from #2558 effectively reverting commits 1da29290e7af03a5dfc207ee6a5c848a9740bd32 through
014a336e592bfc8cb49929b799b9d6d9286dab16.