### PR TITLE
Make channel_type optional in ChannelOpenRequest event.

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -912,7 +912,7 @@ pub enum Event {
 		/// or will be rejected otherwise.
 		///
 		/// [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
-		channel_type: ChannelTypeFeatures,
+		channel_type: Option<ChannelTypeFeatures>,
 	},
 	/// Indicates that the HTLC was accepted, but could not be processed when or after attempting to
 	/// forward it.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -6138,7 +6138,7 @@ where
 				counterparty_node_id: counterparty_node_id.clone(),
 				funding_satoshis: msg.funding_satoshis,
 				push_msat: msg.push_msat,
-				channel_type: msg.channel_type.clone().unwrap(),
+				channel_type: msg.channel_type.clone(),
 			}, None));
 			peer_state.inbound_channel_request_by_id.insert(channel_id, InboundChannelRequest {
 				open_channel_msg: msg.clone(),


### PR DESCRIPTION
Peers may send messages requesting to open a channel without specifying the channel type. This gets inferred by LDK when the channel actually opens, but can be passed to the event handler as an Option so the node may factor the lack of specificity in to the channel opening decision.

This should fix #2804.