### PR TITLE
Introduce Trampoline Packet deserialization for Inbound::Receive

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11867,6 +11867,7 @@ mod tests {
 				payment_secret: PaymentSecret([0; 32]), total_msat: sender_intended_amt_msat,
 			}),
 			custom_tlvs: Vec::new(),
+			trampoline_packet: None
 		};
 		// Check that if the amount we received + the penultimate hop extra fee is less than the sender
 		// intended amount, we fail the payment.
@@ -11889,6 +11890,7 @@ mod tests {
 				payment_secret: PaymentSecret([0; 32]), total_msat: sender_intended_amt_msat,
 			}),
 			custom_tlvs: Vec::new(),
+			trampoline_packet: None
 		};
 		let current_height: u32 = node[0].node.best_block.read().unwrap().height();
 		assert!(create_recv_pending_htlc_info(hop_data, [0; 32], PaymentHash([0; 32]),
@@ -11913,6 +11915,7 @@ mod tests {
 				payment_secret: PaymentSecret([0; 32]), total_msat: 100,
 			}),
 			custom_tlvs: Vec::new(),
+			trampoline_packet: None
 		}, [0; 32], PaymentHash([0; 32]), 100, 23, None, true, None, current_height,
 			node[0].node.default_configuration.accept_mpp_keysend);
 

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -166,6 +166,8 @@ mod sealed {
 		ChannelType | SCIDPrivacy,
 		// Byte 6
 		ZeroConf | Keysend,
+		// Byte 7
+		Trampoline,
 	]);
 	define_context!(ChannelContext, []);
 	define_context!(Bolt11InvoiceContext, [
@@ -415,6 +417,9 @@ mod sealed {
 	define_feature!(55, Keysend, [NodeContext],
 		"Feature flags for keysend payments.", set_keysend_optional, set_keysend_required,
 		supports_keysend, requires_keysend);
+	define_feature!(57, Trampoline, [NodeContext],
+		"Feature flags for Trampoline routing.", set_trampoline_routing_optional, set_trampoline_routing_required,
+		supports_trampoline_routing, requires_trampoline_routing);
 	// Note: update the module-level docs when a new feature bit is added!
 
 	#[cfg(test)]

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -1670,6 +1670,7 @@ mod fuzzy_internal_msgs {
 	use crate::prelude::*;
 	use crate::ln::{PaymentPreimage, PaymentSecret};
 	use crate::ln::features::BlindedHopFeatures;
+	use crate::ln::msgs::OnionPacket;
 
 	// These types aren't intended to be pub, but are exposed for direct fuzzing (as we deserialize
 	// them from untrusted input):
@@ -1727,6 +1728,7 @@ mod fuzzy_internal_msgs {
 			custom_tlvs: Vec<(u64, Vec<u8>)>,
 			amt_msat: u64,
 			outgoing_cltv_value: u32,
+			trampoline_packet: Option<OnionPacket>
 		},
 		BlindedForward {
 			encrypted_tlvs: Vec<u8>,
@@ -2277,13 +2279,17 @@ impl Writeable for OutboundOnionPayload {
 			},
 			Self::Receive {
 				ref payment_data, ref payment_metadata, ref keysend_preimage, amt_msat,
-				outgoing_cltv_value, ref custom_tlvs,
+				outgoing_cltv_value, ref trampoline_packet, ref custom_tlvs
 			} => {
 				// We need to update [`ln::outbound_payment::RecipientOnionFields::with_custom_tlvs`]
 				// to reject any reserved types in the experimental range if new ones are ever
 				// standardized.
 				let keysend_tlv = keysend_preimage.map(|preimage| (5482373484, preimage.encode()));
-				let mut custom_tlvs: Vec<&(u64, Vec<u8>)> = custom_tlvs.iter().chain(keysend_tlv.iter()).collect();
+				let trampoline_tlv = trampoline_packet.as_ref().map(|trampoline| (66100, trampoline.encode()));
+				let mut custom_tlvs: Vec<&(u64, Vec<u8>)> = custom_tlvs.iter()
+					.chain(keysend_tlv.iter())
+					.chain(trampoline_tlv.iter())
+					.collect();
 				custom_tlvs.sort_unstable_by_key(|(typ, _)| *typ);
 				_encode_varint_length_prefixed_tlv!(w, {
 					(2, HighZeroBytesDroppedBigSize(*amt_msat), required),
@@ -4002,6 +4008,7 @@ mod tests {
 			amt_msat: 0x0badf00d01020304,
 			outgoing_cltv_value: 0xffffffff,
 			custom_tlvs: vec![],
+			trampoline_packet: None
 		};
 		let encoded_value = outbound_msg.encode();
 		let target_value = <Vec<u8>>::from_hex("1002080badf00d010203040404ffffffff").unwrap();
@@ -4030,6 +4037,7 @@ mod tests {
 			amt_msat: 0x0badf00d01020304,
 			outgoing_cltv_value: 0xffffffff,
 			custom_tlvs: vec![],
+			trampoline_packet: None
 		};
 		let encoded_value = outbound_msg.encode();
 		let target_value = <Vec<u8>>::from_hex("3602080badf00d010203040404ffffffff082442424242424242424242424242424242424242424242424242424242424242421badca1f").unwrap();
@@ -4069,6 +4077,7 @@ mod tests {
 			custom_tlvs: bad_type_range_tlvs,
 			amt_msat: 0x0badf00d01020304,
 			outgoing_cltv_value: 0xffffffff,
+			trampoline_packet: None
 		};
 		let encoded_value = msg.encode();
 		let node_signer = test_utils::TestKeysInterface::new(&[42; 32], Network::Testnet);
@@ -4101,6 +4110,7 @@ mod tests {
 			custom_tlvs: expected_custom_tlvs.clone(),
 			amt_msat: 0x0badf00d01020304,
 			outgoing_cltv_value: 0xffffffff,
+			trampoline_packet: None
 		};
 		let encoded_value = msg.encode();
 		let target_value = <Vec<u8>>::from_hex("2e02080badf00d010203040404ffffffffff0000000146c6616b021234ff0000000146c6616f084242424242424242").unwrap();

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -216,6 +216,7 @@ pub(super) fn build_onion_payloads(path: &Path, total_msat: u64, mut recipient_o
 					custom_tlvs: recipient_onion.custom_tlvs.clone(),
 					amt_msat: value_msat,
 					outgoing_cltv_value: cltv,
+					trampoline_packet: None
 				});
 			}
 		} else {


### PR DESCRIPTION
This PR builds over #2756.
And addresses Inbound Deserialization in #2299 

- This PR introduces Trampoline Packets to Inbound::Receive
- Implement Readable for VariableLengthOnionPacket struct to allow
    deserialization for Trampoline Packets.
- Make appropriate changes in the rest of the code, to allow proper compiling
     with the new change.

TODO:
- [x] Introduce Trampoline Packets for Inbound::Receive.
- [ ] Write tests for the introduced change.