### PR TITLE
Unlock dynamic dispatch for SignerProvider.

### DIFF
--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -115,7 +115,7 @@ impl OnionMessageContents for TestCustomMessage {
 }
 
 impl Writeable for TestCustomMessage {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		Ok(CUSTOM_MESSAGE_CONTENTS.write(w)?)
 	}
 }

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -1139,7 +1139,7 @@ mod tests {
 	}
 
 	impl lightning::util::ser::Writeable for TestScorer {
-		fn write<W: lightning::util::ser::Writer>(&self, _: &mut W) -> Result<(), lightning::io::Error> { Ok(()) }
+		fn write(&self, _: &mut impl lightning::util::ser::Writer) -> Result<(), lightning::io::Error> { Ok(()) }
 	}
 
 	impl ScoreLookUp for TestScorer {

--- a/lightning-custom-message/src/lib.rs
+++ b/lightning-custom-message/src/lib.rs
@@ -41,7 +41,7 @@
 //! }
 //! impl Writeable for Foo {
 //!     // ...
-//! #     fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
+//! #     fn write(&self, _: &mut impl Writer) -> Result<(), io::Error> {
 //! #         unimplemented!()
 //! #     }
 //! }
@@ -87,7 +87,7 @@
 //! }
 //! impl Writeable for Bar {
 //!     // ...
-//! #     fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
+//! #     fn write(&self, _: &mut impl Writer) -> Result<(), io::Error> {
 //! #         unimplemented!()
 //! #     }
 //! }
@@ -133,7 +133,7 @@
 //! }
 //! impl Writeable for Baz {
 //!     // ...
-//! #     fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
+//! #     fn write(&self, _: &mut impl Writer) -> Result<(), io::Error> {
 //! #         unimplemented!()
 //! #     }
 //! }
@@ -333,7 +333,7 @@ macro_rules! composite_custom_message_handler {
 		}
 
 		impl $crate::lightning::util::ser::Writeable for $message {
-			fn write<W: $crate::lightning::util::ser::Writer>(&self, writer: &mut W) -> Result<(), $crate::lightning::io::Error> {
+			fn write(&self, writer: &mut impl $crate::lightning::util::ser::Writer) -> Result<(), $crate::lightning::io::Error> {
 				match self {
 					$(
 						Self::$variant(message) => message.write(writer),

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -33,7 +33,7 @@ pub(crate) struct ReceiveTlvs {
 }
 
 impl Writeable for ForwardTlvs {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		// TODO: write padding
 		encode_tlv_stream!(writer, {
 			(4, self.next_node_id, required),
@@ -44,7 +44,7 @@ impl Writeable for ForwardTlvs {
 }
 
 impl Writeable for ReceiveTlvs {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		// TODO: write padding
 		encode_tlv_stream!(writer, {
 			(6, self.path_id, option),

--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -125,7 +125,7 @@ impl BlindedPath {
 }
 
 impl Writeable for BlindedPath {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.introduction_node_id.write(w)?;
 		self.blinding_point.write(w)?;
 		(self.blinded_hops.len() as u8).write(w)?;

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -107,7 +107,7 @@ impl From<CounterpartyForwardingInfo> for PaymentRelay {
 }
 
 impl Writeable for ForwardTlvs {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		encode_tlv_stream!(w, {
 			(2, self.short_channel_id, required),
 			(10, self.payment_relay, required),
@@ -119,7 +119,7 @@ impl Writeable for ForwardTlvs {
 }
 
 impl Writeable for ReceiveTlvs {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		encode_tlv_stream!(w, {
 			(12, self.payment_constraints, required),
 			(65536, self.payment_secret, required)
@@ -129,7 +129,7 @@ impl Writeable for ReceiveTlvs {
 }
 
 impl<'a> Writeable for BlindedPaymentTlvsRef<'a> {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		// TODO: write padding
 		match self {
 			Self::Forward(tlvs) => tlvs.write(w)?,

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -109,7 +109,7 @@ pub struct ChannelMonitorUpdate {
 pub const CLOSED_CHANNEL_UPDATE_ID: u64 = core::u64::MAX;
 
 impl Writeable for ChannelMonitorUpdate {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		write_ver_prefix!(w, SERIALIZATION_VERSION, MIN_SERIALIZATION_VERSION);
 		self.update_id.write(w)?;
 		(self.updates.len() as u64).write(w)?;
@@ -298,7 +298,7 @@ struct CounterpartyCommitmentParameters {
 }
 
 impl Writeable for CounterpartyCommitmentParameters {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		w.write_all(&(0 as u64).to_be_bytes())?;
 		write_tlv_fields!(w, {
 			(0, self.counterparty_delayed_payment_base_key, required),
@@ -444,7 +444,7 @@ enum OnchainEvent {
 }
 
 impl Writeable for OnchainEventEntry {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(writer, {
 			(0, self.txid, required),
 			(1, self.transaction, option),
@@ -702,7 +702,7 @@ struct IrrevocablyResolvedHTLC {
 // backwards compatibility we must ensure we always write out a commitment_tx_output_idx field,
 // using `u32::max_value()` as a sentinal to indicate the HTLC was dust.
 impl Writeable for IrrevocablyResolvedHTLC {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let mapped_commitment_tx_output_idx = self.commitment_tx_output_idx.unwrap_or(u32::max_value());
 		write_tlv_fields!(writer, {
 			(0, mapped_commitment_tx_output_idx, required),
@@ -924,7 +924,7 @@ impl<Signer: WriteableEcdsaChannelSigner> PartialEq for ChannelMonitor<Signer> w
 }
 
 impl<Signer: WriteableEcdsaChannelSigner> Writeable for ChannelMonitor<Signer> {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), Error> {
 		self.inner.lock().unwrap().write(writer)
 	}
 }
@@ -934,7 +934,7 @@ const SERIALIZATION_VERSION: u8 = 1;
 const MIN_SERIALIZATION_VERSION: u8 = 1;
 
 impl<Signer: WriteableEcdsaChannelSigner> Writeable for ChannelMonitorImpl<Signer> {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), Error> {
 		write_ver_prefix!(writer, SERIALIZATION_VERSION, MIN_SERIALIZATION_VERSION);
 
 		self.latest_update_id.write(writer)?;

--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -90,7 +90,7 @@ enum OnchainEvent {
 }
 
 impl Writeable for OnchainEventEntry {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(writer, {
 			(0, self.txid, required),
 			(1, self.block_hash, option),
@@ -148,7 +148,7 @@ impl Readable for Option<Vec<Option<(usize, Signature)>>> {
 }
 
 impl Writeable for Option<Vec<Option<(usize, Signature)>>> {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			&Some(ref vec) => {
 				1u8.write(writer)?;
@@ -289,7 +289,7 @@ const SERIALIZATION_VERSION: u8 = 1;
 const MIN_SERIALIZATION_VERSION: u8 = 1;
 
 impl<ChannelSigner: WriteableEcdsaChannelSigner> OnchainTxHandler<ChannelSigner> {
-	pub(crate) fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	pub(crate) fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_ver_prefix!(writer, SERIALIZATION_VERSION, MIN_SERIALIZATION_VERSION);
 
 		self.destination_script.write(writer)?;

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -226,7 +226,7 @@ impl CounterpartyOfferedHTLCOutput {
 }
 
 impl Writeable for CounterpartyOfferedHTLCOutput {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let legacy_deserialization_prevention_marker = chan_utils::legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features);
 		write_tlv_fields!(writer, {
 			(0, self.per_commitment_point, required),
@@ -302,7 +302,7 @@ impl CounterpartyReceivedHTLCOutput {
 }
 
 impl Writeable for CounterpartyReceivedHTLCOutput {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let legacy_deserialization_prevention_marker = chan_utils::legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features);
 		write_tlv_fields!(writer, {
 			(0, self.per_commitment_point, required),
@@ -382,7 +382,7 @@ impl HolderHTLCOutput {
 }
 
 impl Writeable for HolderHTLCOutput {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let legacy_deserialization_prevention_marker = chan_utils::legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features);
 		write_tlv_fields!(writer, {
 			(0, self.amount_msat, required),
@@ -446,7 +446,7 @@ impl HolderFundingOutput {
 }
 
 impl Writeable for HolderFundingOutput {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let legacy_deserialization_prevention_marker = chan_utils::legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features);
 		write_tlv_fields!(writer, {
 			(0, self.funding_redeemscript, required),
@@ -1046,7 +1046,7 @@ impl PackageTemplate {
 }
 
 impl Writeable for PackageTemplate {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		writer.write_all(&(self.inputs.len() as u64).to_be_bytes())?;
 		for (ref outpoint, ref rev_outp) in self.inputs.iter() {
 			outpoint.write(writer)?;

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -980,7 +980,7 @@ pub enum Event {
 }
 
 impl Writeable for Event {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			&Event::FundingGenerationReady { .. } => {
 				0u8.write(writer)?;

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -322,7 +322,7 @@ impl CounterpartyCommitmentSecrets {
 }
 
 impl Writeable for CounterpartyCommitmentSecrets {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		for &(ref secret, ref idx) in self.old_secrets.iter() {
 			writer.write_all(secret)?;
 			writer.write_all(&idx.to_be_bytes())?;
@@ -879,7 +879,7 @@ impl_writeable_tlv_based!(CounterpartyChannelTransactionParameters, {
 });
 
 impl Writeable for ChannelTransactionParameters {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let legacy_deserialization_prevention_marker = legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features);
 		write_tlv_fields!(writer, {
 			(0, self.holder_pubkeys, required),
@@ -1301,7 +1301,7 @@ impl PartialEq for CommitmentTransaction {
 }
 
 impl Writeable for CommitmentTransaction {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let legacy_deserialization_prevention_marker = legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features);
 		write_tlv_fields!(writer, {
 			(0, self.commitment_number, required),

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -7387,7 +7387,7 @@ impl_writeable_tlv_based_enum!(InboundHTLCRemovalReason,;
 );
 
 impl Writeable for ChannelUpdateStatus {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		// We only care about writing out the current state as it was announced, ie only either
 		// Enabled or Disabled. In the case of DisabledStaged, we most recently announced the
 		// channel as enabled, so we write 0. For EnabledStaged, we similarly write a 1.
@@ -7412,7 +7412,7 @@ impl Readable for ChannelUpdateStatus {
 }
 
 impl Writeable for AnnouncementSigsState {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		// We only care about writing out the current state as if we had just disconnected, at
 		// which point we always set anything but AnnouncementSigsReceived to NotSent.
 		match self {
@@ -7435,7 +7435,7 @@ impl Readable for AnnouncementSigsState {
 }
 
 impl<SP: Deref> Writeable for Channel<SP> where SP::Target: SignerProvider {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		// Note that we write out as if remove_uncommitted_htlcs_and_mark_paused had just been
 		// called.
 
@@ -8414,6 +8414,20 @@ mod tests {
 	#[cfg(all(feature = "_test_vectors", not(feature = "grind_signatures")))]
 	fn public_from_secret_hex(secp_ctx: &Secp256k1<bitcoin::secp256k1::All>, hex: &str) -> PublicKey {
 		PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&<Vec<u8>>::from_hex(hex).unwrap()[..]).unwrap())
+	}
+
+	#[test]
+	fn upfront_shutdown_script_incompatibility() {
+		struct Node {
+			signer: dyn SignerProvider<EcdsaSigner = dyn crate::sign::ecdsa::WriteableEcdsaChannelSigner>
+		}
+
+		impl Node{
+			fn new(signer: impl SignerProvider<EcdsaSigner = dyn crate::sign::ecdsa::WriteableEcdsaChannelSigner>) -> Self {
+				Self { signer }
+			}
+		}
+		assert!(true)
 	}
 
 	#[test]

--- a/lightning/src/ln/channel_id.rs
+++ b/lightning/src/ln/channel_id.rs
@@ -64,7 +64,7 @@ impl ChannelId {
 }
 
 impl Writeable for ChannelId {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.0.write(w)
 	}
 }

--- a/lightning/src/ln/channel_keys.rs
+++ b/lightning/src/ln/channel_keys.rs
@@ -76,7 +76,7 @@ macro_rules! key_impl {
 macro_rules! key_read_write {
     ($SelfT:ty) => {
         impl Writeable for $SelfT {
-            fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+            fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
                 self.0.serialize().write(w)
             }
         }

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -383,7 +383,7 @@ impl PaymentId {
 }
 
 impl Writeable for PaymentId {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.0.write(w)
 	}
 }
@@ -408,7 +408,7 @@ impl core::fmt::Display for PaymentId {
 pub struct InterceptId(pub [u8; 32]);
 
 impl Writeable for InterceptId {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.0.write(w)
 	}
 }
@@ -9361,7 +9361,7 @@ impl_writeable_tlv_based!(ChannelCounterparty, {
 });
 
 impl Writeable for ChannelDetails {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		// `user_channel_id` used to be a single u64 value. In order to remain backwards compatible with
 		// versions prior to 0.0.113, the u128 is serialized as two separate u64 values.
 		let user_channel_id_low = self.user_channel_id as u64;
@@ -9518,7 +9518,7 @@ impl_writeable_tlv_based!(PendingHTLCInfo, {
 
 
 impl Writeable for HTLCFailureMsg {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			HTLCFailureMsg::Relay(msgs::UpdateFailHTLC { channel_id, htlc_id, reason }) => {
 				0u8.write(writer)?;
@@ -9605,7 +9605,7 @@ impl_writeable_tlv_based!(HTLCPreviousHopData, {
 });
 
 impl Writeable for ClaimableHTLC {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let (payment_data, keysend_preimage) = match &self.onion_payload {
 			OnionPayload::Invoice { _legacy_hop_data } => (_legacy_hop_data.as_ref(), None),
 			OnionPayload::Spontaneous(preimage) => (None, Some(preimage)),
@@ -9723,7 +9723,7 @@ impl Readable for HTLCSource {
 }
 
 impl Writeable for HTLCSource {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), crate::io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			HTLCSource::OutboundRoute { ref session_priv, ref first_hop_htlc_msat, ref path, payment_id } => {
 				0u8.write(writer)?;
@@ -9756,7 +9756,7 @@ impl_writeable_tlv_based!(PendingAddHTLCInfo, {
 });
 
 impl Writeable for HTLCForwardInfo {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		const FAIL_HTLC_VARIANT_ID: u8 = 1;
 		match self {
 			Self::AddHTLC(info) => {
@@ -9837,7 +9837,7 @@ where
 	R::Target: Router,
 	L::Target: Logger,
 {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let _consistency_lock = self.total_consistency_lock.write().unwrap();
 
 		write_ver_prefix!(writer, SERIALIZATION_VERSION, MIN_SERIALIZATION_VERSION);
@@ -10050,7 +10050,7 @@ where
 }
 
 impl Writeable for VecDeque<(Event, Option<EventCompletionAction>)> {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		(self.len() as u64).write(w)?;
 		for (event, action) in self.iter() {
 			event.write(w)?;

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -932,7 +932,7 @@ impl<T: sealed::UnknownFeature> Features<T> {
 macro_rules! impl_feature_len_prefixed_write {
 	($features: ident) => {
 		impl Writeable for $features {
-			fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+			fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 				(self.flags.len() as u16).write(w)?;
 				self.write_be(w)
 			}
@@ -955,7 +955,7 @@ impl_feature_len_prefixed_write!(BlindedHopFeatures);
 macro_rules! impl_feature_tlv_write {
 	($features: ident) => {
 		impl Writeable for $features {
-			fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+			fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 				WithoutLength(self).write(w)
 			}
 		}
@@ -973,7 +973,7 @@ impl_feature_tlv_write!(ChannelTypeFeatures);
 // requires a length but the former does not.
 
 impl<T: sealed::Context> Writeable for WithoutLength<&Features<T>> {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.0.write_be(w)
 	}
 }

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -891,7 +891,7 @@ impl SocketAddress {
 }
 
 impl Writeable for SocketAddress {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			&SocketAddress::TcpIpV4 { ref addr, ref port } => {
 				1u8.write(writer)?;
@@ -1142,7 +1142,7 @@ pub enum UnsignedGossipMessage<'a> {
 }
 
 impl<'a> Writeable for UnsignedGossipMessage<'a> {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			UnsignedGossipMessage::ChannelAnnouncement(ref msg) => msg.write(writer),
 			UnsignedGossipMessage::ChannelUpdate(ref msg) => msg.write(writer),
@@ -2064,7 +2064,7 @@ impl_writeable_msg!(ChannelReady, {
 });
 
 impl Writeable for Init {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		// global_features gets the bottom 13 bits of our features, and local_features gets all of
 		// our relevant feature bits. This keeps us compatible with old nodes.
 		self.features.write_up_to_13(w)?;
@@ -2201,7 +2201,7 @@ impl_writeable!(OnionErrorPacket, {
 // serialization format in a way which assumes we know the total serialized length/message end
 // position.
 impl Writeable for OnionPacket {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.version.write(w)?;
 		match self.public_key {
 			Ok(pubkey) => pubkey.write(w)?,
@@ -2254,7 +2254,7 @@ impl Readable for OnionMessage {
 }
 
 impl Writeable for OnionMessage {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.blinding_point.write(w)?;
 		let onion_packet_len = self.onion_routing_packet.serialized_length();
 		(onion_packet_len as u16).write(w)?;
@@ -2264,7 +2264,7 @@ impl Writeable for OnionMessage {
 }
 
 impl Writeable for FinalOnionHopData {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.payment_secret.0.write(w)?;
 		HighZeroBytesDroppedBigSize(self.total_msat).write(w)
 	}
@@ -2279,7 +2279,7 @@ impl Readable for FinalOnionHopData {
 }
 
 impl Writeable for OutboundOnionPayload {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			Self::Forward { short_channel_id, amt_to_forward, outgoing_cltv_value } => {
 				_encode_varint_length_prefixed_tlv!(w, {
@@ -2441,7 +2441,7 @@ impl<NS: Deref> ReadableArgs<(Option<PublicKey>, &NS)> for InboundOnionPayload w
 }
 
 impl Writeable for Ping {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.ponglen.write(w)?;
 		vec![0u8; self.byteslen as usize].write(w)?; // size-unchecked write
 		Ok(())
@@ -2462,7 +2462,7 @@ impl Readable for Ping {
 }
 
 impl Writeable for Pong {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		vec![0u8; self.byteslen as usize].write(w)?; // size-unchecked write
 		Ok(())
 	}
@@ -2481,7 +2481,7 @@ impl Readable for Pong {
 }
 
 impl Writeable for UnsignedChannelAnnouncement {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.features.write(w)?;
 		self.chain_hash.write(w)?;
 		self.short_channel_id.write(w)?;
@@ -2518,7 +2518,7 @@ impl_writeable!(ChannelAnnouncement, {
 });
 
 impl Writeable for UnsignedChannelUpdate {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		// `message_flags` used to indicate presence of `htlc_maximum_msat`, but was deprecated in the spec.
 		const MESSAGE_FLAGS: u8 = 1;
 		self.chain_hash.write(w)?;
@@ -2563,7 +2563,7 @@ impl_writeable!(ChannelUpdate, {
 });
 
 impl Writeable for ErrorMessage {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.channel_id.write(w)?;
 		(self.data.len() as u16).write(w)?;
 		w.write_all(self.data.as_bytes())?;
@@ -2590,7 +2590,7 @@ impl Readable for ErrorMessage {
 }
 
 impl Writeable for WarningMessage {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.channel_id.write(w)?;
 		(self.data.len() as u16).write(w)?;
 		w.write_all(self.data.as_bytes())?;
@@ -2617,7 +2617,7 @@ impl Readable for WarningMessage {
 }
 
 impl Writeable for UnsignedNodeAnnouncement {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.features.write(w)?;
 		self.timestamp.write(w)?;
 		self.node_id.write(w)?;
@@ -2740,7 +2740,7 @@ impl Readable for QueryShortChannelIds {
 }
 
 impl Writeable for QueryShortChannelIds {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		// Calculated from 1-byte encoding_type plus 8-bytes per short_channel_id
 		let encoding_len: u16 = 1 + self.short_channel_ids.len() as u16 * 8;
 
@@ -2822,7 +2822,7 @@ impl Readable for ReplyChannelRange {
 }
 
 impl Writeable for ReplyChannelRange {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		let encoding_len: u16 = 1 + self.short_channel_ids.len() as u16 * 8;
 		self.chain_hash.write(w)?;
 		self.first_blocknum.write(w)?;

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -263,7 +263,7 @@ impl BogusOnionHopData {
 	}
 }
 impl Writeable for BogusOnionHopData {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		writer.write_all(&self.data[..])
 	}
 }

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -769,7 +769,7 @@ impl core::fmt::Debug for HTLCFailReason {
 }
 
 impl Writeable for HTLCFailReason {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), crate::io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), crate::io::Error> {
 		self.0.write(writer)
 	}
 }
@@ -1275,7 +1275,7 @@ mod tests {
 		}
 	}
 	impl Writeable for RawOnionHopData {
-		fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+		fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 			writer.write_all(&self.data[..])
 		}
 	}

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -165,7 +165,7 @@ impl wire::Type for Infallible {
 	}
 }
 impl Writeable for Infallible {
-	fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
+	fn write(&self, _: &mut impl Writer) -> Result<(), io::Error> {
 		unreachable!();
 	}
 }

--- a/lightning/src/ln/script.rs
+++ b/lightning/src/ln/script.rs
@@ -41,7 +41,7 @@ enum ShutdownScriptImpl {
 }
 
 impl Writeable for ShutdownScript {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.0.write(w)
 	}
 }

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -101,7 +101,7 @@ pub(crate) enum Message<T> where T: core::fmt::Debug + Type + TestEq {
 }
 
 impl<T> Writeable for Message<T> where T: core::fmt::Debug + Type + TestEq {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			&Message::Init(ref msg) => msg.write(writer),
 			&Message::Error(ref msg) => msg.write(writer),
@@ -787,7 +787,7 @@ mod tests {
 	}
 
 	impl Writeable for TestCustomMessage {
-		fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
+		fn write(&self, _: &mut impl Writer) -> Result<(), io::Error> {
 			Ok(())
 		}
 	}

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1025,19 +1025,19 @@ impl InvoiceFields {
 }
 
 impl Writeable for UnsignedBolt12Invoice {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		WithoutLength(&self.bytes).write(writer)
 	}
 }
 
 impl Writeable for Bolt12Invoice {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		WithoutLength(&self.bytes).write(writer)
 	}
 }
 
 impl Writeable for InvoiceContents {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		self.as_tlv_stream().write(writer)
 	}
 }

--- a/lightning/src/offers/invoice_error.rs
+++ b/lightning/src/offers/invoice_error.rs
@@ -65,7 +65,7 @@ impl core::fmt::Display for InvoiceError {
 }
 
 impl Writeable for InvoiceError {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let tlv_fieldnum = self.erroneous_field.as_ref().map(|f| f.tlv_fieldnum);
 		let suggested_value =
 			self.erroneous_field.as_ref().and_then(|f| f.suggested_value.as_ref());

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -773,19 +773,19 @@ impl InvoiceRequestContentsWithoutPayerId {
 }
 
 impl Writeable for UnsignedInvoiceRequest {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		WithoutLength(&self.bytes).write(writer)
 	}
 }
 
 impl Writeable for InvoiceRequest {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		WithoutLength(&self.bytes).write(writer)
 	}
 }
 
 impl Writeable for InvoiceRequestContents {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		self.as_tlv_stream().write(writer)
 	}
 }

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -259,7 +259,7 @@ pub(super) struct WithoutSignatures<'a>(pub &'a [u8]);
 
 impl<'a> Writeable for WithoutSignatures<'a> {
 	#[inline]
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let tlv_stream = TlvStream::new(self.0);
 		for record in tlv_stream.skip_signatures() {
 			writer.write_all(record.record_bytes)?;

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -749,13 +749,13 @@ impl OfferContents {
 }
 
 impl Writeable for Offer {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		WithoutLength(&self.bytes).write(writer)
 	}
 }
 
 impl Writeable for OfferContents {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		self.as_tlv_stream().write(writer)
 	}
 }

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -646,13 +646,13 @@ impl RefundContents {
 }
 
 impl Writeable for Refund {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		WithoutLength(&self.bytes).write(writer)
 	}
 }
 
 impl Writeable for RefundContents {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		self.as_tlv_stream().write(writer)
 	}
 }

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -95,7 +95,7 @@ impl OnionMessageContents for TestCustomMessage {
 }
 
 impl Writeable for TestCustomMessage {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			TestCustomMessage::Request => Ok(CUSTOM_REQUEST_MESSAGE_CONTENTS.write(w)?),
 			TestCustomMessage::Response => Ok(CUSTOM_RESPONSE_MESSAGE_CONTENTS.write(w)?),
@@ -434,7 +434,7 @@ fn invalid_custom_message_type() {
 	}
 
 	impl Writeable for InvalidCustomMessage {
-		fn write<W: Writer>(&self, _w: &mut W) -> Result<(), io::Error> { unreachable!() }
+		fn write(&self, _: &mut impl Writer) -> Result<(), io::Error> { unreachable!() }
 	}
 
 	let test_msg = InvalidCustomMessage {};

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -124,7 +124,7 @@ pub(super) const MAX_TIMER_TICKS: usize = 2;
 /// # #[derive(Debug)]
 /// # struct YourCustomMessage {}
 /// impl Writeable for YourCustomMessage {
-/// 	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+/// 	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 /// 		# Ok(())
 /// 		// Write your custom onion message to `w`
 /// 	}

--- a/lightning/src/onion_message/offers.rs
+++ b/lightning/src/onion_message/offers.rs
@@ -121,7 +121,7 @@ impl OnionMessageContents for OffersMessage {
 }
 
 impl Writeable for OffersMessage {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			OffersMessage::InvoiceRequest(message) => message.write(w),
 			OffersMessage::Invoice(message) => message.write(w),

--- a/lightning/src/onion_message/packet.rs
+++ b/lightning/src/onion_message/packet.rs
@@ -63,7 +63,7 @@ impl onion_utils::Packet for Packet {
 }
 
 impl Writeable for Packet {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.version.write(w)?;
 		self.public_key.write(w)?;
 		w.write_all(&self.hop_data)?;
@@ -138,7 +138,7 @@ impl<T: OnionMessageContents> OnionMessageContents for ParsedOnionMessageContent
 }
 
 impl<T: OnionMessageContents> Writeable for ParsedOnionMessageContents<T> {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			ParsedOnionMessageContents::Offers(msg) => Ok(msg.write(w)?),
 			ParsedOnionMessageContents::Custom(msg) => Ok(msg.write(w)?),
@@ -174,7 +174,7 @@ pub(super) enum ReceiveControlTlvs {
 
 // Uses the provided secret to simultaneously encode and encrypt the unblinded control TLVs.
 impl<T: OnionMessageContents> Writeable for (Payload<T>, [u8; 32]) {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		match &self.0 {
 			Payload::Forward(ForwardControlTlvs::Blinded(encrypted_bytes)) => {
 				_encode_varint_length_prefixed_tlv!(w, {
@@ -313,7 +313,7 @@ impl Readable for ControlTlvs {
 }
 
 impl Writeable for ControlTlvs {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			Self::Forward(tlvs) => tlvs.write(w),
 			Self::Receive(tlvs) => tlvs.write(w),

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -128,7 +128,7 @@ impl Ord for NodeId {
 }
 
 impl Writeable for NodeId {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		writer.write_all(&self.0)?;
 		Ok(())
 	}
@@ -787,7 +787,7 @@ impl fmt::Display for ChannelUpdateInfo {
 }
 
 impl Writeable for ChannelUpdateInfo {
-	fn write<W: crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(writer, {
 			(0, self.last_update, required),
 			(2, self.enabled, required),
@@ -917,7 +917,7 @@ impl fmt::Display for ChannelInfo {
 }
 
 impl Writeable for ChannelInfo {
-	fn write<W: crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(writer, {
 			(0, self.features, required),
 			(1, self.announcement_received_time, (default_value, 0)),
@@ -1151,7 +1151,7 @@ impl NodeAnnouncementInfo {
 }
 
 impl Writeable for NodeAnnouncementInfo {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let empty_addresses = Vec::<SocketAddress>::new();
 		write_tlv_fields!(writer, {
 			(0, self.features, required),
@@ -1209,7 +1209,7 @@ impl fmt::Display for NodeAlias {
 }
 
 impl Writeable for NodeAlias {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.0.write(w)
 	}
 }
@@ -1240,7 +1240,7 @@ impl fmt::Display for NodeInfo {
 }
 
 impl Writeable for NodeInfo {
-	fn write<W: crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(writer, {
 			// Note that older versions of LDK wrote the lowest inbound fees here at type 0
 			(2, self.announcement_info, option),
@@ -1294,7 +1294,7 @@ const SERIALIZATION_VERSION: u8 = 1;
 const MIN_SERIALIZATION_VERSION: u8 = 1;
 
 impl<L: Deref> Writeable for NetworkGraph<L> where L::Target: Logger {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_ver_prefix!(writer, SERIALIZATION_VERSION, MIN_SERIALIZATION_VERSION);
 
 		self.chain_hash.write(writer)?;

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -331,7 +331,7 @@ impl InFlightHtlcs {
 }
 
 impl Writeable for InFlightHtlcs {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> { self.0.write(writer) }
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> { self.0.write(writer) }
 }
 
 impl Readable for InFlightHtlcs {
@@ -509,7 +509,7 @@ const SERIALIZATION_VERSION: u8 = 1;
 const MIN_SERIALIZATION_VERSION: u8 = 1;
 
 impl Writeable for Route {
-	fn write<W: crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_ver_prefix!(writer, SERIALIZATION_VERSION, MIN_SERIALIZATION_VERSION);
 		(self.paths.len() as u64).write(writer)?;
 		let mut blinded_tails = Vec::new();
@@ -614,7 +614,7 @@ impl RouteParameters {
 }
 
 impl Writeable for RouteParameters {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(writer, {
 			(0, self.payment_params, required),
 			(1, self.max_total_routing_fee_msat, option),
@@ -714,7 +714,7 @@ pub struct PaymentParameters {
 }
 
 impl Writeable for PaymentParameters {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		let mut clear_hints = &vec![];
 		let mut blinded_hints = &vec![];
 		match &self.payee {
@@ -1011,7 +1011,7 @@ impl Features {
 }
 
 impl<'a> Writeable for FeaturesRef<'a> {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		match self {
 			Self::Bolt11(f) => Ok(f.write(w)?),
 			Self::Bolt12(f) => Ok(f.write(w)?),
@@ -1031,7 +1031,7 @@ impl ReadableArgs<bool> for Features {
 pub struct RouteHint(pub Vec<RouteHintHop>);
 
 impl Writeable for RouteHint {
-	fn write<W: crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		(self.0.len() as u64).write(writer)?;
 		for hop in self.0.iter() {
 			hop.write(writer)?;
@@ -3136,7 +3136,7 @@ fn build_route_from_hops_internal<L: Deref>(
 
 	impl<'a> Writeable for HopScorer {
 		#[inline]
-		fn write<W: Writer>(&self, _w: &mut W) -> Result<(), io::Error> {
+		fn write(&self, _: &mut impl Writer) -> Result<(), io::Error> {
 			unreachable!();
 		}
 	}
@@ -6464,7 +6464,7 @@ mod tests {
 
 	#[cfg(c_bindings)]
 	impl Writeable for BadChannelScorer {
-		fn write<W: Writer>(&self, _w: &mut W) -> Result<(), crate::io::Error> { unimplemented!() }
+		fn write(&self, _w: &mut impl Writer) -> Result<(), crate::io::Error> { unimplemented!() }
 	}
 	impl ScoreLookUp for BadChannelScorer {
 		type ScoreParams = ();
@@ -6479,7 +6479,7 @@ mod tests {
 
 	#[cfg(c_bindings)]
 	impl Writeable for BadNodeScorer {
-		fn write<W: Writer>(&self, _w: &mut W) -> Result<(), crate::io::Error> { unimplemented!() }
+		fn write(&self, _w: &mut impl Writer) -> Result<(), crate::io::Error> { unimplemented!() }
 	}
 
 	impl ScoreLookUp for BadNodeScorer {

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -292,7 +292,7 @@ impl<'a, T: Score + 'a> LockableScore<'a> for MultiThreadedLockableScore<T> {
 
 #[cfg(c_bindings)]
 impl<T: Score> Writeable for MultiThreadedLockableScore<T> {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		self.score.read().unwrap().write(writer)
 	}
 }
@@ -336,7 +336,7 @@ impl<'a, T: Score> ScoreLookUp for MultiThreadedScoreLockRead<'a, T> {
 
 #[cfg(c_bindings)]
 impl<'a, T: Score> Writeable for MultiThreadedScoreLockWrite<'a, T> {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), io::Error> {
 		self.0.write(writer)
 	}
 }
@@ -429,7 +429,7 @@ impl ScoreUpdate for FixedPenaltyScorer {
 
 impl Writeable for FixedPenaltyScorer {
 	#[inline]
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(w, {});
 		Ok(())
 	}
@@ -2058,7 +2058,7 @@ use bucketed_history::{LegacyHistoricalBucketRangeTracker, HistoricalBucketRange
 
 impl<G: Deref<Target = NetworkGraph<L>>, L: Deref> Writeable for ProbabilisticScorer<G, L> where L::Target: Logger {
 	#[inline]
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(w, {
 			(0, self.channel_liquidities, required),
 		});
@@ -2088,7 +2088,7 @@ ReadableArgs<(ProbabilisticScoringDecayParameters, G, L)> for ProbabilisticScore
 
 impl Writeable for ChannelLiquidity {
 	#[inline]
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		write_tlv_fields!(w, {
 			(0, self.min_liquidity_offset_msat, required),
 			// 1 was the min_liquidity_offset_history in octile form

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -1300,7 +1300,7 @@ const MIN_SERIALIZATION_VERSION: u8 = 1;
 impl WriteableEcdsaChannelSigner for InMemorySigner {}
 
 impl Writeable for InMemorySigner {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), Error> {
 		write_ver_prefix!(writer, SERIALIZATION_VERSION, MIN_SERIALIZATION_VERSION);
 
 		self.funding_key.write(writer)?;

--- a/lightning/src/util/chacha20poly1305rfc.rs
+++ b/lightning/src/util/chacha20poly1305rfc.rs
@@ -218,7 +218,7 @@ impl<'a, W: Writeable> ChaChaPolyWriteAdapter<'a, W> {
 
 impl<'a, T: Writeable> Writeable for ChaChaPolyWriteAdapter<'a, T> {
 	// Simultaneously write and encrypt Self::writeable.
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		let mut chacha = ChaCha20Poly1305RFC::new(&self.rho, &[0; 12], &[]);
 		let mut chacha_stream = ChaChaPolyWriter { chacha: &mut chacha, write: w };
 		self.writeable.write(&mut chacha_stream)?;

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -524,7 +524,7 @@ impl Default for ChannelConfig {
 }
 
 impl crate::util::ser::Writeable for ChannelConfig {
-	fn write<W: crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), crate::io::Error> {
+	fn write(&self, writer: &mut impl crate::util::ser::Writer) -> Result<(), crate::io::Error> {
 		let max_dust_htlc_exposure_msat_fixed_limit = match self.max_dust_htlc_exposure {
 			MaxDustHTLCExposure::FixedLimitMsat(limit) => limit,
 			MaxDustHTLCExposure::FeeRateMultiplier(_) => 5_000_000,
@@ -638,7 +638,7 @@ impl Default for LegacyChannelConfig {
 }
 
 impl crate::util::ser::Writeable for LegacyChannelConfig {
-	fn write<W: crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), crate::io::Error> {
+	fn write(&self, writer: &mut impl crate::util::ser::Writer) -> Result<(), crate::io::Error> {
 		let max_dust_htlc_exposure_msat_fixed_limit = match self.options.max_dust_htlc_exposure {
 			MaxDustHTLCExposure::FixedLimitMsat(limit) => limit,
 			MaxDustHTLCExposure::FeeRateMultiplier(_) => 5_000_000,

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -577,7 +577,7 @@ macro_rules! _decode_tlv_stream_range {
 ///
 /// For example,
 /// ```
-/// # use lightning::impl_writeable_msg;
+/// # use lightning::{impl_writeable_msg, util::ser::Writer};
 /// struct MyCustomMessage {
 /// 	pub field_1: u32,
 /// 	pub field_2: bool,
@@ -601,7 +601,7 @@ macro_rules! _decode_tlv_stream_range {
 macro_rules! impl_writeable_msg {
 	($st:ident, {$($field:ident),* $(,)*}, {$(($type: expr, $tlvfield: ident, $fieldty: tt)),* $(,)*}) => {
 		impl $crate::util::ser::Writeable for $st {
-			fn write<W: $crate::util::ser::Writer>(&self, w: &mut W) -> Result<(), $crate::io::Error> {
+			fn write(&self, w: &mut impl Writer) -> Result<(), $crate::io::Error> {
 				$( self.$field.write(w)?; )*
 				$crate::encode_tlv_stream!(w, {$(($type, self.$tlvfield.as_ref(), $fieldty)),*});
 				Ok(())
@@ -624,7 +624,7 @@ macro_rules! impl_writeable_msg {
 macro_rules! impl_writeable {
 	($st:ident, {$($field:ident),*}) => {
 		impl $crate::util::ser::Writeable for $st {
-			fn write<W: $crate::util::ser::Writer>(&self, w: &mut W) -> Result<(), $crate::io::Error> {
+			fn write(&self, w: &mut impl $crate::util::ser::Writer) -> Result<(), $crate::io::Error> {
 				$( self.$field.write(w)?; )*
 				Ok(())
 			}
@@ -856,7 +856,7 @@ macro_rules! _init_and_read_tlv_stream {
 macro_rules! impl_writeable_tlv_based {
 	($st: ident, {$(($type: expr, $field: ident, $fieldty: tt)),* $(,)*}) => {
 		impl $crate::util::ser::Writeable for $st {
-			fn write<W: $crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), $crate::io::Error> {
+			fn write(&self, writer: &mut impl $crate::util::ser::Writer) -> Result<(), $crate::io::Error> {
 				$crate::write_tlv_fields!(writer, {
 					$(($type, self.$field, $fieldty)),*
 				});
@@ -924,7 +924,7 @@ macro_rules! tlv_stream {
 		}
 
 		impl<'a> $crate::util::ser::Writeable for $nameref<'a> {
-			fn write<W: $crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), $crate::io::Error> {
+			fn write(&self, writer: &mut impl $crate::util::ser::Writer) -> Result<(), $crate::io::Error> {
 				encode_tlv_stream!(writer, {
 					$(($type, self.$field, (option, encoding: $fieldty))),*
 				});
@@ -979,7 +979,7 @@ macro_rules! _impl_writeable_tlv_based_enum_common {
 	),* $(,)*;
 	$(($tuple_variant_id: expr, $tuple_variant_name: ident)),*  $(,)*) => {
 		impl $crate::util::ser::Writeable for $st {
-			fn write<W: $crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), $crate::io::Error> {
+			fn write(&self, writer: &mut impl $crate::util::ser::Writer) -> Result<(), $crate::io::Error> {
 				match self {
 					$($st::$variant_name { $(ref $field),* } => {
 						let id: u8 = $variant_id;

--- a/lightning/src/util/string.rs
+++ b/lightning/src/util/string.rs
@@ -20,7 +20,7 @@ use crate::util::ser::{Writeable, Writer, Readable};
 pub struct UntrustedString(pub String);
 
 impl Writeable for UntrustedString {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+	fn write(&self, w: &mut impl Writer) -> Result<(), io::Error> {
 		self.0.write(w)
 	}
 }

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -9,7 +9,7 @@
 
 use crate::ln::channel::{ANCHOR_OUTPUT_VALUE_SATOSHI, MIN_CHAN_DUST_LIMIT_SATOSHIS};
 use crate::ln::chan_utils::{HTLCOutputInCommitment, ChannelPublicKeys, HolderCommitmentTransaction, CommitmentTransaction, ChannelTransactionParameters, TrustedCommitmentTransaction, ClosingTransaction};
-use crate::ln::channel_keys::{HtlcKey};
+use crate::ln::channel_keys::HtlcKey;
 use crate::ln::{msgs, PaymentPreimage};
 use crate::sign::{InMemorySigner, ChannelSigner};
 use crate::sign::ecdsa::{EcdsaChannelSigner, WriteableEcdsaChannelSigner};
@@ -33,7 +33,6 @@ use bitcoin::secp256k1::{Secp256k1, ecdsa::Signature};
 use musig2::types::{PartialSignature, PublicNonce, SecretNonce};
 use crate::sign::HTLCDescriptor;
 use crate::util::ser::{Writeable, Writer};
-use crate::io::Error;
 use crate::ln::features::ChannelTypeFeatures;
 #[cfg(taproot)]
 use crate::ln::msgs::PartialSignatureWithNonce;
@@ -322,7 +321,7 @@ impl TaprootChannelSigner for TestChannelSigner {
 }
 
 impl Writeable for TestChannelSigner {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+	fn write(&self, writer: &mut impl Writer) -> Result<(), crate::io::Error> {
 		// TestChannelSigner has two fields - `inner` ([`InMemorySigner`]) and `state`
 		// ([`EnforcementState`]). `inner` is serialized here and deserialized by
 		// [`SignerProvider::read_chan_signer`]. `state` is managed by [`SignerProvider`]

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -1353,7 +1353,7 @@ impl TestScorer {
 
 #[cfg(c_bindings)]
 impl crate::util::ser::Writeable for TestScorer {
-	fn write<W: crate::util::ser::Writer>(&self, _: &mut W) -> Result<(), crate::io::Error> { unreachable!(); }
+	fn write(&self, _: &mut impl crate::util::ser::Writer) -> Result<(), crate::io::Error> { unreachable!(); }
 }
 
 impl ScoreLookUp for TestScorer {


### PR DESCRIPTION
This change makes `lightning::sign::WriteableEcdsaChannelSigner` [object safe](https://doc.rust-lang.org/reference/items/traits.html#object-safety), so a SignerProvider can be built and assigned to a node dynamically based on a config entry. 

Currently it is not possible to use ChannelSigner in a dynamic dispatch, because it is not object safe, since one of the supertraits (Writable) uses generics in one of it's functions. I fixed it by replacing generics with `impl Trait` as it can substitute generics in function arguments (but can not be used in struct properties like `signer_provider:
        Arc<impl SignerProvider<Signer = dyn lightning::sign::WriteableEcdsaChannelSigner>>`).

As a result, this changle allows a cleaner separation of code for different signers because now different SignerProvider implementations can live in different structs implementing the trait.

There is some discussion on how to separate different signers using feature flags and static binding here: https://discord.com/channels/915026692102316113/1098347464358121472/1161785826540261416.