### PR TITLE
Feature-gate `time` use also in `ElectrumSyncClient`

### DIFF
--- a/lightning-transaction-sync/src/electrum.rs
+++ b/lightning-transaction-sync/src/electrum.rs
@@ -86,6 +86,7 @@ where
 		let mut sync_state = self.sync_state.lock().unwrap();
 
 		log_trace!(self.logger, "Starting transaction sync.");
+		#[cfg(feature = "time")]
 		let start_time = Instant::now();
 		let mut num_confirmed = 0;
 		let mut num_unconfirmed = 0;
@@ -210,10 +211,15 @@ where
 				sync_state.pending_sync = false;
 			}
 		}
+		#[cfg(feature = "time")]
 		log_debug!(self.logger,
 			"Finished transaction sync at tip {} in {}ms: {} confirmed, {} unconfirmed.",
 			tip_header.block_hash(), start_time.elapsed().as_millis(), num_confirmed,
 			num_unconfirmed);
+		#[cfg(not(feature = "time"))]
+		log_debug!(self.logger,
+			"Finished transaction sync at tip {}: {} confirmed, {} unconfirmed.",
+			tip_header.block_hash(), num_confirmed, num_unconfirmed);
 		Ok(())
 	}
 


### PR DESCRIPTION
Previously, #2799 introduced the `time` feature to gate the use of `SystemTime` dependent APIs in `EsploraSyncClient`. 
It however omitted doing the same for the Electrum side of things. Here, we address this oversight and make things symmetrical.