### PR TITLE
Fix lightning-net-tokio sometimes dropping messages

### DIFF
--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -502,6 +502,9 @@ impl peer_handler::SocketDescriptor for SocketDescriptor {
 							written_len += res;
 							if written_len == data.len() { return written_len; }
 						},
+						Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+							continue;
+						}
 						Err(_) => return written_len,
 					}
 				},


### PR DESCRIPTION
I was having some issues sending custom messages with `v0.0.118` (when trying to send a rather large number - ~25 - it would stop sending after ~14). After debugging I found that the issue was coming from `lightning-net-tokio` and checking the [documentation](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html#return-3) it seems that when receiving a `WouldBlock` the write should just be retried. I confirmed that this fixed the issue I was having.