### PR TITLE
Change v0.0.120 release name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.120 - Jan 17, 2024 - "Blinded Fuzzers"
+# 0.0.120 - Jan 17, 2024 - "Unblinded Fuzzers"
 
 ## API Updates
  * The `PeerManager` bound on `UtxoLookup` was removed entirely. This enables


### PR DESCRIPTION
"Un"blinded makes more sense, since the fuzzer was unblinded :)