### PR TITLE
Fix deadlock when handling bad calls to `batch_funding.._generated`

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3984,6 +3984,7 @@ where
 						});
 				}
 			}
+			mem::drop(funding_batch_states);
 			for shutdown_result in shutdown_results.drain(..) {
 				self.finish_close_channel(shutdown_result);
 			}


### PR DESCRIPTION
When handling calls to `batch_funding_transaction_generated` which were missing outputs for one of the batch channels, we'd previously deadlock when trying to clean up the now-closed channels. This fixes that and adds a new test case for it.

Found by the full_stack_target fuzzer.