### PR TITLE
doc: change PaymentPreimage to PaymentSecret in ChannelManager::create_inbound_payment

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7832,7 +7832,7 @@ where
 	/// to pay us.
 	///
 	/// This differs from [`create_inbound_payment_for_hash`] only in that it generates the
-	/// [`PaymentHash`] and [`PaymentPreimage`] for you.
+	/// [`PaymentHash`] and [`PaymentSecret`] for you.
 	///
 	/// The [`PaymentPreimage`] will ultimately be returned to you in the [`PaymentClaimable`], which
 	/// will have the [`PaymentClaimable::purpose`] be [`PaymentPurpose::InvoicePayment`] with


### PR DESCRIPTION
Docs mentioned `create_inbound_payment` returns `PaymentHash` and `PaymentPreimage` when it instead returns `PaymentHash` and `PaymentSecret`.