### PR TITLE
Route blinding: add `min_final_cltv_delta` to aggregated CLTV delta

### DIFF
--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -85,14 +85,15 @@ impl BlindedPath {
 
 	/// Create a one-hop blinded path for a payment.
 	pub fn one_hop_for_payment<ES: EntropySource + ?Sized, T: secp256k1::Signing + secp256k1::Verification>(
-		payee_node_id: PublicKey, payee_tlvs: payment::ReceiveTlvs, entropy_source: &ES,
-		secp_ctx: &Secp256k1<T>
+		payee_node_id: PublicKey, payee_tlvs: payment::ReceiveTlvs, min_final_cltv_expiry_delta: u16,
+		entropy_source: &ES, secp_ctx: &Secp256k1<T>
 	) -> Result<(BlindedPayInfo, Self), ()> {
 		// This value is not considered in pathfinding for 1-hop blinded paths, because it's intended to
 		// be in relation to a specific channel.
 		let htlc_maximum_msat = u64::max_value();
 		Self::new_for_payment(
-			&[], payee_node_id, payee_tlvs, htlc_maximum_msat, entropy_source, secp_ctx
+			&[], payee_node_id, payee_tlvs, htlc_maximum_msat, min_final_cltv_expiry_delta,
+			entropy_source, secp_ctx
 		)
 	}
 
@@ -107,8 +108,8 @@ impl BlindedPath {
 	//  TODO: make all payloads the same size with padding + add dummy hops
 	pub fn new_for_payment<ES: EntropySource + ?Sized, T: secp256k1::Signing + secp256k1::Verification>(
 		intermediate_nodes: &[payment::ForwardNode], payee_node_id: PublicKey,
-		payee_tlvs: payment::ReceiveTlvs, htlc_maximum_msat: u64, entropy_source: &ES,
-		secp_ctx: &Secp256k1<T>
+		payee_tlvs: payment::ReceiveTlvs, htlc_maximum_msat: u64, min_final_cltv_expiry_delta: u16,
+		entropy_source: &ES, secp_ctx: &Secp256k1<T>
 	) -> Result<(BlindedPayInfo, Self), ()> {
 		let blinding_secret_bytes = entropy_source.get_secure_random_bytes();
 		let blinding_secret = SecretKey::from_slice(&blinding_secret_bytes[..]).expect("RNG is busted");

--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -114,7 +114,9 @@ impl BlindedPath {
 		let blinding_secret_bytes = entropy_source.get_secure_random_bytes();
 		let blinding_secret = SecretKey::from_slice(&blinding_secret_bytes[..]).expect("RNG is busted");
 
-		let blinded_payinfo = payment::compute_payinfo(intermediate_nodes, &payee_tlvs, htlc_maximum_msat)?;
+		let blinded_payinfo = payment::compute_payinfo(
+			intermediate_nodes, &payee_tlvs, htlc_maximum_msat, min_final_cltv_expiry_delta
+		)?;
 		Ok((blinded_payinfo, BlindedPath {
 			introduction_node_id: intermediate_nodes.first().map_or(payee_node_id, |n| n.node_id),
 			blinding_point: PublicKey::from_secret_key(secp_ctx, &blinding_secret),

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -215,11 +215,12 @@ pub(crate) fn amt_to_forward_msat(inbound_amt_msat: u64, payment_relay: &Payment
 }
 
 pub(super) fn compute_payinfo(
-	intermediate_nodes: &[ForwardNode], payee_tlvs: &ReceiveTlvs, payee_htlc_maximum_msat: u64
+	intermediate_nodes: &[ForwardNode], payee_tlvs: &ReceiveTlvs, payee_htlc_maximum_msat: u64,
+	min_final_cltv_expiry_delta: u16
 ) -> Result<BlindedPayInfo, ()> {
 	let mut curr_base_fee: u64 = 0;
 	let mut curr_prop_mil: u64 = 0;
-	let mut cltv_expiry_delta: u16 = 0;
+	let mut cltv_expiry_delta: u16 = min_final_cltv_expiry_delta;
 	for tlvs in intermediate_nodes.iter().rev().map(|n| &n.tlvs) {
 		// In the future, we'll want to take the intersection of all supported features for the
 		// `BlindedPayInfo`, but there are no features in that context right now.
@@ -292,6 +293,7 @@ mod tests {
 	use crate::blinded_path::payment::{ForwardNode, ForwardTlvs, ReceiveTlvs, PaymentConstraints, PaymentRelay};
 	use crate::ln::PaymentSecret;
 	use crate::ln::features::BlindedHopFeatures;
+	use crate::ln::functional_test_utils::TEST_FINAL_CLTV;
 
 	#[test]
 	fn compute_payinfo() {
@@ -339,10 +341,10 @@ mod tests {
 			},
 		};
 		let htlc_maximum_msat = 100_000;
-		let blinded_payinfo = super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, htlc_maximum_msat).unwrap();
+		let blinded_payinfo = super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, htlc_maximum_msat, TEST_FINAL_CLTV as u16).unwrap();
 		assert_eq!(blinded_payinfo.fee_base_msat, 201);
 		assert_eq!(blinded_payinfo.fee_proportional_millionths, 1001);
-		assert_eq!(blinded_payinfo.cltv_expiry_delta, 288);
+		assert_eq!(blinded_payinfo.cltv_expiry_delta, 288 + TEST_FINAL_CLTV as u16);
 		assert_eq!(blinded_payinfo.htlc_minimum_msat, 900);
 		assert_eq!(blinded_payinfo.htlc_maximum_msat, htlc_maximum_msat);
 	}
@@ -356,10 +358,10 @@ mod tests {
 				htlc_minimum_msat: 1,
 			},
 		};
-		let blinded_payinfo = super::compute_payinfo(&[], &recv_tlvs, 4242).unwrap();
+		let blinded_payinfo = super::compute_payinfo(&[], &recv_tlvs, 4242, TEST_FINAL_CLTV as u16).unwrap();
 		assert_eq!(blinded_payinfo.fee_base_msat, 0);
 		assert_eq!(blinded_payinfo.fee_proportional_millionths, 0);
-		assert_eq!(blinded_payinfo.cltv_expiry_delta, 0);
+		assert_eq!(blinded_payinfo.cltv_expiry_delta, TEST_FINAL_CLTV as u16);
 		assert_eq!(blinded_payinfo.htlc_minimum_msat, 1);
 		assert_eq!(blinded_payinfo.htlc_maximum_msat, 4242);
 	}
@@ -410,7 +412,7 @@ mod tests {
 			},
 		};
 		let htlc_maximum_msat = 100_000;
-		let blinded_payinfo = super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, htlc_maximum_msat).unwrap();
+		let blinded_payinfo = super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, htlc_maximum_msat, TEST_FINAL_CLTV as u16).unwrap();
 		assert_eq!(blinded_payinfo.htlc_minimum_msat, 2_000);
 	}
 
@@ -460,10 +462,10 @@ mod tests {
 			},
 		};
 		let htlc_minimum_msat = 3798;
-		assert!(super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, htlc_minimum_msat - 1).is_err());
+		assert!(super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, htlc_minimum_msat - 1, TEST_FINAL_CLTV as u16).is_err());
 
 		let htlc_maximum_msat = htlc_minimum_msat + 1;
-		let blinded_payinfo = super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, htlc_maximum_msat).unwrap();
+		let blinded_payinfo = super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, htlc_maximum_msat, TEST_FINAL_CLTV as u16).unwrap();
 		assert_eq!(blinded_payinfo.htlc_minimum_msat, htlc_minimum_msat);
 		assert_eq!(blinded_payinfo.htlc_maximum_msat, htlc_maximum_msat);
 	}
@@ -514,7 +516,7 @@ mod tests {
 			},
 		};
 
-		let blinded_payinfo = super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, 10_000).unwrap();
+		let blinded_payinfo = super::compute_payinfo(&intermediate_nodes[..], &recv_tlvs, 10_000, TEST_FINAL_CLTV as u16).unwrap();
 		assert_eq!(blinded_payinfo.htlc_maximum_msat, 3997);
 	}
 }

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -61,7 +61,7 @@ fn blinded_payment_path(
 	let mut secp_ctx = Secp256k1::new();
 	BlindedPath::new_for_payment(
 		&intermediate_nodes[..], *node_ids.last().unwrap(), payee_tlvs,
-		channel_upds.last().unwrap().htlc_maximum_msat, keys_manager, &secp_ctx
+		channel_upds.last().unwrap().htlc_maximum_msat, TEST_FINAL_CLTV as u16, keys_manager, &secp_ctx
 	).unwrap()
 }
 
@@ -100,7 +100,8 @@ fn do_one_hop_blinded_path(success: bool) {
 	};
 	let mut secp_ctx = Secp256k1::new();
 	let blinded_path = BlindedPath::one_hop_for_payment(
-		nodes[1].node.get_our_node_id(), payee_tlvs, &chanmon_cfgs[1].keys_manager, &secp_ctx
+		nodes[1].node.get_our_node_id(), payee_tlvs, TEST_FINAL_CLTV as u16,
+		&chanmon_cfgs[1].keys_manager, &secp_ctx
 	).unwrap();
 
 	let route_params = RouteParameters::from_payment_params_and_value(
@@ -141,7 +142,8 @@ fn mpp_to_one_hop_blinded_path() {
 		},
 	};
 	let blinded_path = BlindedPath::one_hop_for_payment(
-		nodes[3].node.get_our_node_id(), payee_tlvs, &chanmon_cfgs[3].keys_manager, &secp_ctx
+		nodes[3].node.get_our_node_id(), payee_tlvs, TEST_FINAL_CLTV as u16,
+		&chanmon_cfgs[3].keys_manager, &secp_ctx
 	).unwrap();
 
 	let bolt12_features =

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -691,7 +691,7 @@ fn do_multi_hop_receiver_fail(check: ReceiveCheckFail) {
 			commitment_signed_dance!(nodes[2], nodes[1], (), false, true, false, false);
 		},
 		ReceiveCheckFail::ProcessPendingHTLCsCheck => {
-			assert_eq!(payment_event_1_2.msgs[0].cltv_expiry, nodes[0].best_block_info().1 + 1 + excess_final_cltv_delta_opt.unwrap() as u32);
+			assert_eq!(payment_event_1_2.msgs[0].cltv_expiry, nodes[0].best_block_info().1 + 1 + excess_final_cltv_delta_opt.unwrap() as u32 + TEST_FINAL_CLTV);
 			nodes[2].node.handle_update_add_htlc(&nodes[1].node.get_our_node_id(), &payment_event_1_2.msgs[0]);
 			check_added_monitors!(nodes[2], 0);
 			do_commitment_signed_dance(&nodes[2], &nodes[1], &payment_event_1_2.commitment_msg, true, true);

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -16,7 +16,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use crate::blinded_path::{BlindedHop, BlindedPath};
 use crate::blinded_path::payment::{ForwardNode, ForwardTlvs, PaymentConstraints, PaymentRelay, ReceiveTlvs};
 use crate::ln::PaymentHash;
-use crate::ln::channelmanager::{ChannelDetails, PaymentId};
+use crate::ln::channelmanager::{ChannelDetails, PaymentId, MIN_FINAL_CLTV_EXPIRY_DELTA};
 use crate::ln::features::{BlindedHopFeatures, Bolt11InvoiceFeatures, Bolt12InvoiceFeatures, ChannelFeatures, NodeFeatures};
 use crate::ln::msgs::{DecodeError, ErrorAction, LightningError, MAX_VALUE_MSAT};
 use crate::offers::invoice::{BlindedPayInfo, Bolt12Invoice};
@@ -139,7 +139,8 @@ impl<G: Deref<Target = NetworkGraph<L>> + Clone, L: Deref, S: Deref, SP: Sized, 
 			})
 			.map(|forward_node| {
 				BlindedPath::new_for_payment(
-					&[forward_node], recipient, tlvs.clone(), u64::MAX, entropy_source, secp_ctx
+					&[forward_node], recipient, tlvs.clone(), u64::MAX, MIN_FINAL_CLTV_EXPIRY_DELTA,
+					entropy_source, secp_ctx
 				)
 			})
 			.take(MAX_PAYMENT_PATHS)
@@ -149,8 +150,9 @@ impl<G: Deref<Target = NetworkGraph<L>> + Clone, L: Deref, S: Deref, SP: Sized, 
 			Ok(paths) if !paths.is_empty() => Ok(paths),
 			_ => {
 				if network_graph.nodes().contains_key(&NodeId::from_pubkey(&recipient)) {
-					BlindedPath::one_hop_for_payment(recipient, tlvs, entropy_source, secp_ctx)
-						.map(|path| vec![path])
+					BlindedPath::one_hop_for_payment(
+						recipient, tlvs, MIN_FINAL_CLTV_EXPIRY_DELTA, entropy_source, secp_ctx
+					).map(|path| vec![path])
 				} else {
 					Err(())
 				}


### PR DESCRIPTION
Previously we were not including the `min_final_cltv_delta` in the aggregated `BlindedPayInfo::cltv_expiry_delta`. 

IIUC, the spec is currently missing this requirement -- spec authors may have thought that it was implied. Another look at t-bast's gist https://gist.github.com/t-bast/b1371d357a2c5f3e8c09514a62db7079 tipped me off that it was missing in LDK. 