### PR TITLE
export send_onion_message_using_path for testing

### DIFF
--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -807,8 +807,8 @@ where
 		}
 	}
 
-	#[cfg(test)]
-	pub(super) fn send_onion_message_using_path<T: OnionMessageContents>(
+	#[cfg(any(test, feature = "_test_utils"))]
+	pub fn send_onion_message_using_path<T: OnionMessageContents>(
 		&self, path: OnionMessagePath, contents: T, reply_path: Option<BlindedPath>
 	) -> Result<SendSuccess, SendError> {
 		self.enqueue_onion_message(path, contents, reply_path, format_args!(""))


### PR DESCRIPTION
This is a small PR to export OnionMessenger's send_onion_message_using_path for testing. It can be turned on when the "_test_utils" feature is set. Context: We'd like to use this function in LNDK's tests and @jkczyz suggested this approach.