### PR TITLE
Pin ahash version that supports LDK's MSRV.

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,6 +22,7 @@ lightning = { path = "../lightning", features = ["regex", "hashbrown", "_test_ut
 lightning-rapid-gossip-sync = { path = "../lightning-rapid-gossip-sync" }
 bitcoin = { version = "0.30.2", features = ["secp-lowmemory"] }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
+ahash = { version = "=0.8.7" }
 hashbrown = "0.13"
 
 afl = { version = "0.12", optional = true }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -43,7 +43,7 @@ default = ["std", "grind_signatures"]
 bitcoin = { version = "0.30.2", default-features = false, features = ["secp-recovery"] }
 
 hashbrown = { version = "0.13", optional = true }
-ahash = { version = "0.8", optional = true, default-features = false }
+ahash = { version = "=0.8.7", optional = true, default-features = false }
 hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 regex = { version = "1.5.6", optional = true }
 backtrace = { version = "0.3", optional = true }
@@ -54,12 +54,12 @@ libm = { version = "0.2", optional = true, default-features = false }
 # Because ahash no longer (kinda poorly) does it for us, (roughly) list out the targets that
 # getrandom supports and turn on ahash's `runtime-rng` feature for them.
 [target.'cfg(not(any(target_os = "unknown", target_os = "none")))'.dependencies]
-ahash = { version = "0.8", optional = true, default-features = false, features = ["runtime-rng"] }
+ahash = { version = "=0.8.7", optional = true, default-features = false, features = ["runtime-rng"] }
 
 # Not sure what target_os gets set to for sgx, so to be safe always enable runtime-rng for x86_64
 # platforms (assuming LDK isn't being used on embedded x86-64 running directly on metal).
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-ahash = { version = "0.8", optional = true, default-features = false, features = ["runtime-rng"] }
+ahash = { version = "=0.8.7", optional = true, default-features = false, features = ["runtime-rng"] }
 
 [dev-dependencies]
 regex = "1.5.6"


### PR DESCRIPTION
Currently some builds fail because of
```
error: package `ahash v0.8.8` cannot be built because it requires rustc 1.72.0 or newer, while the currently active rustc version is 1.63.0
```

Downgrading it to v0.8.7 solves the issue.