### PR TITLE
Offers builders for C-bindings

### DIFF
--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -37,17 +37,17 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 			let even_pubkey = x_only_pubkey.public_key(Parity::Even);
 			if signing_pubkey == odd_pubkey || signing_pubkey == even_pubkey {
 				unsigned_invoice
-					.sign::<_, Infallible>(
-						|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-					)
+					.sign(|message: &UnsignedBolt12Invoice| -> Result<_, Infallible> {
+						Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+					})
 					.unwrap()
 					.write(&mut buffer)
 					.unwrap();
 			} else {
 				unsigned_invoice
-					.sign::<_, Infallible>(
-						|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-					)
+					.sign(|message: &UnsignedBolt12Invoice| -> Result<_, Infallible> {
+						Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+					})
 					.unwrap_err();
 			}
 		}

--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -9,7 +9,7 @@
 
 use bitcoin::secp256k1::{KeyPair, Parity, PublicKey, Secp256k1, SecretKey, self};
 use crate::utils::test_logger;
-use core::convert::{Infallible, TryFrom};
+use core::convert::TryFrom;
 use lightning::blinded_path::BlindedPath;
 use lightning::sign::EntropySource;
 use lightning::ln::PaymentHash;
@@ -37,17 +37,17 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 			let even_pubkey = x_only_pubkey.public_key(Parity::Even);
 			if signing_pubkey == odd_pubkey || signing_pubkey == even_pubkey {
 				unsigned_invoice
-					.sign(|message: &UnsignedBolt12Invoice| -> Result<_, Infallible> {
+					.sign(|message: &UnsignedBolt12Invoice|
 						Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-					})
+					)
 					.unwrap()
 					.write(&mut buffer)
 					.unwrap();
 			} else {
 				unsigned_invoice
-					.sign(|message: &UnsignedBolt12Invoice| -> Result<_, Infallible> {
+					.sign(|message: &UnsignedBolt12Invoice|
 						Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-					})
+					)
 					.unwrap_err();
 			}
 		}

--- a/fuzz/src/offer_deser.rs
+++ b/fuzz/src/offer_deser.rs
@@ -29,9 +29,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 
 		if let Ok(invoice_request) = build_response(&offer, pubkey) {
 			invoice_request
-				.sign::<_, Infallible>(
-					|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-				)
+				.sign(|message: &UnsignedInvoiceRequest| -> Result<_, Infallible> {
+					Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+				})
 				.unwrap()
 				.write(&mut buffer)
 				.unwrap();

--- a/fuzz/src/offer_deser.rs
+++ b/fuzz/src/offer_deser.rs
@@ -9,7 +9,7 @@
 
 use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, SecretKey};
 use crate::utils::test_logger;
-use core::convert::{Infallible, TryFrom};
+use core::convert::TryFrom;
 use lightning::offers::invoice_request::UnsignedInvoiceRequest;
 use lightning::offers::offer::{Amount, Offer, Quantity};
 use lightning::offers::parse::Bolt12SemanticError;
@@ -29,9 +29,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 
 		if let Ok(invoice_request) = build_response(&offer, pubkey) {
 			invoice_request
-				.sign(|message: &UnsignedInvoiceRequest| -> Result<_, Infallible> {
+				.sign(|message: &UnsignedInvoiceRequest|
 					Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-				})
+				)
 				.unwrap()
 				.write(&mut buffer)
 				.unwrap();

--- a/fuzz/src/refund_deser.rs
+++ b/fuzz/src/refund_deser.rs
@@ -33,9 +33,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 
 		if let Ok(invoice) = build_response(&refund, pubkey, &secp_ctx) {
 			invoice
-				.sign::<_, Infallible>(
-					|message| Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-				)
+				.sign(|message: &UnsignedBolt12Invoice| -> Result<_, Infallible> {
+					Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+				})
 				.unwrap()
 				.write(&mut buffer)
 				.unwrap();

--- a/fuzz/src/refund_deser.rs
+++ b/fuzz/src/refund_deser.rs
@@ -9,7 +9,7 @@
 
 use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, SecretKey, self};
 use crate::utils::test_logger;
-use core::convert::{Infallible, TryFrom};
+use core::convert::TryFrom;
 use lightning::blinded_path::BlindedPath;
 use lightning::sign::EntropySource;
 use lightning::ln::PaymentHash;
@@ -33,9 +33,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 
 		if let Ok(invoice) = build_response(&refund, pubkey, &secp_ctx) {
 			invoice
-				.sign(|message: &UnsignedBolt12Invoice| -> Result<_, Infallible> {
+				.sign(|message: &UnsignedBolt12Invoice|
 					Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-				})
+				)
 				.unwrap()
 				.write(&mut buffer)
 				.unwrap();

--- a/lightning/src/crypto/mod.rs
+++ b/lightning/src/crypto/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(fuzzing))]
 use bitcoin::hashes::cmp::fixed_time_eq;
 
 pub(crate) mod chacha20;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -57,7 +57,7 @@ use crate::ln::msgs::{ChannelMessageHandler, DecodeError, LightningError};
 use crate::ln::outbound_payment;
 use crate::ln::outbound_payment::{Bolt12PaymentError, OutboundPayments, PaymentAttempts, PendingOutboundPayment, SendAlongPathArgs, StaleExpiration};
 use crate::ln::wire::Encode;
-use crate::offers::invoice::{BlindedPayInfo, Bolt12Invoice, DEFAULT_RELATIVE_EXPIRY, DerivedSigningPubkey, ExplicitSigningPubkey, InvoiceBuilder};
+use crate::offers::invoice::{BlindedPayInfo, Bolt12Invoice, DEFAULT_RELATIVE_EXPIRY, DerivedSigningPubkey, ExplicitSigningPubkey, InvoiceBuilder, UnsignedBolt12Invoice};
 use crate::offers::invoice_error::InvoiceError;
 use crate::offers::invoice_request::{DerivedPayerId, InvoiceRequestBuilder};
 use crate::offers::merkle::SignError;
@@ -9302,7 +9302,9 @@ where
 						.and_then(|invoice| {
 							#[cfg(c_bindings)]
 							let mut invoice = invoice;
-							match invoice.sign(|invoice| self.node_signer.sign_bolt12_invoice(invoice)) {
+							match invoice.sign(|invoice: &UnsignedBolt12Invoice|
+								self.node_signer.sign_bolt12_invoice(invoice)
+							) {
 								Ok(invoice) => Ok(OffersMessage::Invoice(invoice)),
 								Err(SignError::Signing(())) => Err(OffersMessage::InvoiceError(
 										InvoiceError::from_string("Failed signing invoice".to_string())

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -9306,7 +9306,7 @@ where
 								self.node_signer.sign_bolt12_invoice(invoice)
 							) {
 								Ok(invoice) => Ok(OffersMessage::Invoice(invoice)),
-								Err(SignError::Signing(())) => Err(OffersMessage::InvoiceError(
+								Err(SignError::Signing) => Err(OffersMessage::InvoiceError(
 										InvoiceError::from_string("Failed signing invoice".to_string())
 								)),
 								Err(SignError::Verification(_)) => Err(OffersMessage::InvoiceError(

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -59,6 +59,7 @@ use crate::ln::outbound_payment::{Bolt12PaymentError, OutboundPayments, PaymentA
 use crate::ln::wire::Encode;
 use crate::offers::invoice::{BlindedPayInfo, Bolt12Invoice, DEFAULT_RELATIVE_EXPIRY, DerivedSigningPubkey, InvoiceBuilder};
 use crate::offers::invoice_error::InvoiceError;
+use crate::offers::invoice_request::{DerivedPayerId, InvoiceRequestBuilder};
 use crate::offers::merkle::SignError;
 use crate::offers::offer::{Offer, OfferBuilder};
 use crate::offers::parse::Bolt12SemanticError;
@@ -7735,9 +7736,11 @@ where
 		let entropy = &*self.entropy_source;
 		let secp_ctx = &self.secp_ctx;
 
-		let builder = offer
+		let builder: InvoiceRequestBuilder<DerivedPayerId, secp256k1::All> = offer
 			.request_invoice_deriving_payer_id(expanded_key, entropy, secp_ctx, payment_id)?
-			.chain_hash(self.chain_hash)?;
+			.into();
+		let builder = builder.chain_hash(self.chain_hash)?;
+
 		let builder = match quantity {
 			None => builder,
 			Some(quantity) => builder.quantity(quantity)?,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -60,7 +60,7 @@ use crate::ln::wire::Encode;
 use crate::offers::invoice::{BlindedPayInfo, Bolt12Invoice, DEFAULT_RELATIVE_EXPIRY, DerivedSigningPubkey, InvoiceBuilder};
 use crate::offers::invoice_error::InvoiceError;
 use crate::offers::merkle::SignError;
-use crate::offers::offer::{DerivedMetadata, Offer, OfferBuilder};
+use crate::offers::offer::{Offer, OfferBuilder};
 use crate::offers::parse::Bolt12SemanticError;
 use crate::offers::refund::{Refund, RefundBuilder};
 use crate::onion_message::messenger::{Destination, MessageRouter, PendingOnionMessage, new_pending_onion_message};
@@ -76,10 +76,15 @@ use crate::util::logger::{Level, Logger, WithContext};
 use crate::util::errors::APIError;
 #[cfg(not(c_bindings))]
 use {
+	crate::offers::offer::DerivedMetadata,
 	crate::routing::router::DefaultRouter,
 	crate::routing::gossip::NetworkGraph,
 	crate::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters},
 	crate::sign::KeysManager,
+};
+#[cfg(c_bindings)]
+use {
+	crate::offers::offer::OfferWithDerivedMetadataBuilder,
 };
 
 use alloc::collections::{btree_map, BTreeMap};
@@ -7520,7 +7525,9 @@ where
 			self.finish_close_channel(failure);
 		}
 	}
+}
 
+macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 	/// Creates an [`OfferBuilder`] such that the [`Offer`] it builds is recognized by the
 	/// [`ChannelManager`] when handling [`InvoiceRequest`] messages for the offer. The offer will
 	/// not have an expiration unless otherwise set on the builder.
@@ -7549,22 +7556,40 @@ where
 	/// [`Offer`]: crate::offers::offer::Offer
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	pub fn create_offer_builder(
-		&self, description: String
-	) -> Result<OfferBuilder<DerivedMetadata, secp256k1::All>, Bolt12SemanticError> {
-		let node_id = self.get_our_node_id();
-		let expanded_key = &self.inbound_payment_key;
-		let entropy = &*self.entropy_source;
-		let secp_ctx = &self.secp_ctx;
+		&$self, description: String
+	) -> Result<$builder, Bolt12SemanticError> {
+		let node_id = $self.get_our_node_id();
+		let expanded_key = &$self.inbound_payment_key;
+		let entropy = &*$self.entropy_source;
+		let secp_ctx = &$self.secp_ctx;
 
-		let path = self.create_blinded_path().map_err(|_| Bolt12SemanticError::MissingPaths)?;
+		let path = $self.create_blinded_path().map_err(|_| Bolt12SemanticError::MissingPaths)?;
 		let builder = OfferBuilder::deriving_signing_pubkey(
 			description, node_id, expanded_key, entropy, secp_ctx
 		)
-			.chain_hash(self.chain_hash)
+			.chain_hash($self.chain_hash)
 			.path(path);
 
-		Ok(builder)
+		Ok(builder.into())
 	}
+} }
+
+impl<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref> ChannelManager<M, T, ES, NS, SP, F, R, L>
+where
+	M::Target: chain::Watch<<SP::Target as SignerProvider>::EcdsaSigner>,
+	T::Target: BroadcasterInterface,
+	ES::Target: EntropySource,
+	NS::Target: NodeSigner,
+	SP::Target: SignerProvider,
+	F::Target: FeeEstimator,
+	R::Target: Router,
+	L::Target: Logger,
+{
+	#[cfg(not(c_bindings))]
+	create_offer_builder!(self, OfferBuilder<DerivedMetadata, secp256k1::All>);
+
+	#[cfg(c_bindings)]
+	create_offer_builder!(self, OfferWithDerivedMetadataBuilder);
 
 	/// Creates a [`RefundBuilder`] such that the [`Refund`] it builds is recognized by the
 	/// [`ChannelManager`] when handling [`Bolt12Invoice`] messages for the refund.

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1306,7 +1306,15 @@ mod tests {
 	use crate::ln::msgs::DecodeError;
 	use crate::offers::invoice_request::InvoiceRequestTlvStreamRef;
 	use crate::offers::merkle::{SignError, SignatureTlvStreamRef, TaggedHash, self};
-	use crate::offers::offer::{Amount, OfferBuilder, OfferTlvStreamRef, Quantity};
+	use crate::offers::offer::{Amount, OfferTlvStreamRef, Quantity};
+	#[cfg(not(c_bindings))]
+	use {
+		crate::offers::offer::OfferBuilder,
+	};
+	#[cfg(c_bindings)]
+	use {
+		crate::offers::offer::OfferWithExplicitMetadataBuilder as OfferBuilder,
+	};
 	use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError};
 	use crate::offers::payer::PayerTlvStreamRef;
 	use crate::offers::refund::RefundBuilder;
@@ -1644,6 +1652,8 @@ mod tests {
 			],
 		};
 
+		#[cfg(c_bindings)]
+		use crate::offers::offer::OfferWithDerivedMetadataBuilder as OfferBuilder;
 		let offer = OfferBuilder
 			::deriving_signing_pubkey(desc, node_id, &expanded_key, &entropy, &secp_ctx)
 			.amount_msats(1000)

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1310,14 +1310,15 @@ mod tests {
 	#[cfg(not(c_bindings))]
 	use {
 		crate::offers::offer::OfferBuilder,
+		crate::offers::refund::RefundBuilder,
 	};
 	#[cfg(c_bindings)]
 	use {
 		crate::offers::offer::OfferWithExplicitMetadataBuilder as OfferBuilder,
+		crate::offers::refund::RefundMaybeWithDerivedMetadataBuilder as RefundBuilder,
 	};
 	use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError};
 	use crate::offers::payer::PayerTlvStreamRef;
-	use crate::offers::refund::RefundBuilder;
 	use crate::offers::test_utils::*;
 	use crate::util::ser::{BigSize, Iterable, Writeable};
 	use crate::util::string::PrintableString;

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -941,7 +941,15 @@ mod tests {
 	use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
 	use crate::offers::invoice::{Bolt12Invoice, SIGNATURE_TAG as INVOICE_SIGNATURE_TAG};
 	use crate::offers::merkle::{SignError, SignatureTlvStreamRef, TaggedHash, self};
-	use crate::offers::offer::{Amount, OfferBuilder, OfferTlvStreamRef, Quantity};
+	use crate::offers::offer::{Amount, OfferTlvStreamRef, Quantity};
+	#[cfg(not(c_bindings))]
+	use {
+		crate::offers::offer::OfferBuilder,
+	};
+	#[cfg(c_bindings)]
+	use {
+		crate::offers::offer::OfferWithExplicitMetadataBuilder as OfferBuilder,
+	};
 	use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError};
 	use crate::offers::payer::PayerTlvStreamRef;
 	use crate::offers::test_utils::*;

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -96,7 +96,7 @@ use crate::ln::channelmanager::PaymentId;
 use crate::ln::features::InvoiceRequestFeatures;
 use crate::ln::inbound_payment::{ExpandedKey, IV_LEN, Nonce};
 use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
-use crate::offers::invoice::{BlindedPayInfo, DerivedSigningPubkey, ExplicitSigningPubkey, InvoiceBuilder};
+use crate::offers::invoice::BlindedPayInfo;
 use crate::offers::invoice_request::{InvoiceRequestTlvStream, InvoiceRequestTlvStreamRef};
 use crate::offers::offer::{OfferTlvStream, OfferTlvStreamRef};
 use crate::offers::parse::{Bech32Encode, Bolt12ParseError, Bolt12SemanticError, ParsedMessage};
@@ -104,6 +104,15 @@ use crate::offers::payer::{PayerContents, PayerTlvStream, PayerTlvStreamRef};
 use crate::offers::signer::{Metadata, MetadataMaterial, self};
 use crate::util::ser::{SeekReadable, WithoutLength, Writeable, Writer};
 use crate::util::string::PrintableString;
+
+#[cfg(not(c_bindings))]
+use {
+	crate::offers::invoice::{DerivedSigningPubkey, ExplicitSigningPubkey, InvoiceBuilder},
+};
+#[cfg(c_bindings)]
+use {
+	crate::offers::invoice::{InvoiceWithDerivedSigningPubkeyBuilder, InvoiceWithExplicitSigningPubkeyBuilder},
+};
 
 use crate::prelude::*;
 
@@ -589,9 +598,16 @@ macro_rules! respond_with_derived_signing_pubkey_methods { ($self: ident, $build
 	}
 } }
 
+#[cfg(not(c_bindings))]
 impl Refund {
 	respond_with_explicit_signing_pubkey_methods!(self, InvoiceBuilder<ExplicitSigningPubkey>);
 	respond_with_derived_signing_pubkey_methods!(self, InvoiceBuilder<DerivedSigningPubkey>);
+}
+
+#[cfg(c_bindings)]
+impl Refund {
+	respond_with_explicit_signing_pubkey_methods!(self, InvoiceWithExplicitSigningPubkeyBuilder);
+	respond_with_derived_signing_pubkey_methods!(self, InvoiceWithDerivedSigningPubkeyBuilder);
 }
 
 #[cfg(test)]

--- a/lightning/src/offers/test_utils.rs
+++ b/lightning/src/offers/test_utils.rs
@@ -20,6 +20,10 @@ use crate::ln::features::BlindedHopFeatures;
 use crate::offers::invoice::BlindedPayInfo;
 use crate::offers::merkle::TaggedHash;
 
+pub(crate) fn fail_sign<T: AsRef<TaggedHash>>(_message: &T) -> Result<Signature, ()> {
+	Err(())
+}
+
 pub(crate) fn payer_keys() -> KeyPair {
 	let secp_ctx = Secp256k1::new();
 	KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap())

--- a/lightning/src/offers/test_utils.rs
+++ b/lightning/src/offers/test_utils.rs
@@ -11,7 +11,7 @@
 
 use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, SecretKey};
 use bitcoin::secp256k1::schnorr::Signature;
-use core::convert::{AsRef, Infallible};
+use core::convert::AsRef; 
 use core::time::Duration;
 use crate::blinded_path::{BlindedHop, BlindedPath};
 use crate::sign::EntropySource;
@@ -29,7 +29,7 @@ pub(crate) fn payer_keys() -> KeyPair {
 	KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap())
 }
 
-pub(crate) fn payer_sign<T: AsRef<TaggedHash>>(message: &T) -> Result<Signature, Infallible> {
+pub(crate) fn payer_sign<T: AsRef<TaggedHash>>(message: &T) -> Result<Signature, ()> {
 	let secp_ctx = Secp256k1::new();
 	let keys = KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 	Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
@@ -44,7 +44,7 @@ pub(crate) fn recipient_keys() -> KeyPair {
 	KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[43; 32]).unwrap())
 }
 
-pub(crate) fn recipient_sign<T: AsRef<TaggedHash>>(message: &T) -> Result<Signature, Infallible> {
+pub(crate) fn recipient_sign<T: AsRef<TaggedHash>>(message: &T) -> Result<Signature, ()> {
 	let secp_ctx = Secp256k1::new();
 	let keys = KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[43; 32]).unwrap());
 	Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))


### PR DESCRIPTION
The builders used in the `offers` module are not exported for bindings because they use move semantics and have impl blocks for specific type parameterizations. Define separate builders that don't use these language features so they can be used in `c_bindings`.