### PR TITLE
Refactor `PeerManager::get_peer_node_ids` in favor of `list_peers`/`peer_by_node_id` returning additional information

### DIFF
--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -737,10 +737,10 @@ pub fn do_test(mut data: &[u8], logger: &Arc<dyn Logger>) {
 			},
 			// 15, 16, 17, 18 is above
 			19 => {
-				let mut list = loss_detector.handler.get_peer_node_ids();
-				list.sort_by_key(|v| v.0);
-				if let Some((id, _)) = list.get(0) {
-					loss_detector.handler.disconnect_by_node_id(*id);
+				let mut list = loss_detector.handler.list_peers();
+				list.sort_by_key(|v| v.counterparty_node_id);
+				if let Some(peer_details) = list.get(0) {
+					loss_detector.handler.disconnect_by_node_id(peer_details.counterparty_node_id);
 				}
 			},
 			20 => loss_detector.handler.disconnect_all_peers(),


### PR DESCRIPTION
~~Previously, we wouldn't offer any way to retrieve the features a peer provided in their `Init` message.~~

~~Here, we allow to retrieve them via `get_peer_node_ids`, similar to the `SocketAddress`es.~~

Here, we introduce `PeerManager::list_peers` and `peer_by_node_id` methods returning `PeerDetails` rather than tuples of peer-associated values.

Previously, we wouldn't offer any way to retrieve the features a peer provided in their `Init` message. Here, we allow to retrieve them via a new `PeerDetails` struct, side-by-side with `SocketAddress`es and a bool indicating the direction
of the peer connection.

For context: This is useful for all kinds of applications, however, most recently I found that it's required for maintaining an Anchor emergency reserve upfront, as we otherwise can't tell if the counterparty supports Anchors before initiating the actual channel open (at least assuming they are not necessarily in the public graph and/or we source our graph data via RGS, in which case we won't have access to their `NodeAnnouncement`).