### PR TITLE
Trampoline onion construction vectors

### DIFF
--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -1798,7 +1798,7 @@ pub struct TrampolineOnionPacket {
 	// Unlike the onion packets used for payments, Trampoline onion packets have to be shorter than
 	// 1300 bytes. The expected default is 650 bytes.
 	// TODO: if 650 ends up being the most common size, optimize this to be:
-	// enum { ThirteenHundred([u8; 650]), VarLen(Vec<u8>) }
+	// enum { SixFifty([u8; 650]), VarLen(Vec<u8>) }
 	pub hop_data: Vec<u8>,
 	/// HMAC to verify the integrity of hop_data
 	pub hmac: [u8; 32],

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -1740,6 +1740,17 @@ mod fuzzy_internal_msgs {
 		}
 	}
 
+	pub(crate) enum OutboundTrampolinePayload {
+		#[allow(unused)]
+		Forward {
+			/// The value, in msat, of the payment after this hop's fee is deducted.
+			amt_to_forward: u64,
+			outgoing_cltv_value: u32,
+			/// The node id to which the trampoline node must find a route
+			outgoing_node_id: PublicKey,
+		}
+	}
+
 	pub struct DecodedOnionErrorPacket {
 		pub(crate) hmac: [u8; 32],
 		pub(crate) failuremsg: Vec<u8>,
@@ -2596,6 +2607,22 @@ impl Writeable for OutboundOnionPayload {
 		Ok(())
 	}
 }
+
+impl Writeable for OutboundTrampolinePayload {
+	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+		match self {
+			Self::Forward { amt_to_forward, outgoing_cltv_value, outgoing_node_id } => {
+				_encode_varint_length_prefixed_tlv!(w, {
+					(2, HighZeroBytesDroppedBigSize(*amt_to_forward), required),
+					(4, HighZeroBytesDroppedBigSize(*outgoing_cltv_value), required),
+					(14, outgoing_node_id, required)
+				});
+			}
+		}
+		Ok(())
+	}
+}
+
 
 impl<NS: Deref> ReadableArgs<(Option<PublicKey>, &NS)> for InboundOnionPayload where NS::Target: NodeSigner {
 	fn read<R: Read>(r: &mut R, args: (Option<PublicKey>, &NS)) -> Result<Self, DecodeError> {

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -291,6 +291,24 @@ pub(super) fn construct_onion_packet(
 	)
 }
 
+#[allow(unused)]
+pub(super) fn construct_trampoline_onion_packet(
+	payloads: Vec<msgs::OutboundTrampolinePayload>, onion_keys: Vec<OnionKeys>,
+	prng_seed: [u8; 32], associated_data: &PaymentHash, length: u16,
+) -> Result<msgs::TrampolineOnionPacket, ()> {
+	let mut packet_data = vec![0u8; length as usize];
+
+	let mut chacha = ChaCha20::new(&prng_seed, &[0; 8]);
+	chacha.process(&vec![0u8; length as usize], &mut packet_data);
+
+	construct_onion_packet_with_init_noise::<_, _>(
+		payloads,
+		onion_keys,
+		packet_data,
+		Some(associated_data),
+	)
+}
+
 #[cfg(test)]
 /// Used in testing to write bogus `BogusOnionHopData` as well as `RawOnionHopData`, which is
 /// otherwise not representable in `msgs::OnionHopData`.


### PR DESCRIPTION
Non-polluting replacement for 2899. Would appreciate a concept ACK prior to undrafting, thanks!

If the methodology for constructing variable-length onions for Trampoline employed in the last commit of this PR is acceptable, it will inform an upstream refactor of #2756 pertaining to the Trampoline onion packet struct type.