### PR TITLE
Introduce ResponseInstructions for OnionMessage Handling

### DIFF
--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -246,6 +246,51 @@ impl OnionMessageRecipient {
 	}
 }
 
+
+/// The `Responder` struct creates an appropriate [`ResponseInstruction`]
+/// for responding to a message.
+pub struct Responder {
+	/// The path along which a response can be sent.
+	reply_path: BlindedPath,
+	path_id: Option<[u8; 32]>
+}
+
+impl Responder {
+	/// Creates a new [`Responder`] instance with the provided reply path.
+	fn new(reply_path: BlindedPath, path_id: Option<[u8; 32]>) -> Self {
+		Responder {
+			reply_path,
+			path_id,
+		}
+	}
+
+	/// Creates the appropriate [`ResponseInstruction`] for a given response.
+	pub fn respond<T: OnionMessageContents>(self, response: T) -> ResponseInstruction<T> {
+		ResponseInstruction::WithoutReplyPath(OnionMessageResponse {
+			message: response,
+			reply_path: self.reply_path,
+			path_id: self.path_id,
+		})
+	}
+}
+
+/// This struct contains the information needed to reply to a received message.
+#[allow(unused)]
+pub struct OnionMessageResponse<T: OnionMessageContents> {
+	message: T,
+	reply_path: BlindedPath,
+	path_id: Option<[u8; 32]>,
+}
+
+/// `ResponseInstruction` represents instructions for responding to received messages.
+pub enum ResponseInstruction<T: OnionMessageContents> {
+	/// Indicates that a response should be sent without including a reply path
+	/// for the recipient to respond back.
+	WithoutReplyPath(OnionMessageResponse<T>),
+	/// Indicates that there's no response to send back.
+	NoResponse,
+}
+
 /// An [`OnionMessage`] for [`OnionMessenger`] to send.
 ///
 /// These are obtained when released from [`OnionMessenger`]'s handlers after which they are

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -135,6 +135,7 @@ pub(super) const MAX_TIMER_TICKS: usize = 2;
 /// 		# let your_custom_message_type = 42;
 /// 		your_custom_message_type
 /// 	}
+/// 	fn msg_type(&self) -> &'static str { "YourCustomMessageType" }
 /// }
 /// // Send a custom onion message to a node id.
 /// let destination = Destination::Node(destination_node_id);
@@ -275,7 +276,6 @@ impl Responder {
 }
 
 /// This struct contains the information needed to reply to a received message.
-#[allow(unused)]
 pub struct OnionMessageResponse<T: OnionMessageContents> {
 	message: T,
 	reply_path: BlindedPath,
@@ -591,7 +591,7 @@ pub trait CustomOnionMessageHandler {
 	/// Called with the custom message that was received, returning a response to send, if any.
 	///
 	/// The returned [`Self::CustomMessage`], if any, is enqueued to be sent by [`OnionMessenger`].
-	fn handle_custom_message(&self, msg: Self::CustomMessage) -> Option<Self::CustomMessage>;
+	fn handle_custom_message(&self, message: Self::CustomMessage, responder: Option<Responder>) -> ResponseInstruction<Self::CustomMessage>;
 
 	/// Read a custom message of type `message_type` from `buffer`, returning `Ok(None)` if the
 	/// message type is unknown.
@@ -978,19 +978,18 @@ where
 	}
 
 	fn handle_onion_message_response<T: OnionMessageContents>(
-		&self, response: Option<T>, reply_path: Option<BlindedPath>, log_suffix: fmt::Arguments
+		&self, response: ResponseInstruction<T>
 	) {
-		if let Some(response) = response {
-			match reply_path {
-				Some(reply_path) => {
-					let _ = self.find_path_and_enqueue_onion_message(
-						response, Destination::BlindedPath(reply_path), None, log_suffix
-					);
-				},
-				None => {
-					log_trace!(self.logger, "Missing reply path {}", log_suffix);
-				},
-			}
+		if let ResponseInstruction::WithoutReplyPath(response) = response {
+			let message_type = response.message.msg_type();
+			let _ = self.find_path_and_enqueue_onion_message(
+				response.message, Destination::BlindedPath(response.reply_path), None,
+				format_args!(
+					"when responding with {} to an onion message with path_id {:02x?}",
+					message_type,
+					response.path_id
+				)
+			);
 		}
 	}
 
@@ -1074,22 +1073,18 @@ where
 
 				match message {
 					ParsedOnionMessageContents::Offers(msg) => {
-						let response = self.offers_handler.handle_message(msg);
-						self.handle_onion_message_response(
-							response, reply_path, format_args!(
-								"when responding to Offers onion message with path_id {:02x?}",
-								path_id
-							)
+						let responder = reply_path.map(
+							|reply_path| Responder::new(reply_path, path_id)
 						);
+						let response_instructions = self.offers_handler.handle_message(msg, responder);
+						self.handle_onion_message_response(response_instructions);
 					},
 					ParsedOnionMessageContents::Custom(msg) => {
-						let response = self.custom_handler.handle_custom_message(msg);
-						self.handle_onion_message_response(
-							response, reply_path, format_args!(
-								"when responding to Custom onion message with path_id {:02x?}",
-								path_id
-							)
+						let responder = reply_path.map(
+							|reply_path| Responder::new(reply_path, path_id)
 						);
+						let response_instructions = self.custom_handler.handle_custom_message(msg, responder);
+						self.handle_onion_message_response(response_instructions);
 					},
 				}
 			},

--- a/lightning/src/onion_message/offers.rs
+++ b/lightning/src/onion_message/offers.rs
@@ -19,6 +19,7 @@ use crate::offers::parse::Bolt12ParseError;
 use crate::onion_message::packet::OnionMessageContents;
 use crate::util::logger::Logger;
 use crate::util::ser::{Readable, ReadableArgs, Writeable, Writer};
+use crate::onion_message::messenger::{ResponseInstruction, Responder};
 #[cfg(not(c_bindings))]
 use crate::onion_message::messenger::PendingOnionMessage;
 
@@ -39,7 +40,7 @@ pub trait OffersMessageHandler {
 	/// The returned [`OffersMessage`], if any, is enqueued to be sent by [`OnionMessenger`].
 	///
 	/// [`OnionMessenger`]: crate::onion_message::messenger::OnionMessenger
-	fn handle_message(&self, message: OffersMessage) -> Option<OffersMessage>;
+	fn handle_message(&self, message: OffersMessage, responder: Option<Responder>) -> ResponseInstruction<OffersMessage>;
 
 	/// Releases any [`OffersMessage`]s that need to be sent.
 	///
@@ -115,6 +116,13 @@ impl OnionMessageContents for OffersMessage {
 			OffersMessage::InvoiceRequest(_) => INVOICE_REQUEST_TLV_TYPE,
 			OffersMessage::Invoice(_) => INVOICE_TLV_TYPE,
 			OffersMessage::InvoiceError(_) => INVOICE_ERROR_TLV_TYPE,
+		}
+	}
+	fn msg_type(&self) -> &'static str {
+		match &self {
+			OffersMessage::InvoiceRequest(_) => "Invoice Request",
+			OffersMessage::Invoice(_) => "Invoice",
+			OffersMessage::InvoiceError(_) => "Invoice Error",
 		}
 	}
 }

--- a/lightning/src/onion_message/packet.rs
+++ b/lightning/src/onion_message/packet.rs
@@ -135,6 +135,12 @@ impl<T: OnionMessageContents> OnionMessageContents for ParsedOnionMessageContent
 			&ParsedOnionMessageContents::Custom(ref msg) => msg.tlv_type(),
 		}
 	}
+	fn msg_type(&self) -> &'static str {
+		match self {
+			ParsedOnionMessageContents::Offers(ref msg) => msg.msg_type(),
+			ParsedOnionMessageContents::Custom(ref msg) => msg.msg_type(),
+		}
+	}
 }
 
 impl<T: OnionMessageContents> Writeable for ParsedOnionMessageContents<T> {
@@ -150,6 +156,9 @@ impl<T: OnionMessageContents> Writeable for ParsedOnionMessageContents<T> {
 pub trait OnionMessageContents: Writeable + core::fmt::Debug {
 	/// Returns the TLV type identifying the message contents. MUST be >= 64.
 	fn tlv_type(&self) -> u64;
+
+	/// Returns the message type
+	fn msg_type(&self) -> &'static str;
 }
 
 /// Forward control TLVs in their blinded and unblinded form.


### PR DESCRIPTION
resolves #2882

Introduce ResponseInstructions for OnionMessage Handling

- Currently, handle_message (or handle_custom_message) only exposes the generated response for an OnionMessage, lacking the necessary reply_path for asynchronous responses.
- This PR introduces a new flow for OnionMessage handling.
- Instead of solely taking the message as input, handle_message now accepts an Optional `responder`, returning a `ResponseInstruction` containing both the response and the reply_path.
- `ResponseInstruction` utilizes different enum variants to indicate how `handle_onion_message_response` should handle the response.
- This enhancement enables exposing the reply_path alongside the response and allows for more complex response mechanisms, such as responding with an added reply_path.