### PR TITLE
Prefer non-Tor nodes when creating blinded paths

### DIFF
--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -843,6 +843,16 @@ impl SocketAddress {
 	/// This maximum length is reached by a hostname address descriptor:
 	/// a hostname with a maximum length of 255, its 1-byte length and a 2-byte port.
 	pub(crate) const MAX_LEN: u16 = 258;
+
+	pub(crate) fn is_tor(&self) -> bool {
+		match self {
+			&SocketAddress::TcpIpV4 {..} => false,
+			&SocketAddress::TcpIpV6 {..} => false,
+			&SocketAddress::OnionV2(_) => true,
+			&SocketAddress::OnionV3 {..} => true,
+			&SocketAddress::Hostname {..} => false,
+		}
+	}
 }
 
 impl Writeable for SocketAddress {


### PR DESCRIPTION
Tor nodes can have high latency which can have a detrimental effect on onion message reliability. Prefer using nodes that aren't Tor-only when creating blinded paths both in offers and in onion message reply paths.

Fixes #2893 