### PR TITLE
Update docs on `PaymentFailureReason::RouteNotFound` to add context

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -368,6 +368,10 @@ pub enum PaymentFailureReason {
 	/// [`PaymentParameters::expiry_time`]: crate::routing::router::PaymentParameters::expiry_time
 	PaymentExpired,
 	/// We failed to find a route while retrying the payment.
+	///
+	/// Note that this generally indicates that we've exhausted the available set of possible
+	/// routes - we tried the payment over a few routes but were not able to find any further
+	/// candidate routes beyond those.
 	RouteNotFound,
 	/// This error should generally never happen. This likely means that there is a problem with
 	/// your router.


### PR DESCRIPTION
tnull noted on discord that its somewhat unclear to users what `RouteNotFound` actually means - that we ran out of routes, rather than could not find a route at all - so the docs are updated here.