### PR TITLE
Prefer implementing `From<PaymentPreimage>` over `Into<PaymentHash>`

### DIFF
--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -112,9 +112,9 @@ impl core::fmt::Display for PaymentPreimage {
 }
 
 /// Converts a `PaymentPreimage` into a `PaymentHash` by hashing the preimage with SHA256.
-impl Into<PaymentHash> for PaymentPreimage {
-	fn into(self) -> PaymentHash {
-		PaymentHash(Sha256::hash(&self.0).to_byte_array())
+impl From<PaymentPreimage> for PaymentHash {
+	fn from(value: PaymentPreimage) -> Self {
+		PaymentHash(Sha256::hash(&value.0).to_byte_array())
 	}
 }
 


### PR DESCRIPTION
In #2916 an `Into<PaymentHash>` implementation was added. 

Here, we change that to `From<PaymentPreimage>` as the [`std` library docs](https://doc.rust-lang.org/std/convert/trait.Into.html) state that implementing Into should be avoided: 

> One should avoid implementing Into and implement From instead. Implementing From automatically provides one with an implementation of Into thanks to the blanket implementation in the standard library.