### PR TITLE
Expose `{prev,next}_user_channel_id` fields in `PaymentForwarded`

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5756,8 +5756,6 @@ where
 				let completed_blocker = RAAMonitorUpdateBlockingAction::from_prev_hop_data(&hop_data);
 				#[cfg(debug_assertions)]
 				let claiming_chan_funding_outpoint = hop_data.outpoint;
-				#[cfg(debug_assertions)]
-				let claiming_channel_id = hop_data.channel_id;
 				let res = self.claim_funds_from_hop(hop_data, payment_preimage,
 					|htlc_claim_value_msat, definitely_duplicate| {
 						let chan_to_release =
@@ -5815,7 +5813,7 @@ where
 										BackgroundEvent::MonitorUpdatesComplete {
 											channel_id, ..
 										} =>
-											*channel_id == claiming_channel_id,
+											*channel_id == prev_channel_id,
 									}
 								}), "{:?}", *background_events);
 							}


### PR DESCRIPTION
This is useful for users that track channels by `user_channel_id`.

For example, in `lightning-liquidity` we currently keep a full `HashMap<ChanelId, u128>` around *just* to be able to associate `PaymentForwarded` events with the channels otherwise tracked by `user_channel_id`.

(cc @wvanlint, @johncantrell97)