### PR TITLE
Impl `PartialEq`/`Eq` for `Offer`/`Refund`

### DIFF
--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -80,6 +80,7 @@ use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, self};
 use core::convert::TryFrom;
+use core::hash::{Hash, Hasher};
 use core::num::NonZeroU64;
 use core::ops::Deref;
 use core::str::FromStr;
@@ -590,6 +591,12 @@ impl PartialEq for Offer {
 }
 
 impl Eq for Offer {}
+
+impl Hash for Offer {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.bytes.hash(state);
+	}
+}
 
 impl OfferContents {
 	pub fn chains(&self) -> Vec<ChainHash> {

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -85,6 +85,7 @@ use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, self};
 use core::convert::TryFrom;
+use core::hash::{Hash, Hasher};
 use core::ops::Deref;
 use core::str::FromStr;
 use core::time::Duration;
@@ -545,6 +546,12 @@ impl PartialEq for Refund {
 }
 
 impl Eq for Refund {}
+
+impl Hash for Refund {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.bytes.hash(state);
+	}
+}
 
 impl RefundContents {
 	pub fn description(&self) -> PrintableString {


### PR DESCRIPTION
We derive the implmentations for a few sub-types, but add custom implementations based on comparing the `bytes` for `Offer`/`Refund` themselves as this is sufficient and should be faster than comapring all fields in the worst case.