### PR TITLE
Provide `Bolt12Invoice` used for inbound payment

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -584,7 +584,9 @@ pub enum Event {
 		payment_id: PaymentId,
 	},
 	/// Indicates that a [`Bolt12Invoice`] was generated in response to an [`InvoiceRequest`] and is
-	/// being prepared to be sent via an [`OnionMessage`].
+	/// being prepared to be sent via an [`OnionMessage`]. The event is provided only for invoices
+	/// corresponding to an [`Offer`], not for a [`Refund`]. For the latter, the invoice is returned
+	/// by [`ChannelManager::request_refund_payment`].
 	///
 	/// Note that this doesn't necessarily mean that the invoice was sent and -- once sent -- it may
 	/// never reach its destination because of the unreliable nature of onion messages. Any of the
@@ -606,10 +608,12 @@ pub enum Event {
 	///
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	/// [`OnionMessage`]: crate::ln::msgs::OnionMessage
+	/// [`Offer`]: crate::offers::offer::Offer
+	/// [`Refund`]: crate::offers::refund::Refund
+	/// [`ChannelManager::request_refund_payment`]: crate::ln::channelmanager::ChannelManager::request_refund_payment
 	/// [`PeerManager`]: crate::ln::peer_handler::PeerManager
 	/// [`MessageRouter`]: crate::onion_message::messenger::MessageRouter
 	/// [`OnionMessagePath`]: crate::onion_message::messenger::OnionMessagePath
-	/// [`Offer`]: crate::offers::offer::Offer
 	InvoiceGenerated {
 		/// An invoice that was generated in response to an [`InvoiceRequest`].
 		///

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -9486,7 +9486,11 @@ where
 				};
 
 				match response {
-					Ok(invoice) => Some(OffersMessage::Invoice(invoice)),
+					Ok(invoice) => {
+						let event = Event::InvoiceGenerated { invoice: invoice.clone() };
+						self.pending_events.lock().unwrap().push_back((event, None));
+						Some(OffersMessage::Invoice(invoice))
+					},
 					Err(error) => Some(OffersMessage::InvoiceError(error.into())),
 				}
 			},

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -9491,21 +9491,25 @@ where
 				}
 			},
 			OffersMessage::Invoice(invoice) => {
-				match invoice.verify(expanded_key, secp_ctx) {
-					Err(()) => {
-						Some(OffersMessage::InvoiceError(InvoiceError::from_string("Unrecognized invoice".to_owned())))
-					},
-					Ok(_) if invoice.invoice_features().requires_unknown_bits_from(&self.bolt12_invoice_features()) => {
-						Some(OffersMessage::InvoiceError(Bolt12SemanticError::UnknownRequiredFeatures.into()))
-					},
-					Ok(payment_id) => {
-						if let Err(e) = self.send_payment_for_bolt12_invoice(&invoice, payment_id) {
-							log_trace!(self.logger, "Failed paying invoice: {:?}", e);
-							Some(OffersMessage::InvoiceError(InvoiceError::from_string(format!("{:?}", e))))
+				let response = invoice
+					.verify(expanded_key, secp_ctx)
+					.map_err(|()| InvoiceError::from_string("Unrecognized invoice".to_owned()))
+					.and_then(|payment_id| {
+						let features = self.bolt12_invoice_features();
+						if invoice.invoice_features().requires_unknown_bits_from(&features) {
+							Err(InvoiceError::from(Bolt12SemanticError::UnknownRequiredFeatures))
 						} else {
-							None
+							self.send_payment_for_bolt12_invoice(&invoice, payment_id)
+								.map_err(|e| {
+									log_trace!(self.logger, "Failed paying invoice: {:?}", e);
+									InvoiceError::from_string(format!("{:?}", e))
+								})
 						}
-					},
+					});
+
+				match response {
+					Ok(()) => None,
+					Err(e) => Some(OffersMessage::InvoiceError(e)),
 				}
 			},
 			OffersMessage::InvoiceError(invoice_error) => {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7906,7 +7906,7 @@ where
 	///
 	/// The resulting invoice uses a [`PaymentHash`] recognized by the [`ChannelManager`] and a
 	/// [`BlindedPath`] containing the [`PaymentSecret`] needed to reconstruct the corresponding
-	/// [`PaymentPreimage`].
+	/// [`PaymentPreimage`]. It is returned purely for informational purposes.
 	///
 	/// # Limitations
 	///
@@ -7921,7 +7921,9 @@ where
 	/// path for the invoice.
 	///
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
-	pub fn request_refund_payment(&self, refund: &Refund) -> Result<(), Bolt12SemanticError> {
+	pub fn request_refund_payment(
+		&self, refund: &Refund
+	) -> Result<Bolt12Invoice, Bolt12SemanticError> {
 		let expanded_key = &self.inbound_payment_key;
 		let entropy = &*self.entropy_source;
 		let secp_ctx = &self.secp_ctx;
@@ -7954,7 +7956,7 @@ where
 				let mut pending_offers_messages = self.pending_offers_messages.lock().unwrap();
 				if refund.paths().is_empty() {
 					let message = new_pending_onion_message(
-						OffersMessage::Invoice(invoice),
+						OffersMessage::Invoice(invoice.clone()),
 						Destination::Node(refund.payer_id()),
 						Some(reply_path),
 					);
@@ -7970,7 +7972,7 @@ where
 					}
 				}
 
-				Ok(())
+				Ok(invoice)
 			},
 			Err(()) => Err(Bolt12SemanticError::InvalidAmount),
 		}

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -492,7 +492,7 @@ fn creates_and_pays_for_refund_using_two_hop_blinded_path() {
 	}
 	expect_recent_payment!(david, RecentPaymentDetails::AwaitingInvoice, payment_id);
 
-	alice.node.request_refund_payment(&refund).unwrap();
+	let expected_invoice = alice.node.request_refund_payment(&refund).unwrap();
 
 	connect_peers(alice, charlie);
 
@@ -503,6 +503,8 @@ fn creates_and_pays_for_refund_using_two_hop_blinded_path() {
 	david.onion_messenger.handle_onion_message(&charlie_id, &onion_message);
 
 	let invoice = extract_invoice(david, &onion_message);
+	assert_eq!(invoice, expected_invoice);
+
 	assert_eq!(invoice.amount_msats(), 10_000_000);
 	assert_ne!(invoice.signing_pubkey(), alice_id);
 	assert!(!invoice.payment_paths().is_empty());
@@ -610,12 +612,14 @@ fn creates_and_pays_for_refund_using_one_hop_blinded_path() {
 	}
 	expect_recent_payment!(bob, RecentPaymentDetails::AwaitingInvoice, payment_id);
 
-	alice.node.request_refund_payment(&refund).unwrap();
+	let expected_invoice = alice.node.request_refund_payment(&refund).unwrap();
 
 	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
 	bob.onion_messenger.handle_onion_message(&alice_id, &onion_message);
 
 	let invoice = extract_invoice(bob, &onion_message);
+	assert_eq!(invoice, expected_invoice);
+
 	assert_eq!(invoice.amount_msats(), 10_000_000);
 	assert_ne!(invoice.signing_pubkey(), alice_id);
 	assert!(!invoice.payment_paths().is_empty());
@@ -704,12 +708,14 @@ fn pays_for_refund_without_blinded_paths() {
 	assert!(refund.paths().is_empty());
 	expect_recent_payment!(bob, RecentPaymentDetails::AwaitingInvoice, payment_id);
 
-	alice.node.request_refund_payment(&refund).unwrap();
+	let expected_invoice = alice.node.request_refund_payment(&refund).unwrap();
 
 	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
 	bob.onion_messenger.handle_onion_message(&alice_id, &onion_message);
 
 	let invoice = extract_invoice(bob, &onion_message);
+	assert_eq!(invoice, expected_invoice);
+
 	route_bolt12_payment(bob, &[alice], &invoice);
 	expect_recent_payment!(bob, RecentPaymentDetails::Pending, payment_id);
 

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -104,7 +104,6 @@
 
 use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::hash_types::{WPubkeyHash, WScriptHash};
-use bitcoin::hashes::Hash;
 use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, self};
 use bitcoin::secp256k1::schnorr::Signature;
@@ -112,6 +111,7 @@ use bitcoin::address::{Address, Payload, WitnessProgram, WitnessVersion};
 use bitcoin::key::TweakedPublicKey;
 use core::convert::{AsRef, TryFrom};
 use core::time::Duration;
+use core::hash::{Hash, Hasher};
 use crate::io;
 use crate::blinded_path::BlindedPath;
 use crate::ln::PaymentHash;
@@ -390,6 +390,7 @@ macro_rules! invoice_builder_methods { (
 	/// Successive calls to this method will add another address. Caller is responsible for not
 	/// adding duplicate addresses and only calling if capable of receiving to P2WSH addresses.
 	pub fn fallback_v0_p2wsh($($self_mut)* $self: $self_type, script_hash: &WScriptHash) -> $return_type {
+		use bitcoin::hashes::Hash;
 		let address = FallbackAddress {
 			version: WitnessVersion::V0.to_num(),
 			program: Vec::from(script_hash.to_byte_array()),
@@ -403,6 +404,7 @@ macro_rules! invoice_builder_methods { (
 	/// Successive calls to this method will add another address. Caller is responsible for not
 	/// adding duplicate addresses and only calling if capable of receiving to P2WPKH addresses.
 	pub fn fallback_v0_p2wpkh($($self_mut)* $self: $self_type, pubkey_hash: &WPubkeyHash) -> $return_type {
+		use bitcoin::hashes::Hash;
 		let address = FallbackAddress {
 			version: WitnessVersion::V0.to_num(),
 			program: Vec::from(pubkey_hash.to_byte_array()),
@@ -614,7 +616,6 @@ impl AsRef<TaggedHash> for UnsignedBolt12Invoice {
 /// [`Refund`]: crate::offers::refund::Refund
 /// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 #[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
 pub struct Bolt12Invoice {
 	bytes: Vec<u8>,
 	contents: InvoiceContents,
@@ -883,6 +884,20 @@ impl Bolt12Invoice {
 		};
 		(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream, invoice_tlv_stream,
 		 signature_tlv_stream)
+	}
+}
+
+impl PartialEq for Bolt12Invoice {
+	fn eq(&self, other: &Self) -> bool {
+		self.bytes.eq(&other.bytes)
+	}
+}
+
+impl Eq for Bolt12Invoice {}
+
+impl Hash for Bolt12Invoice {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.bytes.hash(state);
 	}
 }
 

--- a/lightning/src/offers/invoice_error.rs
+++ b/lightning/src/offers/invoice_error.rs
@@ -11,6 +11,7 @@
 
 use crate::io;
 use crate::ln::msgs::DecodeError;
+use crate::offers::merkle::SignError;
 use crate::offers::parse::Bolt12SemanticError;
 use crate::util::ser::{HighZeroBytesDroppedBigSize, Readable, WithoutLength, Writeable, Writer};
 use crate::util::string::UntrustedString;
@@ -108,6 +109,19 @@ impl From<Bolt12SemanticError> for InvoiceError {
 		InvoiceError {
 			erroneous_field: None,
 			message: UntrustedString(format!("{:?}", error)),
+		}
+	}
+}
+
+impl From<SignError> for InvoiceError {
+	fn from(error: SignError) -> Self {
+		let message = match error {
+			SignError::Signing => "Failed signing invoice",
+			SignError::Verification(_) => "Failed invoice signature verification",
+		};
+		InvoiceError {
+			erroneous_field: None,
+			message: UntrustedString(message.to_string()),
 		}
 	}
 }


### PR DESCRIPTION
`Bolt12Invoice`s are generated internally by `ChannelManager`, so the payment recipient never sees a `payment_hash` until a `PaymentClaimable` is handled. This prevents tracking any pending inbound payments. Expose the `Bolt12Invoice` in a new `InvoiceGenerated` event when responding to an `InvoiceRequest` for an `Offer`. Similarly, return the invoice from `ChannelManager::request_refund_payment`.

For the `Offer` case, the `offer_metadata` returned by `Bolt12Invoice::metadata` may be used as an offer id, if desired, since it is a randomly generated 16-byte nonce for `ChannelManager`-originating offers. Also, a common `Bolt12Invoice::payer_id` may indicated redundant invoice requests.

For the `Refund` case, the metadata will be empty, but the `payment_hash` may be used as an identifier.