### PR TITLE
Avoid new "out of disk space" issues in CI

### DIFF
--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -173,5 +173,7 @@ fi
 
 echo -e "\n\nTest cfg-flag builds"
 RUSTFLAGS="--cfg=taproot" cargo test --verbose --color always -p lightning
+[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=async_signing" cargo test --verbose --color always -p lightning
+[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=dual_funding" cargo test --verbose --color always -p lightning


### PR DESCRIPTION
Our 1.63 build on Ubuntu has been failing for quite some time because it runs out of disk space trying to build tests in the last cfg-flag steps. Thus, we add a few new `cargo clean`s here to fix it.