### PR TITLE
Peer storage feature

### DIFF
--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -632,6 +632,8 @@ mod tests {
 		fn handle_tx_init_rbf(&self, _their_node_id: &PublicKey, _msg: &TxInitRbf) {}
 		fn handle_tx_ack_rbf(&self, _their_node_id: &PublicKey, _msg: &TxAckRbf) {}
 		fn handle_tx_abort(&self, _their_node_id: &PublicKey, _msg: &TxAbort) {}
+		fn handle_peer_storage(&self, _their_node_id: &PublicKey, _msg: &PeerStorageMessage) {}
+		fn handle_your_peer_storage(&self, _their_node_id: &PublicKey, _msg: &YourPeerStorageMessage) {}
 		fn peer_disconnected(&self, their_node_id: &PublicKey) {
 			if *their_node_id == self.expected_pubkey {
 				self.disconnected_flag.store(true, Ordering::SeqCst);

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -544,6 +544,9 @@ pub(crate) enum ChannelMonitorUpdateStep {
 	ShutdownScript {
 		scriptpubkey: ScriptBuf,
 	},
+	LatestPeerStorage {
+		data: Vec<u8>,
+	},
 }
 
 impl ChannelMonitorUpdateStep {
@@ -555,6 +558,7 @@ impl ChannelMonitorUpdateStep {
 			ChannelMonitorUpdateStep::CommitmentSecret { .. } => "CommitmentSecret",
 			ChannelMonitorUpdateStep::ChannelForceClosed { .. } => "ChannelForceClosed",
 			ChannelMonitorUpdateStep::ShutdownScript { .. } => "ShutdownScript",
+			ChannelMonitorUpdateStep::LatestPeerStorage { .. } => "LatestPeerStorage",
 		}
 	}
 }
@@ -587,6 +591,9 @@ impl_writeable_tlv_based_enum_upgradable!(ChannelMonitorUpdateStep,
 	},
 	(5, ShutdownScript) => {
 		(0, scriptpubkey, required),
+	},
+	(6, LatestPeerStorage) => {
+		(0, data, required_vec),
 	},
 );
 
@@ -834,6 +841,8 @@ pub(crate) struct ChannelMonitorImpl<Signer: WriteableEcdsaChannelSigner> {
 	/// remote commitment transactions are automatically removed when commitment transactions are
 	/// revoked.
 	payment_preimages: HashMap<PaymentHash, PaymentPreimage>,
+
+	peer_storage: Vec<u8>,
 
 	// Note that `MonitorEvent`s MUST NOT be generated during update processing, only generated
 	// during chain data processing. This prevents a race in `ChainMonitor::update_channel` (and
@@ -1110,6 +1119,7 @@ impl<Signer: WriteableEcdsaChannelSigner> Writeable for ChannelMonitorImpl<Signe
 			(15, self.counterparty_fulfilled_htlcs, required),
 			(17, self.initial_counterparty_commitment_info, option),
 			(19, self.channel_id, required),
+			(21, self.peer_storage, required_vec),
 		});
 
 		Ok(())
@@ -1289,7 +1299,7 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitor<Signer> {
 			confirmed_commitment_tx_counterparty_output: None,
 			htlcs_resolved_on_chain: Vec::new(),
 			spendable_txids_confirmed: Vec::new(),
-
+			peer_storage: Vec::new(),
 			best_block,
 			counterparty_node_id: Some(counterparty_node_id),
 			initial_counterparty_commitment_info: None,
@@ -1404,6 +1414,11 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitor<Signer> {
 	/// Gets the channel_id of the channel this ChannelMonitor is monitoring for.
 	pub fn channel_id(&self) -> ChannelId {
 		self.inner.lock().unwrap().channel_id()
+	}
+
+	/// Fets peer_storage of this peer.
+	pub fn get_peer_storage(&self) -> Vec<u8> {
+		self.inner.lock().unwrap().peer_storage()
 	}
 
 	/// Gets a list of txids, with their output scripts (in the order they appear in the
@@ -2700,6 +2715,10 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 		}
 	}
 
+	fn update_peer_storage(&mut self, new_data: Vec<u8>) {
+		self.peer_storage = new_data;
+	}
+
 	fn generate_claimable_outpoints_and_watch_outputs(&mut self) -> (Vec<PackageTemplate>, Vec<TransactionOutputs>) {
 		let funding_outp = HolderFundingOutput::build(
 			self.funding_redeemscript.clone(),
@@ -2869,6 +2888,10 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 						panic!("Attempted to replace shutdown script {} with {}", shutdown_script, scriptpubkey);
 					}
 				},
+				ChannelMonitorUpdateStep::LatestPeerStorage { data } => {
+					log_trace!(logger, "Updating ChannelMonitor with latest recieved PeerStorage");
+					self.update_peer_storage(data.clone());
+				}
 			}
 		}
 
@@ -2898,6 +2921,10 @@ impl<Signer: WriteableEcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 
 	fn get_funding_txo(&self) -> &(OutPoint, ScriptBuf) {
 		&self.funding_info
+	}
+
+	pub fn peer_storage(&self) -> Vec<u8> {
+		self.peer_storage.clone()
 	}
 
 	pub fn channel_id(&self) -> ChannelId {
@@ -4601,6 +4628,7 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 		let mut counterparty_fulfilled_htlcs = Some(new_hash_map());
 		let mut initial_counterparty_commitment_info = None;
 		let mut channel_id = None;
+		let mut peer_storage = Some(Vec::new());
 		read_tlv_fields!(reader, {
 			(1, funding_spend_confirmed, option),
 			(3, htlcs_resolved_on_chain, optional_vec),
@@ -4612,6 +4640,7 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			(15, counterparty_fulfilled_htlcs, option),
 			(17, initial_counterparty_commitment_info, option),
 			(19, channel_id, option),
+			(21, peer_storage, optional_vec),
 		});
 
 		// Monitors for anchor outputs channels opened in v0.0.116 suffered from a bug in which the
@@ -4676,7 +4705,7 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			confirmed_commitment_tx_counterparty_output,
 			htlcs_resolved_on_chain: htlcs_resolved_on_chain.unwrap(),
 			spendable_txids_confirmed: spendable_txids_confirmed.unwrap(),
-
+			peer_storage: peer_storage.unwrap(),
 			best_block,
 			counterparty_node_id,
 			initial_counterparty_commitment_info,

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -1959,6 +1959,20 @@ pub enum MessageSendEvent {
 		/// The gossip_timestamp_filter which should be sent.
 		msg: msgs::GossipTimestampFilter,
 	},
+
+	SendPeerStorageMessage {
+		/// The node_id of this message recipient
+		node_id: PublicKey,
+		/// The PeerStorageMessage which should be sent.
+		msg: msgs::PeerStorageMessage,
+	},
+
+	SendYourPeerStorageMessage {
+		/// The node_id of this message recipient
+		node_id: PublicKey,
+		/// The YourPeerStorageMessage which should be sent.
+		msg: msgs::YourPeerStorageMessage,
+	}
 }
 
 /// A trait indicating an object may generate message send events

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -9432,6 +9432,8 @@ pub fn provided_init_features(config: &UserConfig) -> InitFeatures {
 	features.set_scid_privacy_optional();
 	features.set_zero_conf_optional();
 	features.set_route_blinding_optional();
+	features.set_want_peer_backup_storage_optional();
+	features.set_provide_peer_backup_storage_optional();
 	if config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx {
 		features.set_anchors_zero_fee_htlc_tx_optional();
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1401,6 +1401,7 @@ where
 	node_signer: NS,
 	signer_provider: SP,
 
+	peer_storage: RwLock<HashMap<PublicKey, Vec<u8>>>,
 	logger: L,
 }
 
@@ -2483,7 +2484,7 @@ where
 			entropy_source,
 			node_signer,
 			signer_provider,
-
+			peer_storage: RwLock::new(HashMap::new()),
 			logger,
 		}
 	}
@@ -6432,6 +6433,73 @@ where
 		}
 	}
 
+	fn internal_peer_storage(&self, counterparty_node_id: &PublicKey, msg: &msgs::PeerStorageMessage) -> Result<(), ()> {
+		let per_peer_state = self.per_peer_state.read().unwrap();
+		let peer_state_mutex = match per_peer_state.get(counterparty_node_id) {
+			Some(peer_state_mutex) => peer_state_mutex,
+			None => return Err(()),
+		};
+
+		// Check if we have any channels with the peer (Currently we only provide the servie to peers we have a channel with).
+		let chan_info = self.list_channels_with_counterparty(counterparty_node_id);
+		if chan_info.is_empty() {
+			return Err(());
+		}
+
+		// Send ChannelMonitor Update.
+		let sorted_chan_info: Vec<ChannelDetails> = chan_info.iter().cloned().collect();
+		let sorted_chan_info = {
+			let mut sorted_vec: Vec<ChannelDetails> = sorted_chan_info;
+			sorted_vec.sort_by_cached_key(|s| s.funding_txo.unwrap().get_txid());
+			sorted_vec
+		};
+
+		let mut found_funded_chan = false;
+		for chan in &sorted_chan_info {
+			if let Some(funding_txo) = chan.funding_txo {
+				found_funded_chan = true;
+				let peer_storage_update = ChannelMonitorUpdate {
+					update_id: CLOSED_CHANNEL_UPDATE_ID,
+					counterparty_node_id: None,
+					updates: vec![ChannelMonitorUpdateStep::LatestPeerStorage { 
+						data: msg.data.clone(),
+					}],
+					channel_id: Some(chan.channel_id),
+				};
+				// Since channel monitor is already loaded so we do not need to push this onto background event.
+				let update_res: ChannelMonitorUpdateStatus = self.chain_monitor.update_channel(funding_txo, &peer_storage_update);
+				if update_res != ChannelMonitorUpdateStatus::Completed {
+					log_error!(WithContext::from(&self.logger, None, Some(chan.channel_id)),
+						"Critical error: failed to update channel monitor with latest peer storage {:?}: {:?}",
+						msg.data, update_res);
+				}
+				break;
+			}
+		}
+
+		if !found_funded_chan {
+			return Err(());
+		}
+		
+
+		// Update the store.
+		let mut peer_storage = self.peer_storage.write().unwrap();
+		peer_storage.insert(*counterparty_node_id, msg.data.clone());
+
+		let mut peer_state_lock = peer_state_mutex.lock().unwrap();
+		let peer_state = &mut *peer_state_lock;
+
+		// Send ACK.
+		peer_state.pending_msg_events.push(events::MessageSendEvent::SendYourPeerStorageMessage {
+			node_id: counterparty_node_id.clone(),
+			msg: msgs::YourPeerStorageMessage {
+				data: msg.data.clone()
+			},
+		});
+
+		Ok(())
+	}
+
 	fn internal_funding_signed(&self, counterparty_node_id: &PublicKey, msg: &msgs::FundingSigned) -> Result<(), MsgHandleErrInternal> {
 		let best_block = *self.best_block.read().unwrap();
 		let per_peer_state = self.per_peer_state.read().unwrap();
@@ -8743,6 +8811,13 @@ where
 	}
 
 	fn handle_peer_storage(&self, counterparty_node_id: &PublicKey, msg: &msgs::PeerStorageMessage) {
+		match self.internal_peer_storage(counterparty_node_id, msg) {
+			Ok(_) => {},
+			Err(_err) => {
+				let logger = WithContext::from(&self.logger, Some(*counterparty_node_id), None);
+				log_debug!(logger, "Could not store Peer Storage for peer {}", log_pubkey!(counterparty_node_id));
+			},
+		}
 	}
 
 	fn handle_your_peer_storage(&self, counterparty_node_id: &PublicKey, msg: &msgs::YourPeerStorageMessage) {
@@ -9103,6 +9178,19 @@ where
 							debug_assert!(false);
 						}
 					}
+				}
+
+				let peer_storage = self.peer_storage.read().unwrap();
+
+				if let Some(value) = peer_storage.get(counterparty_node_id) {
+					log_debug!(logger, "Generating peerstorage for {}", log_pubkey!(counterparty_node_id));
+
+					pending_msg_events.push(events::MessageSendEvent::SendYourPeerStorageMessage { 
+						node_id: counterparty_node_id.clone(),
+						msg: msgs::YourPeerStorageMessage {
+							data: value.clone()
+						},
+					});
 				}
 			}
 
@@ -10391,6 +10479,7 @@ where
 		let mut channel_closures = VecDeque::new();
 		let mut close_background_events = Vec::new();
 		let mut funding_txo_to_channel_id = hash_map_with_capacity(channel_count as usize);
+		let mut peer_storage_dir: HashMap<PublicKey, Vec<u8>> = HashMap::new();
 		for _ in 0..channel_count {
 			let mut channel: Channel<SP> = Channel::read(reader, (
 				&args.entropy_source, &args.signer_provider, best_block_height, &provided_channel_type_features(&args.default_config)
@@ -10400,6 +10489,9 @@ where
 			funding_txo_to_channel_id.insert(funding_txo, channel.context.channel_id());
 			funding_txo_set.insert(funding_txo.clone());
 			if let Some(ref mut monitor) = args.channel_monitors.get_mut(&funding_txo) {
+				// Load Peer_storage from ChannelMonitor to memory.
+				peer_storage_dir.insert(channel.context.get_counterparty_node_id(), monitor.get_peer_storage());
+
 				if channel.get_cur_holder_commitment_transaction_number() > monitor.get_cur_holder_commitment_number() ||
 						channel.get_revoked_counterparty_commitment_transaction_number() > monitor.get_min_seen_secret() ||
 						channel.get_cur_counterparty_commitment_transaction_number() > monitor.get_cur_counterparty_commitment_number() ||
@@ -11209,7 +11301,7 @@ where
 			entropy_source: args.entropy_source,
 			node_signer: args.node_signer,
 			signer_provider: args.signer_provider,
-
+			peer_storage: RwLock::new(peer_storage_dir),
 			logger: args.logger,
 			default_configuration: args.default_config,
 		};

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8742,6 +8742,13 @@ where
 		let _ = handle_error!(self, self.internal_funding_signed(counterparty_node_id, msg), *counterparty_node_id);
 	}
 
+	fn handle_peer_storage(&self, counterparty_node_id: &PublicKey, msg: &msgs::PeerStorageMessage) {
+	}
+
+	fn handle_your_peer_storage(&self, counterparty_node_id: &PublicKey, msg: &msgs::YourPeerStorageMessage) {
+		//TODO
+	}
+
 	fn handle_channel_ready(&self, counterparty_node_id: &PublicKey, msg: &msgs::ChannelReady) {
 		// Note that we never need to persist the updated ChannelManager for an inbound
 		// channel_ready message - while the channel's state will change, any channel_ready message
@@ -8988,6 +8995,10 @@ where
 						&events::MessageSendEvent::SendShortIdsQuery { .. } => false,
 						&events::MessageSendEvent::SendReplyChannelRange { .. } => false,
 						&events::MessageSendEvent::SendGossipTimestampFilter { .. } => false,
+
+						// Peer Storage
+						&events::MessageSendEvent::SendPeerStorageMessage { .. } => false,
+						&events::MessageSendEvent::SendYourPeerStorageMessage { .. } => false,
 					}
 				});
 				debug_assert!(peer_state.is_connected, "A disconnected peer cannot disconnect");

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -787,6 +787,12 @@ macro_rules! get_htlc_update_msgs {
 /// such messages are intended to all peers.
 pub fn remove_first_msg_event_to_node(msg_node_id: &PublicKey, msg_events: &mut Vec<MessageSendEvent>) -> MessageSendEvent {
 	let ev_index = msg_events.iter().position(|e| { match e {
+		MessageSendEvent::SendPeerStorageMessage { node_id, .. } => {
+			node_id == msg_node_id
+		},
+		MessageSendEvent::SendYourPeerStorageMessage { node_id, .. } => {
+			node_id == msg_node_id
+		},
 		MessageSendEvent::SendAcceptChannel { node_id, .. } => {
 			node_id == msg_node_id
 		},

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -711,6 +711,24 @@ pub struct UpdateFulfillHTLC {
 	pub payment_preimage: PaymentPreimage,
 }
 
+/// A [`PeerStorage`] message to be sent to or received from a peer.
+///
+/// [`PeerStorage`]: https://github.com/lightning/bolts/pull/1110
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct PeerStorageMessage {
+	/// Data included in the msg
+	pub data: Vec<u8>,
+}
+
+/// An [`YourPeerStorage`] message to be sent to or received from a peer.
+/// 
+/// [`YourPeerStorage`]: https://github.com/lightning/bolts/pull/1110
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct YourPeerStorageMessage {
+	/// Data included in the msg
+	pub data: Vec<u8>,
+}
+
 /// An [`update_fail_htlc`] message to be sent to or received from a peer.
 ///
 /// [`update_fail_htlc`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#removing-an-htlc-update_fulfill_htlc-update_fail_htlc-and-update_fail_malformed_htlc
@@ -1461,6 +1479,12 @@ pub trait ChannelMessageHandler : MessageSendEventsProvider {
 	/// Handle an incoming `channel_ready` message from the given peer.
 	fn handle_channel_ready(&self, their_node_id: &PublicKey, msg: &ChannelReady);
 
+	// Peer Storage
+	/// Handle an incoming `peer_storage` message from the given peer.
+	fn handle_peer_storage(&self, their_node_id: &PublicKey, msg: &PeerStorageMessage);
+	/// Handle an incoming `your_peer_storage` message from the given peer.
+	fn handle_your_peer_storage(&self, their_node_id: &PublicKey, msg: &YourPeerStorageMessage);
+
 	// Channel close:
 	/// Handle an incoming `shutdown` message from the given peer.
 	fn handle_shutdown(&self, their_node_id: &PublicKey, msg: &Shutdown);
@@ -2188,6 +2212,14 @@ impl_writeable_msg!(UpdateFulfillHTLC, {
 	channel_id,
 	htlc_id,
 	payment_preimage
+}, {});
+
+impl_writeable_msg!(PeerStorageMessage, {
+	data
+}, {});
+
+impl_writeable_msg!(YourPeerStorageMessage, {
+	data
 }, {});
 
 // Note that this is written as a part of ChannelManager objects, and thus cannot change its
@@ -3979,6 +4011,26 @@ mod tests {
 		};
 		let encoded_value = ping.encode();
 		let target_value = <Vec<u8>>::from_hex("0040004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
+		assert_eq!(encoded_value, target_value);
+	}
+
+	#[test]
+	fn encoding_peer_storage() {
+		let peerstorage = msgs::PeerStorageMessage {
+			data: <Vec<u8>>::from_hex("01020304050607080910").unwrap()
+		};
+		let encoded_value = peerstorage.encode();
+		let target_value = <Vec<u8>>::from_hex("000a01020304050607080910").unwrap();
+		assert_eq!(encoded_value, target_value);
+	}
+
+	#[test]
+	fn encoding_your_peer_storage() {
+		let yourpeerstorage = msgs::YourPeerStorageMessage {
+			data: <Vec<u8>>::from_hex("01020304050607080910").unwrap()
+		};
+		let encoded_value = yourpeerstorage.encode();
+		let target_value = <Vec<u8>>::from_hex("000a01020304050607080910").unwrap();
 		assert_eq!(encoded_value, target_value);
 	}
 

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -283,6 +283,8 @@ impl ChannelMessageHandler for ErroringMessageHandler {
 	}
 	// msgs::ChannelUpdate does not contain the channel_id field, so we just drop them.
 	fn handle_channel_update(&self, _their_node_id: &PublicKey, _msg: &msgs::ChannelUpdate) {}
+	fn handle_peer_storage(&self, _their_node_id: &PublicKey, _msg: &msgs::PeerStorageMessage) {}
+	fn handle_your_peer_storage(&self, _their_node_id: &PublicKey, _msg: &msgs::YourPeerStorageMessage) {}
 	fn peer_disconnected(&self, _their_node_id: &PublicKey) {}
 	fn peer_connected(&self, _their_node_id: &PublicKey, _init: &msgs::Init, _inbound: bool) -> Result<(), ()> { Ok(()) }
 	fn handle_error(&self, _their_node_id: &PublicKey, _msg: &msgs::ErrorMessage) {}
@@ -1686,6 +1688,12 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, OM: Deref, L: Deref, CM
 			wire::Message::ChannelReady(msg) => {
 				self.message_handler.chan_handler.handle_channel_ready(&their_node_id, &msg);
 			},
+			wire::Message::PeerStorageMessage(msg) => {
+				self.message_handler.chan_handler.handle_peer_storage(&their_node_id, &msg);
+			},
+			wire::Message::YourPeerStorageMessage(msg) => {
+				self.message_handler.chan_handler.handle_your_peer_storage(&their_node_id, &msg);
+			},
 
 			// Quiescence messages:
 			wire::Message::Stfu(msg) => {
@@ -1978,6 +1986,14 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, OM: Deref, L: Deref, CM
 				}
 				for event in events_generated.drain(..) {
 					match event {
+						MessageSendEvent::SendPeerStorageMessage { ref node_id, ref msg } => {
+							log_debug!(self.logger, "Handling SendPeerStorageMessage event in peer_handler for {}", log_pubkey!(node_id));
+							self.enqueue_message(&mut *get_peer_for_forwarding!(node_id), msg);
+						},
+						MessageSendEvent::SendYourPeerStorageMessage { ref node_id, ref msg } => {
+							log_debug!(self.logger, "Handling SendYourPeerStorageMessage event in peer_handler for {}", log_pubkey!(node_id));
+							self.enqueue_message(&mut *get_peer_for_forwarding!(node_id), msg);
+						},
 						MessageSendEvent::SendAcceptChannel { ref node_id, ref msg } => {
 							log_debug!(WithContext::from(&self.logger, Some(*node_id), Some(msg.temporary_channel_id)), "Handling SendAcceptChannel event in peer_handler for node {} for channel {}",
 									log_pubkey!(node_id),

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -53,6 +53,8 @@ pub(crate) enum Message<T> where T: core::fmt::Debug + Type + TestEq {
 	Warning(msgs::WarningMessage),
 	Ping(msgs::Ping),
 	Pong(msgs::Pong),
+	PeerStorageMessage(msgs::PeerStorageMessage),
+	YourPeerStorageMessage(msgs::YourPeerStorageMessage),
 	OpenChannel(msgs::OpenChannel),
 	OpenChannelV2(msgs::OpenChannelV2),
 	AcceptChannel(msgs::AcceptChannel),
@@ -108,6 +110,8 @@ impl<T> Writeable for Message<T> where T: core::fmt::Debug + Type + TestEq {
 			&Message::Warning(ref msg) => msg.write(writer),
 			&Message::Ping(ref msg) => msg.write(writer),
 			&Message::Pong(ref msg) => msg.write(writer),
+			&Message::PeerStorageMessage(ref msg) => msg.write(writer),
+			&Message::YourPeerStorageMessage(ref msg) => msg.write(writer),
 			&Message::OpenChannel(ref msg) => msg.write(writer),
 			&Message::OpenChannelV2(ref msg) => msg.write(writer),
 			&Message::AcceptChannel(ref msg) => msg.write(writer),
@@ -163,6 +167,8 @@ impl<T> Type for Message<T> where T: core::fmt::Debug + Type + TestEq {
 			&Message::Warning(ref msg) => msg.type_id(),
 			&Message::Ping(ref msg) => msg.type_id(),
 			&Message::Pong(ref msg) => msg.type_id(),
+			&Message::PeerStorageMessage(ref msg) => msg.type_id(),
+			&Message::YourPeerStorageMessage(ref msg) => msg.type_id(),
 			&Message::OpenChannel(ref msg) => msg.type_id(),
 			&Message::OpenChannelV2(ref msg) => msg.type_id(),
 			&Message::AcceptChannel(ref msg) => msg.type_id(),
@@ -251,6 +257,12 @@ fn do_read<R: io::Read, T, H: core::ops::Deref>(buffer: &mut R, message_type: u1
 		},
 		msgs::Pong::TYPE => {
 			Ok(Message::Pong(Readable::read(buffer)?))
+		},
+		msgs::PeerStorageMessage::TYPE => {
+			Ok(Message::PeerStorageMessage(Readable::read(buffer)?))
+		},
+		msgs::YourPeerStorageMessage::TYPE => {
+			Ok(Message::YourPeerStorageMessage(Readable::read(buffer)?))
 		},
 		msgs::OpenChannel::TYPE => {
 			Ok(Message::OpenChannel(Readable::read(buffer)?))
@@ -611,6 +623,14 @@ impl Encode for msgs::ReplyChannelRange {
 
 impl Encode for msgs::GossipTimestampFilter {
 	const TYPE: u16 = 265;
+}
+
+impl Encode for msgs::PeerStorageMessage {
+	const TYPE: u16 = 7;
+}
+
+impl Encode for msgs::YourPeerStorageMessage {
+	const TYPE: u16 = 9;
 }
 
 #[cfg(test)]

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -857,6 +857,14 @@ impl msgs::ChannelMessageHandler for TestChannelMessageHandler {
 	fn handle_tx_abort(&self, _their_node_id: &PublicKey, msg: &msgs::TxAbort) {
 		self.received_msg(wire::Message::TxAbort(msg.clone()));
 	}
+
+	fn handle_peer_storage(&self, _their_node_id: &PublicKey, msg: &msgs::PeerStorageMessage) {
+		self.received_msg(wire::Message::PeerStorageMessage(msg.clone()));
+	}
+
+	fn handle_your_peer_storage(&self, _their_node_id: &PublicKey, msg: &msgs::YourPeerStorageMessage) {
+		self.received_msg(wire::Message::YourPeerStorageMessage(msg.clone()));
+	}
 }
 
 impl events::MessageSendEventsProvider for TestChannelMessageHandler {


### PR DESCRIPTION
This would enable nodes to distribute small blobs among their peers, which could be retrieved to resume or force-close the channel operation upon data corruption.

Elaborated in detail [here](https://github.com/lightning/bolts/pull/1110)