### PR TITLE
Make `BlindedHopFeatures` optional per spec

### DIFF
--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -169,7 +169,7 @@ impl Readable for BlindedPaymentTlvs {
 				short_channel_id,
 				payment_relay: payment_relay.ok_or(DecodeError::InvalidValue)?,
 				payment_constraints: payment_constraints.0.unwrap(),
-				features: features.ok_or(DecodeError::InvalidValue)?,
+				features: features.unwrap_or_else(BlindedHopFeatures::empty),
 			}))
 		} else {
 			if payment_relay.is_some() || features.is_some() { return Err(DecodeError::InvalidValue) }

--- a/pending_changelog/blinded-hop-features-optional.txt
+++ b/pending_changelog/blinded-hop-features-optional.txt
@@ -1,0 +1,5 @@
+## Bug Fixes
+
+* LDK previously would fail to forward an intermediate blinded payment
+	if the blinded hop features were absent, potentially breaking
+	interoperability.


### PR DESCRIPTION
The spec states that if these features are missing, we MUST process the message as if it were present and contained an empty array. See [[1](https://github.com/lightning/bolts/pull/765/files#diff-ad65f0beaac5cef88f5fd7a8b9ca36cbc5a790f4815b4b50b9ea794a55aaf012R298)]. 

H/t to @carlaKC for catching this! 