### PR TITLE
Tx-Sync: Track spent `WatchedOutput`s and re-add if unconfirmed

### DIFF
--- a/lightning-transaction-sync/src/common.rs
+++ b/lightning-transaction-sync/src/common.rs
@@ -128,6 +128,7 @@ impl FilterQueue {
 #[derive(Debug)]
 pub(crate) struct ConfirmedTx {
 	pub tx: Transaction,
+	pub txid: Txid,
 	pub block_header: Header,
 	pub block_height: u32,
 	pub pos: usize,

--- a/lightning-transaction-sync/src/electrum.rs
+++ b/lightning-transaction-sync/src/electrum.rs
@@ -257,7 +257,7 @@ where
 
 		// First, check the confirmation status of registered transactions as well as the
 		// status of dependent transactions of registered outputs.
-		let mut confirmed_txs = Vec::new();
+		let mut confirmed_txs: Vec<ConfirmedTx> = Vec::new();
 		let mut watched_script_pubkeys = Vec::with_capacity(
 			sync_state.watched_transactions.len() + sync_state.watched_outputs.len());
 		let mut watched_txs = Vec::with_capacity(sync_state.watched_transactions.len());
@@ -305,6 +305,9 @@ where
 
 				for (i, script_history) in tx_results.iter().enumerate() {
 					let (txid, tx) = &watched_txs[i];
+					if confirmed_txs.iter().any(|ctx| ctx.txid == **txid) {
+						continue;
+					}
 					let mut filtered_history = script_history.iter().filter(|h| h.tx_hash == **txid);
 					if let Some(history) = filtered_history.next()
 					{
@@ -324,6 +327,10 @@ where
 						}
 
 						let txid = possible_output_spend.tx_hash;
+						if confirmed_txs.iter().any(|ctx| ctx.txid == txid) {
+							continue;
+						}
+
 						match self.client.transaction_get(&txid) {
 							Ok(tx) => {
 								let mut is_spend = false;
@@ -419,6 +426,7 @@ where
 						}
 						let confirmed_tx = ConfirmedTx {
 							tx: tx.clone(),
+							txid,
 							block_header, block_height: prob_conf_height,
 							pos,
 						};


### PR DESCRIPTION
Fixes #2734.

- Previously, we would track a spending transaction but wouldn't account for it being reorged out of the chain, in which case we wouldn't monitor the `WatchedOutput`s until they'd be reloaded on restart.
 In the first commit, we keep any `WatchedOutput`s around until their spends are sufficiently confirmed and only prune them after `ANTI_REORG_DELAY`.

- Moreover, we dedup any `ConfirmedTx`s entries before handing them to `Confirm::transactions_confirmed`. Previously, we would just push to the `confirmed_txs` `Vec`, leading to redundant `Confirm::transactions_confirmed` calls, especially now that we re-confirm previously disconnected spends.
 In the second commit, we ensure that we don't push additional `ConfirmedTx` entries if already one with matching `Txid` is present. This not only gets rid of the spurious `transactions_confirmed` calls (which are harmless), but
more importantly saves us from issuing unnecessary network calls, which improves latency.