### PR TITLE
Fix sender is the introduction node onion messages

### DIFF
--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -11,60 +11,51 @@
 
 use crate::blinded_path::BlindedPath;
 use crate::events::{Event, EventsProvider};
-use crate::ln::features::InitFeatures;
-use crate::ln::msgs::{self, DecodeError, OnionMessageHandler, SocketAddress};
+use crate::ln::features::{ChannelFeatures, InitFeatures};
+use crate::ln::msgs::{self, DecodeError, OnionMessageHandler};
+use crate::routing::gossip::{NetworkGraph, P2PGossipSync};
+use crate::routing::test_utils::{add_channel, add_or_update_node};
 use crate::sign::{NodeSigner, Recipient};
 use crate::util::ser::{FixedLengthReader, LengthReadable, Writeable, Writer};
 use crate::util::test_utils;
-use super::messenger::{CustomOnionMessageHandler, Destination, MessageRouter, OnionMessagePath, OnionMessenger, PendingOnionMessage, SendError};
+use super::messenger::{CustomOnionMessageHandler, DefaultMessageRouter, Destination, OnionMessagePath, OnionMessenger, PendingOnionMessage, SendError};
 use super::offers::{OffersMessage, OffersMessageHandler};
 use super::packet::{OnionMessageContents, Packet};
 
 use bitcoin::network::constants::Network;
 use bitcoin::hashes::hex::FromHex;
-use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey, self};
+use bitcoin::secp256k1::{All, PublicKey, Secp256k1, SecretKey};
 
 use crate::io;
 use crate::io_extras::read_to_end;
 use crate::sync::{Arc, Mutex};
 
+use core::ops::Deref;
+
 use crate::prelude::*;
 
 struct MessengerNode {
 	node_id: PublicKey,
+	privkey: SecretKey,
 	entropy_source: Arc<test_utils::TestKeysInterface>,
 	messenger: OnionMessenger<
 		Arc<test_utils::TestKeysInterface>,
 		Arc<test_utils::TestNodeSigner>,
 		Arc<test_utils::TestLogger>,
-		Arc<TestMessageRouter>,
+		Arc<DefaultMessageRouter<
+			Arc<NetworkGraph<Arc<test_utils::TestLogger>>>,
+			Arc<test_utils::TestLogger>,
+			Arc<test_utils::TestKeysInterface>
+		>>,
 		Arc<TestOffersMessageHandler>,
 		Arc<TestCustomMessageHandler>
 	>,
 	custom_message_handler: Arc<TestCustomMessageHandler>,
-}
-
-struct TestMessageRouter {}
-
-impl MessageRouter for TestMessageRouter {
-	fn find_path(
-		&self, _sender: PublicKey, _peers: Vec<PublicKey>, destination: Destination
-	) -> Result<OnionMessagePath, ()> {
-		Ok(OnionMessagePath {
-			intermediate_nodes: vec![],
-			destination,
-			first_node_addresses:
-				Some(vec![SocketAddress::TcpIpV4 { addr: [127, 0, 0, 1], port: 1000 }]),
-		})
-	}
-
-	fn create_blinded_paths<
-		T: secp256k1::Signing + secp256k1::Verification
-	>(
-		&self, _recipient: PublicKey, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
-	) -> Result<Vec<BlindedPath>, ()> {
-		unreachable!()
-	}
+	gossip_sync: Arc<P2PGossipSync<
+		Arc<NetworkGraph<Arc<test_utils::TestLogger>>>,
+		Arc<test_utils::TestChainSource>,
+		Arc<test_utils::TestLogger>
+	>>
 }
 
 struct TestOffersMessageHandler {}
@@ -171,6 +162,12 @@ fn create_nodes(num_messengers: u8) -> Vec<MessengerNode> {
 }
 
 fn create_nodes_using_secrets(secrets: Vec<SecretKey>) -> Vec<MessengerNode> {
+	let gossip_logger = Arc::new(test_utils::TestLogger::with_id("gossip".to_string()));
+	let network_graph = Arc::new(NetworkGraph::new(Network::Testnet, gossip_logger.clone()));
+	let gossip_sync = Arc::new(
+		P2PGossipSync::new(network_graph.clone(), None, gossip_logger)
+	);
+
 	let mut nodes = Vec::new();
 	for (i, secret_key) in secrets.into_iter().enumerate() {
 		let logger = Arc::new(test_utils::TestLogger::with_id(format!("node {}", i)));
@@ -178,10 +175,13 @@ fn create_nodes_using_secrets(secrets: Vec<SecretKey>) -> Vec<MessengerNode> {
 		let entropy_source = Arc::new(test_utils::TestKeysInterface::new(&seed, Network::Testnet));
 		let node_signer = Arc::new(test_utils::TestNodeSigner::new(secret_key));
 
-		let message_router = Arc::new(TestMessageRouter {});
+		let message_router = Arc::new(
+			DefaultMessageRouter::new(network_graph.clone(), entropy_source.clone())
+		);
 		let offers_message_handler = Arc::new(TestOffersMessageHandler {});
 		let custom_message_handler = Arc::new(TestCustomMessageHandler::new());
 		nodes.push(MessengerNode {
+			privkey: secret_key,
 			node_id: node_signer.get_node_id(Recipient::Node).unwrap(),
 			entropy_source: entropy_source.clone(),
 			messenger: OnionMessenger::new(
@@ -189,6 +189,7 @@ fn create_nodes_using_secrets(secrets: Vec<SecretKey>) -> Vec<MessengerNode> {
 				offers_message_handler, custom_message_handler.clone()
 			),
 			custom_message_handler,
+			gossip_sync: gossip_sync.clone(),
 		});
 	}
 	for i in 0..nodes.len() - 1 {
@@ -214,6 +215,20 @@ fn release_events(node: &MessengerNode) -> Vec<Event> {
 	let events = core::cell::RefCell::new(Vec::new());
 	node.messenger.process_pending_events(&|e| events.borrow_mut().push(e));
 	events.into_inner()
+}
+
+fn add_channel_to_graph(
+	node_a: &MessengerNode, node_b: &MessengerNode, secp_ctx: &Secp256k1<All>, short_channel_id: u64
+) {
+	let gossip_sync = node_a.gossip_sync.deref();
+	let privkey_a = &node_a.privkey;
+	let privkey_b = &node_b.privkey;
+	let channel_features = ChannelFeatures::empty();
+	let node_features_a = node_a.messenger.provided_node_features();
+	let node_features_b = node_b.messenger.provided_node_features();
+	add_channel(gossip_sync, secp_ctx, privkey_a, privkey_b, channel_features, short_channel_id);
+	add_or_update_node(gossip_sync, secp_ctx, privkey_a, node_features_a, 1);
+	add_or_update_node(gossip_sync, secp_ctx, privkey_b, node_features_b, 1);
 }
 
 fn pass_along_path(path: &Vec<MessengerNode>) {
@@ -492,6 +507,8 @@ fn requests_peer_connection_for_buffered_messages() {
 	let nodes = create_nodes(3);
 	let message = TestCustomMessage::Request;
 	let secp_ctx = Secp256k1::new();
+	add_channel_to_graph(&nodes[0], &nodes[1], &secp_ctx, 42);
+
 	let blinded_path = BlindedPath::new_for_message(
 		&[nodes[1].node_id, nodes[2].node_id], &*nodes[0].entropy_source, &secp_ctx
 	).unwrap();
@@ -527,6 +544,8 @@ fn drops_buffered_messages_waiting_for_peer_connection() {
 	let nodes = create_nodes(3);
 	let message = TestCustomMessage::Request;
 	let secp_ctx = Secp256k1::new();
+	add_channel_to_graph(&nodes[0], &nodes[1], &secp_ctx, 42);
+
 	let blinded_path = BlindedPath::new_for_message(
 		&[nodes[1].node_id, nodes[2].node_id], &*nodes[0].entropy_source, &secp_ctx
 	).unwrap();

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -318,10 +318,10 @@ where
 	ES::Target: EntropySource,
 {
 	fn find_path(
-		&self, _sender: PublicKey, peers: Vec<PublicKey>, destination: Destination
+		&self, sender: PublicKey, peers: Vec<PublicKey>, destination: Destination
 	) -> Result<OnionMessagePath, ()> {
 		let first_node = destination.first_node();
-		if peers.contains(&first_node) {
+		if peers.contains(&first_node) || sender == first_node {
 			Ok(OnionMessagePath {
 				intermediate_nodes: vec![], destination, first_node_addresses: None
 			})

--- a/lightning/src/routing/mod.rs
+++ b/lightning/src/routing/mod.rs
@@ -14,4 +14,4 @@ pub mod gossip;
 pub mod router;
 pub mod scoring;
 #[cfg(test)]
-mod test_utils;
+pub(crate) mod test_utils;

--- a/lightning/src/routing/test_utils.rs
+++ b/lightning/src/routing/test_utils.rs
@@ -9,7 +9,7 @@
 
 use crate::routing::gossip::{NetworkGraph, NodeAlias, P2PGossipSync};
 use crate::ln::features::{ChannelFeatures, NodeFeatures};
-use crate::ln::msgs::{ChannelAnnouncement, ChannelUpdate, MAX_VALUE_MSAT, NodeAnnouncement, RoutingMessageHandler, UnsignedChannelAnnouncement, UnsignedChannelUpdate, UnsignedNodeAnnouncement};
+use crate::ln::msgs::{ChannelAnnouncement, ChannelUpdate, MAX_VALUE_MSAT, NodeAnnouncement, RoutingMessageHandler, SocketAddress, UnsignedChannelAnnouncement, UnsignedChannelUpdate, UnsignedNodeAnnouncement};
 use crate::util::test_utils;
 use crate::util::ser::Writeable;
 
@@ -70,7 +70,7 @@ pub(super) fn add_or_update_node(
 		node_id,
 		rgb: [0; 3],
 		alias: NodeAlias([0; 32]),
-		addresses: Vec::new(),
+		addresses: vec![SocketAddress::TcpIpV4 { addr: [127, 0, 0, 1], port: 1000 }],
 		excess_address_data: Vec::new(),
 		excess_data: Vec::new(),
 	};

--- a/lightning/src/routing/test_utils.rs
+++ b/lightning/src/routing/test_utils.rs
@@ -9,8 +9,7 @@
 
 use crate::routing::gossip::{NetworkGraph, NodeAlias, P2PGossipSync};
 use crate::ln::features::{ChannelFeatures, NodeFeatures};
-use crate::ln::msgs::{UnsignedChannelAnnouncement, ChannelAnnouncement, RoutingMessageHandler,
-	NodeAnnouncement, UnsignedNodeAnnouncement, ChannelUpdate, UnsignedChannelUpdate, MAX_VALUE_MSAT};
+use crate::ln::msgs::{ChannelAnnouncement, ChannelUpdate, MAX_VALUE_MSAT, NodeAnnouncement, RoutingMessageHandler, UnsignedChannelAnnouncement, UnsignedChannelUpdate, UnsignedNodeAnnouncement};
 use crate::util::test_utils;
 use crate::util::ser::Writeable;
 

--- a/lightning/src/routing/test_utils.rs
+++ b/lightning/src/routing/test_utils.rs
@@ -27,7 +27,7 @@ use crate::sync::{self, Arc};
 use crate::routing::gossip::NodeId;
 
 // Using the same keys for LN and BTC ids
-pub(super) fn add_channel(
+pub(crate) fn add_channel(
 	gossip_sync: &P2PGossipSync<Arc<NetworkGraph<Arc<test_utils::TestLogger>>>, Arc<test_utils::TestChainSource>, Arc<test_utils::TestLogger>>,
 	secp_ctx: &Secp256k1<All>, node_1_privkey: &SecretKey, node_2_privkey: &SecretKey, features: ChannelFeatures, short_channel_id: u64
 ) {
@@ -59,7 +59,7 @@ pub(super) fn add_channel(
 	};
 }
 
-pub(super) fn add_or_update_node(
+pub(crate) fn add_or_update_node(
 	gossip_sync: &P2PGossipSync<Arc<NetworkGraph<Arc<test_utils::TestLogger>>>, Arc<test_utils::TestChainSource>, Arc<test_utils::TestLogger>>,
 	secp_ctx: &Secp256k1<All>, node_privkey: &SecretKey, features: NodeFeatures, timestamp: u32
 ) {
@@ -86,7 +86,7 @@ pub(super) fn add_or_update_node(
 	};
 }
 
-pub(super) fn update_channel(
+pub(crate) fn update_channel(
 	gossip_sync: &P2PGossipSync<Arc<NetworkGraph<Arc<test_utils::TestLogger>>>, Arc<test_utils::TestChainSource>, Arc<test_utils::TestLogger>>,
 	secp_ctx: &Secp256k1<All>, node_privkey: &SecretKey, update: UnsignedChannelUpdate
 ) {


### PR DESCRIPTION
`DefaultMessageRouter` will form an `OnionMessagePath` from a `BlindedPath` where the sender is the introduction node but only if the sender is announced. If the sender is unannounced, then `DefaultMessageRouter` will fail. While `DefaultMessageRouter` will only create a blinded path with an announced introduction node, it may receive one where the introduction node is unannounced. Don't return an error in this case, as the `OnionMessenger` can advance the blinded path by one hop.

This may occur when two nodes have an unannounced channel and one (the offer creator) wants to use it for payments without an intermediary node and without putting its node id in the offer.