### PR TITLE
Signal `GossipQuery` support when using `IgnoringMessagHandler`

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -116,7 +116,9 @@ impl RoutingMessageHandler for IgnoringMessageHandler {
 	fn handle_query_short_channel_ids(&self, _their_node_id: &PublicKey, _msg: msgs::QueryShortChannelIds) -> Result<(), LightningError> { Ok(()) }
 	fn provided_node_features(&self) -> NodeFeatures { NodeFeatures::empty() }
 	fn provided_init_features(&self, _their_node_id: &PublicKey) -> InitFeatures {
-		InitFeatures::empty()
+		let mut features = InitFeatures::empty();
+		features.set_gossip_queries_optional();
+		features
 	}
 	fn processing_queue_high(&self) -> bool { false }
 }


### PR DESCRIPTION
With its v24.02 release CLN made `GossipQueries` a required feature (see https://github.com/ElementsProject/lightning/pull/6864 and https://github.com/ElementsProject/lightning/blob/master/CHANGELOG.md#2402---2024-02-27-uint-needs-signature), leading to a incompatibility between LDK and CLN when using `IgnoringMessagHandler` as a `RoutingMessageHandler`, which is usually the case when a node uses RGS.

To fix this issue, we let `IgnoringMessagHandler` signal `GossipQuery` support, just to go ahead and ignore every gossip message the peer will send us. While this is nonsensical and still might result in some unnecessary bandwidth wasted, we have to do something to fix the incompatibility.