### PR TITLE
Compact blinded path handling

### DIFF
--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -11,7 +11,7 @@ use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::blockdata::script::Builder;
 use bitcoin::blockdata::transaction::TxOut;
 
-use lightning::blinded_path::{BlindedHop, BlindedPath};
+use lightning::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 use lightning::chain::transaction::OutPoint;
 use lightning::ln::ChannelId;
 use lightning::ln::channelmanager::{self, ChannelDetails, ChannelCounterparty};
@@ -362,7 +362,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 						});
 					}
 					(payinfo, BlindedPath {
-						introduction_node_id: hop.src_node_id,
+						introduction_node: IntroductionNode::NodeId(hop.src_node_id),
 						blinding_point: dummy_pk,
 						blinded_hops,
 					})

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -1,6 +1,6 @@
 use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
 
-use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
+use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode, NodeIdLookUp};
 use crate::blinded_path::utils;
 use crate::io;
 use crate::io::Cursor;
@@ -82,9 +82,14 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 
 // Advance the blinded onion message path by one hop, so make the second hop into the new
 // introduction node.
-pub(crate) fn advance_path_by_one<NS: Deref, T: secp256k1::Signing + secp256k1::Verification>(
-	path: &mut BlindedPath, node_signer: &NS, secp_ctx: &Secp256k1<T>
-) -> Result<(), ()> where NS::Target: NodeSigner {
+pub(crate) fn advance_path_by_one<NS: Deref, NL: Deref, T>(
+	path: &mut BlindedPath, node_signer: &NS, node_id_lookup: &NL, secp_ctx: &Secp256k1<T>
+) -> Result<(), ()>
+where
+	NS::Target: NodeSigner,
+	NL::Target: NodeIdLookUp,
+	T: secp256k1::Signing + secp256k1::Verification,
+{
 	let control_tlvs_ss = node_signer.ecdh(Recipient::Node, &path.blinding_point, None)?;
 	let rho = onion_utils::gen_rho_from_shared_secret(&control_tlvs_ss.secret_bytes());
 	let encrypted_control_tlvs = path.blinded_hops.remove(0).encrypted_payload;
@@ -96,7 +101,10 @@ pub(crate) fn advance_path_by_one<NS: Deref, T: secp256k1::Signing + secp256k1::
 		}) => {
 			let next_node_id = match next_hop {
 				NextHop::NodeId(pubkey) => pubkey,
-				NextHop::ShortChannelId(_) => todo!(),
+				NextHop::ShortChannelId(scid) => match node_id_lookup.next_node_id(scid) {
+					Some(pubkey) => pubkey,
+					None => return Err(()),
+				},
 			};
 			let mut new_blinding_point = match next_blinding_override {
 				Some(blinding_point) => blinding_point,

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -1,6 +1,6 @@
 use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
 
-use crate::blinded_path::{BlindedHop, BlindedPath};
+use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 use crate::blinded_path::utils;
 use crate::io;
 use crate::io::Cursor;
@@ -94,7 +94,7 @@ pub(crate) fn advance_path_by_one<NS: Deref, T: secp256k1::Signing + secp256k1::
 		Ok(ChaChaPolyReadAdapter {
 			readable: ControlTlvs::Forward(ForwardTlvs { next_hop, next_blinding_override })
 		}) => {
-			let mut next_node_id = match next_hop {
+			let next_node_id = match next_hop {
 				NextHop::NodeId(pubkey) => pubkey,
 				NextHop::ShortChannelId(_) => todo!(),
 			};
@@ -106,7 +106,7 @@ pub(crate) fn advance_path_by_one<NS: Deref, T: secp256k1::Signing + secp256k1::
 				}
 			};
 			mem::swap(&mut path.blinding_point, &mut new_blinding_point);
-			mem::swap(&mut path.introduction_node_id, &mut next_node_id);
+			path.introduction_node = IntroductionNode::NodeId(next_node_id);
 			Ok(())
 		},
 		_ => Err(())

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -33,7 +33,8 @@ pub(crate) struct ReceiveTlvs {
 }
 
 /// The next hop to forward the onion message along its path.
-pub(crate) enum NextHop {
+#[derive(Debug)]
+pub enum NextHop {
 	/// The node id of the next hop.
 	NodeId(PublicKey),
 	/// The short channel id leading to the next hop.

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -17,8 +17,8 @@ use core::ops::Deref;
 /// TLVs to encode in an intermediate onion message packet's hop data. When provided in a blinded
 /// route, they are encoded into [`BlindedHop::encrypted_payload`].
 pub(crate) struct ForwardTlvs {
-	/// The node id of the next hop in the onion message's path.
-	pub(crate) next_node_id: PublicKey,
+	/// The next hop in the onion message's path.
+	pub(crate) next_hop: NextHop,
 	/// Senders to a blinded path use this value to concatenate the route they find to the
 	/// introduction node with the blinded path.
 	pub(crate) next_blinding_override: Option<PublicKey>,
@@ -32,11 +32,24 @@ pub(crate) struct ReceiveTlvs {
 	pub(crate) path_id: Option<[u8; 32]>,
 }
 
+/// The next hop to forward the onion message along its path.
+pub(crate) enum NextHop {
+	/// The node id of the next hop.
+	NodeId(PublicKey),
+	/// The short channel id leading to the next hop.
+	ShortChannelId(u64),
+}
+
 impl Writeable for ForwardTlvs {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+		let (next_node_id, short_channel_id) = match self.next_hop {
+			NextHop::NodeId(pubkey) => (Some(pubkey), None),
+			NextHop::ShortChannelId(scid) => (None, Some(scid)),
+		};
 		// TODO: write padding
 		encode_tlv_stream!(writer, {
-			(4, self.next_node_id, required),
+			(2, short_channel_id, option),
+			(4, next_node_id, option),
 			(8, self.next_blinding_override, option)
 		});
 		Ok(())
@@ -59,9 +72,8 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 ) -> Result<Vec<BlindedHop>, secp256k1::Error> {
 	let blinded_tlvs = unblinded_path.iter()
 		.skip(1) // The first node's TLVs contains the next node's pubkey
-		.map(|pk| {
-			ControlTlvs::Forward(ForwardTlvs { next_node_id: *pk, next_blinding_override: None })
-		})
+		.map(|pk| ForwardTlvs { next_hop: NextHop::NodeId(*pk), next_blinding_override: None })
+		.map(|tlvs| ControlTlvs::Forward(tlvs))
 		.chain(core::iter::once(ControlTlvs::Receive(ReceiveTlvs { path_id: None })));
 
 	utils::construct_blinded_hops(secp_ctx, unblinded_path.iter(), blinded_tlvs, session_priv)
@@ -78,9 +90,13 @@ pub(crate) fn advance_path_by_one<NS: Deref, T: secp256k1::Signing + secp256k1::
 	let mut s = Cursor::new(&encrypted_control_tlvs);
 	let mut reader = FixedLengthReader::new(&mut s, encrypted_control_tlvs.len() as u64);
 	match ChaChaPolyReadAdapter::read(&mut reader, rho) {
-		Ok(ChaChaPolyReadAdapter { readable: ControlTlvs::Forward(ForwardTlvs {
-			mut next_node_id, next_blinding_override,
-		})}) => {
+		Ok(ChaChaPolyReadAdapter {
+			readable: ControlTlvs::Forward(ForwardTlvs { next_hop, next_blinding_override })
+		}) => {
+			let mut next_node_id = match next_hop {
+				NextHop::NodeId(pubkey) => pubkey,
+				NextHop::ShortChannelId(_) => todo!(),
+			};
 			let mut new_blinding_point = match next_blinding_override {
 				Some(blinding_point) => blinding_point,
 				None => {

--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -29,11 +29,11 @@ use crate::prelude::*;
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct BlindedPath {
 	/// To send to a blinded path, the sender first finds a route to the unblinded
-	/// `introduction_node_id`, which can unblind its [`encrypted_payload`] to find out the onion
+	/// `introduction_node`, which can unblind its [`encrypted_payload`] to find out the onion
 	/// message or payment's next hop and forward it along.
 	///
 	/// [`encrypted_payload`]: BlindedHop::encrypted_payload
-	pub introduction_node_id: PublicKey,
+	pub introduction_node: IntroductionNode,
 	/// Used by the introduction node to decrypt its [`encrypted_payload`] to forward the onion
 	/// message or payment.
 	///
@@ -41,6 +41,29 @@ pub struct BlindedPath {
 	pub blinding_point: PublicKey,
 	/// The hops composing the blinded path.
 	pub blinded_hops: Vec<BlindedHop>,
+}
+
+/// The unblinded node in a [`BlindedPath`].
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum IntroductionNode {
+	/// The node id of the introduction node.
+	NodeId(PublicKey),
+	/// The short channel id of the channel leading to the introduction node. The [`Direction`]
+	/// identifies which side of the channel is the introduction node.
+	DirectedShortChannelId(Direction, u64),
+}
+
+/// The side of a channel that is the [`IntroductionNode`] in a [`BlindedPath`]. [BOLT 7] defines
+/// which nodes is which in the [`ChannelAnnouncement`] message.
+///
+/// [BOLT 7]: https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#the-channel_announcement-message
+/// [`ChannelAnnouncement`]: crate::ln::msgs::ChannelAnnouncement
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum Direction {
+	/// The lesser node id when compared lexicographically in ascending order.
+	NodeOne,
+	/// The greater node id when compared lexicographically in ascending order.
+	NodeTwo,
 }
 
 /// An encrypted payload and node id corresponding to a hop in a payment or onion message path, to
@@ -75,10 +98,10 @@ impl BlindedPath {
 		if node_pks.is_empty() { return Err(()) }
 		let blinding_secret_bytes = entropy_source.get_secure_random_bytes();
 		let blinding_secret = SecretKey::from_slice(&blinding_secret_bytes[..]).expect("RNG is busted");
-		let introduction_node_id = node_pks[0];
+		let introduction_node = IntroductionNode::NodeId(node_pks[0]);
 
 		Ok(BlindedPath {
-			introduction_node_id,
+			introduction_node,
 			blinding_point: PublicKey::from_secret_key(secp_ctx, &blinding_secret),
 			blinded_hops: message::blinded_hops(secp_ctx, node_pks, &blinding_secret).map_err(|_| ())?,
 		})
@@ -112,6 +135,9 @@ impl BlindedPath {
 		payee_tlvs: payment::ReceiveTlvs, htlc_maximum_msat: u64, min_final_cltv_expiry_delta: u16,
 		entropy_source: &ES, secp_ctx: &Secp256k1<T>
 	) -> Result<(BlindedPayInfo, Self), ()> {
+		let introduction_node = IntroductionNode::NodeId(
+			intermediate_nodes.first().map_or(payee_node_id, |n| n.node_id)
+		);
 		let blinding_secret_bytes = entropy_source.get_secure_random_bytes();
 		let blinding_secret = SecretKey::from_slice(&blinding_secret_bytes[..]).expect("RNG is busted");
 
@@ -119,7 +145,7 @@ impl BlindedPath {
 			intermediate_nodes, &payee_tlvs, htlc_maximum_msat, min_final_cltv_expiry_delta
 		)?;
 		Ok((blinded_payinfo, BlindedPath {
-			introduction_node_id: intermediate_nodes.first().map_or(payee_node_id, |n| n.node_id),
+			introduction_node,
 			blinding_point: PublicKey::from_secret_key(secp_ctx, &blinding_secret),
 			blinded_hops: payment::blinded_hops(
 				secp_ctx, intermediate_nodes, payee_node_id, payee_tlvs, &blinding_secret
@@ -127,18 +153,40 @@ impl BlindedPath {
 		}))
 	}
 
-	/// Returns the introduction [`NodeId`] of the blinded path.
+	/// Returns the introduction [`NodeId`] of the blinded path, if found in the network graph.
 	pub fn introduction_node_id<'a>(
 		&self, network_graph: &'a ReadOnlyNetworkGraph
 	) -> Option<&'a NodeId> {
-		let node_id = NodeId::from_pubkey(&self.introduction_node_id);
-		network_graph.nodes().get_key_value(&node_id).map(|(key, _)| key)
+		match &self.introduction_node {
+			IntroductionNode::NodeId(pubkey) => {
+				let node_id = NodeId::from_pubkey(pubkey);
+				network_graph.nodes().get_key_value(&node_id).map(|(key, _)| key)
+			},
+			IntroductionNode::DirectedShortChannelId(direction, scid) => {
+				network_graph
+					.channel(*scid)
+					.map(|c| match direction {
+						Direction::NodeOne => &c.node_one,
+						Direction::NodeTwo => &c.node_two,
+					})
+			},
+		}
 	}
 }
 
 impl Writeable for BlindedPath {
 	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
-		self.introduction_node_id.write(w)?;
+		match &self.introduction_node {
+			IntroductionNode::NodeId(pubkey) => pubkey.write(w)?,
+			IntroductionNode::DirectedShortChannelId(direction, scid) => {
+				match direction {
+					Direction::NodeOne => 0u8.write(w)?,
+					Direction::NodeTwo => 1u8.write(w)?,
+				}
+				scid.write(w)?;
+			},
+		}
+
 		self.blinding_point.write(w)?;
 		(self.blinded_hops.len() as u8).write(w)?;
 		for hop in &self.blinded_hops {
@@ -150,7 +198,17 @@ impl Writeable for BlindedPath {
 
 impl Readable for BlindedPath {
 	fn read<R: io::Read>(r: &mut R) -> Result<Self, DecodeError> {
-		let introduction_node_id = Readable::read(r)?;
+		let mut first_byte: u8 = Readable::read(r)?;
+		let introduction_node = match first_byte {
+			0 => IntroductionNode::DirectedShortChannelId(Direction::NodeOne, Readable::read(r)?),
+			1 => IntroductionNode::DirectedShortChannelId(Direction::NodeTwo, Readable::read(r)?),
+			2|3 => {
+				use io::Read;
+				let mut pubkey_read = core::slice::from_mut(&mut first_byte).chain(r.by_ref());
+				IntroductionNode::NodeId(Readable::read(&mut pubkey_read)?)
+			},
+			_ => return Err(DecodeError::InvalidValue),
+		};
 		let blinding_point = Readable::read(r)?;
 		let num_hops: u8 = Readable::read(r)?;
 		if num_hops == 0 { return Err(DecodeError::InvalidValue) }
@@ -159,7 +217,7 @@ impl Readable for BlindedPath {
 			blinded_hops.push(Readable::read(r)?);
 		}
 		Ok(BlindedPath {
-			introduction_node_id,
+			introduction_node,
 			blinding_point,
 			blinded_hops,
 		})

--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -66,6 +66,24 @@ pub enum Direction {
 	NodeTwo,
 }
 
+/// An interface for looking up the node id of a channel counterparty for the purpose of forwarding
+/// an [`OnionMessage`].
+///
+/// [`OnionMessage`]: crate::ln::msgs::OnionMessage
+pub trait NodeIdLookUp {
+	/// Returns the node if of the channel counterparty with `short_channel_id`.
+	fn next_node_id(&self, short_channel_id: u64) -> Option<PublicKey>;
+}
+
+/// A [`NodeIdLookUp`] that always returns `None`.
+pub struct EmptyNodeIdLookUp {}
+
+impl NodeIdLookUp for EmptyNodeIdLookUp {
+	fn next_node_id(&self, _short_channel_id: u64) -> Option<PublicKey> {
+		None
+	}
+}
+
 /// An encrypted payload and node id corresponding to a hop in a payment or onion message path, to
 /// be encoded in the sender's onion packet. These hops cannot be identified by outside observers
 /// and thus can be used to hide the identity of the recipient.

--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -17,6 +17,7 @@ use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
 
 use crate::ln::msgs::DecodeError;
 use crate::offers::invoice::BlindedPayInfo;
+use crate::routing::gossip::{NodeId, ReadOnlyNetworkGraph};
 use crate::sign::EntropySource;
 use crate::util::ser::{Readable, Writeable, Writer};
 
@@ -124,6 +125,14 @@ impl BlindedPath {
 				secp_ctx, intermediate_nodes, payee_node_id, payee_tlvs, &blinding_secret
 			).map_err(|_| ())?,
 		}))
+	}
+
+	/// Returns the introduction [`NodeId`] of the blinded path.
+	pub fn introduction_node_id<'a>(
+		&self, network_graph: &'a ReadOnlyNetworkGraph
+	) -> Option<&'a NodeId> {
+		let node_id = NodeId::from_pubkey(&self.introduction_node_id);
+		network_graph.nodes().get_key_value(&node_id).map(|(key, _)| key)
 	}
 }
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -31,7 +31,7 @@ use bitcoin::secp256k1::{SecretKey,PublicKey};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{secp256k1, Sequence};
 
-use crate::blinded_path::BlindedPath;
+use crate::blinded_path::{BlindedPath, NodeIdLookUp};
 use crate::blinded_path::payment::{PaymentConstraints, ReceiveTlvs};
 use crate::chain;
 use crate::chain::{Confirm, ChannelMonitorUpdateStatus, Watch, BestBlock};
@@ -9525,6 +9525,23 @@ where
 
 	fn release_pending_messages(&self) -> Vec<PendingOnionMessage<OffersMessage>> {
 		core::mem::take(&mut self.pending_offers_messages.lock().unwrap())
+	}
+}
+
+impl<M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref, L: Deref>
+NodeIdLookUp for ChannelManager<M, T, ES, NS, SP, F, R, L>
+where
+	M::Target: chain::Watch<<SP::Target as SignerProvider>::EcdsaSigner>,
+	T::Target: BroadcasterInterface,
+	ES::Target: EntropySource,
+	NS::Target: NodeSigner,
+	SP::Target: SignerProvider,
+	F::Target: FeeEstimator,
+	R::Target: Router,
+	L::Target: Logger,
+{
+	fn next_node_id(&self, short_channel_id: u64) -> Option<PublicKey> {
+		self.short_to_chan_info.read().unwrap().get(&short_channel_id).map(|(pubkey, _)| *pubkey)
 	}
 }
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -415,6 +415,7 @@ type TestOnionMessenger<'chan_man, 'node_cfg, 'chan_mon_cfg> = OnionMessenger<
 	DedicatedEntropy,
 	&'node_cfg test_utils::TestKeysInterface,
 	&'chan_mon_cfg test_utils::TestLogger,
+	&'chan_man TestChannelManager<'node_cfg, 'chan_mon_cfg>,
 	&'node_cfg test_utils::TestMessageRouter<'chan_mon_cfg>,
 	&'chan_man TestChannelManager<'node_cfg, 'chan_mon_cfg>,
 	IgnoringMessageHandler,
@@ -3058,8 +3059,8 @@ pub fn create_network<'a, 'b: 'a, 'c: 'b>(node_count: usize, cfgs: &'b Vec<NodeC
 	for i in 0..node_count {
 		let dedicated_entropy = DedicatedEntropy(RandomBytes::new([i as u8; 32]));
 		let onion_messenger = OnionMessenger::new(
-			dedicated_entropy, cfgs[i].keys_manager, cfgs[i].logger, &cfgs[i].message_router,
-			&chan_mgrs[i], IgnoringMessageHandler {},
+			dedicated_entropy, cfgs[i].keys_manager, cfgs[i].logger, &chan_mgrs[i],
+			&cfgs[i].message_router, &chan_mgrs[i], IgnoringMessageHandler {},
 		);
 		let gossip_sync = P2PGossipSync::new(cfgs[i].network_graph.as_ref(), None, cfgs[i].logger);
 		let wallet_source = Arc::new(test_utils::TestWalletSource::new(SecretKey::from_slice(&[i as u8 + 1; 32]).unwrap()));

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -41,7 +41,7 @@
 //! blinded paths are used.
 
 use core::time::Duration;
-use crate::blinded_path::BlindedPath;
+use crate::blinded_path::{BlindedPath, IntroductionNode};
 use crate::events::{Event, MessageSendEventsProvider, PaymentPurpose};
 use crate::ln::channelmanager::{PaymentId, RecentPaymentDetails, Retry, self};
 use crate::ln::functional_test_utils::*;
@@ -259,8 +259,8 @@ fn prefers_non_tor_nodes_in_blinded_paths() {
 	assert_ne!(offer.signing_pubkey(), bob_id);
 	assert!(!offer.paths().is_empty());
 	for path in offer.paths() {
-		assert_ne!(path.introduction_node_id, bob_id);
-		assert_ne!(path.introduction_node_id, charlie_id);
+		assert_ne!(path.introduction_node, IntroductionNode::NodeId(bob_id));
+		assert_ne!(path.introduction_node, IntroductionNode::NodeId(charlie_id));
 	}
 
 	// Use a one-hop blinded path when Bob is announced and all his peers are Tor-only.
@@ -274,7 +274,7 @@ fn prefers_non_tor_nodes_in_blinded_paths() {
 	assert_ne!(offer.signing_pubkey(), bob_id);
 	assert!(!offer.paths().is_empty());
 	for path in offer.paths() {
-		assert_eq!(path.introduction_node_id, bob_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(bob_id));
 	}
 }
 
@@ -324,7 +324,7 @@ fn prefers_more_connected_nodes_in_blinded_paths() {
 	assert_ne!(offer.signing_pubkey(), bob_id);
 	assert!(!offer.paths().is_empty());
 	for path in offer.paths() {
-		assert_eq!(path.introduction_node_id, nodes[4].node.get_our_node_id());
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(nodes[4].node.get_our_node_id()));
 	}
 }
 
@@ -373,7 +373,7 @@ fn creates_and_pays_for_offer_using_two_hop_blinded_path() {
 	assert_ne!(offer.signing_pubkey(), alice_id);
 	assert!(!offer.paths().is_empty());
 	for path in offer.paths() {
-		assert_eq!(path.introduction_node_id, bob_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(bob_id));
 	}
 
 	let payment_id = PaymentId([1; 32]);
@@ -394,7 +394,7 @@ fn creates_and_pays_for_offer_using_two_hop_blinded_path() {
 	let (invoice_request, reply_path) = extract_invoice_request(alice, &onion_message);
 	assert_eq!(invoice_request.amount_msats(), None);
 	assert_ne!(invoice_request.payer_id(), david_id);
-	assert_eq!(reply_path.unwrap().introduction_node_id, charlie_id);
+	assert_eq!(reply_path.unwrap().introduction_node, IntroductionNode::NodeId(charlie_id));
 
 	let onion_message = alice.onion_messenger.next_onion_message_for_peer(charlie_id).unwrap();
 	charlie.onion_messenger.handle_onion_message(&alice_id, &onion_message);
@@ -407,7 +407,7 @@ fn creates_and_pays_for_offer_using_two_hop_blinded_path() {
 	assert_ne!(invoice.signing_pubkey(), alice_id);
 	assert!(!invoice.payment_paths().is_empty());
 	for (_, path) in invoice.payment_paths() {
-		assert_eq!(path.introduction_node_id, bob_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(bob_id));
 	}
 
 	route_bolt12_payment(david, &[charlie, bob, alice], &invoice);
@@ -468,7 +468,7 @@ fn creates_and_pays_for_refund_using_two_hop_blinded_path() {
 	assert_ne!(refund.payer_id(), david_id);
 	assert!(!refund.paths().is_empty());
 	for path in refund.paths() {
-		assert_eq!(path.introduction_node_id, charlie_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(charlie_id));
 	}
 	expect_recent_payment!(david, RecentPaymentDetails::AwaitingInvoice, payment_id);
 
@@ -487,7 +487,7 @@ fn creates_and_pays_for_refund_using_two_hop_blinded_path() {
 	assert_ne!(invoice.signing_pubkey(), alice_id);
 	assert!(!invoice.payment_paths().is_empty());
 	for (_, path) in invoice.payment_paths() {
-		assert_eq!(path.introduction_node_id, bob_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(bob_id));
 	}
 
 	route_bolt12_payment(david, &[charlie, bob, alice], &invoice);
@@ -521,7 +521,7 @@ fn creates_and_pays_for_offer_using_one_hop_blinded_path() {
 	assert_ne!(offer.signing_pubkey(), alice_id);
 	assert!(!offer.paths().is_empty());
 	for path in offer.paths() {
-		assert_eq!(path.introduction_node_id, alice_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(alice_id));
 	}
 
 	let payment_id = PaymentId([1; 32]);
@@ -534,7 +534,7 @@ fn creates_and_pays_for_offer_using_one_hop_blinded_path() {
 	let (invoice_request, reply_path) = extract_invoice_request(alice, &onion_message);
 	assert_eq!(invoice_request.amount_msats(), None);
 	assert_ne!(invoice_request.payer_id(), bob_id);
-	assert_eq!(reply_path.unwrap().introduction_node_id, bob_id);
+	assert_eq!(reply_path.unwrap().introduction_node, IntroductionNode::NodeId(bob_id));
 
 	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
 	bob.onion_messenger.handle_onion_message(&alice_id, &onion_message);
@@ -544,7 +544,7 @@ fn creates_and_pays_for_offer_using_one_hop_blinded_path() {
 	assert_ne!(invoice.signing_pubkey(), alice_id);
 	assert!(!invoice.payment_paths().is_empty());
 	for (_, path) in invoice.payment_paths() {
-		assert_eq!(path.introduction_node_id, alice_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(alice_id));
 	}
 
 	route_bolt12_payment(bob, &[alice], &invoice);
@@ -584,7 +584,7 @@ fn creates_and_pays_for_refund_using_one_hop_blinded_path() {
 	assert_ne!(refund.payer_id(), bob_id);
 	assert!(!refund.paths().is_empty());
 	for path in refund.paths() {
-		assert_eq!(path.introduction_node_id, bob_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(bob_id));
 	}
 	expect_recent_payment!(bob, RecentPaymentDetails::AwaitingInvoice, payment_id);
 
@@ -598,7 +598,7 @@ fn creates_and_pays_for_refund_using_one_hop_blinded_path() {
 	assert_ne!(invoice.signing_pubkey(), alice_id);
 	assert!(!invoice.payment_paths().is_empty());
 	for (_, path) in invoice.payment_paths() {
-		assert_eq!(path.introduction_node_id, alice_id);
+		assert_eq!(path.introduction_node, IntroductionNode::NodeId(alice_id));
 	}
 
 	route_bolt12_payment(bob, &[alice], &invoice);

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1454,7 +1454,7 @@ mod tests {
 	use bitcoin::key::TweakedPublicKey;
 	use core::convert::TryFrom;
 	use core::time::Duration;
-	use crate::blinded_path::{BlindedHop, BlindedPath};
+	use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 	use crate::sign::KeyMaterial;
 	use crate::ln::features::{Bolt12InvoiceFeatures, InvoiceRequestFeatures, OfferFeatures};
 	use crate::ln::inbound_payment::ExpandedKey;
@@ -1802,7 +1802,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 
 		let blinded_path = BlindedPath {
-			introduction_node_id: pubkey(40),
+			introduction_node: IntroductionNode::NodeId(pubkey(40)),
 			blinding_point: pubkey(41),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: pubkey(42), encrypted_payload: vec![0; 43] },

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -1063,7 +1063,7 @@ mod tests {
 	use core::convert::TryFrom;
 	use core::num::NonZeroU64;
 	use core::time::Duration;
-	use crate::blinded_path::{BlindedHop, BlindedPath};
+	use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 	use crate::sign::KeyMaterial;
 	use crate::ln::features::OfferFeatures;
 	use crate::ln::inbound_payment::ExpandedKey;
@@ -1234,7 +1234,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 
 		let blinded_path = BlindedPath {
-			introduction_node_id: pubkey(40),
+			introduction_node: IntroductionNode::NodeId(pubkey(40)),
 			blinding_point: pubkey(41),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: pubkey(42), encrypted_payload: vec![0; 43] },
@@ -1380,7 +1380,7 @@ mod tests {
 	fn builds_offer_with_paths() {
 		let paths = vec![
 			BlindedPath {
-				introduction_node_id: pubkey(40),
+				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
@@ -1388,7 +1388,7 @@ mod tests {
 				],
 			},
 			BlindedPath {
-				introduction_node_id: pubkey(40),
+				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(45), encrypted_payload: vec![0; 45] },
@@ -1570,7 +1570,7 @@ mod tests {
 	fn parses_offer_with_paths() {
 		let offer = OfferBuilder::new("foo".into(), pubkey(42))
 			.path(BlindedPath {
-				introduction_node_id: pubkey(40),
+				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
@@ -1578,7 +1578,7 @@ mod tests {
 				],
 			})
 			.path(BlindedPath {
-				introduction_node_id: pubkey(40),
+				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(45), encrypted_payload: vec![0; 45] },

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -896,7 +896,7 @@ mod tests {
 	use bitcoin::secp256k1::{KeyPair, Secp256k1, SecretKey};
 	use core::convert::TryFrom;
 	use core::time::Duration;
-	use crate::blinded_path::{BlindedHop, BlindedPath};
+	use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 	use crate::sign::KeyMaterial;
 	use crate::ln::channelmanager::PaymentId;
 	use crate::ln::features::{InvoiceRequestFeatures, OfferFeatures};
@@ -1050,7 +1050,7 @@ mod tests {
 		let payment_id = PaymentId([1; 32]);
 
 		let blinded_path = BlindedPath {
-			introduction_node_id: pubkey(40),
+			introduction_node: IntroductionNode::NodeId(pubkey(40)),
 			blinding_point: pubkey(41),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
@@ -1139,7 +1139,7 @@ mod tests {
 	fn builds_refund_with_paths() {
 		let paths = vec![
 			BlindedPath {
-				introduction_node_id: pubkey(40),
+				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
@@ -1147,7 +1147,7 @@ mod tests {
 				],
 			},
 			BlindedPath {
-				introduction_node_id: pubkey(40),
+				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(45), encrypted_payload: vec![0; 45] },
@@ -1356,7 +1356,7 @@ mod tests {
 		let past_expiry = Duration::from_secs(0);
 		let paths = vec![
 			BlindedPath {
-				introduction_node_id: pubkey(40),
+				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
@@ -1364,7 +1364,7 @@ mod tests {
 				],
 			},
 			BlindedPath {
-				introduction_node_id: pubkey(40),
+				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(45), encrypted_payload: vec![0; 45] },

--- a/lightning/src/offers/test_utils.rs
+++ b/lightning/src/offers/test_utils.rs
@@ -13,7 +13,7 @@ use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1, SecretKey};
 use bitcoin::secp256k1::schnorr::Signature;
 use core::convert::AsRef; 
 use core::time::Duration;
-use crate::blinded_path::{BlindedHop, BlindedPath};
+use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 use crate::sign::EntropySource;
 use crate::ln::PaymentHash;
 use crate::ln::features::BlindedHopFeatures;
@@ -66,7 +66,7 @@ pub(super) fn privkey(byte: u8) -> SecretKey {
 pub(crate) fn payment_paths() -> Vec<(BlindedPayInfo, BlindedPath)> {
 	let paths = vec![
 		BlindedPath {
-			introduction_node_id: pubkey(40),
+			introduction_node: IntroductionNode::NodeId(pubkey(40)),
 			blinding_point: pubkey(41),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
@@ -74,7 +74,7 @@ pub(crate) fn payment_paths() -> Vec<(BlindedPayInfo, BlindedPath)> {
 			],
 		},
 		BlindedPath {
-			introduction_node_id: pubkey(40),
+			introduction_node: IntroductionNode::NodeId(pubkey(40)),
 			blinding_point: pubkey(41),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: pubkey(45), encrypted_payload: vec![0; 45] },

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -9,7 +9,7 @@
 
 //! Onion message testing and test utilities live here.
 
-use crate::blinded_path::BlindedPath;
+use crate::blinded_path::{BlindedPath, EmptyNodeIdLookUp};
 use crate::events::{Event, EventsProvider};
 use crate::ln::features::{ChannelFeatures, InitFeatures};
 use crate::ln::msgs::{self, DecodeError, OnionMessageHandler};
@@ -42,6 +42,7 @@ struct MessengerNode {
 		Arc<test_utils::TestKeysInterface>,
 		Arc<test_utils::TestNodeSigner>,
 		Arc<test_utils::TestLogger>,
+		Arc<EmptyNodeIdLookUp>,
 		Arc<DefaultMessageRouter<
 			Arc<NetworkGraph<Arc<test_utils::TestLogger>>>,
 			Arc<test_utils::TestLogger>,
@@ -175,6 +176,7 @@ fn create_nodes_using_secrets(secrets: Vec<SecretKey>) -> Vec<MessengerNode> {
 		let entropy_source = Arc::new(test_utils::TestKeysInterface::new(&seed, Network::Testnet));
 		let node_signer = Arc::new(test_utils::TestNodeSigner::new(secret_key));
 
+		let node_id_lookup = Arc::new(EmptyNodeIdLookUp {});
 		let message_router = Arc::new(
 			DefaultMessageRouter::new(network_graph.clone(), entropy_source.clone())
 		);
@@ -185,7 +187,7 @@ fn create_nodes_using_secrets(secrets: Vec<SecretKey>) -> Vec<MessengerNode> {
 			node_id: node_signer.get_node_id(Recipient::Node).unwrap(),
 			entropy_source: entropy_source.clone(),
 			messenger: OnionMessenger::new(
-				entropy_source, node_signer, logger.clone(), message_router,
+				entropy_source, node_signer, logger.clone(), node_id_lookup, message_router,
 				offers_message_handler, custom_message_handler.clone()
 			),
 			custom_message_handler,

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -15,7 +15,7 @@ use bitcoin::hashes::hmac::{Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::{self, PublicKey, Scalar, Secp256k1, SecretKey};
 
-use crate::blinded_path::BlindedPath;
+use crate::blinded_path::{BlindedPath, IntroductionNode};
 use crate::blinded_path::message::{advance_path_by_one, ForwardTlvs, NextHop, ReceiveTlvs};
 use crate::blinded_path::utils;
 use crate::events::{Event, EventHandler, EventsProvider};
@@ -444,7 +444,12 @@ impl Destination {
 	fn first_node(&self) -> PublicKey {
 		match self {
 			Destination::Node(node_id) => *node_id,
-			Destination::BlindedPath(BlindedPath { introduction_node_id: node_id, .. }) => *node_id,
+			Destination::BlindedPath(BlindedPath { introduction_node, .. }) => {
+				match introduction_node {
+					IntroductionNode::NodeId(pubkey) => *pubkey,
+					IntroductionNode::DirectedShortChannelId(..) => todo!(),
+				}
+			},
 		}
 	}
 }
@@ -569,9 +574,13 @@ where
 	// advance the blinded path by 1 hop so the second hop is the new introduction node.
 	if intermediate_nodes.len() == 0 {
 		if let Destination::BlindedPath(ref mut blinded_path) = destination {
+			let introduction_node_id = match blinded_path.introduction_node {
+				IntroductionNode::NodeId(pubkey) => pubkey,
+				IntroductionNode::DirectedShortChannelId(..) => todo!(),
+			};
 			let our_node_id = node_signer.get_node_id(Recipient::Node)
 				.map_err(|()| SendError::GetNodeIdFailed)?;
-			if blinded_path.introduction_node_id == our_node_id {
+			if introduction_node_id == our_node_id {
 				advance_path_by_one(blinded_path, node_signer, &secp_ctx)
 					.map_err(|()| SendError::BlindedPathAdvanceFailed)?;
 			}
@@ -583,10 +592,14 @@ where
 	let (first_node_id, blinding_point) = if let Some(first_node_id) = intermediate_nodes.first() {
 		(*first_node_id, PublicKey::from_secret_key(&secp_ctx, &blinding_secret))
 	} else {
-		match destination {
-			Destination::Node(pk) => (pk, PublicKey::from_secret_key(&secp_ctx, &blinding_secret)),
-			Destination::BlindedPath(BlindedPath { introduction_node_id, blinding_point, .. }) =>
-				(introduction_node_id, blinding_point),
+		match &destination {
+			Destination::Node(pk) => (*pk, PublicKey::from_secret_key(&secp_ctx, &blinding_secret)),
+			Destination::BlindedPath(BlindedPath { introduction_node, blinding_point, .. }) => {
+				match introduction_node {
+					IntroductionNode::NodeId(pubkey) => (*pubkey, *blinding_point),
+					IntroductionNode::DirectedShortChannelId(..) => todo!(),
+				}
+			}
 		}
 	};
 	let (packet_payloads, packet_keys) = packet_payloads_and_keys(
@@ -1123,9 +1136,16 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 	let mut payloads = Vec::with_capacity(num_hops);
 	let mut onion_packet_keys = Vec::with_capacity(num_hops);
 
-	let (mut intro_node_id_blinding_pt, num_blinded_hops) = if let Destination::BlindedPath(BlindedPath {
-		introduction_node_id, blinding_point, blinded_hops }) = &destination {
-		(Some((*introduction_node_id, *blinding_point)), blinded_hops.len()) } else { (None, 0) };
+	let (mut intro_node_id_blinding_pt, num_blinded_hops) = match &destination {
+		Destination::Node(_) => (None, 0),
+		Destination::BlindedPath(BlindedPath { introduction_node, blinding_point, blinded_hops }) => {
+			let introduction_node_id = match introduction_node {
+				IntroductionNode::NodeId(pubkey) => pubkey,
+				IntroductionNode::DirectedShortChannelId(..) => todo!(),
+			};
+			(Some((*introduction_node_id, *blinding_point)), blinded_hops.len())
+		},
+	};
 	let num_unblinded_hops = num_hops - num_blinded_hops;
 
 	let mut unblinded_path_idx = 0;

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -538,7 +538,7 @@ pub trait CustomOnionMessageHandler {
 #[derive(Debug)]
 pub enum PeeledOnion<T: OnionMessageContents> {
 	/// Forwarded onion, with the next node id and a new onion
-	Forward(PublicKey, OnionMessage),
+	Forward(NextHop, OnionMessage),
 	/// Received onion message, with decrypted contents, path_id, and reply path
 	Receive(ParsedOnionMessageContents<T>, Option<[u8; 32]>, Option<BlindedPath>)
 }
@@ -685,12 +685,7 @@ where
 				onion_routing_packet: outgoing_packet,
 			};
 
-			let next_node_id = match next_hop {
-				NextHop::NodeId(pubkey) => pubkey,
-				NextHop::ShortChannelId(_) => todo!(),
-			};
-
-			Ok(PeeledOnion::Forward(next_node_id, onion_message))
+			Ok(PeeledOnion::Forward(next_hop, onion_message))
 		},
 		Err(e) => {
 			log_trace!(logger, "Errored decoding onion message packet: {:?}", e);
@@ -959,7 +954,12 @@ where
 					},
 				}
 			},
-			Ok(PeeledOnion::Forward(next_node_id, onion_message)) => {
+			Ok(PeeledOnion::Forward(next_hop, onion_message)) => {
+				let next_node_id = match next_hop {
+					NextHop::NodeId(pubkey) => pubkey,
+					NextHop::ShortChannelId(_) => todo!(),
+				};
+
 				let mut message_recipients = self.message_recipients.lock().unwrap();
 				if outbound_buffer_full(&next_node_id, &message_recipients) {
 					log_trace!(self.logger, "Dropping forwarded onion message to peer {:?}: outbound buffer full", next_node_id);

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -16,7 +16,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::{self, PublicKey, Scalar, Secp256k1, SecretKey};
 
 use crate::blinded_path::BlindedPath;
-use crate::blinded_path::message::{advance_path_by_one, ForwardTlvs, ReceiveTlvs};
+use crate::blinded_path::message::{advance_path_by_one, ForwardTlvs, NextHop, ReceiveTlvs};
 use crate::blinded_path::utils;
 use crate::events::{Event, EventHandler, EventsProvider};
 use crate::sign::{EntropySource, NodeSigner, Recipient};
@@ -647,9 +647,9 @@ where
 			Ok(PeeledOnion::Receive(message, path_id, reply_path))
 		},
 		Ok((Payload::Forward(ForwardControlTlvs::Unblinded(ForwardTlvs {
-			next_node_id, next_blinding_override
+			next_hop, next_blinding_override
 		})), Some((next_hop_hmac, new_packet_bytes)))) => {
-			// TODO: we need to check whether `next_node_id` is our node, in which case this is a dummy
+			// TODO: we need to check whether `next_hop` is our node, in which case this is a dummy
 			// blinded hop and this onion message is destined for us. In this situation, we should keep
 			// unwrapping the onion layers to get to the final payload. Since we don't have the option
 			// of creating blinded paths with dummy hops currently, we should be ok to not handle this
@@ -683,6 +683,11 @@ where
 					}
 				},
 				onion_routing_packet: outgoing_packet,
+			};
+
+			let next_node_id = match next_hop {
+				NextHop::NodeId(pubkey) => pubkey,
+				NextHop::ShortChannelId(_) => todo!(),
 			};
 
 			Ok(PeeledOnion::Forward(next_node_id, onion_message))
@@ -1133,7 +1138,7 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 				if let Some(ss) = prev_control_tlvs_ss.take() {
 					payloads.push((Payload::Forward(ForwardControlTlvs::Unblinded(
 						ForwardTlvs {
-							next_node_id: unblinded_pk_opt.unwrap(),
+							next_hop: NextHop::NodeId(unblinded_pk_opt.unwrap()),
 							next_blinding_override: None,
 						}
 					)), ss));
@@ -1143,7 +1148,7 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 			} else if let Some((intro_node_id, blinding_pt)) = intro_node_id_blinding_pt.take() {
 				if let Some(control_tlvs_ss) = prev_control_tlvs_ss.take() {
 					payloads.push((Payload::Forward(ForwardControlTlvs::Unblinded(ForwardTlvs {
-						next_node_id: intro_node_id,
+						next_hop: NextHop::NodeId(intro_node_id),
 						next_blinding_override: Some(blinding_pt),
 					})), control_tlvs_ss));
 				}

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -15,7 +15,7 @@ use bitcoin::hashes::hmac::{Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::{self, PublicKey, Scalar, Secp256k1, SecretKey};
 
-use crate::blinded_path::{BlindedPath, Direction, IntroductionNode};
+use crate::blinded_path::{BlindedPath, Direction, IntroductionNode, NodeIdLookUp};
 use crate::blinded_path::message::{advance_path_by_one, ForwardTlvs, NextHop, ReceiveTlvs};
 use crate::blinded_path::utils;
 use crate::events::{Event, EventHandler, EventsProvider};
@@ -70,7 +70,7 @@ pub(super) const MAX_TIMER_TICKS: usize = 2;
 /// # use bitcoin::hashes::_export::_core::time::Duration;
 /// # use bitcoin::hashes::hex::FromHex;
 /// # use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey, self};
-/// # use lightning::blinded_path::BlindedPath;
+/// # use lightning::blinded_path::{BlindedPath, EmptyNodeIdLookUp};
 /// # use lightning::sign::{EntropySource, KeysManager};
 /// # use lightning::ln::peer_handler::IgnoringMessageHandler;
 /// # use lightning::onion_message::messenger::{Destination, MessageRouter, OnionMessagePath, OnionMessenger};
@@ -111,14 +111,15 @@ pub(super) const MAX_TIMER_TICKS: usize = 2;
 /// # let hop_node_id1 = PublicKey::from_secret_key(&secp_ctx, &node_secret);
 /// # let (hop_node_id3, hop_node_id4) = (hop_node_id1, hop_node_id1);
 /// # let destination_node_id = hop_node_id1;
+/// # let node_id_lookup = EmptyNodeIdLookUp {};
 /// # let message_router = Arc::new(FakeMessageRouter {});
 /// # let custom_message_handler = IgnoringMessageHandler {};
 /// # let offers_message_handler = IgnoringMessageHandler {};
 /// // Create the onion messenger. This must use the same `keys_manager` as is passed to your
 /// // ChannelManager.
 /// let onion_messenger = OnionMessenger::new(
-///     &keys_manager, &keys_manager, logger, message_router, &offers_message_handler,
-///     &custom_message_handler
+///     &keys_manager, &keys_manager, logger, &node_id_lookup, message_router,
+///     &offers_message_handler, &custom_message_handler
 /// );
 
 /// # #[derive(Debug)]
@@ -155,11 +156,12 @@ pub(super) const MAX_TIMER_TICKS: usize = 2;
 ///
 /// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 /// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
-pub struct OnionMessenger<ES: Deref, NS: Deref, L: Deref, MR: Deref, OMH: Deref, CMH: Deref>
+pub struct OnionMessenger<ES: Deref, NS: Deref, L: Deref, NL: Deref, MR: Deref, OMH: Deref, CMH: Deref>
 where
 	ES::Target: EntropySource,
 	NS::Target: NodeSigner,
 	L::Target: Logger,
+	NL::Target: NodeIdLookUp,
 	MR::Target: MessageRouter,
 	OMH::Target: OffersMessageHandler,
 	CMH::Target: CustomOnionMessageHandler,
@@ -169,6 +171,7 @@ where
 	logger: L,
 	message_recipients: Mutex<HashMap<PublicKey, OnionMessageRecipient>>,
 	secp_ctx: Secp256k1<secp256k1::All>,
+	node_id_lookup: NL,
 	message_router: MR,
 	offers_handler: OMH,
 	custom_handler: CMH,
@@ -584,13 +587,15 @@ pub enum PeeledOnion<T: OnionMessageContents> {
 ///
 /// Returns the node id of the peer to send the message to, the message itself, and any addresses
 /// need to connect to the first node.
-pub fn create_onion_message<ES: Deref, NS: Deref, T: OnionMessageContents>(
-	entropy_source: &ES, node_signer: &NS, secp_ctx: &Secp256k1<secp256k1::All>,
-	path: OnionMessagePath, contents: T, reply_path: Option<BlindedPath>,
+pub fn create_onion_message<ES: Deref, NS: Deref, NL: Deref, T: OnionMessageContents>(
+	entropy_source: &ES, node_signer: &NS, node_id_lookup: &NL,
+	secp_ctx: &Secp256k1<secp256k1::All>, path: OnionMessagePath, contents: T,
+	reply_path: Option<BlindedPath>,
 ) -> Result<(PublicKey, OnionMessage, Option<Vec<SocketAddress>>), SendError>
 where
 	ES::Target: EntropySource,
 	NS::Target: NodeSigner,
+	NL::Target: NodeIdLookUp,
 {
 	let OnionMessagePath { intermediate_nodes, mut destination, first_node_addresses } = path;
 	if let Destination::BlindedPath(BlindedPath { ref blinded_hops, .. }) = destination {
@@ -614,7 +619,7 @@ where
 			let our_node_id = node_signer.get_node_id(Recipient::Node)
 				.map_err(|()| SendError::GetNodeIdFailed)?;
 			if introduction_node_id == our_node_id {
-				advance_path_by_one(blinded_path, node_signer, &secp_ctx)
+				advance_path_by_one(blinded_path, node_signer, node_id_lookup, &secp_ctx)
 					.map_err(|()| SendError::BlindedPathAdvanceFailed)?;
 			}
 		}
@@ -746,12 +751,13 @@ where
 	}
 }
 
-impl<ES: Deref, NS: Deref, L: Deref, MR: Deref, OMH: Deref, CMH: Deref>
-OnionMessenger<ES, NS, L, MR, OMH, CMH>
+impl<ES: Deref, NS: Deref, L: Deref, NL: Deref, MR: Deref, OMH: Deref, CMH: Deref>
+OnionMessenger<ES, NS, L, NL, MR, OMH, CMH>
 where
 	ES::Target: EntropySource,
 	NS::Target: NodeSigner,
 	L::Target: Logger,
+	NL::Target: NodeIdLookUp,
 	MR::Target: MessageRouter,
 	OMH::Target: OffersMessageHandler,
 	CMH::Target: CustomOnionMessageHandler,
@@ -759,8 +765,8 @@ where
 	/// Constructs a new `OnionMessenger` to send, forward, and delegate received onion messages to
 	/// their respective handlers.
 	pub fn new(
-		entropy_source: ES, node_signer: NS, logger: L, message_router: MR, offers_handler: OMH,
-		custom_handler: CMH
+		entropy_source: ES, node_signer: NS, logger: L, node_id_lookup: NL, message_router: MR,
+		offers_handler: OMH, custom_handler: CMH
 	) -> Self {
 		let mut secp_ctx = Secp256k1::new();
 		secp_ctx.seeded_randomize(&entropy_source.get_secure_random_bytes());
@@ -770,6 +776,7 @@ where
 			message_recipients: Mutex::new(new_hash_map()),
 			secp_ctx,
 			logger,
+			node_id_lookup,
 			message_router,
 			offers_handler,
 			custom_handler,
@@ -846,7 +853,8 @@ where
 		log_trace!(self.logger, "Constructing onion message {}: {:?}", log_suffix, contents);
 
 		let (first_node_id, onion_message, addresses) = create_onion_message(
-			&self.entropy_source, &self.node_signer, &self.secp_ctx, path, contents, reply_path
+			&self.entropy_source, &self.node_signer, &self.node_id_lookup, &self.secp_ctx, path,
+			contents, reply_path,
 		)?;
 
 		let mut message_recipients = self.message_recipients.lock().unwrap();
@@ -942,12 +950,13 @@ fn outbound_buffer_full(peer_node_id: &PublicKey, buffer: &HashMap<PublicKey, On
 	false
 }
 
-impl<ES: Deref, NS: Deref, L: Deref, MR: Deref, OMH: Deref, CMH: Deref> EventsProvider
-for OnionMessenger<ES, NS, L, MR, OMH, CMH>
+impl<ES: Deref, NS: Deref, L: Deref, NL: Deref, MR: Deref, OMH: Deref, CMH: Deref> EventsProvider
+for OnionMessenger<ES, NS, L, NL, MR, OMH, CMH>
 where
 	ES::Target: EntropySource,
 	NS::Target: NodeSigner,
 	L::Target: Logger,
+	NL::Target: NodeIdLookUp,
 	MR::Target: MessageRouter,
 	OMH::Target: OffersMessageHandler,
 	CMH::Target: CustomOnionMessageHandler,
@@ -963,12 +972,13 @@ where
 	}
 }
 
-impl<ES: Deref, NS: Deref, L: Deref, MR: Deref, OMH: Deref, CMH: Deref> OnionMessageHandler
-for OnionMessenger<ES, NS, L, MR, OMH, CMH>
+impl<ES: Deref, NS: Deref, L: Deref, NL: Deref, MR: Deref, OMH: Deref, CMH: Deref> OnionMessageHandler
+for OnionMessenger<ES, NS, L, NL, MR, OMH, CMH>
 where
 	ES::Target: EntropySource,
 	NS::Target: NodeSigner,
 	L::Target: Logger,
+	NL::Target: NodeIdLookUp,
 	MR::Target: MessageRouter,
 	OMH::Target: OffersMessageHandler,
 	CMH::Target: CustomOnionMessageHandler,
@@ -1005,7 +1015,13 @@ where
 			Ok(PeeledOnion::Forward(next_hop, onion_message)) => {
 				let next_node_id = match next_hop {
 					NextHop::NodeId(pubkey) => pubkey,
-					NextHop::ShortChannelId(_) => todo!(),
+					NextHop::ShortChannelId(scid) => match self.node_id_lookup.next_node_id(scid) {
+						Some(pubkey) => pubkey,
+						None => {
+							log_trace!(self.logger, "Dropping forwarded onion message to unresolved peer using SCID {}", scid);
+							return
+						},
+					},
 				};
 
 				let mut message_recipients = self.message_recipients.lock().unwrap();
@@ -1137,6 +1153,7 @@ pub type SimpleArcOnionMessenger<M, T, F, L> = OnionMessenger<
 	Arc<KeysManager>,
 	Arc<KeysManager>,
 	Arc<L>,
+	Arc<SimpleArcChannelManager<M, T, F, L>>,
 	Arc<DefaultMessageRouter<Arc<NetworkGraph<Arc<L>>>, Arc<L>, Arc<KeysManager>>>,
 	Arc<SimpleArcChannelManager<M, T, F, L>>,
 	IgnoringMessageHandler
@@ -1156,8 +1173,9 @@ pub type SimpleRefOnionMessenger<
 	&'a KeysManager,
 	&'a KeysManager,
 	&'b L,
-	&'i DefaultMessageRouter<&'g NetworkGraph<&'b L>, &'b L, &'a KeysManager>,
-	&'j SimpleRefChannelManager<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, M, T, F, L>,
+	&'i SimpleRefChannelManager<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, M, T, F, L>,
+	&'j DefaultMessageRouter<&'g NetworkGraph<&'b L>, &'b L, &'a KeysManager>,
+	&'i SimpleRefChannelManager<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, M, T, F, L>,
 	IgnoringMessageHandler
 >;
 

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -15,7 +15,7 @@ use bitcoin::hashes::hmac::{Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::{self, PublicKey, Scalar, Secp256k1, SecretKey};
 
-use crate::blinded_path::{BlindedPath, IntroductionNode};
+use crate::blinded_path::{BlindedPath, Direction, IntroductionNode};
 use crate::blinded_path::message::{advance_path_by_one, ForwardTlvs, NextHop, ReceiveTlvs};
 use crate::blinded_path::utils;
 use crate::events::{Event, EventHandler, EventsProvider};
@@ -23,7 +23,7 @@ use crate::sign::{EntropySource, NodeSigner, Recipient};
 use crate::ln::features::{InitFeatures, NodeFeatures};
 use crate::ln::msgs::{self, OnionMessage, OnionMessageHandler, SocketAddress};
 use crate::ln::onion_utils;
-use crate::routing::gossip::{NetworkGraph, NodeId};
+use crate::routing::gossip::{NetworkGraph, NodeId, ReadOnlyNetworkGraph};
 use super::packet::OnionMessageContents;
 use super::packet::ParsedOnionMessageContents;
 use super::offers::OffersMessageHandler;
@@ -318,15 +318,21 @@ where
 	ES::Target: EntropySource,
 {
 	fn find_path(
-		&self, sender: PublicKey, peers: Vec<PublicKey>, destination: Destination
+		&self, sender: PublicKey, peers: Vec<PublicKey>, mut destination: Destination
 	) -> Result<OnionMessagePath, ()> {
-		let first_node = destination.first_node();
+		let network_graph = self.network_graph.deref().read_only();
+		destination.resolve(&network_graph);
+
+		let first_node = match destination.first_node() {
+			Some(first_node) => first_node,
+			None => return Err(()),
+		};
+
 		if peers.contains(&first_node) || sender == first_node {
 			Ok(OnionMessagePath {
 				intermediate_nodes: vec![], destination, first_node_addresses: None
 			})
 		} else {
-			let network_graph = self.network_graph.deref().read_only();
 			let node_announcement = network_graph
 				.node(&NodeId::from_pubkey(&first_node))
 				.and_then(|node_info| node_info.announcement_info.as_ref())
@@ -416,11 +422,11 @@ pub struct OnionMessagePath {
 
 impl OnionMessagePath {
 	/// Returns the first node in the path.
-	pub fn first_node(&self) -> PublicKey {
+	pub fn first_node(&self) -> Option<PublicKey> {
 		self.intermediate_nodes
 			.first()
 			.copied()
-			.unwrap_or_else(|| self.destination.first_node())
+			.or_else(|| self.destination.first_node())
 	}
 }
 
@@ -434,6 +440,27 @@ pub enum Destination {
 }
 
 impl Destination {
+	/// Attempts to resolve the [`IntroductionNode::DirectedShortChannelId`] of a
+	/// [`Destination::BlindedPath`] to a [`IntroductionNode::NodeId`], if applicable, using the
+	/// provided [`ReadOnlyNetworkGraph`].
+	pub fn resolve(&mut self, network_graph: &ReadOnlyNetworkGraph) {
+		if let Destination::BlindedPath(path) = self {
+			let introduction_node = &mut path.introduction_node;
+			if let IntroductionNode::DirectedShortChannelId(direction, scid) = introduction_node {
+				let pubkey = network_graph
+					.channel(*scid)
+					.map(|c| match direction {
+						Direction::NodeOne => c.node_one,
+						Direction::NodeTwo => c.node_two,
+					})
+					.and_then(|node_id| node_id.as_pubkey().ok());
+				if let Some(pubkey) = pubkey {
+					*introduction_node = IntroductionNode::NodeId(pubkey);
+				}
+			}
+		}
+	}
+
 	pub(super) fn num_hops(&self) -> usize {
 		match self {
 			Destination::Node(_) => 1,
@@ -441,13 +468,13 @@ impl Destination {
 		}
 	}
 
-	fn first_node(&self) -> PublicKey {
+	fn first_node(&self) -> Option<PublicKey> {
 		match self {
-			Destination::Node(node_id) => *node_id,
+			Destination::Node(node_id) => Some(*node_id),
 			Destination::BlindedPath(BlindedPath { introduction_node, .. }) => {
 				match introduction_node {
-					IntroductionNode::NodeId(pubkey) => *pubkey,
-					IntroductionNode::DirectedShortChannelId(..) => todo!(),
+					IntroductionNode::NodeId(pubkey) => Some(*pubkey),
+					IntroductionNode::DirectedShortChannelId(..) => None,
 				}
 			},
 		}
@@ -492,6 +519,10 @@ pub enum SendError {
 	///
 	/// [`NodeSigner`]: crate::sign::NodeSigner
 	GetNodeIdFailed,
+	/// The provided [`Destination`] has a blinded path with an unresolved introduction node. An
+	/// attempt to resolved it in the [`MessageRouter`] when finding an [`OnionMessagePath`] likely
+	/// failed.
+	UnresolvedIntroductionNode,
 	/// We attempted to send to a blinded path where we are the introduction node, and failed to
 	/// advance the blinded path to make the second hop the new introduction node. Either
 	/// [`NodeSigner::ecdh`] failed, we failed to tweak the current blinding point to get the
@@ -576,7 +607,9 @@ where
 		if let Destination::BlindedPath(ref mut blinded_path) = destination {
 			let introduction_node_id = match blinded_path.introduction_node {
 				IntroductionNode::NodeId(pubkey) => pubkey,
-				IntroductionNode::DirectedShortChannelId(..) => todo!(),
+				IntroductionNode::DirectedShortChannelId(..) => {
+					return Err(SendError::UnresolvedIntroductionNode);
+				},
 			};
 			let our_node_id = node_signer.get_node_id(Recipient::Node)
 				.map_err(|()| SendError::GetNodeIdFailed)?;
@@ -597,14 +630,16 @@ where
 			Destination::BlindedPath(BlindedPath { introduction_node, blinding_point, .. }) => {
 				match introduction_node {
 					IntroductionNode::NodeId(pubkey) => (*pubkey, *blinding_point),
-					IntroductionNode::DirectedShortChannelId(..) => todo!(),
+					IntroductionNode::DirectedShortChannelId(..) => {
+						return Err(SendError::UnresolvedIntroductionNode);
+					},
 				}
 			}
 		}
 	};
 	let (packet_payloads, packet_keys) = packet_payloads_and_keys(
-		&secp_ctx, &intermediate_nodes, destination, contents, reply_path, &blinding_secret)
-		.map_err(|e| SendError::Secp256k1(e))?;
+		&secp_ctx, &intermediate_nodes, destination, contents, reply_path, &blinding_secret
+	)?;
 
 	let prng_seed = entropy_source.get_secure_random_bytes();
 	let onion_routing_packet = construct_onion_message_packet(
@@ -1131,7 +1166,7 @@ pub type SimpleRefOnionMessenger<
 fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<S>, unblinded_path: &[PublicKey], destination: Destination, message: T,
 	mut reply_path: Option<BlindedPath>, session_priv: &SecretKey
-) -> Result<(Vec<(Payload<T>, [u8; 32])>, Vec<onion_utils::OnionKeys>), secp256k1::Error> {
+) -> Result<(Vec<(Payload<T>, [u8; 32])>, Vec<onion_utils::OnionKeys>), SendError> {
 	let num_hops = unblinded_path.len() + destination.num_hops();
 	let mut payloads = Vec::with_capacity(num_hops);
 	let mut onion_packet_keys = Vec::with_capacity(num_hops);
@@ -1141,7 +1176,9 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 		Destination::BlindedPath(BlindedPath { introduction_node, blinding_point, blinded_hops }) => {
 			let introduction_node_id = match introduction_node {
 				IntroductionNode::NodeId(pubkey) => pubkey,
-				IntroductionNode::DirectedShortChannelId(..) => todo!(),
+				IntroductionNode::DirectedShortChannelId(..) => {
+					return Err(SendError::UnresolvedIntroductionNode);
+				},
 			};
 			(Some((*introduction_node_id, *blinding_point)), blinded_hops.len())
 		},
@@ -1193,7 +1230,7 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 				mu,
 			});
 		}
-	)?;
+	).map_err(|e| SendError::Secp256k1(e))?;
 
 	if let Some(control_tlvs) = final_control_tlvs {
 		payloads.push((Payload::Receive {

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -1181,6 +1181,11 @@ pub struct PrivateHopCandidate<'a> {
 /// A [`CandidateRouteHop::Blinded`] entry.
 #[derive(Clone, Debug)]
 pub struct BlindedPathCandidate<'a> {
+	/// The node id of the introduction node, resolved from either the [`NetworkGraph`] or first
+	/// hops.
+	///
+	/// This is not exported to bindings users as lifetimes are not expressable in most languages.
+	pub source_node_id: &'a NodeId,
 	/// Information about the blinded path including the fee, HTLC amount limits, and
 	/// cryptographic material required to build an HTLC through the given path.
 	///
@@ -1196,6 +1201,11 @@ pub struct BlindedPathCandidate<'a> {
 /// A [`CandidateRouteHop::OneHopBlinded`] entry.
 #[derive(Clone, Debug)]
 pub struct OneHopBlindedPathCandidate<'a> {
+	/// The node id of the introduction node, resolved from either the [`NetworkGraph`] or first
+	/// hops.
+	///
+	/// This is not exported to bindings users as lifetimes are not expressable in most languages.
+	pub source_node_id: &'a NodeId,
 	/// Information about the blinded path including the fee, HTLC amount limits, and
 	/// cryptographic material required to build an HTLC terminating with the given path.
 	///
@@ -1409,8 +1419,8 @@ impl<'a> CandidateRouteHop<'a> {
 			CandidateRouteHop::FirstHop(hop) => *hop.payer_node_id,
 			CandidateRouteHop::PublicHop(hop) => *hop.info.source(),
 			CandidateRouteHop::PrivateHop(hop) => hop.hint.src_node_id.into(),
-			CandidateRouteHop::Blinded(hop) => hop.hint.1.introduction_node_id.into(),
-			CandidateRouteHop::OneHopBlinded(hop) => hop.hint.1.introduction_node_id.into(),
+			CandidateRouteHop::Blinded(hop) => *hop.source_node_id,
+			CandidateRouteHop::OneHopBlinded(hop) => *hop.source_node_id,
 		}
 	}
 	/// Returns the target node id of this hop, if known.
@@ -2515,26 +2525,38 @@ where L::Target: Logger {
 		// earlier than general path finding, they will be somewhat prioritized, although currently
 		// it matters only if the fees are exactly the same.
 		for (hint_idx, hint) in payment_params.payee.blinded_route_hints().iter().enumerate() {
-			let intro_node_id = NodeId::from_pubkey(&hint.1.introduction_node_id);
-			let have_intro_node_in_graph =
-				// Only add the hops in this route to our candidate set if either
-				// we have a direct channel to the first hop or the first hop is
-				// in the regular network graph.
-				first_hop_targets.get(&intro_node_id).is_some() ||
-				network_nodes.get(&intro_node_id).is_some();
-			if !have_intro_node_in_graph || our_node_id == intro_node_id { continue }
+			// Only add the hops in this route to our candidate set if either
+			// we have a direct channel to the first hop or the first hop is
+			// in the regular network graph.
+			let source_node_id = match hint.1.introduction_node_id(network_graph) {
+				Some(node_id) => node_id,
+				None => {
+					let node_id = NodeId::from_pubkey(&hint.1.introduction_node_id);
+					match first_hop_targets.get_key_value(&node_id).map(|(key, _)| key) {
+						Some(node_id) => node_id,
+						None => continue,
+					}
+				},
+			};
+			if our_node_id == *source_node_id { continue }
 			let candidate = if hint.1.blinded_hops.len() == 1 {
-				CandidateRouteHop::OneHopBlinded(OneHopBlindedPathCandidate { hint, hint_idx })
-			} else { CandidateRouteHop::Blinded(BlindedPathCandidate { hint, hint_idx }) };
+				CandidateRouteHop::OneHopBlinded(
+					OneHopBlindedPathCandidate { source_node_id, hint, hint_idx }
+				)
+			} else {
+				CandidateRouteHop::Blinded(BlindedPathCandidate { source_node_id, hint, hint_idx })
+			};
 			let mut path_contribution_msat = path_value_msat;
 			if let Some(hop_used_msat) = add_entry!(&candidate,
 				0, path_contribution_msat, 0, 0_u64, 0, 0)
 			{
 				path_contribution_msat = hop_used_msat;
 			} else { continue }
-			if let Some(first_channels) = first_hop_targets.get_mut(&NodeId::from_pubkey(&hint.1.introduction_node_id)) {
-				sort_first_hop_channels(first_channels, &used_liquidities, recommended_value_msat,
-					our_node_pubkey);
+			if let Some(first_channels) = first_hop_targets.get(source_node_id) {
+				let mut first_channels = first_channels.clone();
+				sort_first_hop_channels(
+					&mut first_channels, &used_liquidities, recommended_value_msat, our_node_pubkey
+				);
 				for details in first_channels {
 					let first_hop_candidate = CandidateRouteHop::FirstHop(FirstHopCandidate {
 						details, payer_node_id: &our_node_id,
@@ -2630,9 +2652,11 @@ where L::Target: Logger {
 						.saturating_add(1);
 
 					// Searching for a direct channel between last checked hop and first_hop_targets
-					if let Some(first_channels) = first_hop_targets.get_mut(target) {
-						sort_first_hop_channels(first_channels, &used_liquidities,
-							recommended_value_msat, our_node_pubkey);
+					if let Some(first_channels) = first_hop_targets.get(target) {
+						let mut first_channels = first_channels.clone();
+						sort_first_hop_channels(
+							&mut first_channels, &used_liquidities, recommended_value_msat, our_node_pubkey
+						);
 						for details in first_channels {
 							let first_hop_candidate = CandidateRouteHop::FirstHop(FirstHopCandidate {
 								details, payer_node_id: &our_node_id,
@@ -2677,9 +2701,11 @@ where L::Target: Logger {
 						// Note that we *must* check if the last hop was added as `add_entry`
 						// always assumes that the third argument is a node to which we have a
 						// path.
-						if let Some(first_channels) = first_hop_targets.get_mut(&NodeId::from_pubkey(&hop.src_node_id)) {
-							sort_first_hop_channels(first_channels, &used_liquidities,
-								recommended_value_msat, our_node_pubkey);
+						if let Some(first_channels) = first_hop_targets.get(&NodeId::from_pubkey(&hop.src_node_id)) {
+							let mut first_channels = first_channels.clone();
+							sort_first_hop_channels(
+								&mut first_channels, &used_liquidities, recommended_value_msat, our_node_pubkey
+							);
 							for details in first_channels {
 								let first_hop_candidate = CandidateRouteHop::FirstHop(FirstHopCandidate {
 									details, payer_node_id: &our_node_id,

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -11,7 +11,7 @@
 
 use bitcoin::secp256k1::{PublicKey, Secp256k1, self};
 
-use crate::blinded_path::{BlindedHop, BlindedPath};
+use crate::blinded_path::{BlindedHop, BlindedPath, Direction, IntroductionNode};
 use crate::blinded_path::payment::{ForwardNode, ForwardTlvs, PaymentConstraints, PaymentRelay, ReceiveTlvs};
 use crate::ln::PaymentHash;
 use crate::ln::channelmanager::{ChannelDetails, PaymentId, MIN_FINAL_CLTV_EXPIRY_DELTA};
@@ -1735,8 +1735,20 @@ impl<'a> fmt::Display for LoggedCandidateHop<'a> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self.0 {
 			CandidateRouteHop::Blinded(BlindedPathCandidate { hint, .. }) | CandidateRouteHop::OneHopBlinded(OneHopBlindedPathCandidate { hint, .. }) => {
-				"blinded route hint with introduction node id ".fmt(f)?;
-				hint.1.introduction_node_id.fmt(f)?;
+				"blinded route hint with introduction node ".fmt(f)?;
+				match &hint.1.introduction_node {
+					IntroductionNode::NodeId(pubkey) => write!(f, "id {}", pubkey)?,
+					IntroductionNode::DirectedShortChannelId(direction, scid) => {
+						match direction {
+							Direction::NodeOne => {
+								write!(f, "one on channel with SCID {}", scid)?;
+							},
+							Direction::NodeTwo => {
+								write!(f, "two on channel with SCID {}", scid)?;
+							},
+						}
+					}
+				}
 				" and blinding point ".fmt(f)?;
 				hint.1.blinding_point.fmt(f)
 			},
@@ -2530,12 +2542,35 @@ where L::Target: Logger {
 			// in the regular network graph.
 			let source_node_id = match hint.1.introduction_node_id(network_graph) {
 				Some(node_id) => node_id,
-				None => {
-					let node_id = NodeId::from_pubkey(&hint.1.introduction_node_id);
-					match first_hop_targets.get_key_value(&node_id).map(|(key, _)| key) {
-						Some(node_id) => node_id,
-						None => continue,
-					}
+				None => match &hint.1.introduction_node {
+					IntroductionNode::NodeId(pubkey) => {
+						let node_id = NodeId::from_pubkey(&pubkey);
+						match first_hop_targets.get_key_value(&node_id).map(|(key, _)| key) {
+							Some(node_id) => node_id,
+							None => continue,
+						}
+					},
+					IntroductionNode::DirectedShortChannelId(direction, scid) => {
+						let first_hop = first_hop_targets.iter().find(|(_, channels)|
+							channels
+								.iter()
+								.any(|details| Some(*scid) == details.get_outbound_payment_scid())
+						);
+						match first_hop {
+							Some((counterparty_node_id, _)) => {
+								let (node_one, node_two) = if our_node_id < *counterparty_node_id {
+									(&our_node_id, counterparty_node_id)
+								} else {
+									(counterparty_node_id, &our_node_id)
+								};
+								match direction {
+									Direction::NodeOne => node_one,
+									Direction::NodeTwo => node_two,
+								}
+							},
+							None => continue,
+						}
+					},
 				},
 			};
 			if our_node_id == *source_node_id { continue }
@@ -3249,7 +3284,7 @@ fn build_route_from_hops_internal<L: Deref>(
 
 #[cfg(test)]
 mod tests {
-	use crate::blinded_path::{BlindedHop, BlindedPath};
+	use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 	use crate::routing::gossip::{NetworkGraph, P2PGossipSync, NodeId, EffectiveCapacity};
 	use crate::routing::utxo::UtxoResult;
 	use crate::routing::router::{get_route, build_route_from_hops_internal, add_random_cltv_offset, default_node_features,
@@ -5118,7 +5153,7 @@ mod tests {
 		// MPP to a 1-hop blinded path for nodes[2]
 		let bolt12_features = channelmanager::provided_bolt12_invoice_features(&config);
 		let blinded_path = BlindedPath {
-			introduction_node_id: nodes[2],
+			introduction_node: IntroductionNode::NodeId(nodes[2]),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: vec![BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() }],
 		};
@@ -5136,18 +5171,18 @@ mod tests {
 
 		// MPP to 3 2-hop blinded paths
 		let mut blinded_path_node_0 = blinded_path.clone();
-		blinded_path_node_0.introduction_node_id = nodes[0];
+		blinded_path_node_0.introduction_node = IntroductionNode::NodeId(nodes[0]);
 		blinded_path_node_0.blinded_hops.push(blinded_path.blinded_hops[0].clone());
 		let mut node_0_payinfo = blinded_payinfo.clone();
 		node_0_payinfo.htlc_maximum_msat = 50_000;
 
 		let mut blinded_path_node_7 = blinded_path_node_0.clone();
-		blinded_path_node_7.introduction_node_id = nodes[7];
+		blinded_path_node_7.introduction_node = IntroductionNode::NodeId(nodes[7]);
 		let mut node_7_payinfo = blinded_payinfo.clone();
 		node_7_payinfo.htlc_maximum_msat = 60_000;
 
 		let mut blinded_path_node_1 = blinded_path_node_0.clone();
-		blinded_path_node_1.introduction_node_id = nodes[1];
+		blinded_path_node_1.introduction_node = IntroductionNode::NodeId(nodes[1]);
 		let mut node_1_payinfo = blinded_payinfo.clone();
 		node_1_payinfo.htlc_maximum_msat = 180_000;
 
@@ -7233,7 +7268,7 @@ mod tests {
 
 		// Make sure this works for blinded route hints.
 		let blinded_path = BlindedPath {
-			introduction_node_id: intermed_node_id,
+			introduction_node: IntroductionNode::NodeId(intermed_node_id),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(42), encrypted_payload: vec![] },
@@ -7267,7 +7302,7 @@ mod tests {
 	#[test]
 	fn blinded_route_ser() {
 		let blinded_path_1 = BlindedPath {
-			introduction_node_id: ln_test_utils::pubkey(42),
+			introduction_node: IntroductionNode::NodeId(ln_test_utils::pubkey(42)),
 			blinding_point: ln_test_utils::pubkey(43),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(44), encrypted_payload: Vec::new() },
@@ -7275,7 +7310,7 @@ mod tests {
 			],
 		};
 		let blinded_path_2 = BlindedPath {
-			introduction_node_id: ln_test_utils::pubkey(46),
+			introduction_node: IntroductionNode::NodeId(ln_test_utils::pubkey(46)),
 			blinding_point: ln_test_utils::pubkey(47),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(48), encrypted_payload: Vec::new() },
@@ -7334,7 +7369,7 @@ mod tests {
 		// account for the blinded tail's final amount_msat.
 		let mut inflight_htlcs = InFlightHtlcs::new();
 		let blinded_path = BlindedPath {
-			introduction_node_id: ln_test_utils::pubkey(43),
+			introduction_node: IntroductionNode::NodeId(ln_test_utils::pubkey(43)),
 			blinding_point: ln_test_utils::pubkey(48),
 			blinded_hops: vec![BlindedHop { blinded_node_id: ln_test_utils::pubkey(49), encrypted_payload: Vec::new() }],
 		};
@@ -7349,7 +7384,7 @@ mod tests {
 				maybe_announced_channel: false,
 			},
 			RouteHop {
-				pubkey: blinded_path.introduction_node_id,
+				pubkey: ln_test_utils::pubkey(43),
 				node_features: NodeFeatures::empty(),
 				short_channel_id: 43,
 				channel_features: ChannelFeatures::empty(),
@@ -7373,7 +7408,7 @@ mod tests {
 	fn blinded_path_cltv_shadow_offset() {
 		// Make sure we add a shadow offset when sending to blinded paths.
 		let blinded_path = BlindedPath {
-			introduction_node_id: ln_test_utils::pubkey(43),
+			introduction_node: IntroductionNode::NodeId(ln_test_utils::pubkey(43)),
 			blinding_point: ln_test_utils::pubkey(44),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(45), encrypted_payload: Vec::new() },
@@ -7391,7 +7426,7 @@ mod tests {
 				maybe_announced_channel: false,
 			},
 			RouteHop {
-				pubkey: blinded_path.introduction_node_id,
+				pubkey: ln_test_utils::pubkey(43),
 				node_features: NodeFeatures::empty(),
 				short_channel_id: 43,
 				channel_features: ChannelFeatures::empty(),
@@ -7433,7 +7468,7 @@ mod tests {
 		let random_seed_bytes = keys_manager.get_secure_random_bytes();
 
 		let mut blinded_path = BlindedPath {
-			introduction_node_id: nodes[2],
+			introduction_node: IntroductionNode::NodeId(nodes[2]),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: Vec::with_capacity(num_blinded_hops),
 		};
@@ -7491,7 +7526,7 @@ mod tests {
 		let random_seed_bytes = keys_manager.get_secure_random_bytes();
 
 		let mut invalid_blinded_path = BlindedPath {
-			introduction_node_id: nodes[2],
+			introduction_node: IntroductionNode::NodeId(nodes[2]),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(43), encrypted_payload: vec![0; 43] },
@@ -7507,7 +7542,7 @@ mod tests {
 		};
 
 		let mut invalid_blinded_path_2 = invalid_blinded_path.clone();
-		invalid_blinded_path_2.introduction_node_id = ln_test_utils::pubkey(45);
+		invalid_blinded_path_2.introduction_node = IntroductionNode::NodeId(ln_test_utils::pubkey(45));
 		let payment_params = PaymentParameters::blinded(vec![
 			(blinded_payinfo.clone(), invalid_blinded_path.clone()),
 			(blinded_payinfo.clone(), invalid_blinded_path_2)]);
@@ -7521,7 +7556,7 @@ mod tests {
 			_ => panic!("Expected error")
 		}
 
-		invalid_blinded_path.introduction_node_id = our_id;
+		invalid_blinded_path.introduction_node = IntroductionNode::NodeId(our_id);
 		let payment_params = PaymentParameters::blinded(vec![(blinded_payinfo.clone(), invalid_blinded_path.clone())]);
 		let route_params = RouteParameters::from_payment_params_and_value(payment_params, 1001);
 		match get_route(&our_id, &route_params, &network_graph, None, Arc::clone(&logger), &scorer,
@@ -7533,7 +7568,7 @@ mod tests {
 			_ => panic!("Expected error")
 		}
 
-		invalid_blinded_path.introduction_node_id = ln_test_utils::pubkey(46);
+		invalid_blinded_path.introduction_node = IntroductionNode::NodeId(ln_test_utils::pubkey(46));
 		invalid_blinded_path.blinded_hops.clear();
 		let payment_params = PaymentParameters::blinded(vec![(blinded_payinfo, invalid_blinded_path)]);
 		let route_params = RouteParameters::from_payment_params_and_value(payment_params, 1001);
@@ -7562,7 +7597,7 @@ mod tests {
 
 		let bolt12_features = channelmanager::provided_bolt12_invoice_features(&config);
 		let blinded_path_1 = BlindedPath {
-			introduction_node_id: nodes[2],
+			introduction_node: IntroductionNode::NodeId(nodes[2]),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },
@@ -7659,7 +7694,7 @@ mod tests {
 			get_channel_details(Some(1), nodes[1], InitFeatures::from_le_bytes(vec![0b11]), 10_000_000)];
 
 		let blinded_path = BlindedPath {
-			introduction_node_id: nodes[1],
+			introduction_node: IntroductionNode::NodeId(nodes[1]),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },
@@ -7728,7 +7763,7 @@ mod tests {
 				18446744073709551615)];
 
 		let blinded_path = BlindedPath {
-			introduction_node_id: nodes[1],
+			introduction_node: IntroductionNode::NodeId(nodes[1]),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },
@@ -7784,7 +7819,7 @@ mod tests {
 		let amt_msat = 21_7020_5185_1423_0019;
 
 		let blinded_path = BlindedPath {
-			introduction_node_id: our_id,
+			introduction_node: IntroductionNode::NodeId(our_id),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },
@@ -7803,7 +7838,7 @@ mod tests {
 			(blinded_payinfo.clone(), blinded_path.clone()),
 			(blinded_payinfo.clone(), blinded_path.clone()),
 		];
-		blinded_hints[1].1.introduction_node_id = nodes[6];
+		blinded_hints[1].1.introduction_node = IntroductionNode::NodeId(nodes[6]);
 
 		let bolt12_features = channelmanager::provided_bolt12_invoice_features(&config);
 		let payment_params = PaymentParameters::blinded(blinded_hints.clone())
@@ -7836,7 +7871,7 @@ mod tests {
 		let amt_msat = 21_7020_5185_1423_0019;
 
 		let blinded_path = BlindedPath {
-			introduction_node_id: our_id,
+			introduction_node: IntroductionNode::NodeId(our_id),
 			blinding_point: ln_test_utils::pubkey(42),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },
@@ -7860,7 +7895,7 @@ mod tests {
 		blinded_hints[1].0.htlc_minimum_msat = 21_7020_5185_1423_0019;
 		blinded_hints[1].0.htlc_maximum_msat = 1844_6744_0737_0955_1615;
 
-		blinded_hints[2].1.introduction_node_id = nodes[6];
+		blinded_hints[2].1.introduction_node = IntroductionNode::NodeId(nodes[6]);
 
 		let bolt12_features = channelmanager::provided_bolt12_invoice_features(&config);
 		let payment_params = PaymentParameters::blinded(blinded_hints.clone())
@@ -7907,7 +7942,7 @@ mod tests {
 		let htlc_min = 2_5165_8240;
 		let payment_params = if blinded_payee {
 			let blinded_path = BlindedPath {
-				introduction_node_id: nodes[0],
+				introduction_node: IntroductionNode::NodeId(nodes[0]),
 				blinding_point: ln_test_utils::pubkey(42),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },
@@ -7987,7 +8022,7 @@ mod tests {
 		let htlc_mins = [1_4392, 19_7401, 1027, 6_5535];
 		let payment_params = if blinded_payee {
 			let blinded_path = BlindedPath {
-				introduction_node_id: nodes[0],
+				introduction_node: IntroductionNode::NodeId(nodes[0]),
 				blinding_point: ln_test_utils::pubkey(42),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },
@@ -8088,7 +8123,7 @@ mod tests {
 				cltv_expiry_delta: 10,
 				features: BlindedHopFeatures::empty(),
 			}, BlindedPath {
-				introduction_node_id: nodes[0],
+				introduction_node: IntroductionNode::NodeId(nodes[0]),
 				blinding_point: ln_test_utils::pubkey(42),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },
@@ -8138,7 +8173,7 @@ mod tests {
 		let htlc_mins = [49_0000, 1125_0000];
 		let payment_params = {
 			let blinded_path = BlindedPath {
-				introduction_node_id: nodes[0],
+				introduction_node: IntroductionNode::NodeId(nodes[0]),
 				blinding_point: ln_test_utils::pubkey(42),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: ln_test_utils::pubkey(42 as u8), encrypted_payload: Vec::new() },

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -1863,17 +1863,17 @@ where L::Target: Logger {
 			}
 		},
 		Payee::Blinded { route_hints, .. } => {
-			if route_hints.iter().all(|(_, path)| &path.introduction_node_id == our_node_pubkey) {
+			if route_hints.iter().all(|(_, path)| path.introduction_node_id(network_graph) == Some(&our_node_id)) {
 				return Err(LightningError{err: "Cannot generate a route to blinded paths if we are the introduction node to all of them".to_owned(), action: ErrorAction::IgnoreError});
 			}
 			for (_, blinded_path) in route_hints.iter() {
 				if blinded_path.blinded_hops.len() == 0 {
 					return Err(LightningError{err: "0-hop blinded path provided".to_owned(), action: ErrorAction::IgnoreError});
-				} else if &blinded_path.introduction_node_id == our_node_pubkey {
+				} else if blinded_path.introduction_node_id(network_graph) == Some(&our_node_id) {
 					log_info!(logger, "Got blinded path with ourselves as the introduction node, ignoring");
 				} else if blinded_path.blinded_hops.len() == 1 &&
 					route_hints.iter().any( |(_, p)| p.blinded_hops.len() == 1
-						&& p.introduction_node_id != blinded_path.introduction_node_id)
+						&& p.introduction_node_id(network_graph) != blinded_path.introduction_node_id(network_graph))
 				{
 					return Err(LightningError{err: format!("1-hop blinded paths must all have matching introduction node ids"), action: ErrorAction::IgnoreError});
 				}
@@ -5303,10 +5303,15 @@ mod tests {
 				if let Some(bt) = &path.blinded_tail {
 					assert_eq!(path.hops.len() + if bt.hops.len() == 1 { 0 } else { 1 }, 2);
 					if bt.hops.len() > 1 {
-						assert_eq!(path.hops.last().unwrap().pubkey,
+						let network_graph = network_graph.read_only();
+						assert_eq!(
+							NodeId::from_pubkey(&path.hops.last().unwrap().pubkey),
 							payment_params.payee.blinded_route_hints().iter()
 								.find(|(p, _)| p.htlc_maximum_msat == path.final_value_msat())
-								.map(|(_, p)| p.introduction_node_id).unwrap());
+								.and_then(|(_, p)| p.introduction_node_id(&network_graph))
+								.copied()
+								.unwrap()
+						);
 					} else {
 						assert_eq!(path.hops.last().unwrap().pubkey, nodes[2]);
 					}
@@ -7434,7 +7439,10 @@ mod tests {
 		assert_eq!(tail.final_value_msat, 1001);
 
 		let final_hop = route.paths[0].hops.last().unwrap();
-		assert_eq!(final_hop.pubkey, blinded_path.introduction_node_id);
+		assert_eq!(
+			NodeId::from_pubkey(&final_hop.pubkey),
+			*blinded_path.introduction_node_id(&network_graph).unwrap()
+		);
 		if tail.hops.len() > 1 {
 			assert_eq!(final_hop.fee_msat,
 				blinded_payinfo.fee_base_msat as u64 + blinded_payinfo.fee_proportional_millionths as u64 * tail.final_value_msat / 1000000);

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -2153,7 +2153,7 @@ impl Readable for ChannelLiquidity {
 #[cfg(test)]
 mod tests {
 	use super::{ChannelLiquidity, HistoricalBucketRangeTracker, ProbabilisticScoringFeeParameters, ProbabilisticScoringDecayParameters, ProbabilisticScorer};
-	use crate::blinded_path::{BlindedHop, BlindedPath};
+	use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 	use crate::util::config::UserConfig;
 
 	use crate::ln::channelmanager;
@@ -3568,7 +3568,7 @@ mod tests {
 		let mut path = payment_path_for_amount(768);
 		let recipient_hop = path.hops.pop().unwrap();
 		let blinded_path = BlindedPath {
-			introduction_node_id: path.hops.last().as_ref().unwrap().pubkey,
+			introduction_node: IntroductionNode::NodeId(path.hops.last().as_ref().unwrap().pubkey),
 			blinding_point: test_utils::pubkey(42),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: test_utils::pubkey(44), encrypted_payload: Vec::new() }

--- a/lightning/src/util/indexed_map.rs
+++ b/lightning/src/util/indexed_map.rs
@@ -58,6 +58,11 @@ impl<K: Clone + Hash + Ord, V> IndexedMap<K, V> {
 		self.map.get_mut(key)
 	}
 
+	/// Fetches the key-value pair corresponding to the supplied key, if one exists.
+	pub fn get_key_value(&self, key: &K) -> Option<(&K, &V)> {
+		self.map.get_key_value(key)
+	}
+
 	#[inline]
 	/// Returns true if an element with the given `key` exists in the map.
 	pub fn contains_key(&self, key: &K) -> bool {


### PR DESCRIPTION
Blinded paths may be specified using a more compact representation, replacing pubkeys with short channel ids as described in #2921. This PR implements this in the following manner:
- Update `BlindedPath` and `message::ForwardTlvs` to support the compact representation
- Add a `NodeIdLookUp` trait used in `OnionMessenger` to handle forwarding
- Implement `NodeIdLookUp` for `ChannelManager`
- To resolve the `IntroductionNode`:
  - For messaging, use the `NetworkGraph` in `DefaultMessageRouter`
  - For payments, use either the `NetworkGraph` or first hops in `DefaultRouter`

Does not yet include any tests as the creation methods need to be updated still.