### PR TITLE
Use `AChannelManager` in `BackgroundProcessor`

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -607,9 +607,9 @@ use core::task;
 ///			sleeper,
 ///			mobile_interruptable_platform,
 ///			|| Some(SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap())
-///			)
-///			.await
-///			.expect("Failed to process events");
+///		)
+///		.await
+///		.expect("Failed to process events");
 ///	});
 ///
 ///	// Stop the background processing.

--- a/lightning/src/util/persist.rs
+++ b/lightning/src/util/persist.rs
@@ -162,7 +162,6 @@ impl<'a, A: KVStore, M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Der
 		R::Target: 'static + Router,
 		L::Target: 'static + Logger,
 {
-	/// Persist the given [`ChannelManager`] to disk, returning an error if persistence failed.
 	fn persist_manager(&self, channel_manager: &ChannelManager<M, T, ES, NS, SP, F, R, L>) -> Result<(), io::Error> {
 		self.write(CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
 			CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
@@ -170,7 +169,6 @@ impl<'a, A: KVStore, M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Der
 			&channel_manager.encode())
 	}
 
-	/// Persist the given [`NetworkGraph`] to disk, returning an error if persistence failed.
 	fn persist_graph(&self, network_graph: &NetworkGraph<L>) -> Result<(), io::Error> {
 		self.write(NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE,
 			NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE,
@@ -178,7 +176,6 @@ impl<'a, A: KVStore, M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Der
 			&network_graph.encode())
 	}
 
-	/// Persist the given [`WriteableScore`] to disk, returning an error if persistence failed.
 	fn persist_scorer(&self, scorer: &S) -> Result<(), io::Error> {
 		self.write(SCORER_PERSISTENCE_PRIMARY_NAMESPACE,
 			SCORER_PERSISTENCE_SECONDARY_NAMESPACE,
@@ -197,7 +194,6 @@ impl<'a, M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref
 		R::Target: 'static + Router,
 		L::Target: 'static + Logger,
 {
-	/// Persist the given [`ChannelManager`] to disk, returning an error if persistence failed.
 	fn persist_manager(&self, channel_manager: &ChannelManager<M, T, ES, NS, SP, F, R, L>) -> Result<(), io::Error> {
 		self.write(CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
 			CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
@@ -205,7 +201,6 @@ impl<'a, M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref
 			&channel_manager.encode())
 	}
 
-	/// Persist the given [`NetworkGraph`] to disk, returning an error if persistence failed.
 	fn persist_graph(&self, network_graph: &NetworkGraph<L>) -> Result<(), io::Error> {
 		self.write(NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE,
 			NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE,
@@ -213,7 +208,6 @@ impl<'a, M: Deref, T: Deref, ES: Deref, NS: Deref, SP: Deref, F: Deref, R: Deref
 			&network_graph.encode())
 	}
 
-	/// Persist the given [`WriteableScore`] to disk, returning an error if persistence failed.
 	fn persist_scorer(&self, scorer: &S) -> Result<(), io::Error> {
 		self.write(SCORER_PERSISTENCE_PRIMARY_NAMESPACE,
 			SCORER_PERSISTENCE_SECONDARY_NAMESPACE,


### PR DESCRIPTION
Replace instance of `ChannelManager` in `BackgroundProcessor` and in`Persister` with `AChannelManager`. This reduces the number of type parameters need in those types, which would need to be repeated in an `async` version of `Persister`.