### PR TITLE
Fix unknown handling in `impl_writeable_tlv_based_enum_upgradable`

### DIFF
--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -94,7 +94,9 @@ pub use std::io;
 pub use core2::io;
 
 #[cfg(not(feature = "std"))]
-mod io_extras {
+#[doc(hidden)]
+/// IO utilities public only for use by in-crate macros. These should not be used externally
+pub mod io_extras {
 	use core2::io::{self, Read, Write};
 
 	/// A writer which will move data into the void.
@@ -154,6 +156,8 @@ mod io_extras {
 }
 
 #[cfg(feature = "std")]
+#[doc(hidden)]
+/// IO utilities public only for use by in-crate macros. These should not be used externally
 mod io_extras {
 	pub fn read_to_end<D: ::std::io::Read>(mut d: D) -> Result<Vec<u8>, ::std::io::Error> {
 		let mut buf = Vec::new();


### PR DESCRIPTION
`impl_writeable_tlv_based_enum_upgradable` professed to supporting upgrades by returning `None` from `MaybeReadable` when unknown variants written by newer versions of LDK were read. However, it generally didn't support this as it didn't discard bytes for unknown types, resulting in corrupt reading.

This is fixed here for enum variants written as a TLV stream, however we don't have a length prefix for tuple enum variants, so the documentation on the macro is updated to mention that downgrades are not supported for tuple variants.