### PR TITLE
Reset the channel state before restarting the channel establishment process.

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1247,6 +1247,29 @@ impl UnfundedChannelContext {
 	}
 }
 
+/// Stores values related to retrying the handshake process for outbound channels
+/// after disconnection and reconnection.
+pub(super) struct OutboundContext {
+	received_accept_channel_msg: Option<msgs::AcceptChannel>,
+	created_funding_transaction: Option<FundingTransaction>
+}
+
+impl OutboundContext {
+	/// Create a new [`OutboundContext`] with blank values.
+	pub fn new() -> Self {
+		OutboundContext {
+			received_accept_channel_msg: None,
+			created_funding_transaction: None,
+		}
+	}
+}
+
+struct FundingTransaction {
+	funding_transaction: Transaction,
+	outpoint: OutPoint,
+	is_batch_funding: bool,
+}
+
 /// Contains everything about the channel including state, and various flags.
 pub(super) struct ChannelContext<SP: Deref> where SP::Target: SignerProvider {
 	config: LegacyChannelConfig,
@@ -7285,6 +7308,7 @@ impl<SP: Deref> Channel<SP> where
 pub(super) struct OutboundV1Channel<SP: Deref> where SP::Target: SignerProvider {
 	pub context: ChannelContext<SP>,
 	pub unfunded_context: UnfundedChannelContext,
+	pub outbound_context: OutboundContext,
 }
 
 impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
@@ -7327,7 +7351,8 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 				holder_signer,
 				pubkeys,
 			)?,
-			unfunded_context: UnfundedChannelContext { unfunded_channel_age_ticks: 0 }
+			unfunded_context: UnfundedChannelContext { unfunded_channel_age_ticks: 0 },
+			outbound_context: OutboundContext::new(),
 		};
 		Ok(chan)
 	}

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -20,7 +20,7 @@ use crate::chain::transaction::OutPoint;
 use crate::sign::{ecdsa::EcdsaChannelSigner, EntropySource, OutputSpender, SignerProvider};
 use crate::events::{Event, MessageSendEvent, MessageSendEventsProvider, PathFailure, PaymentPurpose, ClosureReason, HTLCDestination, PaymentFailureReason};
 use crate::ln::{ChannelId, PaymentPreimage, PaymentSecret, PaymentHash};
-use crate::ln::channel::{commitment_tx_base_weight, COMMITMENT_TX_WEIGHT_PER_HTLC, CONCURRENT_INBOUND_HTLC_FEE_BUFFER, FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE, MIN_AFFORDABLE_HTLC_COUNT, get_holder_selected_channel_reserve_satoshis, OutboundV1Channel, InboundV1Channel, COINBASE_MATURITY, ChannelPhase};
+use crate::ln::channel::{commitment_tx_base_weight, get_holder_selected_channel_reserve_satoshis, ChannelPhase, InboundV1Channel, OutboundV1Channel, TransactionEnum, COINBASE_MATURITY, COMMITMENT_TX_WEIGHT_PER_HTLC, CONCURRENT_INBOUND_HTLC_FEE_BUFFER, FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE, MIN_AFFORDABLE_HTLC_COUNT};
 use crate::ln::channelmanager::{self, PaymentId, RAACommitmentOrder, PaymentSendFailure, RecipientOnionFields, BREAKDOWN_TIMEOUT, ENABLE_GOSSIP_TICKS, DISABLE_GOSSIP_TICKS, MIN_CLTV_EXPIRY_DELTA};
 use crate::ln::channel::{DISCONNECT_PEER_AWAITING_RESPONSE_TICKS, ChannelError};
 use crate::ln::{chan_utils, onion_utils};
@@ -9235,7 +9235,8 @@ fn test_duplicate_chan_id() {
 		match a_peer_state.channel_by_id.remove(&open_chan_2_msg.common_fields.temporary_channel_id).unwrap() {
 			ChannelPhase::UnfundedOutboundV1(mut chan) => {
 				let logger = test_utils::TestLogger::new();
-				chan.get_funding_created(tx.clone(), funding_outpoint, false, &&logger).map_err(|_| ()).unwrap()
+				let transaction = TransactionEnum::new_funding_transaction(tx.clone(), funding_outpoint, false);
+				chan.get_funding_created(transaction, &&logger).map_err(|_| ()).unwrap()
 			},
 			_ => panic!("Unexpected ChannelPhase variant"),
 		}.unwrap()


### PR DESCRIPTION
Fixes #2982

When our counterparty disconnects during channel creation, we could have progressed along the channel creation process.
In such cases, retrying to send the OpenChannel message would fail because the channel state had progressed, leading to a panic in the `get_open_channel`.
To prevent this issue, introduce a new function, `reset_channel_state`, which resets the channel state to its initial state and uses it before regenerating the OpenChannel message for an Unfunded Outbound channel.