### PR TITLE
Add splicing feature flag

### DIFF
--- a/ci/check-cfg-flags.py
+++ b/ci/check-cfg-flags.py
@@ -98,6 +98,8 @@ def check_cfg_tag(cfg):
         pass
     elif cfg == "dual_funding":
         pass
+    elif cfg == "splicing":
+        pass
     else:
         print("Bad cfg tag: " + cfg)
         assert False

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -177,3 +177,5 @@ RUSTFLAGS="--cfg=taproot" cargo test --verbose --color always -p lightning
 RUSTFLAGS="--cfg=async_signing" cargo test --verbose --color always -p lightning
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=dual_funding" cargo test --verbose --color always -p lightning
+[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
+RUSTFLAGS="--cfg=splicing" cargo test --verbose --color always -p lightning

--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -624,11 +624,11 @@ mod tests {
 		fn handle_open_channel_v2(&self, _their_node_id: &PublicKey, _msg: &OpenChannelV2) {}
 		fn handle_accept_channel_v2(&self, _their_node_id: &PublicKey, _msg: &AcceptChannelV2) {}
 		fn handle_stfu(&self, _their_node_id: &PublicKey, _msg: &Stfu) {}
-		#[cfg(dual_funding)]
+		#[cfg(splicing)]
 		fn handle_splice(&self, _their_node_id: &PublicKey, _msg: &Splice) {}
-		#[cfg(dual_funding)]
+		#[cfg(splicing)]
 		fn handle_splice_ack(&self, _their_node_id: &PublicKey, _msg: &SpliceAck) {}
-		#[cfg(dual_funding)]
+		#[cfg(splicing)]
 		fn handle_splice_locked(&self, _their_node_id: &PublicKey, _msg: &SpliceLocked) {}
 		fn handle_tx_add_input(&self, _their_node_id: &PublicKey, _msg: &TxAddInput) {}
 		fn handle_tx_add_output(&self, _their_node_id: &PublicKey, _msg: &TxAddOutput) {}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -918,9 +918,9 @@ impl <SP: Deref> PeerState<SP> where SP::Target: SignerProvider {
 			match phase {
 				ChannelPhase::Funded(_) | ChannelPhase::UnfundedOutboundV1(_) => true,
 				ChannelPhase::UnfundedInboundV1(_) => false,
-				#[cfg(dual_funding)]
+				#[cfg(any(dual_funding, splicing))]
 				ChannelPhase::UnfundedOutboundV2(_) => true,
-				#[cfg(dual_funding)]
+				#[cfg(any(dual_funding, splicing))]
 				ChannelPhase::UnfundedInboundV2(_) => false,
 			}
 		)
@@ -2774,11 +2774,11 @@ macro_rules! convert_chan_phase_err {
 			ChannelPhase::UnfundedInboundV1(channel) => {
 				convert_chan_phase_err!($self, $err, channel, $channel_id, UNFUNDED_CHANNEL)
 			},
-			#[cfg(dual_funding)]
+			#[cfg(any(dual_funding, splicing))]
 			ChannelPhase::UnfundedOutboundV2(channel) => {
 				convert_chan_phase_err!($self, $err, channel, $channel_id, UNFUNDED_CHANNEL)
 			},
-			#[cfg(dual_funding)]
+			#[cfg(any(dual_funding, splicing))]
 			ChannelPhase::UnfundedInboundV2(channel) => {
 				convert_chan_phase_err!($self, $err, channel, $channel_id, UNFUNDED_CHANNEL)
 			},
@@ -3653,8 +3653,8 @@ where
 						// Unfunded channel has no update
 						(None, chan_phase.context().get_counterparty_node_id())
 					},
-					// TODO(dual_funding): Combine this match arm with above once #[cfg(dual_funding)] is removed.
-					#[cfg(dual_funding)]
+					// TODO(dual_funding): Combine this match arm with above once #[cfg(any(dual_funding, splicing))] is removed.
+					#[cfg(any(dual_funding, splicing))]
 					ChannelPhase::UnfundedOutboundV2(_) | ChannelPhase::UnfundedInboundV2(_) => {
 						self.finish_close_channel(chan_phase.context_mut().force_shutdown(false, closure_reason));
 						// Unfunded channel has no update
@@ -5882,12 +5882,12 @@ where
 								process_unfunded_channel_tick(chan_id, &mut chan.context, &mut chan.unfunded_context,
 									pending_msg_events, counterparty_node_id)
 							},
-							#[cfg(dual_funding)]
+							#[cfg(any(dual_funding, splicing))]
 							ChannelPhase::UnfundedInboundV2(chan) => {
 								process_unfunded_channel_tick(chan_id, &mut chan.context, &mut chan.unfunded_context,
 									pending_msg_events, counterparty_node_id)
 							},
-							#[cfg(dual_funding)]
+							#[cfg(any(dual_funding, splicing))]
 							ChannelPhase::UnfundedOutboundV2(chan) => {
 								process_unfunded_channel_tick(chan_id, &mut chan.context, &mut chan.unfunded_context,
 									pending_msg_events, counterparty_node_id)
@@ -7059,8 +7059,8 @@ where
 						num_unfunded_channels += 1;
 					}
 				},
-				// TODO(dual_funding): Combine this match arm with above once #[cfg(dual_funding)] is removed.
-				#[cfg(dual_funding)]
+				// TODO(dual_funding): Combine this match arm with above once #[cfg(any(dual_funding, splicing))] is removed.
+				#[cfg(any(dual_funding, splicing))]
 				ChannelPhase::UnfundedInboundV2(chan) => {
 					// Only inbound V2 channels that are not 0conf and that we do not contribute to will be
 					// included in the unfunded count.
@@ -7073,8 +7073,8 @@ where
 					// Outbound channels don't contribute to the unfunded count in the DoS context.
 					continue;
 				},
-				// TODO(dual_funding): Combine this match arm with above once #[cfg(dual_funding)] is removed.
-				#[cfg(dual_funding)]
+				// TODO(dual_funding): Combine this match arm with above once #[cfg(any(dual_funding, splicing))] is removed.
+				#[cfg(any(dual_funding, splicing))]
 				ChannelPhase::UnfundedOutboundV2(_) => {
 					// Outbound channels don't contribute to the unfunded count in the DoS context.
 					continue;
@@ -7501,7 +7501,7 @@ where
 						finish_shutdown = Some(chan.context_mut().force_shutdown(false, ClosureReason::CounterpartyCoopClosedUnfundedChannel));
 					},
 					// TODO(dual_funding): Combine this match arm with above.
-					#[cfg(dual_funding)]
+					#[cfg(any(dual_funding, splicing))]
 					ChannelPhase::UnfundedInboundV2(_) | ChannelPhase::UnfundedOutboundV2(_) => {
 						let context = phase.context_mut();
 						log_error!(self.logger, "Immediately closing unfunded channel {} as peer asked to cooperatively shut it down (which is unnecessary)", &msg.channel_id);
@@ -9450,7 +9450,7 @@ where
 						// Retain unfunded channels.
 						ChannelPhase::UnfundedOutboundV1(_) | ChannelPhase::UnfundedInboundV1(_) => true,
 						// TODO(dual_funding): Combine this match arm with above.
-						#[cfg(dual_funding)]
+						#[cfg(any(dual_funding, splicing))]
 						ChannelPhase::UnfundedOutboundV2(_) | ChannelPhase::UnfundedInboundV2(_) => true,
 						ChannelPhase::Funded(channel) => {
 							let res = f(channel);
@@ -9756,21 +9756,21 @@ where
 			 msg.channel_id.clone())), *counterparty_node_id);
 	}
 
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice(&self, counterparty_node_id: &PublicKey, msg: &msgs::Splice) {
 		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
 			"Splicing not supported".to_owned(),
 			 msg.channel_id.clone())), *counterparty_node_id);
 	}
 
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice_ack(&self, counterparty_node_id: &PublicKey, msg: &msgs::SpliceAck) {
 		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
 			"Splicing not supported (splice_ack)".to_owned(),
 			 msg.channel_id.clone())), *counterparty_node_id);
 	}
 
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice_locked(&self, counterparty_node_id: &PublicKey, msg: &msgs::SpliceLocked) {
 		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
 			"Splicing not supported (splice_locked)".to_owned(),
@@ -9928,11 +9928,11 @@ where
 						ChannelPhase::UnfundedInboundV1(chan) => {
 							&mut chan.context
 						},
-						#[cfg(dual_funding)]
+						#[cfg(any(dual_funding, splicing))]
 						ChannelPhase::UnfundedOutboundV2(chan) => {
 							&mut chan.context
 						},
-						#[cfg(dual_funding)]
+						#[cfg(any(dual_funding, splicing))]
 						ChannelPhase::UnfundedInboundV2(chan) => {
 							&mut chan.context
 						},
@@ -10093,8 +10093,8 @@ where
 							});
 						}
 
-						// TODO(dual_funding): Combine this match arm with above once #[cfg(dual_funding)] is removed.
-						#[cfg(dual_funding)]
+						// TODO(dual_funding): Combine this match arm with above once #[cfg(any(dual_funding, splicing))] is removed.
+						#[cfg(any(dual_funding, splicing))]
 						ChannelPhase::UnfundedOutboundV2(chan) => {
 							pending_msg_events.push(events::MessageSendEvent::SendOpenChannelV2 {
 								node_id: chan.context.get_counterparty_node_id(),
@@ -10109,8 +10109,8 @@ where
 							debug_assert!(false);
 						}
 
-						// TODO(dual_funding): Combine this match arm with above once #[cfg(dual_funding)] is removed.
-						#[cfg(dual_funding)]
+						// TODO(dual_funding): Combine this match arm with above once #[cfg(any(dual_funding, splicing))] is removed.
+						#[cfg(any(dual_funding, splicing))]
 						ChannelPhase::UnfundedInboundV2(channel) => {
 							// Since unfunded inbound channel maps are cleared upon disconnecting a peer,
 							// they are not persisted and won't be recovered after a crash.
@@ -10213,7 +10213,7 @@ where
 							return;
 						}
 					},
-					#[cfg(dual_funding)]
+					#[cfg(any(dual_funding, splicing))]
 					Some(ChannelPhase::UnfundedOutboundV2(ref mut chan)) => {
 						if let Ok(msg) = chan.maybe_handle_error_without_close(self.chain_hash, &self.fee_estimator) {
 							peer_state.pending_msg_events.push(events::MessageSendEvent::SendOpenChannelV2 {
@@ -10224,7 +10224,7 @@ where
 						}
 					},
 					None | Some(ChannelPhase::UnfundedInboundV1(_) | ChannelPhase::Funded(_)) => (),
-					#[cfg(dual_funding)]
+					#[cfg(any(dual_funding, splicing))]
 					Some(ChannelPhase::UnfundedInboundV2(_)) => (),
 				}
 			}

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -1462,13 +1462,13 @@ pub trait ChannelMessageHandler : MessageSendEventsProvider {
 
 	// Splicing
 	/// Handle an incoming `splice` message from the given peer.
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice(&self, their_node_id: &PublicKey, msg: &Splice);
 	/// Handle an incoming `splice_ack` message from the given peer.
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice_ack(&self, their_node_id: &PublicKey, msg: &SpliceAck);
 	/// Handle an incoming `splice_locked` message from the given peer.
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice_locked(&self, their_node_id: &PublicKey, msg: &SpliceLocked);
 
 	// Interactive channel construction

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -248,15 +248,15 @@ impl ChannelMessageHandler for ErroringMessageHandler {
 	fn handle_stfu(&self, their_node_id: &PublicKey, msg: &msgs::Stfu) {
 		ErroringMessageHandler::push_error(&self, their_node_id, msg.channel_id);
 	}
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice(&self, their_node_id: &PublicKey, msg: &msgs::Splice) {
 		ErroringMessageHandler::push_error(&self, their_node_id, msg.channel_id);
 	}
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice_ack(&self, their_node_id: &PublicKey, msg: &msgs::SpliceAck) {
 		ErroringMessageHandler::push_error(&self, their_node_id, msg.channel_id);
 	}
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice_locked(&self, their_node_id: &PublicKey, msg: &msgs::SpliceLocked) {
 		ErroringMessageHandler::push_error(&self, their_node_id, msg.channel_id);
 	}
@@ -1787,16 +1787,16 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, OM: Deref, L: Deref, CM
 				self.message_handler.chan_handler.handle_stfu(&their_node_id, &msg);
 			}
 
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			// Splicing messages:
 			wire::Message::Splice(msg) => {
 				self.message_handler.chan_handler.handle_splice(&their_node_id, &msg);
 			}
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			wire::Message::SpliceAck(msg) => {
 				self.message_handler.chan_handler.handle_splice_ack(&their_node_id, &msg);
 			}
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			wire::Message::SpliceLocked(msg) => {
 				self.message_handler.chan_handler.handle_splice_locked(&their_node_id, &msg);
 			}

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -60,11 +60,11 @@ pub(crate) enum Message<T> where T: core::fmt::Debug + Type + TestEq {
 	FundingCreated(msgs::FundingCreated),
 	FundingSigned(msgs::FundingSigned),
 	Stfu(msgs::Stfu),
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	Splice(msgs::Splice),
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	SpliceAck(msgs::SpliceAck),
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	SpliceLocked(msgs::SpliceLocked),
 	TxAddInput(msgs::TxAddInput),
 	TxAddOutput(msgs::TxAddOutput),
@@ -118,11 +118,11 @@ impl<T> Writeable for Message<T> where T: core::fmt::Debug + Type + TestEq {
 			&Message::FundingCreated(ref msg) => msg.write(writer),
 			&Message::FundingSigned(ref msg) => msg.write(writer),
 			&Message::Stfu(ref msg) => msg.write(writer),
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			&Message::Splice(ref msg) => msg.write(writer),
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			&Message::SpliceAck(ref msg) => msg.write(writer),
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			&Message::SpliceLocked(ref msg) => msg.write(writer),
 			&Message::TxAddInput(ref msg) => msg.write(writer),
 			&Message::TxAddOutput(ref msg) => msg.write(writer),
@@ -176,11 +176,11 @@ impl<T> Type for Message<T> where T: core::fmt::Debug + Type + TestEq {
 			&Message::FundingCreated(ref msg) => msg.type_id(),
 			&Message::FundingSigned(ref msg) => msg.type_id(),
 			&Message::Stfu(ref msg) => msg.type_id(),
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			&Message::Splice(ref msg) => msg.type_id(),
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			&Message::SpliceAck(ref msg) => msg.type_id(),
-			#[cfg(dual_funding)]
+			#[cfg(splicing)]
 			&Message::SpliceLocked(ref msg) => msg.type_id(),
 			&Message::TxAddInput(ref msg) => msg.type_id(),
 			&Message::TxAddOutput(ref msg) => msg.type_id(),
@@ -279,18 +279,18 @@ fn do_read<R: io::Read, T, H: core::ops::Deref>(buffer: &mut R, message_type: u1
 		msgs::FundingSigned::TYPE => {
 			Ok(Message::FundingSigned(Readable::read(buffer)?))
 		},
-		#[cfg(dual_funding)]
+		#[cfg(splicing)]
 		msgs::Splice::TYPE => {
 			Ok(Message::Splice(Readable::read(buffer)?))
 		},
 		msgs::Stfu::TYPE => {
 			Ok(Message::Stfu(Readable::read(buffer)?))
 		},
-		#[cfg(dual_funding)]
+		#[cfg(splicing)]
 		msgs::SpliceAck::TYPE => {
 			Ok(Message::SpliceAck(Readable::read(buffer)?))
 		},
-		#[cfg(dual_funding)]
+		#[cfg(splicing)]
 		msgs::SpliceLocked::TYPE => {
 			Ok(Message::SpliceLocked(Readable::read(buffer)?))
 		},

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -768,15 +768,15 @@ impl msgs::ChannelMessageHandler for TestChannelMessageHandler {
 	fn handle_stfu(&self, _their_node_id: &PublicKey, msg: &msgs::Stfu) {
 		self.received_msg(wire::Message::Stfu(msg.clone()));
 	}
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice(&self, _their_node_id: &PublicKey, msg: &msgs::Splice) {
 		self.received_msg(wire::Message::Splice(msg.clone()));
 	}
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice_ack(&self, _their_node_id: &PublicKey, msg: &msgs::SpliceAck) {
 		self.received_msg(wire::Message::SpliceAck(msg.clone()));
 	}
-	#[cfg(dual_funding)]
+	#[cfg(splicing)]
 	fn handle_splice_locked(&self, _their_node_id: &PublicKey, msg: &msgs::SpliceLocked) {
 		self.received_msg(wire::Message::SpliceLocked(msg.clone()));
 	}


### PR DESCRIPTION
Add `splicing` feature flag, also triggers dual_funding, as it's a prerequisite to splicing.

Change all dual_funding code to be gated by `#[cfg(any(dual_funding, splicing))]`
Change splicing code (few empty handler methods at this point) to be gated by `#[cfg(splicing)]`
LDK should work with both 'dual_funding' and 'splicing' flags (or both).

Housekeeping: may interfere with V2 PR #2023, but resolution should be straightforward.