### PR TITLE
Make `OutputSweeper::track_spendable_outputs` fallible

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -1665,7 +1665,7 @@ mod tests {
 			.expect("Events not handled within deadline");
 		match event {
 			Event::SpendableOutputs { outputs, channel_id } => {
-				nodes[0].sweeper.track_spendable_outputs(outputs, channel_id, false, Some(153));
+				nodes[0].sweeper.track_spendable_outputs(outputs, channel_id, false, Some(153)).unwrap();
 			},
 			_ => panic!("Unexpected event: {:?}", event),
 		}


### PR DESCRIPTION
.. as otherwise we might only log an error and continue if we fail to persist the sweeper state.

This came up during the LDK Node upgrade to 0.0.123-beta. It's nice for the user to be sure that during migration the sweeper has been successfully persisted before it can safely remove the previously-persisted output information.