### PR TITLE
Add more information to OpenChannelRequest Event

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -1113,6 +1113,10 @@ pub enum Event {
 		///
 		/// [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
 		channel_type: ChannelTypeFeatures,
+		/// True if this channel is (or will be) publicly-announced.
+		is_public: bool,
+		/// Opening fields for the channel given by the counterparty.
+		open_fields: msgs::CommonOpenChannelFields,
 	},
 	/// Indicates that the HTLC was accepted, but could not be processed when or after attempting to
 	/// forward it.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7169,12 +7169,15 @@ where
 					MsgHandleErrInternal::from_chan_no_close(e, msg.common_fields.temporary_channel_id)
 				)?;
 			let mut pending_events = self.pending_events.lock().unwrap();
+			let is_public = (msg.common_fields.channel_flags & 1) == 1;
 			pending_events.push_back((events::Event::OpenChannelRequest {
 				temporary_channel_id: msg.common_fields.temporary_channel_id.clone(),
 				counterparty_node_id: counterparty_node_id.clone(),
 				funding_satoshis: msg.common_fields.funding_satoshis,
 				push_msat: msg.push_msat,
 				channel_type,
+				is_public,
+				open_fields: msg.common_fields.clone(),
 			}, None));
 			peer_state.inbound_channel_request_by_id.insert(channel_id, InboundChannelRequest {
 				open_channel_msg: msg.clone(),


### PR DESCRIPTION
Noticed it was missing `is_public` and figured could just add all the fields since this isn't serialized.