### PR TITLE
Fix new rustc `#[macro_export]` warning in doctests

### DIFF
--- a/lightning-custom-message/src/lib.rs
+++ b/lightning-custom-message/src/lib.rs
@@ -12,6 +12,7 @@
 //! `Foo` and `Bar` messages, and further composing it with a handler for `Baz` messages.
 //!
 //!```
+//! # fn main() {} // Avoid #[macro_export] generating an in-function warning
 //! # extern crate bitcoin;
 //! extern crate lightning;
 //! #[macro_use]
@@ -167,7 +168,6 @@
 //! #     }
 //! }
 //!
-//! # fn main() {
 //! // The first crate may define a handler composing `FooHandler` and `BarHandler` and export the
 //! // corresponding message type ids as a macro to use in further composition.
 //!
@@ -207,7 +207,6 @@
 //! macro_rules! foo_bar_baz_type_ids {
 //!     () => { foo_bar_type_ids!() | baz_type_id!() }
 //! }
-//! # }
 //!```
 //!
 //! [BOLT 1]: https://github.com/lightning/bolts/blob/master/01-messaging.md


### PR DESCRIPTION
rustc now warns any time a `#[macro_export]` is used inside a function as it generates surprising results. Because doctests are run inside implicit test functions this means any use of `#[macro_export]` inside a doctest will now warn. We do this in `lightning-custom-message` to demonstrated how to use the crate, which now fails to compile.

Here we fix this by adding an `fn main() {}` to the doctest, which causes doctests to be compiled as freestanding code rather than inside a test function.

Note that while discussing this upstream it came up that rustc is also planning on changing the way doctests are compiled to compile an entire crate's doctests in one go rather than in separate crates, causing doctests to have a shared namespace which may generate future surprising outcomes.