### PR TITLE
Fix overflow in lightning-invoice `amount_pico_btc`

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -1068,9 +1068,10 @@ impl RawBolt11Invoice {
 		find_all_extract!(self.known_tagged_fields(), TaggedField::PrivateRoute(ref x), x).collect()
 	}
 
+	/// Returns `None` if no amount is set or on overflow.
 	pub fn amount_pico_btc(&self) -> Option<u64> {
-		self.hrp.raw_amount.map(|v| {
-			v * self.hrp.si_prefix.as_ref().map_or(1_000_000_000_000, |si| { si.multiplier() })
+		self.hrp.raw_amount.and_then(|v| {
+			v.checked_mul(self.hrp.si_prefix.as_ref().map_or(1_000_000_000_000, |si| { si.multiplier() }))
 		})
 	}
 


### PR DESCRIPTION
Fixes #3027. Thanks @mikedilger for catching this! 