### PR TITLE
Wake `background-processor` from `ChainMonitor` on new blocks

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -296,6 +296,8 @@ pub struct ChainMonitor<ChannelSigner: WriteableEcdsaChannelSigner, C: Deref, T:
 	/// The best block height seen, used as a proxy for the passage of time.
 	highest_chain_height: AtomicUsize,
 
+	/// A [`Notifier`] used to wake up the background processor in case we have any [`Event`]s for
+	/// it to give to users (or [`MonitorEvent`]s for `ChannelManager` to process).
 	event_notifier: Notifier,
 }
 
@@ -738,6 +740,8 @@ where
 			monitor.block_connected(
 				header, txdata, height, &*self.broadcaster, &*self.fee_estimator, &self.logger)
 		});
+		// Assume we may have some new events and wake the event processor
+		self.event_notifier.notify();
 	}
 
 	fn block_disconnected(&self, header: &Header, height: u32) {
@@ -765,6 +769,8 @@ where
 			monitor.transactions_confirmed(
 				header, txdata, height, &*self.broadcaster, &*self.fee_estimator, &self.logger)
 		});
+		// Assume we may have some new events and wake the event processor
+		self.event_notifier.notify();
 	}
 
 	fn transaction_unconfirmed(&self, txid: &Txid) {
@@ -785,6 +791,8 @@ where
 				header, height, &*self.broadcaster, &*self.fee_estimator, &self.logger
 			)
 		});
+		// Assume we may have some new events and wake the event processor
+		self.event_notifier.notify();
 	}
 
 	fn get_relevant_txids(&self) -> Vec<(Txid, u32, Option<BlockHash>)> {


### PR DESCRIPTION
When we receive a new block we may generate
`Event::SpendableOutputs` in `ChannelMonitor`s which then need to be processed by the background processor. While it will do so eventually when its normal loop goes around, this may cause user tests to be delayed in finding events, so we should notify the BP immediately to wake it on new blocks.

We implement that here, unconditionally notifying the `background-processor` whenever we receive a new block or confirmed transactions.