### PR TITLE
[0.0.123] Don't attempt to resume channels if we already exchanged funding

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -7436,6 +7436,12 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 		Ok(self.get_open_channel(chain_hash))
 	}
 
+	/// Returns true if we can resume the channel by sending the [`msgs::OpenChannel`] again.
+	pub fn is_resumable(&self) -> bool {
+		!self.context.have_received_message() &&
+			self.context.cur_holder_commitment_transaction_number == INITIAL_COMMITMENT_NUMBER
+	}
+
 	pub fn get_open_channel(&self, chain_hash: ChainHash) -> msgs::OpenChannel {
 		if !self.context.is_outbound() {
 			panic!("Tried to open a channel for an inbound channel?");


### PR DESCRIPTION
ddf75afd16 introduced the ability to re-exchange our `ChannelOpen` after a peer disconnects if we didn't complete funding on our end. It did not implement nor consider what would happen if we re-connected after we created our own funding transactions, and currently it panics (and even if it did not it would replay the `FundingTransactionGenerated` event to users).

This addresses this in a temporary fashion to fix the immediate panic for 0.0.123, allowing us to fix the issue more fully later.

Note that this branch is not targeting upstream but rather the 0.0.123 branch.