### PR TITLE
Followups to #2957

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -984,7 +984,6 @@ mod tests {
 		let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 		create_announced_chan_between_nodes(&nodes, 0, 1);
 
-		chanmon_cfgs[0].persister.chain_sync_monitor_persistences.lock().unwrap().clear();
 		chanmon_cfgs[0].persister.set_update_ret(ChannelMonitorUpdateStatus::UnrecoverableError);
 
 		assert!(std::panic::catch_unwind(|| {

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -1101,7 +1101,6 @@ fn do_test_dup_htlc_onchain_doesnt_fail_on_reload(persist_manager_post_event: bo
 	// Now connect the HTLC claim transaction with the ChainMonitor-generated ChannelMonitor update
 	// returning InProgress. This should cause the claim event to never make its way to the
 	// ChannelManager.
-	chanmon_cfgs[0].persister.chain_sync_monitor_persistences.lock().unwrap().clear();
 	chanmon_cfgs[0].persister.set_update_ret(ChannelMonitorUpdateStatus::InProgress);
 
 	if payment_timeout {


### PR DESCRIPTION
Based on #2957
* Stop tracking chain_sync_monitor_persistences in TestPersister
* Minor Doc fixes
* Make a log trace log