### PR TITLE
Make timer_tick_occurred a second long timer

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -93,7 +93,7 @@ pub struct BackgroundProcessor {
 }
 
 #[cfg(not(test))]
-const FRESHNESS_TIMER: u64 = 60;
+const FRESHNESS_TIMER: u64 = 1;
 #[cfg(test)]
 const FRESHNESS_TIMER: u64 = 1;
 
@@ -933,7 +933,7 @@ mod tests {
 	use lightning::events::{Event, PathFailure, MessageSendEventsProvider, MessageSendEvent};
 	use lightning::{get_event_msg, get_event};
 	use lightning::ln::types::{PaymentHash, ChannelId};
-	use lightning::ln::channelmanager;
+	use lightning::ln::channelmanager::{self, TICKS_PER_MINUTE};
 	use lightning::ln::channelmanager::{BREAKDOWN_TIMEOUT, ChainParameters, MIN_CLTV_EXPIRY_DELTA, PaymentId};
 	use lightning::ln::features::{ChannelFeatures, NodeFeatures};
 	use lightning::ln::functional_test_utils::*;
@@ -960,7 +960,7 @@ mod tests {
 	use lightning_rapid_gossip_sync::RapidGossipSync;
 	use super::{BackgroundProcessor, GossipSync, FRESHNESS_TIMER};
 
-	const EVENT_DEADLINE: u64 = 5 * FRESHNESS_TIMER;
+	const EVENT_DEADLINE: u64 = 5 * TICKS_PER_MINUTE as u64 * FRESHNESS_TIMER;
 
 	#[derive(Clone, Hash, PartialEq, Eq)]
 	struct TestDescriptor{}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -957,7 +957,7 @@ pub(super) struct InboundChannelRequest {
 
 /// The number of ticks that may elapse while we're waiting for an unaccepted inbound channel to be
 /// accepted. An unaccepted channel that exceeds this limit will be abandoned.
-const UNACCEPTED_INBOUND_CHANNEL_AGE_LIMIT_TICKS: i32 = 2;
+const UNACCEPTED_INBOUND_CHANNEL_AGE_LIMIT_TICKS: i32 = 2 * TICKS_PER_MINUTE as i32;
 
 /// Stores a PaymentSecret and any other data we may need to validate an inbound payment is
 /// actually ours and not some duplicate HTLC sent to us by a node along the route.
@@ -2259,16 +2259,20 @@ const CHECK_CLTV_EXPIRY_SANITY: u32 = MIN_CLTV_EXPIRY_DELTA as u32 - LATENCY_GRA
 #[allow(dead_code)]
 const CHECK_CLTV_EXPIRY_SANITY_2: u32 = MIN_CLTV_EXPIRY_DELTA as u32 - LATENCY_GRACE_PERIOD_BLOCKS - 2*CLTV_CLAIM_BUFFER;
 
+/// Constant that keeps track of the number of times [`ChannelManager::timer_tick_occurred`]
+/// is called every minute.
+pub const TICKS_PER_MINUTE: u8 = 60;
+
 /// The number of ticks of [`ChannelManager::timer_tick_occurred`] until expiry of incomplete MPPs
-pub(crate) const MPP_TIMEOUT_TICKS: u8 = 3;
+pub(crate) const MPP_TIMEOUT_TICKS: u8 = 3 * TICKS_PER_MINUTE;
 
 /// The number of ticks of [`ChannelManager::timer_tick_occurred`] where a peer is disconnected
 /// until we mark the channel disabled and gossip the update.
-pub(crate) const DISABLE_GOSSIP_TICKS: u8 = 10;
+pub(crate) const DISABLE_GOSSIP_TICKS: u16 = 10 * TICKS_PER_MINUTE as u16;
 
 /// The number of ticks of [`ChannelManager::timer_tick_occurred`] where a peer is connected until
 /// we mark the channel enabled and gossip the update.
-pub(crate) const ENABLE_GOSSIP_TICKS: u8 = 5;
+pub(crate) const ENABLE_GOSSIP_TICKS: u16 = 5 * TICKS_PER_MINUTE as u16;
 
 /// The maximum number of unfunded channels we can have per-peer before we start rejecting new
 /// (inbound) ones. The number of peers with unfunded channels is limited separately in

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -10,6 +10,7 @@
 //! Tests of our shutdown and closing_signed negotiation logic as well as some assorted force-close
 //! handling tests.
 
+use crate::ln::channel::UNPROGRESS_CLOSING_SIGNED_NEGOTIATION_AGE_LIMIT_TICKS;
 use crate::sign::{EntropySource, SignerProvider};
 use crate::chain::ChannelMonitorUpdateStatus;
 use crate::chain::transaction::OutPoint;
@@ -1161,8 +1162,9 @@ fn do_test_closing_signed_reinit_timeout(timeout_step: TimeoutStep) {
 		assert_eq!(nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap().len(), 1);
 	}
 
-	nodes[1].node.timer_tick_occurred();
-	nodes[1].node.timer_tick_occurred();
+	for _ in 0..UNPROGRESS_CLOSING_SIGNED_NEGOTIATION_AGE_LIMIT_TICKS + 1 {
+		nodes[1].node.timer_tick_occurred();
+	}
 
 	let txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap().clone();
 	assert_eq!(txn.len(), 1);


### PR DESCRIPTION
This PR updates timer_tick_occurred to operate on a second-long timer, providing finer timing control.


Reasoning:
1. This PR is the prerequisite of #3010, which introduces the ability to retry the InvoiceRequest message in a finite time if we have not received the corresponding BOLT12 Invoice back.
2. The retries need to be faster than a standard minute-long timer.
3. The discussion was between introducing a new counter vs changing timer_tick duration (see [comment](https://github.com/lightningdevkit/rust-lightning/pull/3010#issuecomment-2108708311)). This PR is an attempt at the second approach.