### PR TITLE
Add PersistClaimInfo and ClaimInfoRequest events

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -1332,7 +1332,8 @@ pub enum Event {
 		/// Destination of the HTLC that failed to be processed.
 		failed_next_destination: HTLCDestination,
 	},
-	/// Used to request [`ClaimInfo`] for a specific counterparty commitment transaction.
+	/// Indicates that a [`ClaimInfo`] for a specific counterparty commitment transaction must be 
+	/// supplied to ldk if available.
 	///
 	/// This event is generated when there is a need for [`ClaimInfo`] that was previously stored
 	/// using [`PersistClaimInfo`] for the specified counterparty commitment transaction.


### PR DESCRIPTION
Based on #3057 

Introduce two new events i.e. PersistClaimInfo and ClaimInfoRequest.

PersistClaimInfo: Indicates that [`ClaimInfo`] should be durably persisted.

ClaimInfoRequest: Used to request [`ClaimInfo`] for a specific counterparty commitment transaction.

This PR is still in progress as event writing changes are pending and is not in mergeable state but the api and interface can still be reviewed. Mostly ignore docs, they should be legible but need some more work.

As part of https://github.com/lightningdevkit/rust-lightning/issues/3049