### PR TITLE
Re-export bitcoin crate

### DIFF
--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -61,7 +61,7 @@ compile_error!("Tests will always fail with cfg=fuzzing");
 
 #[macro_use]
 extern crate alloc;
-extern crate bitcoin;
+pub extern crate bitcoin;
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 


### PR DESCRIPTION
For the same reason the `bitcoin` crate is re-exporting the `secp256k1` crate the `lightning` crate should re-export the `bitcoin` crate: to ease the burden on calling code to maintain compatible `bitcoin` versions.

The `lightning` crate makes heavy use of types defined in (or re-exported by) the `bitcoin` crate. Compilation will fail if e.g. comparisons or `match` expressions are done with types from `bitcoin` crate versions with a non-equal minor version. This forces calling code to depend on a `bitcoin` crate with a compatible version. This becomes a maintenance nightmare once two or more crates, that use `bitcoin` types in their public API, are used in calling code simultaneously.