### PR TITLE
Reintroduce addresses to NodeAnnouncementInfo.

### DIFF
--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -383,15 +383,14 @@ where
 				intermediate_nodes: vec![], destination, first_node_addresses: None
 			})
 		} else {
-			let node_announcement = network_graph
+			let node_details = network_graph
 				.node(&NodeId::from_pubkey(&first_node))
 				.and_then(|node_info| node_info.announcement_info.as_ref())
-				.and_then(|announcement_info| announcement_info.announcement_message.as_ref())
-				.map(|node_announcement| &node_announcement.contents);
+				.map(|announcement_info| (announcement_info.features(), announcement_info.addresses()));
 
-			match node_announcement {
-				Some(node_announcement) if node_announcement.features.supports_onion_messages() => {
-					let first_node_addresses = Some(node_announcement.addresses.clone());
+			match node_details {
+				Some((features, addresses)) if features.supports_onion_messages() && addresses.len() > 0 => {
+					let first_node_addresses = Some(addresses.clone());
 					Ok(OnionMessagePath {
 						intermediate_nodes: vec![], destination, first_node_addresses
 					})

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -1984,7 +1984,7 @@ where L::Target: Logger {
 		true
 	} else if let Some(payee) = payee_node_id_opt {
 		network_nodes.get(&payee).map_or(false, |node| node.announcement_info.as_ref().map_or(false,
-			|info| info.features.supports_basic_mpp()))
+			|info| info.features().supports_basic_mpp()))
 	} else { false };
 
 	let max_total_routing_fee_msat = route_params.max_total_routing_fee_msat.unwrap_or(u64::max_value());
@@ -2469,7 +2469,7 @@ where L::Target: Logger {
 				}
 
 				let features = if let Some(node_info) = $node.announcement_info.as_ref() {
-					&node_info.features
+					&node_info.features()
 				} else {
 					&default_node_features
 				};
@@ -2799,7 +2799,7 @@ where L::Target: Logger {
 					if !features_set {
 						if let Some(node) = network_nodes.get(&target) {
 							if let Some(node_info) = node.announcement_info.as_ref() {
-								ordered_hops.last_mut().unwrap().1 = node_info.features.clone();
+								ordered_hops.last_mut().unwrap().1 = node_info.features().clone();
 							} else {
 								ordered_hops.last_mut().unwrap().1 = default_node_features.clone();
 							}


### PR DESCRIPTION
Parsing v2 gossip, which will include socket addresses, but no signatures, will require the ability to store addresses on the `NodeAnnouncementInfo` object without a corresponding (signed) `NodeAnnouncement` message.

This approach is to effectively revert commit 6f5e5e3898da67da809e939e6980bc3fbe647112. Some alternative approaches could be setting an enum for either a signed or unsigned node announcement, or even to have an enum for either a signed node announcement or the addresses field.