### PR TITLE
Introduce RecipientData and use it to allow abandon failed payments

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -31,6 +31,7 @@ use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::hash_types::{BlockHash, WPubkeyHash};
 
 use lightning::blinded_path::BlindedPath;
+use lightning::blinded_path::message::RecipientData;
 use lightning::blinded_path::payment::ReceiveTlvs;
 use lightning::chain;
 use lightning::chain::{BestBlock, ChannelMonitorUpdateStatus, chainmonitor, channelmonitor, Confirm, Watch};
@@ -119,7 +120,7 @@ impl MessageRouter for FuzzRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _recipient_data: Option<RecipientData>, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPath>, ()> {
 		unreachable!()
 	}

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -28,6 +28,7 @@ use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::hash_types::{Txid, BlockHash, WPubkeyHash};
 
 use lightning::blinded_path::BlindedPath;
+use lightning::blinded_path::message::RecipientData;
 use lightning::blinded_path::payment::ReceiveTlvs;
 use lightning::chain;
 use lightning::chain::{BestBlock, ChannelMonitorUpdateStatus, Confirm, Listen};
@@ -157,7 +158,7 @@ impl MessageRouter for FuzzRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _recipient_data: Option<RecipientData>, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPath>, ()> {
 		unreachable!()
 	}

--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -74,8 +74,8 @@ fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
 ) -> Result<UnsignedBolt12Invoice, Bolt12SemanticError> {
 	let entropy_source = Randomness {};
 	let paths = vec![
-		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], &entropy_source, secp_ctx).unwrap(),
-		BlindedPath::new_for_message(&[pubkey(45), pubkey(46), pubkey(42)], &entropy_source, secp_ctx).unwrap(),
+		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], None, &entropy_source, secp_ctx).unwrap(),
+		BlindedPath::new_for_message(&[pubkey(45), pubkey(46), pubkey(42)], None, &entropy_source, secp_ctx).unwrap(),
 	];
 
 	let payinfo = vec![

--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -89,7 +89,7 @@ impl MessageRouter for TestMessageRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _recipient_data: Option<RecipientData>, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPath>, ()> {
 		unreachable!()
 	}

--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -7,6 +7,7 @@ use bitcoin::secp256k1::ecdsa::RecoverableSignature;
 use bitcoin::secp256k1::schnorr;
 
 use lightning::blinded_path::{BlindedPath, EmptyNodeIdLookUp};
+use lightning::blinded_path::message::RecipientData;
 use lightning::ln::features::InitFeatures;
 use lightning::ln::msgs::{self, DecodeError, OnionMessageHandler};
 use lightning::ln::script::ShutdownScript;
@@ -97,7 +98,7 @@ impl MessageRouter for TestMessageRouter {
 struct TestOffersMessageHandler {}
 
 impl OffersMessageHandler for TestOffersMessageHandler {
-	fn handle_message(&self, _message: OffersMessage, _responder: Option<Responder>) -> ResponseInstruction<OffersMessage> {
+	fn handle_message(&self, _message: OffersMessage, _responder: Option<Responder>, _recipient_data: RecipientData) -> ResponseInstruction<OffersMessage> {
 		ResponseInstruction::NoResponse
 	}
 }
@@ -127,7 +128,7 @@ struct TestCustomMessageHandler {}
 
 impl CustomOnionMessageHandler for TestCustomMessageHandler {
 	type CustomMessage = TestCustomMessage;
-	fn handle_custom_message(&self, message: Self::CustomMessage, responder: Option<Responder>) -> ResponseInstruction<Self::CustomMessage> {
+	fn handle_custom_message(&self, message: Self::CustomMessage, responder: Option<Responder>, _recipient_data: RecipientData) -> ResponseInstruction<Self::CustomMessage> {
 		match responder {
 			Some(responder) => responder.respond(message),
 			None => ResponseInstruction::NoResponse

--- a/fuzz/src/refund_deser.rs
+++ b/fuzz/src/refund_deser.rs
@@ -63,8 +63,8 @@ fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
 ) -> Result<UnsignedBolt12Invoice, Bolt12SemanticError> {
 	let entropy_source = Randomness {};
 	let paths = vec![
-		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], &entropy_source, secp_ctx).unwrap(),
-		BlindedPath::new_for_message(&[pubkey(45), pubkey(46), pubkey(42)], &entropy_source, secp_ctx).unwrap(),
+		BlindedPath::new_for_message(&[pubkey(43), pubkey(44), pubkey(42)], None, &entropy_source, secp_ctx).unwrap(),
+		BlindedPath::new_for_message(&[pubkey(45), pubkey(46), pubkey(42)], None, &entropy_source, secp_ctx).unwrap(),
 	];
 
 	let payinfo = vec![

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -91,13 +91,15 @@ impl Writeable for ReceiveTlvs {
 
 /// Construct blinded onion message hops for the given `unblinded_path`.
 pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
-	secp_ctx: &Secp256k1<T>, unblinded_path: &[PublicKey], session_priv: &SecretKey
+	secp_ctx: &Secp256k1<T>, unblinded_path: &[PublicKey], recipient_data: Option<RecipientData>,
+	session_priv: &SecretKey
 ) -> Result<Vec<BlindedHop>, secp256k1::Error> {
+	let recipient_data = recipient_data.unwrap_or(RecipientData::new());
 	let blinded_tlvs = unblinded_path.iter()
 		.skip(1) // The first node's TLVs contains the next node's pubkey
 		.map(|pk| ForwardTlvs { next_hop: NextMessageHop::NodeId(*pk), next_blinding_override: None })
 		.map(|tlvs| ControlTlvs::Forward(tlvs))
-		.chain(core::iter::once(ControlTlvs::Receive(ReceiveTlvs { path_id: None, recipient_data: RecipientData::new() })));
+		.chain(core::iter::once(ControlTlvs::Receive(ReceiveTlvs { path_id: None, recipient_data })));
 
 	utils::construct_blinded_hops(secp_ctx, unblinded_path.iter(), blinded_tlvs, session_priv)
 }

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -1,3 +1,7 @@
+//! Data structures and methods for constructing [`BlindedPath`]s to send a message over.
+//!
+//! [`BlindedPath`]: crate::blinded_path::BlindedPath
+
 use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
 
 use crate::ln::channelmanager::PaymentId;

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -1,5 +1,6 @@
 use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
 
+use crate::ln::channelmanager::PaymentId;
 #[allow(unused_imports)]
 use crate::prelude::*;
 
@@ -32,6 +33,28 @@ pub(crate) struct ReceiveTlvs {
 	/// sending to. This is useful for receivers to check that said blinded path is being used in
 	/// the right context.
 	pub(crate) path_id: Option<[u8; 32]>,
+	pub recipient_data: RecipientData,
+}
+
+/// Represents additional data appended along with the sent reply path.
+///
+/// This data can be utilized by the final recipient for further processing
+/// upon receiving it back.
+#[derive(Clone, Debug)]
+pub struct RecipientData {
+	/// Payment ID of the outbound BOLT12 payment.
+	pub payment_id: Option<PaymentId>
+	// TODO: Introduce a more general form of RecipientData
+	// that can be used by Custom Messages
+}
+
+impl RecipientData {
+	/// Creates a new, empty RecipientData instance.
+	pub fn new() -> Self {
+		RecipientData {
+			payment_id: None,
+		}
+	}
 }
 
 impl Writeable for ForwardTlvs {
@@ -53,8 +76,10 @@ impl Writeable for ForwardTlvs {
 impl Writeable for ReceiveTlvs {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
 		// TODO: write padding
+		let RecipientData { payment_id } = self.recipient_data;
 		encode_tlv_stream!(writer, {
 			(6, self.path_id, option),
+			(65537, payment_id, option),
 		});
 		Ok(())
 	}
@@ -68,7 +93,7 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 		.skip(1) // The first node's TLVs contains the next node's pubkey
 		.map(|pk| ForwardTlvs { next_hop: NextMessageHop::NodeId(*pk), next_blinding_override: None })
 		.map(|tlvs| ControlTlvs::Forward(tlvs))
-		.chain(core::iter::once(ControlTlvs::Receive(ReceiveTlvs { path_id: None })));
+		.chain(core::iter::once(ControlTlvs::Receive(ReceiveTlvs { path_id: None, recipient_data: RecipientData::new() })));
 
 	utils::construct_blinded_hops(secp_ctx, unblinded_path.iter(), blinded_tlvs, session_priv)
 }

--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -10,7 +10,7 @@
 //! Creating blinded paths and related utilities live here.
 
 pub mod payment;
-pub(crate) mod message;
+pub mod message;
 pub(crate) mod utils;
 
 use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -31,6 +31,7 @@ use bitcoin::secp256k1::{SecretKey,PublicKey};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{secp256k1, Sequence};
 
+use crate::blinded_path::message::RecipientData;
 use crate::blinded_path::{BlindedPath, NodeIdLookUp};
 use crate::blinded_path::payment::{Bolt12OfferContext, Bolt12RefundContext, PaymentConstraints, PaymentContext, ReceiveTlvs};
 use crate::chain;
@@ -10348,9 +10349,15 @@ where
 	R::Target: Router,
 	L::Target: Logger,
 {
-	fn handle_message(&self, message: OffersMessage, responder: Option<Responder>) -> ResponseInstruction<OffersMessage> {
+	fn handle_message(&self, message: OffersMessage, responder: Option<Responder>, recipient_data: RecipientData) -> ResponseInstruction<OffersMessage> {
 		let secp_ctx = &self.secp_ctx;
 		let expanded_key = &self.inbound_payment_key;
+
+		let abandon_if_payment = |payment_id| {
+			if let Some(payment_id) = payment_id {
+				self.abandon_payment(payment_id);
+			}
+		};
 
 		match message {
 			OffersMessage::InvoiceRequest(invoice_request) => {
@@ -10460,8 +10467,12 @@ where
 					});
 
 				match (responder, response) {
-					(Some(responder), Err(e)) => responder.respond(OffersMessage::InvoiceError(e)),
+					(Some(responder), Err(e)) => {
+						abandon_if_payment(recipient_data.payment_id);
+						responder.respond(OffersMessage::InvoiceError(e))
+					},
 					(None, Err(_)) => {
+						abandon_if_payment(recipient_data.payment_id);
 						log_trace!(
 							self.logger,
 							"A response was generated, but there is no reply_path specified for sending the response."
@@ -10472,6 +10483,7 @@ where
 				}
 			},
 			OffersMessage::InvoiceError(invoice_error) => {
+				abandon_if_payment(recipient_data.payment_id);
 				log_trace!(self.logger, "Received invoice_error: {}", invoice_error);
 				return ResponseInstruction::NoResponse;
 			},

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8572,7 +8572,7 @@ macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 		let entropy = &*$self.entropy_source;
 		let secp_ctx = &$self.secp_ctx;
 
-		let path = $self.create_blinded_path().map_err(|_| Bolt12SemanticError::MissingPaths)?;
+		let path = $self.create_blinded_path(None).map_err(|_| Bolt12SemanticError::MissingPaths)?;
 		let builder = OfferBuilder::deriving_signing_pubkey(
 			node_id, expanded_key, entropy, secp_ctx
 		)
@@ -8639,7 +8639,11 @@ macro_rules! create_refund_builder { ($self: ident, $builder: ty) => {
 		let entropy = &*$self.entropy_source;
 		let secp_ctx = &$self.secp_ctx;
 
-		let path = $self.create_blinded_path().map_err(|_| Bolt12SemanticError::MissingPaths)?;
+		let recipient_data = RecipientData {
+			payment_id: Some(payment_id)
+		};
+
+		let path = $self.create_blinded_path(Some(recipient_data)).map_err(|_| Bolt12SemanticError::MissingPaths)?;
 		let builder = RefundBuilder::deriving_payer_id(
 			node_id, expanded_key, entropy, secp_ctx, amount_msats, payment_id
 		)?
@@ -8762,7 +8766,10 @@ where
 			Some(payer_note) => builder.payer_note(payer_note),
 		};
 		let invoice_request = builder.build_and_sign()?;
-		let reply_path = self.create_blinded_path().map_err(|_| Bolt12SemanticError::MissingPaths)?;
+		let recipient_data = RecipientData {
+			payment_id: Some(payment_id)
+		};
+		let reply_path = self.create_blinded_path(Some(recipient_data)).map_err(|_| Bolt12SemanticError::MissingPaths)?;
 
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 
@@ -8862,7 +8869,7 @@ where
 				)?;
 				let builder: InvoiceBuilder<DerivedSigningPubkey> = builder.into();
 				let invoice = builder.allow_mpp().build_and_sign(secp_ctx)?;
-				let reply_path = self.create_blinded_path()
+				let reply_path = self.create_blinded_path(None)
 					.map_err(|_| Bolt12SemanticError::MissingPaths)?;
 
 				let mut pending_offers_messages = self.pending_offers_messages.lock().unwrap();
@@ -8991,7 +8998,7 @@ where
 	/// Creates a blinded path by delegating to [`MessageRouter::create_blinded_paths`].
 	///
 	/// Errors if the `MessageRouter` errors or returns an empty `Vec`.
-	fn create_blinded_path(&self) -> Result<BlindedPath, ()> {
+	fn create_blinded_path(&self, recipient_data: Option<RecipientData>) -> Result<BlindedPath, ()> {
 		let recipient = self.get_our_node_id();
 		let secp_ctx = &self.secp_ctx;
 
@@ -9002,7 +9009,7 @@ where
 			.collect::<Vec<_>>();
 
 		self.router
-			.create_blinded_paths(recipient, peers, secp_ctx)
+			.create_blinded_paths(recipient, recipient_data, peers, secp_ctx)
 			.and_then(|paths| paths.into_iter().next().ok_or(()))
 	}
 

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -996,6 +996,16 @@ fn fails_sending_invoice_without_blinded_payment_paths_for_offer() {
 
 	let invoice_error = extract_invoice_error(david, &onion_message);
 	assert_eq!(invoice_error, InvoiceError::from(Bolt12SemanticError::MissingPaths));
+
+	// Confirm that david drops this failed payment from his pending outbound payments.
+	let events = david.node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match events[0] {
+		Event::InvoiceRequestFailed { payment_id: pay_id} => {
+			assert_eq!(pay_id, payment_id)
+		},
+		_ => panic!("Unexpected Event"),
+	}
 }
 
 #[test]

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -180,7 +180,7 @@ fn extract_invoice_request<'a, 'b, 'c>(
 	node: &Node<'a, 'b, 'c>, message: &OnionMessage
 ) -> (InvoiceRequest, Option<BlindedPath>) {
 	match node.onion_messenger.peel_onion_message(message) {
-		Ok(PeeledOnion::Receive(message, _, reply_path)) => match message {
+		Ok(PeeledOnion::Receive(message, _, _, reply_path)) => match message {
 			ParsedOnionMessageContents::Offers(offers_message) => match offers_message {
 				OffersMessage::InvoiceRequest(invoice_request) => (invoice_request, reply_path),
 				OffersMessage::Invoice(invoice) => panic!("Unexpected invoice: {:?}", invoice),
@@ -195,7 +195,7 @@ fn extract_invoice_request<'a, 'b, 'c>(
 
 fn extract_invoice<'a, 'b, 'c>(node: &Node<'a, 'b, 'c>, message: &OnionMessage) -> Bolt12Invoice {
 	match node.onion_messenger.peel_onion_message(message) {
-		Ok(PeeledOnion::Receive(message, _, _)) => match message {
+		Ok(PeeledOnion::Receive(message, _, _, _)) => match message {
 			ParsedOnionMessageContents::Offers(offers_message) => match offers_message {
 				OffersMessage::InvoiceRequest(invoice_request) => panic!("Unexpected invoice_request: {:?}", invoice_request),
 				OffersMessage::Invoice(invoice) => invoice,
@@ -212,7 +212,7 @@ fn extract_invoice_error<'a, 'b, 'c>(
 	node: &Node<'a, 'b, 'c>, message: &OnionMessage
 ) -> InvoiceError {
 	match node.onion_messenger.peel_onion_message(message) {
-		Ok(PeeledOnion::Receive(message, _, _)) => match message {
+		Ok(PeeledOnion::Receive(message, _, _, _)) => match message {
 			ParsedOnionMessageContents::Offers(offers_message) => match offers_message {
 				OffersMessage::InvoiceRequest(invoice_request) => panic!("Unexpected invoice_request: {:?}", invoice_request),
 				OffersMessage::Invoice(invoice) => panic!("Unexpected invoice: {:?}", invoice),

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -18,6 +18,7 @@
 use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::secp256k1::{self, Secp256k1, SecretKey, PublicKey};
 
+use crate::blinded_path::message::RecipientData;
 use crate::sign::{NodeSigner, Recipient};
 use crate::events::{EventHandler, EventsProvider, MessageSendEvent, MessageSendEventsProvider};
 use crate::ln::types::ChannelId;
@@ -137,13 +138,13 @@ impl OnionMessageHandler for IgnoringMessageHandler {
 }
 
 impl OffersMessageHandler for IgnoringMessageHandler {
-	fn handle_message(&self, _message: OffersMessage, _responder: Option<Responder>) -> ResponseInstruction<OffersMessage> {
+	fn handle_message(&self, _message: OffersMessage, _responder: Option<Responder>, _recipient_data: RecipientData) -> ResponseInstruction<OffersMessage> {
 		ResponseInstruction::NoResponse
 	}
 }
 impl CustomOnionMessageHandler for IgnoringMessageHandler {
 	type CustomMessage = Infallible;
-	fn handle_custom_message(&self, _message: Self::CustomMessage, _responder: Option<Responder>) -> ResponseInstruction<Self::CustomMessage> {
+	fn handle_custom_message(&self, _message: Self::CustomMessage, _responder: Option<Responder>, _recipient_data: RecipientData) -> ResponseInstruction<Self::CustomMessage> {
 		// Since we always return `None` in the read the handle method should never be called.
 		unreachable!();
 	}

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -80,20 +80,20 @@ impl OffersMessageHandler for TestOffersMessageHandler {
 
 #[derive(Clone, Debug, PartialEq)]
 enum TestCustomMessage {
-	Request,
-	Response,
+	Ping,
+	Pong,
 }
 
-const CUSTOM_REQUEST_MESSAGE_TYPE: u64 = 4242;
-const CUSTOM_RESPONSE_MESSAGE_TYPE: u64 = 4343;
-const CUSTOM_REQUEST_MESSAGE_CONTENTS: [u8; 32] = [42; 32];
-const CUSTOM_RESPONSE_MESSAGE_CONTENTS: [u8; 32] = [43; 32];
+const CUSTOM_PING_MESSAGE_TYPE: u64 = 4242;
+const CUSTOM_PONG_MESSAGE_TYPE: u64 = 4343;
+const CUSTOM_PING_MESSAGE_CONTENTS: [u8; 32] = [42; 32];
+const CUSTOM_PONG_MESSAGE_CONTENTS: [u8; 32] = [43; 32];
 
 impl OnionMessageContents for TestCustomMessage {
 	fn tlv_type(&self) -> u64 {
 		match self {
-			TestCustomMessage::Request => CUSTOM_REQUEST_MESSAGE_TYPE,
-			TestCustomMessage::Response => CUSTOM_RESPONSE_MESSAGE_TYPE,
+			TestCustomMessage::Ping => CUSTOM_PING_MESSAGE_TYPE,
+			TestCustomMessage::Pong => CUSTOM_PONG_MESSAGE_TYPE,
 		}
 	}
 	fn msg_type(&self) -> &'static str {
@@ -104,8 +104,8 @@ impl OnionMessageContents for TestCustomMessage {
 impl Writeable for TestCustomMessage {
 	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
 		match self {
-			TestCustomMessage::Request => Ok(CUSTOM_REQUEST_MESSAGE_CONTENTS.write(w)?),
-			TestCustomMessage::Response => Ok(CUSTOM_RESPONSE_MESSAGE_CONTENTS.write(w)?),
+			TestCustomMessage::Ping => Ok(CUSTOM_PING_MESSAGE_CONTENTS.write(w)?),
+			TestCustomMessage::Pong => Ok(CUSTOM_PONG_MESSAGE_CONTENTS.write(w)?),
 		}
 	}
 }
@@ -143,8 +143,8 @@ impl CustomOnionMessageHandler for TestCustomMessageHandler {
 			None => panic!("Unexpected message: {:?}", msg),
 		}
 		let response_option = match msg {
-			TestCustomMessage::Request => Some(TestCustomMessage::Response),
-			TestCustomMessage::Response => None,
+			TestCustomMessage::Ping => Some(TestCustomMessage::Pong),
+			TestCustomMessage::Pong => None,
 		};
 		if let (Some(response), Some(responder)) = (response_option, responder) {
 			responder.respond(response)
@@ -154,15 +154,15 @@ impl CustomOnionMessageHandler for TestCustomMessageHandler {
 	}
 	fn read_custom_message<R: io::Read>(&self, message_type: u64, buffer: &mut R) -> Result<Option<Self::CustomMessage>, DecodeError> where Self: Sized {
 		match message_type {
-			CUSTOM_REQUEST_MESSAGE_TYPE => {
+			CUSTOM_PING_MESSAGE_TYPE => {
 				let buf = read_to_end(buffer)?;
-				assert_eq!(buf, CUSTOM_REQUEST_MESSAGE_CONTENTS);
-				Ok(Some(TestCustomMessage::Request))
+				assert_eq!(buf, CUSTOM_PING_MESSAGE_CONTENTS);
+				Ok(Some(TestCustomMessage::Ping))
 			},
-			CUSTOM_RESPONSE_MESSAGE_TYPE => {
+			CUSTOM_PONG_MESSAGE_TYPE => {
 				let buf = read_to_end(buffer)?;
-				assert_eq!(buf, CUSTOM_RESPONSE_MESSAGE_CONTENTS);
-				Ok(Some(TestCustomMessage::Response))
+				assert_eq!(buf, CUSTOM_PONG_MESSAGE_CONTENTS);
+				Ok(Some(TestCustomMessage::Pong))
 			},
 			_ => Ok(None),
 		}
@@ -297,18 +297,18 @@ fn pass_along_path(path: &Vec<MessengerNode>) {
 #[test]
 fn one_unblinded_hop() {
 	let nodes = create_nodes(2);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let destination = Destination::Node(nodes[1].node_id);
 	nodes[0].messenger.send_onion_message(test_msg, destination, None).unwrap();
-	nodes[1].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[1].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	pass_along_path(&nodes);
 }
 
 #[test]
 fn two_unblinded_hops() {
 	let nodes = create_nodes(3);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let path = OnionMessagePath {
 		intermediate_nodes: vec![nodes[1].node_id],
@@ -317,27 +317,27 @@ fn two_unblinded_hops() {
 	};
 
 	nodes[0].messenger.send_onion_message_using_path(path, test_msg, None).unwrap();
-	nodes[2].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[2].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	pass_along_path(&nodes);
 }
 
 #[test]
 fn one_blinded_hop() {
 	let nodes = create_nodes(2);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
 	let blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id], &*nodes[1].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	nodes[0].messenger.send_onion_message(test_msg, destination, None).unwrap();
-	nodes[1].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[1].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	pass_along_path(&nodes);
 }
 
 #[test]
 fn two_unblinded_two_blinded() {
 	let nodes = create_nodes(5);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
 	let blinded_path = BlindedPath::new_for_message(&[nodes[3].node_id, nodes[4].node_id], &*nodes[4].entropy_source, &secp_ctx).unwrap();
@@ -348,21 +348,21 @@ fn two_unblinded_two_blinded() {
 	};
 
 	nodes[0].messenger.send_onion_message_using_path(path, test_msg, None).unwrap();
-	nodes[4].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[4].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	pass_along_path(&nodes);
 }
 
 #[test]
 fn three_blinded_hops() {
 	let nodes = create_nodes(4);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
 	let blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id, nodes[2].node_id, nodes[3].node_id], &*nodes[3].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 
 	nodes[0].messenger.send_onion_message(test_msg, destination, None).unwrap();
-	nodes[3].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[3].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	pass_along_path(&nodes);
 }
 
@@ -376,7 +376,7 @@ fn async_response_over_one_blinded_hop() {
 	let bob = &nodes[1];
 
 	// 2. Define the message sent from Bob to Alice.
-	let message = TestCustomMessage::Request;
+	let message = TestCustomMessage::Ping;
 	let path_id = Some([2; 32]);
 
 	// 3. Simulate the creation of a Blinded Reply path provided by Bob.
@@ -396,7 +396,7 @@ fn async_response_over_one_blinded_hop() {
 		Ok(Some(SendSuccess::Buffered)),
 	);
 
-	bob.custom_message_handler.expect_message(TestCustomMessage::Response);
+	bob.custom_message_handler.expect_message(TestCustomMessage::Pong);
 
 	pass_along_path(&nodes);
 }
@@ -405,7 +405,7 @@ fn async_response_over_one_blinded_hop() {
 fn too_big_packet_error() {
 	// Make sure we error as expected if a packet is too big to send.
 	let nodes = create_nodes(2);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let hop_node_id = nodes[1].node_id;
 	let hops = vec![hop_node_id; 400];
@@ -423,21 +423,21 @@ fn we_are_intro_node() {
 	// If we are sending straight to a blinded path and we are the introduction node, we need to
 	// advance the blinded path by 1 hop so the second hop is the new introduction node.
 	let mut nodes = create_nodes(3);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
 	let blinded_path = BlindedPath::new_for_message(&[nodes[0].node_id, nodes[1].node_id, nodes[2].node_id], &*nodes[2].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 
 	nodes[0].messenger.send_onion_message(test_msg.clone(), destination, None).unwrap();
-	nodes[2].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[2].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	pass_along_path(&nodes);
 
 	// Try with a two-hop blinded path where we are the introduction node.
 	let blinded_path = BlindedPath::new_for_message(&[nodes[0].node_id, nodes[1].node_id], &*nodes[1].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	nodes[0].messenger.send_onion_message(test_msg, destination, None).unwrap();
-	nodes[1].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[1].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	nodes.remove(2);
 	pass_along_path(&nodes);
 }
@@ -446,7 +446,7 @@ fn we_are_intro_node() {
 fn invalid_blinded_path_error() {
 	// Make sure we error as expected if a provided blinded path has 0 hops.
 	let nodes = create_nodes(3);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
 	let mut blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id, nodes[2].node_id], &*nodes[2].entropy_source, &secp_ctx).unwrap();
@@ -459,7 +459,7 @@ fn invalid_blinded_path_error() {
 #[test]
 fn reply_path() {
 	let mut nodes = create_nodes(4);
-	let test_msg = TestCustomMessage::Request;
+	let test_msg = TestCustomMessage::Ping;
 	let secp_ctx = Secp256k1::new();
 
 	// Destination::Node
@@ -470,10 +470,10 @@ fn reply_path() {
 	};
 	let reply_path = BlindedPath::new_for_message(&[nodes[2].node_id, nodes[1].node_id, nodes[0].node_id], &*nodes[0].entropy_source, &secp_ctx).unwrap();
 	nodes[0].messenger.send_onion_message_using_path(path, test_msg.clone(), Some(reply_path)).unwrap();
-	nodes[3].custom_message_handler.expect_message(TestCustomMessage::Request);
+	nodes[3].custom_message_handler.expect_message(TestCustomMessage::Ping);
 	pass_along_path(&nodes);
 	// Make sure the last node successfully decoded the reply path.
-	nodes[0].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[0].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	nodes.reverse();
 	pass_along_path(&nodes);
 
@@ -483,11 +483,11 @@ fn reply_path() {
 	let reply_path = BlindedPath::new_for_message(&[nodes[2].node_id, nodes[1].node_id, nodes[0].node_id], &*nodes[0].entropy_source, &secp_ctx).unwrap();
 
 	nodes[0].messenger.send_onion_message(test_msg, destination, Some(reply_path)).unwrap();
-	nodes[3].custom_message_handler.expect_message(TestCustomMessage::Request);
+	nodes[3].custom_message_handler.expect_message(TestCustomMessage::Ping);
 	pass_along_path(&nodes);
 
 	// Make sure the last node successfully decoded the reply path.
-	nodes[0].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[0].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	nodes.reverse();
 	pass_along_path(&nodes);
 }
@@ -521,7 +521,7 @@ fn invalid_custom_message_type() {
 #[test]
 fn peer_buffer_full() {
 	let nodes = create_nodes(2);
-	let test_msg = TestCustomMessage::Request;
+	let test_msg = TestCustomMessage::Ping;
 	let destination = Destination::Node(nodes[1].node_id);
 	for _ in 0..188 { // Based on MAX_PER_PEER_BUFFER_SIZE in OnionMessenger
 		nodes[0].messenger.send_onion_message(test_msg.clone(), destination.clone(), None).unwrap();
@@ -536,7 +536,7 @@ fn many_hops() {
 	// of size [`crate::onion_message::packet::BIG_PACKET_HOP_DATA_LEN`].
 	let num_nodes: usize = 25;
 	let nodes = create_nodes(num_nodes as u8);
-	let test_msg = TestCustomMessage::Response;
+	let test_msg = TestCustomMessage::Pong;
 
 	let mut intermediate_nodes = vec![];
 	for i in 1..(num_nodes-1) {
@@ -549,14 +549,14 @@ fn many_hops() {
 		first_node_addresses: None,
 	};
 	nodes[0].messenger.send_onion_message_using_path(path, test_msg, None).unwrap();
-	nodes[num_nodes-1].custom_message_handler.expect_message(TestCustomMessage::Response);
+	nodes[num_nodes-1].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	pass_along_path(&nodes);
 }
 
 #[test]
 fn requests_peer_connection_for_buffered_messages() {
 	let nodes = create_nodes(3);
-	let message = TestCustomMessage::Request;
+	let message = TestCustomMessage::Ping;
 	let secp_ctx = Secp256k1::new();
 	add_channel_to_graph(&nodes[0], &nodes[1], &secp_ctx, 42);
 
@@ -593,7 +593,7 @@ fn requests_peer_connection_for_buffered_messages() {
 #[test]
 fn drops_buffered_messages_waiting_for_peer_connection() {
 	let nodes = create_nodes(3);
-	let message = TestCustomMessage::Request;
+	let message = TestCustomMessage::Ping;
 	let secp_ctx = Secp256k1::new();
 	add_channel_to_graph(&nodes[0], &nodes[1], &secp_ctx, 42);
 
@@ -644,7 +644,7 @@ fn intercept_offline_peer_oms() {
 		}
 	}
 
-	let message = TestCustomMessage::Response;
+	let message = TestCustomMessage::Pong;
 	let secp_ctx = Secp256k1::new();
 	let blinded_path = BlindedPath::new_for_message(
 		&[nodes[1].node_id, nodes[2].node_id], &*nodes[2].entropy_source, &secp_ctx
@@ -683,7 +683,7 @@ fn intercept_offline_peer_oms() {
 	}
 
 	nodes[1].messenger.forward_onion_message(onion_message, &final_node_vec[0].node_id).unwrap();
-	final_node_vec[0].custom_message_handler.expect_message(TestCustomMessage::Response);
+	final_node_vec[0].custom_message_handler.expect_message(TestCustomMessage::Pong);
 	pass_along_path(&vec![nodes.remove(1), final_node_vec.remove(0)]);
 }
 

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -358,7 +358,7 @@ fn one_blinded_hop() {
 	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
-	let blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id], &*nodes[1].entropy_source, &secp_ctx).unwrap();
+	let blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id], None, &*nodes[1].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	nodes[0].messenger.send_onion_message(test_msg, destination, None).unwrap();
 	nodes[1].custom_message_handler.expect_message(TestCustomMessage::Pong);
@@ -371,7 +371,7 @@ fn two_unblinded_two_blinded() {
 	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
-	let blinded_path = BlindedPath::new_for_message(&[nodes[3].node_id, nodes[4].node_id], &*nodes[4].entropy_source, &secp_ctx).unwrap();
+	let blinded_path = BlindedPath::new_for_message(&[nodes[3].node_id, nodes[4].node_id], None, &*nodes[4].entropy_source, &secp_ctx).unwrap();
 	let path = OnionMessagePath {
 		intermediate_nodes: vec![nodes[1].node_id, nodes[2].node_id],
 		destination: Destination::BlindedPath(blinded_path),
@@ -389,7 +389,7 @@ fn three_blinded_hops() {
 	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
-	let blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id, nodes[2].node_id, nodes[3].node_id], &*nodes[3].entropy_source, &secp_ctx).unwrap();
+	let blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id, nodes[2].node_id, nodes[3].node_id], None, &*nodes[3].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 
 	nodes[0].messenger.send_onion_message(test_msg, destination, None).unwrap();
@@ -412,7 +412,7 @@ fn async_response_over_one_blinded_hop() {
 
 	// 3. Simulate the creation of a Blinded Reply path provided by Bob.
 	let secp_ctx = Secp256k1::new();
-	let reply_path = BlindedPath::new_for_message(&[nodes[1].node_id], &*nodes[1].entropy_source, &secp_ctx).unwrap();
+	let reply_path = BlindedPath::new_for_message(&[nodes[1].node_id], None, &*nodes[1].entropy_source, &secp_ctx).unwrap();
 
 	// 4. Create a responder using the reply path for Alice.
 	let responder = Some(Responder::new(reply_path, path_id));
@@ -448,7 +448,9 @@ fn async_response_with_reply_path_succeeds() {
 	// Alice receives a message from Bob with an added reply_path for responding back.
 	let message = TestCustomMessage::Ping;
 	let path_id = Some([2; 32]);
-	let reply_path = BlindedPath::new_for_message(&[bob.node_id], &*bob.entropy_source, &secp_ctx).unwrap();
+
+	let secp_ctx = Secp256k1::new();
+	let reply_path = BlindedPath::new_for_message(&[bob.node_id], None, &*bob.entropy_source, &secp_ctx).unwrap();
 
 	// Alice asynchronously responds to Bob, expecting a response back from him.
 	let responder = Responder::new(reply_path, path_id);
@@ -485,7 +487,7 @@ fn async_response_with_reply_path_fails() {
 	// Alice receives a message from Bob with an added reply_path for responding back.
 	let message = TestCustomMessage::Ping;
 	let path_id = Some([2; 32]);
-	let reply_path = BlindedPath::new_for_message(&[bob.node_id], &*bob.entropy_source, &secp_ctx).unwrap();
+	let reply_path = BlindedPath::new_for_message(&[bob.node_id], None, &*bob.entropy_source, &secp_ctx).unwrap();
 
 	// Alice tries to asynchronously respond to Bob, but fails because the nodes are unannounced.
 	// Therefore, the reply_path cannot be used for the response.
@@ -524,7 +526,7 @@ fn we_are_intro_node() {
 	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
-	let blinded_path = BlindedPath::new_for_message(&[nodes[0].node_id, nodes[1].node_id, nodes[2].node_id], &*nodes[2].entropy_source, &secp_ctx).unwrap();
+	let blinded_path = BlindedPath::new_for_message(&[nodes[0].node_id, nodes[1].node_id, nodes[2].node_id], None, &*nodes[2].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 
 	nodes[0].messenger.send_onion_message(test_msg.clone(), destination, None).unwrap();
@@ -532,7 +534,7 @@ fn we_are_intro_node() {
 	pass_along_path(&nodes);
 
 	// Try with a two-hop blinded path where we are the introduction node.
-	let blinded_path = BlindedPath::new_for_message(&[nodes[0].node_id, nodes[1].node_id], &*nodes[1].entropy_source, &secp_ctx).unwrap();
+	let blinded_path = BlindedPath::new_for_message(&[nodes[0].node_id, nodes[1].node_id], None, &*nodes[1].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	nodes[0].messenger.send_onion_message(test_msg, destination, None).unwrap();
 	nodes[1].custom_message_handler.expect_message(TestCustomMessage::Pong);
@@ -547,7 +549,7 @@ fn invalid_blinded_path_error() {
 	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
-	let mut blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id, nodes[2].node_id], &*nodes[2].entropy_source, &secp_ctx).unwrap();
+	let mut blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id, nodes[2].node_id], None, &*nodes[2].entropy_source, &secp_ctx).unwrap();
 	blinded_path.blinded_hops.clear();
 	let destination = Destination::BlindedPath(blinded_path);
 	let err = nodes[0].messenger.send_onion_message(test_msg, destination, None).unwrap_err();
@@ -566,7 +568,7 @@ fn reply_path() {
 		destination: Destination::Node(nodes[3].node_id),
 		first_node_addresses: None,
 	};
-	let reply_path = BlindedPath::new_for_message(&[nodes[2].node_id, nodes[1].node_id, nodes[0].node_id], &*nodes[0].entropy_source, &secp_ctx).unwrap();
+	let reply_path = BlindedPath::new_for_message(&[nodes[2].node_id, nodes[1].node_id, nodes[0].node_id], None, &*nodes[0].entropy_source, &secp_ctx).unwrap();
 	nodes[0].messenger.send_onion_message_using_path(path, test_msg.clone(), Some(reply_path)).unwrap();
 	nodes[3].custom_message_handler.expect_message(TestCustomMessage::Ping);
 	pass_along_path(&nodes);
@@ -576,9 +578,9 @@ fn reply_path() {
 	pass_along_path(&nodes);
 
 	// Destination::BlindedPath
-	let blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id, nodes[2].node_id, nodes[3].node_id], &*nodes[3].entropy_source, &secp_ctx).unwrap();
+	let blinded_path = BlindedPath::new_for_message(&[nodes[1].node_id, nodes[2].node_id, nodes[3].node_id], None, &*nodes[3].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
-	let reply_path = BlindedPath::new_for_message(&[nodes[2].node_id, nodes[1].node_id, nodes[0].node_id], &*nodes[0].entropy_source, &secp_ctx).unwrap();
+	let reply_path = BlindedPath::new_for_message(&[nodes[2].node_id, nodes[1].node_id, nodes[0].node_id], None, &*nodes[0].entropy_source, &secp_ctx).unwrap();
 
 	nodes[0].messenger.send_onion_message(test_msg, destination, Some(reply_path)).unwrap();
 	nodes[3].custom_message_handler.expect_message(TestCustomMessage::Ping);
@@ -659,7 +661,7 @@ fn requests_peer_connection_for_buffered_messages() {
 	add_channel_to_graph(&nodes[0], &nodes[1], &secp_ctx, 42);
 
 	let blinded_path = BlindedPath::new_for_message(
-		&[nodes[1].node_id, nodes[2].node_id], &*nodes[0].entropy_source, &secp_ctx
+		&[nodes[1].node_id, nodes[2].node_id], None, &*nodes[0].entropy_source, &secp_ctx
 	).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 
@@ -696,7 +698,7 @@ fn drops_buffered_messages_waiting_for_peer_connection() {
 	add_channel_to_graph(&nodes[0], &nodes[1], &secp_ctx, 42);
 
 	let blinded_path = BlindedPath::new_for_message(
-		&[nodes[1].node_id, nodes[2].node_id], &*nodes[0].entropy_source, &secp_ctx
+		&[nodes[1].node_id, nodes[2].node_id], None, &*nodes[0].entropy_source, &secp_ctx
 	).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 
@@ -745,7 +747,7 @@ fn intercept_offline_peer_oms() {
 	let message = TestCustomMessage::Pong;
 	let secp_ctx = Secp256k1::new();
 	let blinded_path = BlindedPath::new_for_message(
-		&[nodes[1].node_id, nodes[2].node_id], &*nodes[2].entropy_source, &secp_ctx
+		&[nodes[1].node_id, nodes[2].node_id], None, &*nodes[2].entropy_source, &secp_ctx
 	).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -432,6 +432,73 @@ fn async_response_over_one_blinded_hop() {
 }
 
 #[test]
+fn async_response_with_reply_path_succeeds() {
+	// Simulate an asynchronous interaction between two nodes, Alice and Bob.
+	// Create a channel between the two nodes to establish them as announced nodes,
+	// which allows the creation of the reply_path for successful communication.
+
+	let mut nodes = create_nodes(2);
+	let alice = &nodes[0];
+	let bob = &nodes[1];
+	let secp_ctx = Secp256k1::new();
+
+	add_channel_to_graph(alice, bob, &secp_ctx, 24);
+
+	// Alice receives a message from Bob with an added reply_path for responding back.
+	let message = TestCustomMessage::Ping;
+	let path_id = Some([2; 32]);
+	let reply_path = BlindedPath::new_for_message(&[bob.node_id], &*bob.entropy_source, &secp_ctx).unwrap();
+
+	// Alice asynchronously responds to Bob, expecting a response back from him.
+	let responder = Responder::new(reply_path, path_id);
+	alice.custom_message_handler.expect_message_and_response(message.clone());
+	let response_instruction = alice.custom_message_handler.handle_custom_message(message, Some(responder));
+
+	assert_eq!(
+		alice.messenger.handle_onion_message_response(response_instruction),
+		Ok(Some(SendSuccess::Buffered)),
+	);
+
+	// Set Bob's expectation and pass the Onion Message along the path.
+	bob.custom_message_handler.expect_message(TestCustomMessage::Pong);
+	pass_along_path(&nodes);
+
+	// Bob responds back to Alice using the reply_path she included with the OnionMessage.
+	// Set Alice's expectation and reverse the path for the response.
+	alice.custom_message_handler.expect_message(TestCustomMessage::Ping);
+	nodes.reverse();
+	pass_along_path(&nodes);
+}
+
+#[test]
+fn async_response_with_reply_path_fails() {
+	// Simulate an asynchronous interaction between two unannounced nodes, Alice and Bob.
+	// Since the nodes are unannounced, attempting to respond using a reply_path
+	// will fail, leading to an expected failure in communication.
+
+	let nodes = create_nodes(2);
+	let alice = &nodes[0];
+	let bob = &nodes[1];
+	let secp_ctx = Secp256k1::new();
+
+	// Alice receives a message from Bob with an added reply_path for responding back.
+	let message = TestCustomMessage::Ping;
+	let path_id = Some([2; 32]);
+	let reply_path = BlindedPath::new_for_message(&[bob.node_id], &*bob.entropy_source, &secp_ctx).unwrap();
+
+	// Alice tries to asynchronously respond to Bob, but fails because the nodes are unannounced.
+	// Therefore, the reply_path cannot be used for the response.
+	let responder = Responder::new(reply_path, path_id);
+	alice.custom_message_handler.expect_message_and_response(message.clone());
+	let response_instruction = alice.custom_message_handler.handle_custom_message(message, Some(responder));
+
+	assert_eq!(
+		alice.messenger.handle_onion_message_response(response_instruction),
+		Err(SendError::PathNotFound),
+	);
+}
+
+#[test]
 fn too_big_packet_error() {
 	// Make sure we error as expected if a packet is too big to send.
 	let nodes = create_nodes(2);

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -111,16 +111,39 @@ impl Writeable for TestCustomMessage {
 }
 
 struct TestCustomMessageHandler {
-	expected_messages: Mutex<VecDeque<TestCustomMessage>>,
+	expectations: Mutex<VecDeque<OnHandleCustomMessage>>,
+}
+
+struct OnHandleCustomMessage {
+	expect: TestCustomMessage,
+	include_reply_path: bool,
 }
 
 impl TestCustomMessageHandler {
 	fn new() -> Self {
-		Self { expected_messages: Mutex::new(VecDeque::new()) }
+		Self { expectations: Mutex::new(VecDeque::new()) }
 	}
 
 	fn expect_message(&self, message: TestCustomMessage) {
-		self.expected_messages.lock().unwrap().push_back(message);
+		self.expectations.lock().unwrap().push_back(
+			OnHandleCustomMessage {
+				expect: message,
+				include_reply_path: false,
+			}
+		);
+	}
+
+	fn expect_message_and_response(&self, message: TestCustomMessage) {
+		self.expectations.lock().unwrap().push_back(
+			OnHandleCustomMessage {
+				expect: message,
+				include_reply_path: true,
+			}
+		);
+	}
+
+	fn get_next_expectation(&self) -> OnHandleCustomMessage {
+		self.expectations.lock().unwrap().pop_front().expect("No expectations remaining")
 	}
 }
 
@@ -131,25 +154,32 @@ impl Drop for TestCustomMessageHandler {
 				return;
 			}
 		}
-		assert!(self.expected_messages.lock().unwrap().is_empty());
+		assert!(self.expectations.lock().unwrap().is_empty());
 	}
 }
 
 impl CustomOnionMessageHandler for TestCustomMessageHandler {
 	type CustomMessage = TestCustomMessage;
 	fn handle_custom_message(&self, msg: Self::CustomMessage, responder: Option<Responder>) -> ResponseInstruction<Self::CustomMessage> {
-		match self.expected_messages.lock().unwrap().pop_front() {
-			Some(expected_msg) => assert_eq!(expected_msg, msg),
-			None => panic!("Unexpected message: {:?}", msg),
-		}
-		let response_option = match msg {
-			TestCustomMessage::Ping => Some(TestCustomMessage::Pong),
-			TestCustomMessage::Pong => None,
+		let expectation = self.get_next_expectation();
+		assert_eq!(msg, expectation.expect);
+
+		let response = match msg {
+			TestCustomMessage::Ping => TestCustomMessage::Pong,
+			TestCustomMessage::Pong => TestCustomMessage::Ping,
 		};
-		if let (Some(response), Some(responder)) = (response_option, responder) {
-			responder.respond(response)
-		} else {
-			ResponseInstruction::NoResponse
+
+		// Sanity check: expecting to include reply path when responder is absent should panic.
+		if expectation.include_reply_path && responder.is_none() {
+			panic!("Expected to include a reply_path, but the responder was absent.")
+		}
+
+		match responder {
+			Some(responder) if expectation.include_reply_path => {
+				responder.respond_with_reply_path(response)
+			},
+			Some(responder) => responder.respond(response),
+			None => ResponseInstruction::NoResponse,
 		}
 	}
 	fn read_custom_message<R: io::Read>(&self, message_type: u64, buffer: &mut R) -> Result<Option<Self::CustomMessage>, DecodeError> where Self: Sized {

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -367,6 +367,37 @@ fn three_blinded_hops() {
 }
 
 #[test]
+fn async_response_over_one_blinded_hop() {
+	// Simulate an asynchronous interaction between two nodes, Alice and Bob.
+
+	// 1. Set up the network with two nodes: Alice and Bob.
+	let nodes = create_nodes(2);
+	let alice = &nodes[0];
+	let bob = &nodes[1];
+
+	// 2. Define the message sent from Bob to Alice.
+	let message = TestCustomMessage::Request;
+	let path_id = Some([2; 32]);
+
+	// 3. Simulate the creation of a Blinded Reply path provided by Bob.
+	let secp_ctx = Secp256k1::new();
+	let reply_path = BlindedPath::new_for_message(&[nodes[1].node_id], &*nodes[1].entropy_source, &secp_ctx).unwrap();
+
+	// 4. Create a responder using the reply path for Alice.
+	let responder = Some(Responder::new(reply_path, path_id));
+
+	// 5. Expect Alice to receive the message and create a response instruction for it.
+	alice.custom_message_handler.expect_message(message.clone());
+	let response_instruction = nodes[0].custom_message_handler.handle_custom_message(message, responder);
+
+	// 6. Simulate Alice asynchronously responding back to Bob with a response.
+	nodes[0].messenger.handle_onion_message_response(response_instruction);
+	bob.custom_message_handler.expect_message(TestCustomMessage::Response);
+
+	pass_along_path(&nodes);
+}
+
+#[test]
 fn too_big_packet_error() {
 	// Make sure we error as expected if a packet is too big to send.
 	let nodes = create_nodes(2);

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -9,6 +9,7 @@
 
 //! Onion message testing and test utilities live here.
 
+use crate::blinded_path::message::RecipientData;
 use crate::blinded_path::{BlindedPath, EmptyNodeIdLookUp};
 use crate::events::{Event, EventsProvider};
 use crate::ln::features::{ChannelFeatures, InitFeatures};
@@ -73,7 +74,7 @@ impl Drop for MessengerNode {
 struct TestOffersMessageHandler {}
 
 impl OffersMessageHandler for TestOffersMessageHandler {
-	fn handle_message(&self, _message: OffersMessage, _responder: Option<Responder>) -> ResponseInstruction<OffersMessage> {
+	fn handle_message(&self, _message: OffersMessage, _responder: Option<Responder>, _recipient_data: RecipientData) -> ResponseInstruction<OffersMessage> {
 		ResponseInstruction::NoResponse
 	}
 }
@@ -160,7 +161,7 @@ impl Drop for TestCustomMessageHandler {
 
 impl CustomOnionMessageHandler for TestCustomMessageHandler {
 	type CustomMessage = TestCustomMessage;
-	fn handle_custom_message(&self, msg: Self::CustomMessage, responder: Option<Responder>) -> ResponseInstruction<Self::CustomMessage> {
+	fn handle_custom_message(&self, msg: Self::CustomMessage, responder: Option<Responder>, _recipient_data: RecipientData) -> ResponseInstruction<Self::CustomMessage> {
 		let expectation = self.get_next_expectation();
 		assert_eq!(msg, expectation.expect);
 
@@ -418,7 +419,7 @@ fn async_response_over_one_blinded_hop() {
 
 	// 5. Expect Alice to receive the message and create a response instruction for it.
 	alice.custom_message_handler.expect_message(message.clone());
-	let response_instruction = nodes[0].custom_message_handler.handle_custom_message(message, responder);
+	let response_instruction = nodes[0].custom_message_handler.handle_custom_message(message, responder, RecipientData::new());
 
 	// 6. Simulate Alice asynchronously responding back to Bob with a response.
 	assert_eq!(
@@ -452,7 +453,7 @@ fn async_response_with_reply_path_succeeds() {
 	// Alice asynchronously responds to Bob, expecting a response back from him.
 	let responder = Responder::new(reply_path, path_id);
 	alice.custom_message_handler.expect_message_and_response(message.clone());
-	let response_instruction = alice.custom_message_handler.handle_custom_message(message, Some(responder));
+	let response_instruction = alice.custom_message_handler.handle_custom_message(message, Some(responder), RecipientData::new());
 
 	assert_eq!(
 		alice.messenger.handle_onion_message_response(response_instruction),
@@ -490,7 +491,7 @@ fn async_response_with_reply_path_fails() {
 	// Therefore, the reply_path cannot be used for the response.
 	let responder = Responder::new(reply_path, path_id);
 	alice.custom_message_handler.expect_message_and_response(message.clone());
-	let response_instruction = alice.custom_message_handler.handle_custom_message(message, Some(responder));
+	let response_instruction = alice.custom_message_handler.handle_custom_message(message, Some(responder), RecipientData::new());
 
 	assert_eq!(
 		alice.messenger.handle_onion_message_response(response_instruction),

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -18,7 +18,7 @@ use crate::routing::test_utils::{add_channel, add_or_update_node};
 use crate::sign::{NodeSigner, Recipient};
 use crate::util::ser::{FixedLengthReader, LengthReadable, Writeable, Writer};
 use crate::util::test_utils;
-use super::messenger::{CustomOnionMessageHandler, DefaultMessageRouter, Destination, OnionMessagePath, OnionMessenger, PendingOnionMessage, Responder, ResponseInstruction, SendError};
+use super::messenger::{CustomOnionMessageHandler, DefaultMessageRouter, Destination, OnionMessagePath, OnionMessenger, PendingOnionMessage, Responder, ResponseInstruction, SendError, SendSuccess};
 use super::offers::{OffersMessage, OffersMessageHandler};
 use super::packet::{OnionMessageContents, Packet};
 
@@ -391,7 +391,11 @@ fn async_response_over_one_blinded_hop() {
 	let response_instruction = nodes[0].custom_message_handler.handle_custom_message(message, responder);
 
 	// 6. Simulate Alice asynchronously responding back to Bob with a response.
-	nodes[0].messenger.handle_onion_message_response(response_instruction);
+	assert_eq!(
+		nodes[0].messenger.handle_onion_message_response(response_instruction),
+		Ok(Some(SendSuccess::Buffered)),
+	);
+
 	bob.custom_message_handler.expect_message(TestCustomMessage::Response);
 
 	pass_along_path(&nodes);

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -260,7 +260,7 @@ pub struct Responder {
 
 impl Responder {
 	/// Creates a new [`Responder`] instance with the provided reply path.
-	fn new(reply_path: BlindedPath, path_id: Option<[u8; 32]>) -> Self {
+	pub(super) fn new(reply_path: BlindedPath, path_id: Option<[u8; 32]>) -> Self {
 		Responder {
 			reply_path,
 			path_id,
@@ -1043,7 +1043,9 @@ where
 		)
 	}
 
-	fn handle_onion_message_response<T: OnionMessageContents>(
+	/// Handles the response to an [`OnionMessage`] based on its [`ResponseInstruction`],
+	/// enqueueing any response for sending.
+	pub fn handle_onion_message_response<T: OnionMessageContents>(
 		&self, response: ResponseInstruction<T>
 	) {
 		if let ResponseInstruction::WithoutReplyPath(response) = response {

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -613,7 +613,7 @@ pub trait CustomOnionMessageHandler {
 	/// Called with the custom message that was received, returning a response to send, if any.
 	///
 	/// The returned [`Self::CustomMessage`], if any, is enqueued to be sent by [`OnionMessenger`].
-	fn handle_custom_message(&self, message: Self::CustomMessage, responder: Option<Responder>) -> ResponseInstruction<Self::CustomMessage>;
+	fn handle_custom_message(&self, message: Self::CustomMessage, responder: Option<Responder>, recipient_data: RecipientData) -> ResponseInstruction<Self::CustomMessage>;
 
 	/// Read a custom message of type `message_type` from `buffer`, returning `Ok(None)` if the
 	/// message type is unknown.
@@ -1209,7 +1209,7 @@ where
 	fn handle_onion_message(&self, peer_node_id: &PublicKey, msg: &OnionMessage) {
 		let logger = WithContext::from(&self.logger, Some(*peer_node_id), None, None);
 		match self.peel_onion_message(msg) {
-			Ok(PeeledOnion::Receive(message, path_id, _, reply_path)) => {
+			Ok(PeeledOnion::Receive(message, path_id, recipient_data, reply_path)) => {
 				log_trace!(
 					logger,
 					"Received an onion message with path_id {:02x?} and {} reply_path: {:?}",
@@ -1220,14 +1220,14 @@ where
 						let responder = reply_path.map(
 							|reply_path| Responder::new(reply_path, path_id)
 						);
-						let response_instructions = self.offers_handler.handle_message(msg, responder);
+						let response_instructions = self.offers_handler.handle_message(msg, responder, recipient_data);
 						let _ = self.handle_onion_message_response(response_instructions);
 					},
 					ParsedOnionMessageContents::Custom(msg) => {
 						let responder = reply_path.map(
 							|reply_path| Responder::new(reply_path, path_id)
 						);
-						let response_instructions = self.custom_handler.handle_custom_message(msg, responder);
+						let response_instructions = self.custom_handler.handle_custom_message(msg, responder, recipient_data);
 						let _ = self.handle_onion_message_response(response_instructions);
 					},
 				}

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -16,7 +16,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::{self, PublicKey, Scalar, Secp256k1, SecretKey};
 
 use crate::blinded_path::{BlindedPath, IntroductionNode, NextMessageHop, NodeIdLookUp};
-use crate::blinded_path::message::{advance_path_by_one, ForwardTlvs, ReceiveTlvs};
+use crate::blinded_path::message::{advance_path_by_one, ForwardTlvs, ReceiveTlvs, RecipientData};
 use crate::blinded_path::utils;
 use crate::events::{Event, EventHandler, EventsProvider};
 use crate::sign::{EntropySource, NodeSigner, Recipient};
@@ -641,7 +641,7 @@ pub enum PeeledOnion<T: OnionMessageContents> {
 	/// Forwarded onion, with the next node id and a new onion
 	Forward(NextMessageHop, OnionMessage),
 	/// Received onion message, with decrypted contents, path_id, and reply path
-	Receive(ParsedOnionMessageContents<T>, Option<[u8; 32]>, Option<BlindedPath>)
+	Receive(ParsedOnionMessageContents<T>, Option<[u8; 32]>, RecipientData, Option<BlindedPath>)
 }
 
 
@@ -791,9 +791,9 @@ where
 		(control_tlvs_ss, custom_handler.deref(), logger.deref())
 	) {
 		Ok((Payload::Receive::<ParsedOnionMessageContents<<<CMH as Deref>::Target as CustomOnionMessageHandler>::CustomMessage>> {
-			message, control_tlvs: ReceiveControlTlvs::Unblinded(ReceiveTlvs { path_id }), reply_path,
+			message, control_tlvs: ReceiveControlTlvs::Unblinded(ReceiveTlvs { path_id , recipient_data }), reply_path,
 		}, None)) => {
-			Ok(PeeledOnion::Receive(message, path_id, reply_path))
+			Ok(PeeledOnion::Receive(message, path_id, recipient_data, reply_path))
 		},
 		Ok((Payload::Forward(ForwardControlTlvs::Unblinded(ForwardTlvs {
 			next_hop, next_blinding_override
@@ -1209,7 +1209,7 @@ where
 	fn handle_onion_message(&self, peer_node_id: &PublicKey, msg: &OnionMessage) {
 		let logger = WithContext::from(&self.logger, Some(*peer_node_id), None, None);
 		match self.peel_onion_message(msg) {
-			Ok(PeeledOnion::Receive(message, path_id, reply_path)) => {
+			Ok(PeeledOnion::Receive(message, path_id, _, reply_path)) => {
 				log_trace!(
 					logger,
 					"Received an onion message with path_id {:02x?} and {} reply_path: {:?}",
@@ -1496,7 +1496,7 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 		}, prev_control_tlvs_ss.unwrap()));
 	} else {
 		payloads.push((Payload::Receive {
-			control_tlvs: ReceiveControlTlvs::Unblinded(ReceiveTlvs { path_id: None, }),
+			control_tlvs: ReceiveControlTlvs::Unblinded(ReceiveTlvs { path_id: None, recipient_data: RecipientData::new() }),
 			reply_path: reply_path.take(),
 			message,
 		}, prev_control_tlvs_ss.unwrap()));

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -71,6 +71,7 @@ pub(super) const MAX_TIMER_TICKS: usize = 2;
 /// # use bitcoin::hashes::hex::FromHex;
 /// # use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey, self};
 /// # use lightning::blinded_path::{BlindedPath, EmptyNodeIdLookUp};
+/// # use lightning::blinded_path::message::RecipientData;
 /// # use lightning::sign::{EntropySource, KeysManager};
 /// # use lightning::ln::peer_handler::IgnoringMessageHandler;
 /// # use lightning::onion_message::messenger::{Destination, MessageRouter, OnionMessagePath, OnionMessenger};
@@ -97,7 +98,7 @@ pub(super) const MAX_TIMER_TICKS: usize = 2;
 /// #         })
 /// #     }
 /// #     fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-/// #         &self, _recipient: PublicKey, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>
+/// #         &self, _recipient: PublicKey, _recipient_data: Option<RecipientData>, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>
 /// #     ) -> Result<Vec<BlindedPath>, ()> {
 /// #         unreachable!()
 /// #     }
@@ -146,7 +147,8 @@ pub(super) const MAX_TIMER_TICKS: usize = 2;
 /// // Create a blinded path to yourself, for someone to send an onion message to.
 /// # let your_node_id = hop_node_id1;
 /// let hops = [hop_node_id3, hop_node_id4, your_node_id];
-/// let blinded_path = BlindedPath::new_for_message(&hops, &keys_manager, &secp_ctx).unwrap();
+/// let recipient_data = Some(RecipientData::new());
+/// let blinded_path = BlindedPath::new_for_message(&hops, recipient_data, &keys_manager, &secp_ctx).unwrap();
 ///
 /// // Send a custom onion message to a blinded path.
 /// let destination = Destination::BlindedPath(blinded_path);
@@ -353,7 +355,7 @@ pub trait MessageRouter {
 	fn create_blinded_paths<
 		T: secp256k1::Signing + secp256k1::Verification
 	>(
-		&self, recipient: PublicKey, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, recipient_data: Option<RecipientData>, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPath>, ()>;
 }
 
@@ -420,7 +422,7 @@ where
 	fn create_blinded_paths<
 		T: secp256k1::Signing + secp256k1::Verification
 	>(
-		&self, recipient: PublicKey, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, recipient_data: Option<RecipientData>, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPath>, ()> {
 		// Limit the number of blinded paths that are computed.
 		const MAX_PATHS: usize = 3;
@@ -452,7 +454,7 @@ where
 
 		let paths = peer_info.into_iter()
 			.map(|(pubkey, _, _)| vec![pubkey, recipient])
-			.map(|node_pks| BlindedPath::new_for_message(&node_pks, &*self.entropy_source, secp_ctx))
+			.map(|node_pks| BlindedPath::new_for_message(&node_pks, recipient_data.clone(), &*self.entropy_source, secp_ctx))
 			.take(MAX_PATHS)
 			.collect::<Result<Vec<_>, _>>();
 
@@ -460,7 +462,7 @@ where
 			Ok(paths) if !paths.is_empty() => Ok(paths),
 			_ => {
 				if is_recipient_announced {
-					BlindedPath::one_hop_for_message(recipient, &*self.entropy_source, secp_ctx)
+					BlindedPath::one_hop_for_message(recipient, recipient_data, &*self.entropy_source, secp_ctx)
 						.map(|path| vec![path])
 				} else {
 					Err(())
@@ -991,7 +993,7 @@ where
 			.map_err(|_| SendError::PathNotFound)
 	}
 
-	fn create_blinded_path(&self) -> Result<BlindedPath, SendError> {
+	fn create_blinded_path(&self, recipient_data: Option<RecipientData>) -> Result<BlindedPath, SendError> {
 		let recipient = self.node_signer
 			.get_node_id(Recipient::Node)
 			.map_err(|_| SendError::GetNodeIdFailed)?;
@@ -1004,7 +1006,7 @@ where
 			.collect();
 
 		self.message_router
-			.create_blinded_paths(recipient, peers, secp_ctx)
+			.create_blinded_paths(recipient, recipient_data, peers, secp_ctx)
 			.and_then(|paths| paths.into_iter().next().ok_or(()))
 			.map_err(|_| SendError::PathNotFound)
 	}
@@ -1094,7 +1096,7 @@ where
 
 		let message_type = response.message.msg_type();
 		let reply_path = if create_reply_path {
-			match self.create_blinded_path() {
+			match self.create_blinded_path(None) {
 				Ok(reply_path) => Some(reply_path),
 				Err(err) => {
 					log_trace!(

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -267,9 +267,22 @@ impl Responder {
 		}
 	}
 
-	/// Creates the appropriate [`ResponseInstruction`] for a given response.
+	/// Creates a [`ResponseInstruction::WithoutReplyPath`] for a given response.
+	///
+	/// Use when the recipient doesn't need to send back a reply to us.
 	pub fn respond<T: OnionMessageContents>(self, response: T) -> ResponseInstruction<T> {
 		ResponseInstruction::WithoutReplyPath(OnionMessageResponse {
+			message: response,
+			reply_path: self.reply_path,
+			path_id: self.path_id,
+		})
+	}
+
+	/// Creates a [`ResponseInstruction::WithReplyPath`] for a given response.
+	///
+	/// Use when the recipient needs to send back a reply to us.
+	pub fn respond_with_reply_path<T: OnionMessageContents>(self, response: T) -> ResponseInstruction<T> {
+		ResponseInstruction::WithReplyPath(OnionMessageResponse {
 			message: response,
 			reply_path: self.reply_path,
 			path_id: self.path_id,
@@ -286,6 +299,9 @@ pub struct OnionMessageResponse<T: OnionMessageContents> {
 
 /// `ResponseInstruction` represents instructions for responding to received messages.
 pub enum ResponseInstruction<T: OnionMessageContents> {
+	/// Indicates that a response should be sent including a reply path for
+	/// the recipient to respond back.
+	WithReplyPath(OnionMessageResponse<T>),
 	/// Indicates that a response should be sent without including a reply path
 	/// for the recipient to respond back.
 	WithoutReplyPath(OnionMessageResponse<T>),
@@ -554,7 +570,11 @@ pub enum SendError {
 	TooFewBlindedHops,
 	/// The first hop is not a peer and doesn't have a known [`SocketAddress`].
 	InvalidFirstHop(PublicKey),
-	/// A path from the sender to the destination could not be found by the [`MessageRouter`].
+	/// Indicates that a path could not be found by the [`MessageRouter`].
+	///
+	/// This occurs when either:
+	/// - No path from the sender to the destination was found to send the onion message
+	/// - No reply path to the sender could be created when responding to an onion message
 	PathNotFound,
 	/// Onion message contents must have a TLV type >= 64.
 	InvalidMessage,
@@ -971,6 +991,24 @@ where
 			.map_err(|_| SendError::PathNotFound)
 	}
 
+	fn create_blinded_path(&self) -> Result<BlindedPath, SendError> {
+		let recipient = self.node_signer
+			.get_node_id(Recipient::Node)
+			.map_err(|_| SendError::GetNodeIdFailed)?;
+		let secp_ctx = &self.secp_ctx;
+
+		let peers = self.message_recipients.lock().unwrap()
+			.iter()
+			.filter(|(_, peer)| matches!(peer, OnionMessageRecipient::ConnectedPeer(_)))
+			.map(|(node_id, _)| *node_id)
+			.collect();
+
+		self.message_router
+			.create_blinded_paths(recipient, peers, secp_ctx)
+			.and_then(|paths| paths.into_iter().next().ok_or(()))
+			.map_err(|_| SendError::PathNotFound)
+	}
+
 	fn enqueue_onion_message<T: OnionMessageContents>(
 		&self, path: OnionMessagePath, contents: T, reply_path: Option<BlindedPath>,
 		log_suffix: fmt::Arguments
@@ -1047,18 +1085,37 @@ where
 	/// enqueueing any response for sending.
 	pub fn handle_onion_message_response<T: OnionMessageContents>(
 		&self, response: ResponseInstruction<T>
-	) {
-		if let ResponseInstruction::WithoutReplyPath(response) = response {
-			let message_type = response.message.msg_type();
-			let _ = self.find_path_and_enqueue_onion_message(
-				response.message, Destination::BlindedPath(response.reply_path), None,
-				format_args!(
-					"when responding with {} to an onion message with path_id {:02x?}",
-					message_type,
-					response.path_id
-				)
-			);
-		}
+	) -> Result<Option<SendSuccess>, SendError> {
+		let (response, create_reply_path) = match response {
+			ResponseInstruction::WithReplyPath(response) => (response, true),
+			ResponseInstruction::WithoutReplyPath(response) => (response, false),
+			ResponseInstruction::NoResponse => return Ok(None),
+		};
+
+		let message_type = response.message.msg_type();
+		let reply_path = if create_reply_path {
+			match self.create_blinded_path() {
+				Ok(reply_path) => Some(reply_path),
+				Err(err) => {
+					log_trace!(
+						self.logger,
+						"Failed to create reply path when responding with {} to an onion message \
+						with path_id {:02x?}: {:?}",
+						message_type, response.path_id, err
+					);
+					return Err(err);
+				}
+			}
+		} else { None };
+
+		self.find_path_and_enqueue_onion_message(
+			response.message, Destination::BlindedPath(response.reply_path), reply_path,
+			format_args!(
+				"when responding with {} to an onion message with path_id {:02x?}",
+				message_type,
+				response.path_id
+			)
+		).map(|result| Some(result))
 	}
 
 	#[cfg(test)]
@@ -1164,14 +1221,14 @@ where
 							|reply_path| Responder::new(reply_path, path_id)
 						);
 						let response_instructions = self.offers_handler.handle_message(msg, responder);
-						self.handle_onion_message_response(response_instructions);
+						let _ = self.handle_onion_message_response(response_instructions);
 					},
 					ParsedOnionMessageContents::Custom(msg) => {
 						let responder = reply_path.map(
 							|reply_path| Responder::new(reply_path, path_id)
 						);
 						let response_instructions = self.custom_handler.handle_custom_message(msg, responder);
-						self.handle_onion_message_response(response_instructions);
+						let _ = self.handle_onion_message_response(response_instructions);
 					},
 				}
 			},

--- a/lightning/src/onion_message/offers.rs
+++ b/lightning/src/onion_message/offers.rs
@@ -10,6 +10,7 @@
 //! Message handling for BOLT 12 Offers.
 
 use core::fmt;
+use crate::blinded_path::message::RecipientData;
 use crate::io::{self, Read};
 use crate::ln::msgs::DecodeError;
 use crate::offers::invoice_error::InvoiceError;
@@ -40,7 +41,7 @@ pub trait OffersMessageHandler {
 	/// The returned [`OffersMessage`], if any, is enqueued to be sent by [`OnionMessenger`].
 	///
 	/// [`OnionMessenger`]: crate::onion_message::messenger::OnionMessenger
-	fn handle_message(&self, message: OffersMessage, responder: Option<Responder>) -> ResponseInstruction<OffersMessage>;
+	fn handle_message(&self, message: OffersMessage, responder: Option<Responder>, recipient_data: RecipientData) -> ResponseInstruction<OffersMessage>;
 
 	/// Releases any [`OffersMessage`]s that need to be sent.
 	///

--- a/lightning/src/onion_message/packet.rs
+++ b/lightning/src/onion_message/packet.rs
@@ -13,7 +13,7 @@ use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::ecdh::SharedSecret;
 
 use crate::blinded_path::{BlindedPath, NextMessageHop};
-use crate::blinded_path::message::{ForwardTlvs, ReceiveTlvs};
+use crate::blinded_path::message::{ForwardTlvs, ReceiveTlvs, RecipientData};
 use crate::blinded_path::utils::Padding;
 use crate::ln::msgs::DecodeError;
 use crate::ln::onion_utils;
@@ -304,6 +304,7 @@ impl Readable for ControlTlvs {
 			(4, next_node_id, option),
 			(6, path_id, option),
 			(8, next_blinding_override, option),
+			(65537, payment_id, option),
 		});
 		let _padding: Option<Padding> = _padding;
 
@@ -325,6 +326,7 @@ impl Readable for ControlTlvs {
 		} else if valid_recv_fmt {
 			ControlTlvs::Receive(ReceiveTlvs {
 				path_id,
+				recipient_data: RecipientData { payment_id },
 			})
 		} else {
 			return Err(DecodeError::InvalidValue)

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -11,6 +11,7 @@
 
 use bitcoin::secp256k1::{PublicKey, Secp256k1, self};
 
+use crate::blinded_path::message::RecipientData;
 use crate::blinded_path::{BlindedHop, BlindedPath, Direction, IntroductionNode};
 use crate::blinded_path::payment::{ForwardNode, ForwardTlvs, PaymentConstraints, PaymentRelay, ReceiveTlvs};
 use crate::ln::{PaymentHash, PaymentPreimage};
@@ -171,9 +172,9 @@ impl< G: Deref<Target = NetworkGraph<L>> + Clone, L: Deref, ES: Deref, S: Deref,
 	fn create_blinded_paths<
 		T: secp256k1::Signing + secp256k1::Verification
 	> (
-		&self, recipient: PublicKey, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, recipient_data: Option<RecipientData>, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPath>, ()> {
-		self.message_router.create_blinded_paths(recipient, peers, secp_ctx)
+		self.message_router.create_blinded_paths(recipient, recipient_data, peers, secp_ctx)
 	}
 }
 

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -7,6 +7,7 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
+use crate::blinded_path::message::RecipientData;
 use crate::blinded_path::BlindedPath;
 use crate::blinded_path::payment::ReceiveTlvs;
 use crate::chain;
@@ -246,9 +247,9 @@ impl<'a> MessageRouter for TestRouter<'a> {
 	fn create_blinded_paths<
 		T: secp256k1::Signing + secp256k1::Verification
 	>(
-		&self, recipient: PublicKey, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, recipient_data: Option<RecipientData>, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPath>, ()> {
-		self.router.create_blinded_paths(recipient, peers, secp_ctx)
+		self.router.create_blinded_paths(recipient, recipient_data, peers, secp_ctx)
 	}
 }
 
@@ -281,9 +282,9 @@ impl<'a> MessageRouter for TestMessageRouter<'a> {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, recipient: PublicKey, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, recipient_data: Option<RecipientData>, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPath>, ()> {
-		self.inner.create_blinded_paths(recipient, peers, secp_ctx)
+		self.inner.create_blinded_paths(recipient, recipient_data, peers, secp_ctx)
 	}
 }
 


### PR DESCRIPTION
<p><strong>Resolves #2837</strong></p>

<h3>Summary</h3>

<p>This PR introduces a new field, <code>RecipientData</code>, in the <code>ReceiveTlvs</code> struct. The key changes are as follows:</p>

<ol>
  <li>
    <strong>Introduction of <code>RecipientData</code>:</strong>
    <ul>
      <li>This struct allows users to append additional data to the created <code>reply_path</code>, which they expect to receive back from the counterparty along with their response.</li>
    </ul>
  </li>
  <li>
    <strong>Optional <code>PaymentId</code> in <code>RecipientData</code>:</strong>
    <ul>
      <li><code>RecipientData</code> includes an optional <code>PaymentId</code> field that can be utilized by <code>OffersMessage</code>.</li>
      <li>This feature enables users to abandon outbound payments that fail for any reason.</li>
    </ul>
  </li>
  <li>
    <strong>Integration with <code>create_blinded_path</code> flow:</strong>
    <ul>
      <li>The PR integrates <code>RecipientData</code> into the <code>create_blinded_path</code> process.</li>
      <li>This enhancement is utilized in the <code>pay_for_offer</code> and <code>create_refund_builder</code> functions to pass <code>PaymentId</code> along with the generated <code>reply_path</code> and path respectively.</li>
    </ul>
  </li>
</ol>

<p>These improvements aim to allow passing additional information with the create <code>reply_path</code> and managing outbound payment failures more robustly.</p>

**Note:**
This PR builds on #2996

