### PR TITLE
Allow blinded path diversification by expanding `create_blinded_paths`

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -120,7 +120,7 @@ impl MessageRouter for FuzzRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _peers: Vec<ForwardNode>, _secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _peers: Vec<ForwardNode>, _secp_ctx: &Secp256k1<T>, count: usize,
 	) -> Result<Vec<BlindedPath>, ()> {
 		unreachable!()
 	}

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -158,7 +158,7 @@ impl MessageRouter for FuzzRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _peers: Vec<ForwardNode>, _secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _peers: Vec<ForwardNode>, _secp_ctx: &Secp256k1<T>, count: usize,
 	) -> Result<Vec<BlindedPath>, ()> {
 		unreachable!()
 	}

--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -89,7 +89,7 @@ impl MessageRouter for TestMessageRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _peers: Vec<ForwardNode>, _secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _peers: Vec<ForwardNode>, _secp_ctx: &Secp256k1<T>, count: usize
 	) -> Result<Vec<BlindedPath>, ()> {
 		unreachable!()
 	}

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -345,11 +345,17 @@ fn prefers_more_connected_nodes_in_blinded_paths() {
 		.amount_msats(10_000_000)
 		.build().unwrap();
 	assert_ne!(offer.signing_pubkey(), Some(bob_id));
-	assert!(!offer.paths().is_empty());
-	for path in offer.paths() {
-		let introduction_node_id = resolve_introduction_node(david, &path);
-		assert_eq!(introduction_node_id, nodes[4].node.get_our_node_id());
-	}
+
+	// Ensure both potential paths are calculated for the offer.
+	assert_eq!(offer.paths().len(), 2);
+
+	// Verify that the most connected introduction node is chosen first.
+	let introduction_node_id_1 = resolve_introduction_node(david, &offer.paths()[0]);
+	assert_eq!(introduction_node_id_1, nodes[4].node.get_our_node_id());
+
+	// Verify that the next most connected introduction node is chosen second.
+	let introduction_node_id_2 = resolve_introduction_node(david, &offer.paths()[1]);
+	assert_eq!(introduction_node_id_2, charlie.node.get_our_node_id());
 }
 
 /// Checks that an offer can be paid through blinded paths and that ephemeral pubkeys are used

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1833,14 +1833,14 @@ mod tests {
 		let entropy = FixedEntropy {};
 		let secp_ctx = Secp256k1::new();
 
-		let blinded_path = BlindedPath {
+		let blinded_path = vec![BlindedPath {
 			introduction_node: IntroductionNode::NodeId(pubkey(40)),
 			blinding_point: pubkey(41),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: pubkey(42), encrypted_payload: vec![0; 43] },
 				BlindedHop { blinded_node_id: node_id, encrypted_payload: vec![0; 44] },
 			],
-		};
+		}];
 
 		#[cfg(c_bindings)]
 		use crate::offers::offer::OfferWithDerivedMetadataBuilder as OfferBuilder;
@@ -2409,8 +2409,7 @@ mod tests {
 		let invoice = OfferBuilder::new(recipient_pubkey())
 			.clear_signing_pubkey()
 			.amount_msats(1000)
-			.path(paths[0].clone())
-			.path(paths[1].clone())
+			.path(paths.clone())
 			.build().unwrap()
 			.request_invoice(vec![1; 32], payer_pubkey()).unwrap()
 			.build().unwrap()
@@ -2431,8 +2430,7 @@ mod tests {
 		let invoice = OfferBuilder::new(recipient_pubkey())
 			.clear_signing_pubkey()
 			.amount_msats(1000)
-			.path(paths[0].clone())
-			.path(paths[1].clone())
+			.path(paths.clone())
 			.build().unwrap()
 			.request_invoice(vec![1; 32], payer_pubkey()).unwrap()
 			.build().unwrap()

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -33,8 +33,8 @@
 //! # #[cfg(feature = "std")]
 //! # use std::time::SystemTime;
 //! #
-//! # fn create_blinded_path() -> BlindedPath { unimplemented!() }
-//! # fn create_another_blinded_path() -> BlindedPath { unimplemented!() }
+//! # fn create_blinded_path(count: usize) -> Vec<BlindedPath> { unimplemented!() }
+//! # fn create_another_blinded_path(count: usize) -> Vec<BlindedPath> { unimplemented!() }
 //! #
 //! # #[cfg(feature = "std")]
 //! # fn build() -> Result<(), Bolt12ParseError> {
@@ -49,8 +49,8 @@
 //!     .supported_quantity(Quantity::Unbounded)
 //!     .absolute_expiry(expiration.duration_since(SystemTime::UNIX_EPOCH).unwrap())
 //!     .issuer("Foo Bar".to_string())
-//!     .path(create_blinded_path())
-//!     .path(create_another_blinded_path())
+//!     .path(create_blinded_path(1))
+//!     .path(create_another_blinded_path(1))
 //!     .build()?;
 //!
 //! // Encode as a bech32 string for use in a QR code.
@@ -344,8 +344,11 @@ macro_rules! offer_builder_methods { (
 	///
 	/// Successive calls to this method will add another blinded path. Caller is responsible for not
 	/// adding duplicate paths.
-	pub fn path($($self_mut)* $self: $self_type, path: BlindedPath) -> $return_type {
-		$self.offer.paths.get_or_insert_with(Vec::new).push(path);
+	pub fn path($($self_mut)* $self: $self_type, paths: Vec<BlindedPath>) -> $return_type {
+		let entry = $self.offer.paths.get_or_insert_with(Vec::new);
+		for path in paths {
+			entry.push(path)
+		}
 		$return_value
 	}
 
@@ -1316,14 +1319,14 @@ mod tests {
 		let entropy = FixedEntropy {};
 		let secp_ctx = Secp256k1::new();
 
-		let blinded_path = BlindedPath {
+		let blinded_path = vec![BlindedPath {
 			introduction_node: IntroductionNode::NodeId(pubkey(40)),
 			blinding_point: pubkey(41),
 			blinded_hops: vec![
 				BlindedHop { blinded_node_id: pubkey(42), encrypted_payload: vec![0; 43] },
 				BlindedHop { blinded_node_id: node_id, encrypted_payload: vec![0; 44] },
 			],
-		};
+		}];
 
 		#[cfg(c_bindings)]
 		use super::OfferWithDerivedMetadataBuilder as OfferBuilder;
@@ -1509,8 +1512,7 @@ mod tests {
 		];
 
 		let offer = OfferBuilder::new(pubkey(42))
-			.path(paths[0].clone())
-			.path(paths[1].clone())
+			.path(paths.clone())
 			.build()
 			.unwrap();
 		let tlv_stream = offer.as_tlv_stream();
@@ -1693,22 +1695,21 @@ mod tests {
 	#[test]
 	fn parses_offer_with_paths() {
 		let offer = OfferBuilder::new(pubkey(42))
-			.path(BlindedPath {
+			.path(vec![BlindedPath {
 				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
 					BlindedHop { blinded_node_id: pubkey(44), encrypted_payload: vec![0; 44] },
 				],
-			})
-			.path(BlindedPath {
+			}, BlindedPath {
 				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(45), encrypted_payload: vec![0; 45] },
 					BlindedHop { blinded_node_id: pubkey(46), encrypted_payload: vec![0; 46] },
 				],
-			})
+			}])
 			.build()
 			.unwrap();
 		if let Err(e) = offer.to_string().parse::<Offer>() {
@@ -1716,14 +1717,14 @@ mod tests {
 		}
 
 		let offer = OfferBuilder::new(pubkey(42))
-			.path(BlindedPath {
+			.path(vec![BlindedPath {
 				introduction_node: IntroductionNode::NodeId(pubkey(40)),
 				blinding_point: pubkey(41),
 				blinded_hops: vec![
 					BlindedHop { blinded_node_id: pubkey(43), encrypted_payload: vec![0; 43] },
 					BlindedHop { blinded_node_id: pubkey(44), encrypted_payload: vec![0; 44] },
 				],
-			})
+			}])
 			.clear_signing_pubkey()
 			.build()
 			.unwrap();

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -172,9 +172,9 @@ impl< G: Deref<Target = NetworkGraph<L>> + Clone, L: Deref, ES: Deref, S: Deref,
 	fn create_blinded_paths<
 		T: secp256k1::Signing + secp256k1::Verification
 	> (
-		&self, recipient: PublicKey, peers: Vec<message::ForwardNode>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, peers: Vec<message::ForwardNode>, secp_ctx: &Secp256k1<T>, count: usize,
 	) -> Result<Vec<BlindedPath>, ()> {
-		self.message_router.create_blinded_paths(recipient, peers, secp_ctx)
+		self.message_router.create_blinded_paths(recipient, peers, secp_ctx, count)
 	}
 }
 

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -247,9 +247,9 @@ impl<'a> MessageRouter for TestRouter<'a> {
 	fn create_blinded_paths<
 		T: secp256k1::Signing + secp256k1::Verification
 	>(
-		&self, recipient: PublicKey, peers: Vec<ForwardNode>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, peers: Vec<ForwardNode>, secp_ctx: &Secp256k1<T>, count: usize
 	) -> Result<Vec<BlindedPath>, ()> {
-		self.router.create_blinded_paths(recipient, peers, secp_ctx)
+		self.router.create_blinded_paths(recipient, peers, secp_ctx, count)
 	}
 }
 
@@ -282,9 +282,9 @@ impl<'a> MessageRouter for TestMessageRouter<'a> {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, recipient: PublicKey, peers: Vec<ForwardNode>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, peers: Vec<ForwardNode>, secp_ctx: &Secp256k1<T>, count: usize,
 	) -> Result<Vec<BlindedPath>, ()> {
-		self.inner.create_blinded_paths(recipient, peers, secp_ctx)
+		self.inner.create_blinded_paths(recipient, peers, secp_ctx, count)
 	}
 }
 


### PR DESCRIPTION
- The current usage of `blinded_paths` is limited because `create_blinded_path` only returns a single `BlindedPath`.
- This PR expands the functionality of `create_blinded_path` by allowing it to return multiple `BlindedPaths`, as determined by the new `count` parameter.
- Additionally, this PR integrates this new capability throughout the codebase by:
    - Allowing multiple paths in offers and refund builders.
    - Sending Offers Response messages, such as `InvoiceRequest` (in `pay_for_offer`) and `Invoice` (in `request_refund_payment`), using multiple reply paths.
- As a proof-of-concept, this PR increases the maximum count of `create_blinded_paths` to 10, enabling the generation of more reply paths. It also increases the number of `blinded_paths` used in offer and refund builders and responders to 5, demonstrating the usage of multiple reply paths.