### PR TITLE
[0.0.123-bindings] Minimal updates to `lightning-transaction-sync` for bindings

### DIFF
--- a/lightning-transaction-sync/src/common.rs
+++ b/lightning-transaction-sync/src/common.rs
@@ -33,8 +33,8 @@ impl SyncState {
 			pending_sync: false,
 		}
 	}
-	pub fn sync_unconfirmed_transactions(
-		&mut self, confirmables: &Vec<&(dyn Confirm + Sync + Send)>,
+	pub fn sync_unconfirmed_transactions<C: Confirm>(
+		&mut self, confirmables: &Vec<C>,
 		unconfirmed_txs: Vec<Txid>,
 	) {
 		for txid in unconfirmed_txs {
@@ -57,8 +57,8 @@ impl SyncState {
 		}
 	}
 
-	pub fn sync_confirmed_transactions(
-		&mut self, confirmables: &Vec<&(dyn Confirm + Sync + Send)>,
+	pub fn sync_confirmed_transactions<C: Confirm>(
+		&mut self, confirmables: &Vec<C>,
 		confirmed_txs: Vec<ConfirmedTx>
 	) {
 		for ctx in confirmed_txs {

--- a/lightning-transaction-sync/src/electrum.rs
+++ b/lightning-transaction-sync/src/electrum.rs
@@ -1,3 +1,5 @@
+//! Chain sync using the electrum protocol
+
 use crate::common::{ConfirmedTx, SyncState, FilterQueue};
 use crate::error::{TxSyncError, InternalError};
 
@@ -83,7 +85,7 @@ where
 	/// [`ChainMonitor`]: lightning::chain::chainmonitor::ChainMonitor
 	/// [`ChannelManager`]: lightning::ln::channelmanager::ChannelManager
 	/// [`Filter`]: lightning::chain::Filter
-	pub fn sync(&self, confirmables: Vec<&(dyn Confirm + Sync + Send)>) -> Result<(), TxSyncError> {
+	pub fn sync<C: Confirm>(&self, confirmables: Vec<C>) -> Result<(), TxSyncError> {
 		// This lock makes sure we're syncing once at a time.
 		let mut sync_state = self.sync_state.lock().unwrap();
 
@@ -378,8 +380,8 @@ where
 		Ok(confirmed_txs)
 	}
 
-	fn get_unconfirmed_transactions(
-		&self, confirmables: &Vec<&(dyn Confirm + Sync + Send)>,
+	fn get_unconfirmed_transactions<C: Confirm>(
+		&self, confirmables: &Vec<C>,
 	) -> Result<Vec<Txid>, InternalError> {
 		// Query the interface for relevant txids and check whether the relevant blocks are still
 		// in the best chain, mark them unconfirmed otherwise

--- a/lightning-transaction-sync/src/error.rs
+++ b/lightning-transaction-sync/src/error.rs
@@ -1,3 +1,5 @@
+//! Common error types
+
 use std::fmt;
 
 #[derive(Debug)]

--- a/lightning-transaction-sync/src/esplora.rs
+++ b/lightning-transaction-sync/src/esplora.rs
@@ -1,3 +1,5 @@
+//! Chain sync using the Esplora API
+
 use crate::error::{TxSyncError, InternalError};
 use crate::common::{SyncState, FilterQueue, ConfirmedTx};
 
@@ -84,7 +86,7 @@ where
 	/// [`ChannelManager`]: lightning::ln::channelmanager::ChannelManager
 	/// [`Filter`]: lightning::chain::Filter
 	#[maybe_async]
-	pub fn sync(&self, confirmables: Vec<&(dyn Confirm + Sync + Send)>) -> Result<(), TxSyncError> {
+	pub fn sync<C: Confirm>(&self, confirmables: Vec<C>) -> Result<(), TxSyncError> {
 		// This lock makes sure we're syncing once at a time.
 		#[cfg(not(feature = "async-interface"))]
 		let mut sync_state = self.sync_state.lock().unwrap();
@@ -239,8 +241,8 @@ where
 	}
 
 	#[maybe_async]
-	fn sync_best_block_updated(
-		&self, confirmables: &Vec<&(dyn Confirm + Sync + Send)>, sync_state: &mut SyncState, tip_hash: &BlockHash,
+	fn sync_best_block_updated<C: Confirm>(
+		&self, confirmables: &Vec<C>, sync_state: &mut SyncState, tip_hash: &BlockHash,
 	) -> Result<(), InternalError> {
 
 		// Inform the interface of the new block.
@@ -369,8 +371,8 @@ where
 	}
 
 	#[maybe_async]
-	fn get_unconfirmed_transactions(
-		&self, confirmables: &Vec<&(dyn Confirm + Sync + Send)>,
+	fn get_unconfirmed_transactions<C: Confirm>(
+		&self, confirmables: &Vec<C>,
 	) -> Result<Vec<Txid>, InternalError> {
 		// Query the interface for relevant txids and check whether the relevant blocks are still
 		// in the best chain, mark them unconfirmed otherwise

--- a/lightning-transaction-sync/src/lib.rs
+++ b/lightning-transaction-sync/src/lib.rs
@@ -71,15 +71,15 @@
 extern crate bdk_macros;
 
 #[cfg(any(feature = "esplora-blocking", feature = "esplora-async"))]
-mod esplora;
+pub mod esplora;
 
 #[cfg(any(feature = "electrum"))]
-mod electrum;
+pub mod electrum;
 
 #[cfg(any(feature = "esplora-blocking", feature = "esplora-async", feature = "electrum"))]
 mod common;
 #[cfg(any(feature = "esplora-blocking", feature = "esplora-async", feature = "electrum"))]
-mod error;
+pub mod error;
 #[cfg(any(feature = "esplora-blocking", feature = "esplora-async", feature = "electrum"))]
 pub use error::TxSyncError;
 


### PR DESCRIPTION
Bindings don't accept dyn traits, but instead map any traits to a
single dynamic struct. Thus, we can always take a specific trait
to accept any implementation, which we do here.