### PR TITLE
Rename `Htlc::to_bitcoin_amount` to `satoshi_amount`

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -3282,7 +3282,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 				for (htlc, _) in per_commitment_claimable_data {
 					if let Some(transaction_output_index) = htlc.transaction_output_index {
 						if transaction_output_index as usize >= tx.output.len() ||
-								tx.output[transaction_output_index as usize].value != htlc.to_bitcoin_amount() {
+								tx.output[transaction_output_index as usize].value != htlc.satoshi_amount() {
 							// per_commitment_data is corrupt or our commitment signing key leaked!
 							return (claimable_outpoints, to_counterparty_output_info);
 						}
@@ -3389,7 +3389,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 			if let Some(transaction_output_index) = htlc.transaction_output_index {
 				if let Some(transaction) = tx {
 					if transaction_output_index as usize >= transaction.output.len() ||
-						transaction.output[transaction_output_index as usize].value != htlc.to_bitcoin_amount() {
+						transaction.output[transaction_output_index as usize].value != htlc.satoshi_amount() {
 							// per_commitment_data is corrupt or our commitment signing key leaked!
 							return (claimable_outpoints, to_counterparty_output_info);
 						}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4273,7 +4273,7 @@ impl<SP: Deref> Channel<SP> where
 
 				let htlc_redeemscript = chan_utils::get_htlc_redeemscript(&htlc, &self.context.channel_type, &keys);
 				let htlc_sighashtype = if self.context.channel_type.supports_anchors_zero_fee_htlc_tx() { EcdsaSighashType::SinglePlusAnyoneCanPay } else { EcdsaSighashType::All };
-				let htlc_sighash = hash_to_message!(&sighash::SighashCache::new(&htlc_tx).p2wsh_signature_hash(0, &htlc_redeemscript, htlc.to_bitcoin_amount(), htlc_sighashtype).unwrap()[..]);
+				let htlc_sighash = hash_to_message!(&sighash::SighashCache::new(&htlc_tx).p2wsh_signature_hash(0, &htlc_redeemscript, htlc.satoshi_amount(), htlc_sighashtype).unwrap()[..]);
 				log_trace!(logger, "Checking HTLC tx signature {} by key {} against tx {} (sighash {}) with redeemscript {} in channel {}.",
 					log_bytes!(msg.htlc_signatures[idx].serialize_compact()[..]), log_bytes!(keys.countersignatory_htlc_key.to_public_key().serialize()),
 					encode::serialize_hex(&htlc_tx), log_bytes!(htlc_sighash[..]), encode::serialize_hex(&htlc_redeemscript), &self.context.channel_id());
@@ -10050,7 +10050,7 @@ mod tests {
 						&htlc, $opt_anchors, &keys.broadcaster_delayed_payment_key, &keys.revocation_key);
 					let htlc_redeemscript = chan_utils::get_htlc_redeemscript(&htlc, $opt_anchors, &keys);
 					let htlc_sighashtype = if $opt_anchors.supports_anchors_zero_fee_htlc_tx() { EcdsaSighashType::SinglePlusAnyoneCanPay } else { EcdsaSighashType::All };
-					let htlc_sighash = Message::from_digest(sighash::SighashCache::new(&htlc_tx).p2wsh_signature_hash(0, &htlc_redeemscript, htlc.to_bitcoin_amount(), htlc_sighashtype).unwrap().as_raw_hash().to_byte_array());
+					let htlc_sighash = Message::from_digest(sighash::SighashCache::new(&htlc_tx).p2wsh_signature_hash(0, &htlc_redeemscript, htlc.satoshi_amount(), htlc_sighashtype).unwrap().as_raw_hash().to_byte_array());
 					assert!(secp_ctx.verify_ecdsa(&htlc_sighash, &remote_signature, &keys.countersignatory_htlc_key.to_public_key()).is_ok(), "verify counterparty htlc sig");
 
 					let mut preimage: Option<PaymentPreimage> = None;

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -621,7 +621,7 @@ impl HTLCDescriptor {
 	) -> TxOut {
 		TxOut {
 			script_pubkey: self.witness_script(secp).to_p2wsh(),
-			value: self.htlc.to_bitcoin_amount(),
+			value: self.htlc.satoshi_amount(),
 		}
 	}
 
@@ -1439,7 +1439,7 @@ impl EcdsaChannelSigner for InMemorySigner {
 					.p2wsh_signature_hash(
 						0,
 						&htlc_redeemscript,
-						htlc.to_bitcoin_amount(),
+						htlc.satoshi_amount(),
 						htlc_sighashtype
 					)
 					.unwrap()[..]
@@ -1593,7 +1593,7 @@ impl EcdsaChannelSigner for InMemorySigner {
 			.p2wsh_signature_hash(
 				input,
 				&witness_script,
-				htlc_descriptor.htlc.to_bitcoin_amount(),
+				htlc_descriptor.htlc.satoshi_amount(),
 				EcdsaSighashType::All,
 			)
 			.map_err(|_| ())?;

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -251,7 +251,7 @@ impl EcdsaChannelSigner for TestChannelSigner {
 				EcdsaSighashType::All
 			};
 			let sighash = &sighash::SighashCache::new(&*htlc_tx).p2wsh_signature_hash(
-				input, &witness_script, htlc_descriptor.htlc.to_bitcoin_amount(), sighash_type
+				input, &witness_script, htlc_descriptor.htlc.satoshi_amount(), sighash_type
 			).unwrap();
 			let countersignatory_htlc_key = HtlcKey::from_basepoint(
 				&secp_ctx, &self.inner.counterparty_pubkeys().unwrap().htlc_basepoint, &htlc_descriptor.per_commitment_point,


### PR DESCRIPTION
Per https://github.com/lightningdevkit/rust-lightning/pull/3063#discussion_r1622867330 .

I believe it's soon enough after the method was first introduced that renaming it should not have big negative impact, if any.