### PR TITLE
Clarify `Display` text for `ClosureReason::HolderForceClosed` some

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -372,7 +372,7 @@ impl core::fmt::Display for ClosureReason {
 			ClosureReason::HolderForceClosed { broadcasted_latest_txn } => {
 				f.write_str("user force-closed the channel")?;
 				if let Some(brodcasted) = broadcasted_latest_txn {
-					write!(f, " and {} the latest transaction", if *brodcasted { "broadcasted" } else { "did not broadcast" })
+					write!(f, " and {} the latest transaction", if *brodcasted { "broadcasted" } else { "elected not to broadcast" })
 				} else {
 					Ok(())
 				}


### PR DESCRIPTION
... to make it clear that we elected not to broadcast, rather than failed to broadcast.

https://github.com/lightningdevkit/rust-lightning/pull/3107#discussion_r1635329386