### PR TITLE
Implement accepting dual-funded channels without contributing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ check-cfg = [
     "cfg(taproot)",
     "cfg(async_signing)",
     "cfg(require_route_graph_test)",
-    "cfg(dual_funding)",
     "cfg(splicing)",
     "cfg(async_payments)",
 ]

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -166,8 +166,6 @@ RUSTFLAGS="--cfg=taproot" cargo test --verbose --color always -p lightning
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=async_signing" cargo test --verbose --color always -p lightning
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
-RUSTFLAGS="--cfg=dual_funding" cargo test --verbose --color always -p lightning
-[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=splicing" cargo test --verbose --color always -p lightning
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=async_payments" cargo test --verbose --color always -p lightning

--- a/lightning-types/src/features.rs
+++ b/lightning-types/src/features.rs
@@ -49,6 +49,8 @@
 //!     (see [BOLT-4](https://github.com/lightning/bolts/blob/master/04-onion-routing.md#route-blinding) for more information).
 //! - `ShutdownAnySegwit` - requires/supports that future segwit versions are allowed in `shutdown`
 //!     (see [BOLT-2](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md) for more information).
+//! - `DualFund` - requires/supports V2 channel establishment
+//!     (see [BOLT-2](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#channel-establishment-v2) for more information).
 //! - `OnionMessages` - requires/supports forwarding onion messages
 //!     (see [BOLT-7](https://github.com/lightning/bolts/pull/759/files) for more information).
 //     TODO: update link
@@ -146,7 +148,7 @@ mod sealed {
 			// Byte 2
 			BasicMPP | Wumbo | AnchorsNonzeroFeeHtlcTx | AnchorsZeroFeeHtlcTx,
 			// Byte 3
-			RouteBlinding | ShutdownAnySegwit | Taproot,
+			RouteBlinding | ShutdownAnySegwit | DualFund | Taproot,
 			// Byte 4
 			OnionMessages,
 			// Byte 5
@@ -167,7 +169,7 @@ mod sealed {
 			// Byte 2
 			BasicMPP | Wumbo | AnchorsNonzeroFeeHtlcTx | AnchorsZeroFeeHtlcTx,
 			// Byte 3
-			RouteBlinding | ShutdownAnySegwit | Taproot,
+			RouteBlinding | ShutdownAnySegwit | DualFund | Taproot,
 			// Byte 4
 			OnionMessages,
 			// Byte 5
@@ -501,6 +503,16 @@ mod sealed {
 		set_shutdown_any_segwit_required,
 		supports_shutdown_anysegwit,
 		requires_shutdown_anysegwit
+	);
+	define_feature!(
+		29,
+		DualFund,
+		[InitContext, NodeContext],
+		"Feature flags for `option_dual_fund`.",
+		set_dual_fund_optional,
+		set_dual_fund_required,
+		supports_dual_fund,
+		requires_dual_fund
 	);
 	define_feature!(
 		31,

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -1361,7 +1361,7 @@ pub enum Event {
 	///
 	/// # Failure Behavior and Persistence
 	/// This event will eventually be replayed after failures-to-handle (i.e., the event handler
-	/// returning `Err(ReplayEvent ())`) and will be persisted across restarts.
+	/// returning `Err(ReplayEvent ())`) and won't be persisted across restarts.
 	///
 	/// [`ChannelManager::accept_inbound_channel`]: crate::ln::channelmanager::ChannelManager::accept_inbound_channel
 	/// [`ChannelManager::force_close_without_broadcasting_txn`]: crate::ln::channelmanager::ChannelManager::force_close_without_broadcasting_txn

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -606,6 +606,20 @@ impl_writeable_tlv_based_enum_upgradable!(PaymentFailureReason,
 	(10, UnexpectedError) => {},
 );
 
+/// Used to indicate the kind of funding for this channel by the channel acceptor (us).
+///
+/// Allows the differentiation between a request for a dual-funded and non-dual-funded channel.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InboundChannelFunds {
+	/// For a non-dual-funded channel, the `push_msat` value from the channel initiator to us.
+	PushMsat(u64),
+	/// Indicates the open request is for a dual funded channel.
+	///
+	/// Note that these channels do not support starting with initial funds pushed from the counterparty,
+	/// who is the channel opener in this case.
+	DualFunded,
+}
+
 /// An Event which you should probably take some action in response to.
 ///
 /// Note that while Writeable and Readable are implemented for Event, you probably shouldn't use
@@ -1337,9 +1351,10 @@ pub enum Event {
 	},
 	/// Indicates a request to open a new channel by a peer.
 	///
-	/// To accept the request, call [`ChannelManager::accept_inbound_channel`]. To reject the request,
-	/// call [`ChannelManager::force_close_without_broadcasting_txn`]. Note that a ['ChannelClosed`]
-	/// event will _not_ be triggered if the channel is rejected.
+	/// To accept the request (and in the case of a dual-funded channel, not contribute funds),
+	/// call [`ChannelManager::accept_inbound_channel`].
+	/// To reject the request, call [`ChannelManager::force_close_without_broadcasting_txn`].
+	/// Note that a ['ChannelClosed`] event will _not_ be triggered if the channel is rejected.
 	///
 	/// The event is only triggered when a new open channel request is received and the
 	/// [`UserConfig::manually_accept_inbound_channels`] config flag is set to true.
@@ -1373,8 +1388,10 @@ pub enum Event {
 		counterparty_node_id: PublicKey,
 		/// The channel value of the requested channel.
 		funding_satoshis: u64,
-		/// Our starting balance in the channel if the request is accepted, in milli-satoshi.
-		push_msat: u64,
+		/// If `channel_negotiation_type` is `InboundChannelFunds::DualFunded`, this indicates that the peer wishes to
+		/// open a dual-funded channel. Otherwise, this field will be `InboundChannelFunds::PushMsats`,
+		/// indicating the `push_msats` value our peer is pushing to us for a non-dual-funded channel.
+		channel_negotiation_type: InboundChannelFunds,
 		/// The features that this channel will operate with. If you reject the channel, a
 		/// well-behaved counterparty may automatically re-attempt the channel with a new set of
 		/// feature flags.

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -28,6 +28,7 @@ use bitcoin::secp256k1;
 use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentPreimage, PaymentHash};
 use crate::types::features::{ChannelTypeFeatures, InitFeatures};
+use crate::ln::interactivetxs::InteractiveTxConstructor;
 use crate::ln::msgs;
 use crate::ln::msgs::{ClosingSigned, ClosingSignedFeeRange, DecodeError};
 use crate::ln::script::{self, ShutdownScript};
@@ -8132,7 +8133,7 @@ impl<SP: Deref> InboundV1Channel<SP> where SP::Target: SignerProvider {
 				msg.push_msat,
 				msg.common_fields.clone(),
 			)?,
-			unfunded_context: UnfundedChannelContext { unfunded_channel_age_ticks: 0 }
+			unfunded_context: UnfundedChannelContext { unfunded_channel_age_ticks: 0 },
 		};
 		Ok(chan)
 	}
@@ -8266,6 +8267,8 @@ pub(super) struct OutboundV2Channel<SP: Deref> where SP::Target: SignerProvider 
 	pub context: ChannelContext<SP>,
 	pub unfunded_context: UnfundedChannelContext,
 	pub dual_funding_context: DualFundingChannelContext,
+	/// The current interactive transaction construction session under negotiation.
+	interactive_tx_constructor: Option<InteractiveTxConstructor>,
 }
 
 impl<SP: Deref> OutboundV2Channel<SP> where SP::Target: SignerProvider {
@@ -8317,7 +8320,8 @@ impl<SP: Deref> OutboundV2Channel<SP> where SP::Target: SignerProvider {
 				their_funding_satoshis: 0,
 				funding_tx_locktime,
 				funding_feerate_sat_per_1000_weight,
-			}
+			},
+			interactive_tx_constructor: None,
 		};
 		Ok(chan)
 	}
@@ -8391,6 +8395,8 @@ pub(super) struct InboundV2Channel<SP: Deref> where SP::Target: SignerProvider {
 	pub context: ChannelContext<SP>,
 	pub unfunded_context: UnfundedChannelContext,
 	pub dual_funding_context: DualFundingChannelContext,
+	/// The current interactive transaction construction session under negotiation.
+	interactive_tx_constructor: Option<InteractiveTxConstructor>,
 }
 
 impl<SP: Deref> InboundV2Channel<SP> where SP::Target: SignerProvider {
@@ -8462,7 +8468,8 @@ impl<SP: Deref> InboundV2Channel<SP> where SP::Target: SignerProvider {
 				their_funding_satoshis: msg.common_fields.funding_satoshis,
 				funding_tx_locktime: msg.locktime,
 				funding_feerate_sat_per_1000_weight: msg.funding_feerate_sat_per_1000_weight,
-			}
+			},
+			interactive_tx_constructor: None,
 		};
 
 		Ok(chan)

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -10316,7 +10316,7 @@ mod tests {
 		// Make sure A's dust limit is as we expect.
 		let open_channel_msg = node_a_chan.get_open_channel(ChainHash::using_genesis_block(network));
 		let node_b_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[7; 32]).unwrap());
-		let mut node_b_chan = InboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_channel_type_features(&config), &channelmanager::provided_init_features(&config), &open_channel_msg, 7, &config, 0, &&logger, /*is_0conf=*/false).unwrap();
+		let node_b_chan = InboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_channel_type_features(&config), &channelmanager::provided_init_features(&config), &open_channel_msg, 7, &config, 0, &&logger, /*is_0conf=*/false).unwrap();
 
 		// Node B --> Node A: accept channel, explicitly setting B's dust limit.
 		let mut accept_channel_msg = node_b_chan.accept_inbound_channel();
@@ -10448,7 +10448,7 @@ mod tests {
 		// Create Node B's channel by receiving Node A's open_channel message
 		let open_channel_msg = node_a_chan.get_open_channel(chain_hash);
 		let node_b_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[7; 32]).unwrap());
-		let mut node_b_chan = InboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_channel_type_features(&config), &channelmanager::provided_init_features(&config), &open_channel_msg, 7, &config, 0, &&logger, /*is_0conf=*/false).unwrap();
+		let node_b_chan = InboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_channel_type_features(&config), &channelmanager::provided_init_features(&config), &open_channel_msg, 7, &config, 0, &&logger, /*is_0conf=*/false).unwrap();
 
 		// Node B --> Node A: accept channel
 		let accept_channel_msg = node_b_chan.accept_inbound_channel();
@@ -10635,7 +10635,7 @@ mod tests {
 		// Make sure A's dust limit is as we expect.
 		let open_channel_msg = node_a_chan.get_open_channel(ChainHash::using_genesis_block(network));
 		let node_b_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[7; 32]).unwrap());
-		let mut node_b_chan = InboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_channel_type_features(&config), &channelmanager::provided_init_features(&config), &open_channel_msg, 7, &config, 0, &&logger, /*is_0conf=*/false).unwrap();
+		let node_b_chan = InboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_channel_type_features(&config), &channelmanager::provided_init_features(&config), &open_channel_msg, 7, &config, 0, &&logger, /*is_0conf=*/false).unwrap();
 
 		// Node B --> Node A: accept channel, explicitly setting B's dust limit.
 		let mut accept_channel_msg = node_b_chan.accept_inbound_channel();
@@ -11815,7 +11815,7 @@ mod tests {
 
 		let open_channel_msg = node_a_chan.get_open_channel(ChainHash::using_genesis_block(network));
 		let node_b_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[7; 32]).unwrap());
-		let mut node_b_chan = InboundV1Channel::<&TestKeysInterface>::new(
+		let node_b_chan = InboundV1Channel::<&TestKeysInterface>::new(
 			&feeest,
 			&&keys_provider,
 			&&keys_provider,

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -3840,7 +3840,6 @@ pub(super) struct DualFundingChannelContext {
 // Counterparty designates channel data owned by the another channel participant entity.
 pub(super) struct Channel<SP: Deref> where SP::Target: SignerProvider {
 	pub context: ChannelContext<SP>,
-	pub dual_funding_channel_context: Option<DualFundingChannelContext>,
 }
 
 #[cfg(any(test, fuzzing))]
@@ -8024,7 +8023,6 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 
 		let mut channel = Channel {
 			context: self.context,
-			dual_funding_channel_context: None,
 		};
 
 		let need_channel_ready = channel.check_get_channel_ready(0, logger).is_some();
@@ -8253,7 +8251,6 @@ impl<SP: Deref> InboundV1Channel<SP> where SP::Target: SignerProvider {
 		// `ChannelMonitor`.
 		let mut channel = Channel {
 			context: self.context,
-			dual_funding_channel_context: None,
 		};
 		let need_channel_ready = channel.check_get_channel_ready(0, logger).is_some();
 		channel.monitor_updating_paused(false, false, need_channel_ready, Vec::new(), Vec::new(), Vec::new());
@@ -9610,7 +9607,6 @@ impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, u32, &'c Ch
 				blocked_monitor_updates: blocked_monitor_updates.unwrap(),
 				is_manual_broadcast: is_manual_broadcast.unwrap_or(false),
 			},
-			dual_funding_channel_context: None,
 		})
 	}
 }

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1121,9 +1121,7 @@ impl_writeable_tlv_based!(PendingChannelMonitorUpdate, {
 pub(super) enum ChannelPhase<SP: Deref> where SP::Target: SignerProvider {
 	UnfundedOutboundV1(OutboundV1Channel<SP>),
 	UnfundedInboundV1(InboundV1Channel<SP>),
-	#[cfg(any(dual_funding, splicing))]
 	UnfundedOutboundV2(OutboundV2Channel<SP>),
-	#[cfg(any(dual_funding, splicing))]
 	UnfundedInboundV2(InboundV2Channel<SP>),
 	Funded(Channel<SP>),
 }
@@ -1137,9 +1135,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 			ChannelPhase::Funded(chan) => &chan.context,
 			ChannelPhase::UnfundedOutboundV1(chan) => &chan.context,
 			ChannelPhase::UnfundedInboundV1(chan) => &chan.context,
-			#[cfg(any(dual_funding, splicing))]
 			ChannelPhase::UnfundedOutboundV2(chan) => &chan.context,
-			#[cfg(any(dual_funding, splicing))]
 			ChannelPhase::UnfundedInboundV2(chan) => &chan.context,
 		}
 	}
@@ -1149,9 +1145,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 			ChannelPhase::Funded(ref mut chan) => &mut chan.context,
 			ChannelPhase::UnfundedOutboundV1(ref mut chan) => &mut chan.context,
 			ChannelPhase::UnfundedInboundV1(ref mut chan) => &mut chan.context,
-			#[cfg(any(dual_funding, splicing))]
 			ChannelPhase::UnfundedOutboundV2(ref mut chan) => &mut chan.context,
-			#[cfg(any(dual_funding, splicing))]
 			ChannelPhase::UnfundedInboundV2(ref mut chan) => &mut chan.context,
 		}
 	}
@@ -3822,7 +3816,6 @@ pub(crate) fn get_legacy_default_holder_selected_channel_reserve_satoshis(channe
 ///
 /// This is used both for outbound and inbound channels and has lower bound
 /// of `dust_limit_satoshis`.
-#[cfg(any(dual_funding, splicing))]
 fn get_v2_channel_reserve_satoshis(channel_value_satoshis: u64, dust_limit_satoshis: u64) -> u64 {
 	// Fixed at 1% of channel value by spec.
 	let (q, _) = channel_value_satoshis.overflowing_div(100);
@@ -3830,7 +3823,6 @@ fn get_v2_channel_reserve_satoshis(channel_value_satoshis: u64, dust_limit_satos
 }
 
 /// Context for dual-funded channels.
-#[cfg(any(dual_funding, splicing))]
 pub(super) struct DualFundingChannelContext {
 	/// The amount in satoshis we will be contributing to the channel.
 	pub our_funding_satoshis: u64,
@@ -3847,7 +3839,6 @@ pub(super) struct DualFundingChannelContext {
 // Counterparty designates channel data owned by the another channel participant entity.
 pub(super) struct Channel<SP: Deref> where SP::Target: SignerProvider {
 	pub context: ChannelContext<SP>,
-	#[cfg(any(dual_funding, splicing))]
 	pub dual_funding_channel_context: Option<DualFundingChannelContext>,
 }
 
@@ -8032,7 +8023,6 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 
 		let mut channel = Channel {
 			context: self.context,
-			#[cfg(any(dual_funding, splicing))]
 			dual_funding_channel_context: None,
 		};
 
@@ -8262,7 +8252,6 @@ impl<SP: Deref> InboundV1Channel<SP> where SP::Target: SignerProvider {
 		// `ChannelMonitor`.
 		let mut channel = Channel {
 			context: self.context,
-			#[cfg(any(dual_funding, splicing))]
 			dual_funding_channel_context: None,
 		};
 		let need_channel_ready = channel.check_get_channel_ready(0, logger).is_some();
@@ -8273,15 +8262,12 @@ impl<SP: Deref> InboundV1Channel<SP> where SP::Target: SignerProvider {
 }
 
 // A not-yet-funded outbound (from holder) channel using V2 channel establishment.
-#[cfg(any(dual_funding, splicing))]
 pub(super) struct OutboundV2Channel<SP: Deref> where SP::Target: SignerProvider {
 	pub context: ChannelContext<SP>,
 	pub unfunded_context: UnfundedChannelContext,
-	#[cfg(any(dual_funding, splicing))]
 	pub dual_funding_context: DualFundingChannelContext,
 }
 
-#[cfg(any(dual_funding, splicing))]
 impl<SP: Deref> OutboundV2Channel<SP> where SP::Target: SignerProvider {
 	pub fn new<ES: Deref, F: Deref, L: Deref>(
 		fee_estimator: &LowerBoundedFeeEstimator<F>, entropy_source: &ES, signer_provider: &SP,
@@ -8401,14 +8387,12 @@ impl<SP: Deref> OutboundV2Channel<SP> where SP::Target: SignerProvider {
 }
 
 // A not-yet-funded inbound (from counterparty) channel using V2 channel establishment.
-#[cfg(any(dual_funding, splicing))]
 pub(super) struct InboundV2Channel<SP: Deref> where SP::Target: SignerProvider {
 	pub context: ChannelContext<SP>,
 	pub unfunded_context: UnfundedChannelContext,
 	pub dual_funding_context: DualFundingChannelContext,
 }
 
-#[cfg(any(dual_funding, splicing))]
 impl<SP: Deref> InboundV2Channel<SP> where SP::Target: SignerProvider {
 	/// Creates a new dual-funded channel from a remote side's request for one.
 	/// Assumes chain_hash has already been checked and corresponds with what we expect!
@@ -9619,7 +9603,6 @@ impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, u32, &'c Ch
 				blocked_monitor_updates: blocked_monitor_updates.unwrap(),
 				is_manual_broadcast: is_manual_broadcast.unwrap_or(false),
 			},
-			#[cfg(any(dual_funding, splicing))]
 			dual_funding_channel_context: None,
 		})
 	}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1129,6 +1129,7 @@ impl_writeable_tlv_based!(PendingChannelMonitorUpdate, {
 pub(super) enum ChannelPhase<SP: Deref> where SP::Target: SignerProvider {
 	UnfundedOutboundV1(OutboundV1Channel<SP>),
 	UnfundedInboundV1(InboundV1Channel<SP>),
+	#[allow(dead_code)] // TODO(dual_funding): Remove once creating V2 channels is enabled.
 	UnfundedOutboundV2(OutboundV2Channel<SP>),
 	UnfundedInboundV2(InboundV2Channel<SP>),
 	Funded(Channel<SP>),
@@ -4182,6 +4183,7 @@ pub(super) struct DualFundingChannelContext {
 	/// Note that the `our_funding_satoshis` field is equal to the total value of `our_funding_inputs`
 	/// minus any fees paid for our contributed weight. This means that change will never be generated
 	/// and the maximum value possible will go towards funding the channel.
+	#[allow(dead_code)] // TODO(dual_funding): Remove once contribution to V2 channels is enabled.
 	pub our_funding_inputs: Vec<(TxIn, TransactionU16LenLimited)>,
 }
 
@@ -8710,6 +8712,7 @@ pub(super) struct OutboundV2Channel<SP: Deref> where SP::Target: SignerProvider 
 }
 
 impl<SP: Deref> OutboundV2Channel<SP> where SP::Target: SignerProvider {
+	#[allow(dead_code)] // TODO(dual_funding): Remove once creating V2 channels is enabled.
 	pub fn new<ES: Deref, F: Deref, L: Deref>(
 		fee_estimator: &LowerBoundedFeeEstimator<F>, entropy_source: &ES, signer_provider: &SP,
 		counterparty_node_id: PublicKey, their_features: &InitFeatures, funding_satoshis: u64,
@@ -9021,6 +9024,7 @@ impl<SP: Deref> InboundV2Channel<SP> where SP::Target: SignerProvider {
 	///
 	/// [`msgs::AcceptChannelV2`]: crate::ln::msgs::AcceptChannelV2
 	#[cfg(test)]
+	#[allow(dead_code)] // TODO(dual_funding): Remove once contribution to V2 channels is enabled.
 	pub fn get_accept_channel_v2_message(&self) -> msgs::AcceptChannelV2 {
 		self.generate_accept_channel_v2_message()
 	}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -8564,7 +8564,7 @@ impl<SP: Deref> InboundV2Channel<SP> where SP::Target: SignerProvider {
 	/// Assumes chain_hash has already been checked and corresponds with what we expect!
 	pub fn new<ES: Deref, F: Deref, L: Deref>(
 		fee_estimator: &LowerBoundedFeeEstimator<F>, entropy_source: &ES, signer_provider: &SP,
-		counterparty_node_id: PublicKey, our_supported_features: &ChannelTypeFeatures,
+		holder_node_id: PublicKey, counterparty_node_id: PublicKey, our_supported_features: &ChannelTypeFeatures,
 		their_features: &InitFeatures, msg: &msgs::OpenChannelV2,
 		funding_inputs: Vec<(TxIn, TransactionU16LenLimited)>, total_witness_weight: Weight,
 		user_id: u128, config: &UserConfig, current_chain_height: u32, logger: &L,
@@ -8640,6 +8640,8 @@ impl<SP: Deref> InboundV2Channel<SP> where SP::Target: SignerProvider {
 		let interactive_tx_constructor = Some(InteractiveTxConstructor::new(
 			InteractiveTxConstructorArgs {
 				entropy_source,
+				holder_node_id,
+				counterparty_node_id,
 				channel_id: context.channel_id,
 				feerate_sat_per_kw: dual_funding_context.funding_feerate_sat_per_1000_weight,
 				funding_tx_locktime: dual_funding_context.funding_tx_locktime,

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4071,6 +4071,20 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider {
 			partial_signature_with_nonce: None,
 		})
 	}
+
+	#[cfg(test)]
+	pub fn get_initial_counterparty_commitment_signature_for_test<L: Deref>(
+		&mut self, logger: &L, channel_transaction_parameters: ChannelTransactionParameters,
+		counterparty_cur_commitment_point_override: PublicKey,
+	) -> Result<Signature, ChannelError>
+	where
+		SP::Target: SignerProvider,
+		L::Target: Logger
+	{
+		self.counterparty_cur_commitment_point = Some(counterparty_cur_commitment_point_override);
+		self.channel_transaction_parameters = channel_transaction_parameters;
+		self.get_initial_counterparty_commitment_signature(logger)
+	}
 }
 
 // Internal utility functions for channels
@@ -8942,7 +8956,7 @@ impl<SP: Deref> InboundV2Channel<SP> where SP::Target: SignerProvider {
 				is_initiator: false,
 				inputs_to_contribute: funding_inputs,
 				outputs_to_contribute: Vec::new(),
-				expected_remote_shared_funding_output: Some((context.get_funding_redeemscript(), context.channel_value_satoshis)),
+				expected_remote_shared_funding_output: Some((context.get_funding_redeemscript().to_p2wsh(), context.channel_value_satoshis)),
 			}
 		).map_err(|_| ChannelError::Close((
 			"V2 channel rejected due to sender error".into(),

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -12297,6 +12297,7 @@ pub fn provided_init_features(config: &UserConfig) -> InitFeatures {
 	if config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx {
 		features.set_anchors_zero_fee_htlc_tx_optional();
 	}
+	features.set_dual_fund_optional();
 	features
 }
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -18,7 +18,7 @@
 //! imply it needs to fail HTLCs/payments/channels it manages).
 
 use bitcoin::block::Header;
-use bitcoin::transaction::Transaction;
+use bitcoin::transaction::{Transaction, TxIn};
 use bitcoin::constants::ChainHash;
 use bitcoin::key::constants::SECRET_KEY_SIZE;
 use bitcoin::network::Network;
@@ -30,7 +30,7 @@ use bitcoin::hash_types::{BlockHash, Txid};
 
 use bitcoin::secp256k1::{SecretKey,PublicKey};
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::{secp256k1, Sequence};
+use bitcoin::{secp256k1, Sequence, Weight};
 
 use crate::events::FundingInfo;
 use crate::blinded_path::message::{AsyncPaymentsContext, MessageContext, OffersContext};
@@ -42,14 +42,13 @@ use crate::chain::{Confirm, ChannelMonitorUpdateStatus, Watch, BestBlock};
 use crate::chain::chaininterface::{BroadcasterInterface, ConfirmationTarget, FeeEstimator, LowerBoundedFeeEstimator};
 use crate::chain::channelmonitor::{Balance, ChannelMonitor, ChannelMonitorUpdate, WithChannelMonitor, ChannelMonitorUpdateStep, HTLC_FAIL_BACK_BUFFER, CLTV_CLAIM_BUFFER, LATENCY_GRACE_PERIOD_BLOCKS, ANTI_REORG_DELAY, MonitorEvent};
 use crate::chain::transaction::{OutPoint, TransactionData};
-use crate::events;
-use crate::events::{Event, EventHandler, EventsProvider, MessageSendEvent, MessageSendEventsProvider, ClosureReason, HTLCDestination, PaymentFailureReason, ReplayEvent};
+use crate::events::{self, Event, EventHandler, EventsProvider, InboundChannelFunds, MessageSendEvent, MessageSendEventsProvider, ClosureReason, HTLCDestination, PaymentFailureReason, ReplayEvent};
 // Since this struct is returned in `list_channels` methods, expose it here in case users want to
 // construct one themselves.
 use crate::ln::inbound_payment;
 use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
-use crate::ln::channel::{self, Channel, ChannelPhase, ChannelError, ChannelUpdateStatus, ShutdownResult, UpdateFulfillCommitFetch, OutboundV1Channel, InboundV1Channel, WithChannelContext};
+use crate::ln::channel::{self, Channel, ChannelPhase, ChannelError, ChannelUpdateStatus, ShutdownResult, UpdateFulfillCommitFetch, OutboundV1Channel, InboundV1Channel, WithChannelContext, InboundV2Channel, InteractivelyFunded as _};
 use crate::ln::channel_state::ChannelDetails;
 use crate::types::features::{Bolt12InvoiceFeatures, ChannelFeatures, ChannelTypeFeatures, InitFeatures, NodeFeatures};
 #[cfg(any(feature = "_test_utils", test))]
@@ -85,6 +84,7 @@ use crate::util::wakers::{Future, Notifier};
 use crate::util::scid_utils::fake_scid;
 use crate::util::string::UntrustedString;
 use crate::util::ser::{BigSize, FixedLengthReader, Readable, ReadableArgs, MaybeReadable, Writeable, Writer, VecWriter};
+use crate::util::ser::TransactionU16LenLimited;
 use crate::util::logger::{Level, Logger, WithContext};
 use crate::util::errors::APIError;
 
@@ -1357,11 +1357,22 @@ impl <SP: Deref> PeerState<SP> where SP::Target: SignerProvider {
 	}
 }
 
+#[derive(Clone)]
+pub(super) enum OpenChannelMessage {
+	V1(msgs::OpenChannel),
+	V2(msgs::OpenChannelV2),
+}
+
+pub(super) enum OpenChannelMessageRef<'a> {
+	V1(&'a msgs::OpenChannel),
+	V2(&'a msgs::OpenChannelV2),
+}
+
 /// A not-yet-accepted inbound (from counterparty) channel. Once
 /// accepted, the parameters will be used to construct a channel.
 pub(super) struct InboundChannelRequest {
 	/// The original OpenChannel message.
-	pub open_channel_msg: msgs::OpenChannel,
+	pub open_channel_msg: OpenChannelMessage,
 	/// The number of ticks remaining before the request expires.
 	pub ticks_remaining: i32,
 }
@@ -7591,7 +7602,7 @@ where
 	/// [`Event::OpenChannelRequest`]: events::Event::OpenChannelRequest
 	/// [`Event::ChannelClosed::user_channel_id`]: events::Event::ChannelClosed::user_channel_id
 	pub fn accept_inbound_channel(&self, temporary_channel_id: &ChannelId, counterparty_node_id: &PublicKey, user_channel_id: u128) -> Result<(), APIError> {
-		self.do_accept_inbound_channel(temporary_channel_id, counterparty_node_id, false, user_channel_id)
+		self.do_accept_inbound_channel(temporary_channel_id, counterparty_node_id, false, user_channel_id, vec![], Weight::from_wu(0))
 	}
 
 	/// Accepts a request to open a channel after a [`events::Event::OpenChannelRequest`], treating
@@ -7613,11 +7624,14 @@ where
 	/// [`Event::OpenChannelRequest`]: events::Event::OpenChannelRequest
 	/// [`Event::ChannelClosed::user_channel_id`]: events::Event::ChannelClosed::user_channel_id
 	pub fn accept_inbound_channel_from_trusted_peer_0conf(&self, temporary_channel_id: &ChannelId, counterparty_node_id: &PublicKey, user_channel_id: u128) -> Result<(), APIError> {
-		self.do_accept_inbound_channel(temporary_channel_id, counterparty_node_id, true, user_channel_id)
+		self.do_accept_inbound_channel(temporary_channel_id, counterparty_node_id, true, user_channel_id, vec![], Weight::from_wu(0))
 	}
 
-	fn do_accept_inbound_channel(&self, temporary_channel_id: &ChannelId, counterparty_node_id: &PublicKey, accept_0conf: bool, user_channel_id: u128) -> Result<(), APIError> {
-
+	fn do_accept_inbound_channel(
+		&self, temporary_channel_id: &ChannelId, counterparty_node_id: &PublicKey, accept_0conf: bool,
+		user_channel_id: u128, funding_inputs: Vec<(TxIn, TransactionU16LenLimited)>,
+		total_witness_weight: Weight,
+	) -> Result<(), APIError> {
 		let logger = WithContext::from(&self.logger, Some(*counterparty_node_id), Some(*temporary_channel_id), None);
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 
@@ -7642,12 +7656,44 @@ where
 		let res = match peer_state.inbound_channel_request_by_id.remove(temporary_channel_id) {
 			Some(unaccepted_channel) => {
 				let best_block_height = self.best_block.read().unwrap().height;
-				InboundV1Channel::new(&self.fee_estimator, &self.entropy_source, &self.signer_provider,
-					counterparty_node_id.clone(), &self.channel_type_features(), &peer_state.latest_features,
-					&unaccepted_channel.open_channel_msg, user_channel_id, &self.default_configuration, best_block_height,
-					&self.logger, accept_0conf).map_err(|err| MsgHandleErrInternal::from_chan_no_close(err, *temporary_channel_id))
+				match unaccepted_channel.open_channel_msg {
+					OpenChannelMessage::V1(open_channel_msg) => {
+						InboundV1Channel::new(
+							&self.fee_estimator, &self.entropy_source, &self.signer_provider, *counterparty_node_id,
+							&self.channel_type_features(), &peer_state.latest_features, &open_channel_msg,
+							user_channel_id, &self.default_configuration, best_block_height, &self.logger, accept_0conf
+						).map_err(|err| MsgHandleErrInternal::from_chan_no_close(err, *temporary_channel_id)
+						).map(|channel| {
+							let message_send_event = events::MessageSendEvent::SendAcceptChannel {
+								node_id: *counterparty_node_id,
+								msg: channel.accept_inbound_channel(),
+							};
+							(*temporary_channel_id, ChannelPhase::UnfundedInboundV1(channel), message_send_event)
+						})
+					},
+					OpenChannelMessage::V2(open_channel_msg) => {
+						InboundV2Channel::new(&self.fee_estimator, &self.entropy_source, &self.signer_provider,
+							*counterparty_node_id, &self.channel_type_features(), &peer_state.latest_features,
+							&open_channel_msg, funding_inputs, total_witness_weight, user_channel_id,
+							&self.default_configuration, best_block_height, &self.logger
+						).map_err(|_| MsgHandleErrInternal::from_chan_no_close(
+							ChannelError::Close(
+								(
+									"V2 channel rejected due to sender error".into(),
+									ClosureReason::HolderForceClosed { broadcasted_latest_txn: Some(false) },
+								)
+							), *temporary_channel_id)
+						).map(|channel| {
+							let message_send_event =  events::MessageSendEvent::SendAcceptChannelV2 {
+								node_id: channel.context.get_counterparty_node_id(),
+								msg: channel.accept_inbound_dual_funded_channel()
+							};
+							(channel.context.channel_id(), ChannelPhase::UnfundedInboundV2(channel), message_send_event)
+						})
+					},
+				}
 			},
-			_ => {
+			None => {
 				let err_str = "No such channel awaiting to be accepted.".to_owned();
 				log_error!(logger, "{}", err_str);
 
@@ -7655,10 +7701,14 @@ where
 			}
 		};
 
-		match res {
+		// We have to match below instead of map_err on the above as in the map_err closure the borrow checker
+		// would consider peer_state moved even though we would bail out with the `?` operator.
+		let (channel_id, mut channel_phase, message_send_event) = match res {
+			Ok(res) => res,
 			Err(err) => {
 				mem::drop(peer_state_lock);
 				mem::drop(per_peer_state);
+				// TODO(dunxen): Find/make less icky way to do this.
 				match handle_error!(self, Result::<(), MsgHandleErrInternal>::Err(err), *counterparty_node_id) {
 					Ok(_) => unreachable!("`handle_error` only returns Err as we've passed in an Err"),
 					Err(e) => {
@@ -7666,55 +7716,50 @@ where
 					},
 				}
 			}
-			Ok(mut channel) => {
-				if accept_0conf {
-					// This should have been correctly configured by the call to InboundV1Channel::new.
-					debug_assert!(channel.context.minimum_depth().unwrap() == 0);
-				} else if channel.context.get_channel_type().requires_zero_conf() {
-					let send_msg_err_event = events::MessageSendEvent::HandleError {
-						node_id: channel.context.get_counterparty_node_id(),
-						action: msgs::ErrorAction::SendErrorMessage{
-							msg: msgs::ErrorMessage { channel_id: temporary_channel_id.clone(), data: "No zero confirmation channels accepted".to_owned(), }
-						}
-					};
-					peer_state.pending_msg_events.push(send_msg_err_event);
-					let err_str = "Please use accept_inbound_channel_from_trusted_peer_0conf to accept channels with zero confirmations.".to_owned();
-					log_error!(logger, "{}", err_str);
+		};
 
-					return Err(APIError::APIMisuseError { err: err_str });
-				} else {
-					// If this peer already has some channels, a new channel won't increase our number of peers
-					// with unfunded channels, so as long as we aren't over the maximum number of unfunded
-					// channels per-peer we can accept channels from a peer with existing ones.
-					if is_only_peer_channel && peers_without_funded_channels >= MAX_UNFUNDED_CHANNEL_PEERS {
-						let send_msg_err_event = events::MessageSendEvent::HandleError {
-							node_id: channel.context.get_counterparty_node_id(),
-							action: msgs::ErrorAction::SendErrorMessage{
-								msg: msgs::ErrorMessage { channel_id: temporary_channel_id.clone(), data: "Have too many peers with unfunded channels, not accepting new ones".to_owned(), }
-							}
-						};
-						peer_state.pending_msg_events.push(send_msg_err_event);
-						let err_str = "Too many peers with unfunded channels, refusing to accept new ones".to_owned();
-						log_error!(logger, "{}", err_str);
-
-						return Err(APIError::APIMisuseError { err: err_str });
-					}
+		if accept_0conf {
+			// This should have been correctly configured by the call to Inbound(V1/V2)Channel::new.
+			debug_assert!(channel_phase.context().minimum_depth().unwrap() == 0);
+		} else if channel_phase.context().get_channel_type().requires_zero_conf() {
+			let send_msg_err_event = events::MessageSendEvent::HandleError {
+				node_id: channel_phase.context().get_counterparty_node_id(),
+				action: msgs::ErrorAction::SendErrorMessage{
+					msg: msgs::ErrorMessage { channel_id: *temporary_channel_id, data: "No zero confirmation channels accepted".to_owned(), }
 				}
+			};
+			peer_state.pending_msg_events.push(send_msg_err_event);
+			let err_str = "Please use accept_inbound_channel_from_trusted_peer_0conf to accept channels with zero confirmations.".to_owned();
+			log_error!(logger, "{}", err_str);
 
-				// Now that we know we have a channel, assign an outbound SCID alias.
-				let outbound_scid_alias = self.create_and_insert_outbound_scid_alias();
-				channel.context.set_outbound_scid_alias(outbound_scid_alias);
+			return Err(APIError::APIMisuseError { err: err_str });
+		} else {
+			// If this peer already has some channels, a new channel won't increase our number of peers
+			// with unfunded channels, so as long as we aren't over the maximum number of unfunded
+			// channels per-peer we can accept channels from a peer with existing ones.
+			if is_only_peer_channel && peers_without_funded_channels >= MAX_UNFUNDED_CHANNEL_PEERS {
+				let send_msg_err_event = events::MessageSendEvent::HandleError {
+					node_id: channel_phase.context().get_counterparty_node_id(),
+					action: msgs::ErrorAction::SendErrorMessage{
+						msg: msgs::ErrorMessage { channel_id: *temporary_channel_id, data: "Have too many peers with unfunded channels, not accepting new ones".to_owned(), }
+					}
+				};
+				peer_state.pending_msg_events.push(send_msg_err_event);
+				let err_str = "Too many peers with unfunded channels, refusing to accept new ones".to_owned();
+				log_error!(logger, "{}", err_str);
 
-				peer_state.pending_msg_events.push(events::MessageSendEvent::SendAcceptChannel {
-					node_id: channel.context.get_counterparty_node_id(),
-					msg: channel.accept_inbound_channel(),
-				});
-
-				peer_state.channel_by_id.insert(temporary_channel_id.clone(), ChannelPhase::UnfundedInboundV1(channel));
-
-				Ok(())
-			},
+				return Err(APIError::APIMisuseError { err: err_str });
+			}
 		}
+
+		// Now that we know we have a channel, assign an outbound SCID alias.
+		let outbound_scid_alias = self.create_and_insert_outbound_scid_alias();
+		channel_phase.context_mut().set_outbound_scid_alias(outbound_scid_alias);
+
+		peer_state.pending_msg_events.push(message_send_event);
+		peer_state.channel_by_id.insert(channel_id, channel_phase);
+
+		Ok(())
 	}
 
 	/// Gets the number of peers which match the given filter and do not have any funded, outbound,
@@ -7777,17 +7822,24 @@ where
 		num_unfunded_channels + peer.inbound_channel_request_by_id.len()
 	}
 
-	fn internal_open_channel(&self, counterparty_node_id: &PublicKey, msg: &msgs::OpenChannel) -> Result<(), MsgHandleErrInternal> {
+	fn internal_open_channel(&self, counterparty_node_id: &PublicKey, msg: OpenChannelMessageRef<'_>) -> Result<(), MsgHandleErrInternal> {
+		let common_fields = match msg {
+			OpenChannelMessageRef::V1(msg) => &msg.common_fields,
+			OpenChannelMessageRef::V2(msg) => &msg.common_fields,
+		};
+
+		// Do common open_channel(2) checks
+
 		// Note that the ChannelManager is NOT re-persisted on disk after this, so any changes are
 		// likely to be lost on restart!
-		if msg.common_fields.chain_hash != self.chain_hash {
+		if common_fields.chain_hash != self.chain_hash {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close("Unknown genesis block hash".to_owned(),
-				 msg.common_fields.temporary_channel_id.clone()));
+				 common_fields.temporary_channel_id));
 		}
 
 		if !self.default_configuration.accept_inbound_channels {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close("No inbound channels accepted".to_owned(),
-				 msg.common_fields.temporary_channel_id.clone()));
+				 common_fields.temporary_channel_id));
 		}
 
 		// Get the number of peers with channels, but without funded ones. We don't care too much
@@ -7802,7 +7854,7 @@ where
 				debug_assert!(false);
 				MsgHandleErrInternal::send_err_msg_no_close(
 					format!("Can't find a peer matching the passed counterparty node_id {}", counterparty_node_id),
-					msg.common_fields.temporary_channel_id.clone())
+					common_fields.temporary_channel_id)
 			})?;
 		let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 		let peer_state = &mut *peer_state_lock;
@@ -7816,44 +7868,51 @@ where
 		{
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(
 				"Have too many peers with unfunded channels, not accepting new ones".to_owned(),
-				msg.common_fields.temporary_channel_id.clone()));
+				common_fields.temporary_channel_id));
 		}
 
 		let best_block_height = self.best_block.read().unwrap().height;
 		if Self::unfunded_channel_count(peer_state, best_block_height) >= MAX_UNFUNDED_CHANS_PER_PEER {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(
 				format!("Refusing more than {} unfunded channels.", MAX_UNFUNDED_CHANS_PER_PEER),
-				msg.common_fields.temporary_channel_id.clone()));
+				common_fields.temporary_channel_id));
 		}
 
-		let channel_id = msg.common_fields.temporary_channel_id;
+		let channel_id = common_fields.temporary_channel_id;
 		let channel_exists = peer_state.has_channel(&channel_id);
 		if channel_exists {
 			return Err(MsgHandleErrInternal::send_err_msg_no_close(
 				"temporary_channel_id collision for the same peer!".to_owned(),
-				msg.common_fields.temporary_channel_id.clone()));
+				common_fields.temporary_channel_id));
 		}
+
+		// We can get the channel type at this point already as we'll need it immediately in both the
+		// manual and the automatic acceptance cases.
+		let channel_type = channel::channel_type_from_open_channel(
+			common_fields, &peer_state.latest_features, &self.channel_type_features()
+		).map_err(|e| MsgHandleErrInternal::from_chan_no_close(e, common_fields.temporary_channel_id))?;
 
 		// If we're doing manual acceptance checks on the channel, then defer creation until we're sure we want to accept.
 		if self.default_configuration.manually_accept_inbound_channels {
-			let channel_type = channel::channel_type_from_open_channel(
-					&msg.common_fields, &peer_state.latest_features, &self.channel_type_features()
-				).map_err(|e|
-					MsgHandleErrInternal::from_chan_no_close(e, msg.common_fields.temporary_channel_id)
-				)?;
 			let mut pending_events = self.pending_events.lock().unwrap();
-			let is_announced = (msg.common_fields.channel_flags & 1) == 1;
+			let is_announced = (common_fields.channel_flags & 1) == 1;
 			pending_events.push_back((events::Event::OpenChannelRequest {
-				temporary_channel_id: msg.common_fields.temporary_channel_id.clone(),
-				counterparty_node_id: counterparty_node_id.clone(),
-				funding_satoshis: msg.common_fields.funding_satoshis,
-				push_msat: msg.push_msat,
+				temporary_channel_id: common_fields.temporary_channel_id,
+				counterparty_node_id: *counterparty_node_id,
+				funding_satoshis: common_fields.funding_satoshis,
+				channel_negotiation_type: match msg {
+					OpenChannelMessageRef::V1(msg) => InboundChannelFunds::PushMsat(msg.push_msat),
+					OpenChannelMessageRef::V2(_) => InboundChannelFunds::DualFunded,
+				},
 				channel_type,
 				is_announced,
-				params: msg.common_fields.channel_parameters(),
+				params: common_fields.channel_parameters(),
 			}, None));
 			peer_state.inbound_channel_request_by_id.insert(channel_id, InboundChannelRequest {
-				open_channel_msg: msg.clone(),
+				open_channel_msg: match msg {
+					OpenChannelMessageRef::V1(msg) => OpenChannelMessage::V1(msg.clone()),
+					OpenChannelMessageRef::V2(msg) => OpenChannelMessage::V2(msg.clone()),
+				},
 				ticks_remaining: UNACCEPTED_INBOUND_CHANNEL_AGE_LIMIT_TICKS,
 			});
 			return Ok(());
@@ -7863,36 +7922,47 @@ where
 		let mut random_bytes = [0u8; 16];
 		random_bytes.copy_from_slice(&self.entropy_source.get_secure_random_bytes()[..16]);
 		let user_channel_id = u128::from_be_bytes(random_bytes);
-		let mut channel = match InboundV1Channel::new(&self.fee_estimator, &self.entropy_source, &self.signer_provider,
-			counterparty_node_id.clone(), &self.channel_type_features(), &peer_state.latest_features, msg, user_channel_id,
-			&self.default_configuration, best_block_height, &self.logger, /*is_0conf=*/false)
-		{
-			Err(e) => {
-				return Err(MsgHandleErrInternal::from_chan_no_close(e, msg.common_fields.temporary_channel_id));
-			},
-			Ok(res) => res
-		};
 
-		let channel_type = channel.context.get_channel_type();
 		if channel_type.requires_zero_conf() {
-			return Err(MsgHandleErrInternal::send_err_msg_no_close(
-				"No zero confirmation channels accepted".to_owned(),
-				msg.common_fields.temporary_channel_id.clone()));
+			return Err(MsgHandleErrInternal::send_err_msg_no_close("No zero confirmation channels accepted".to_owned(), common_fields.temporary_channel_id));
 		}
 		if channel_type.requires_anchors_zero_fee_htlc_tx() {
-			return Err(MsgHandleErrInternal::send_err_msg_no_close(
-				"No channels with anchor outputs accepted".to_owned(),
-				msg.common_fields.temporary_channel_id.clone()));
+			return Err(MsgHandleErrInternal::send_err_msg_no_close("No channels with anchor outputs accepted".to_owned(), common_fields.temporary_channel_id));
 		}
 
-		let outbound_scid_alias = self.create_and_insert_outbound_scid_alias();
-		channel.context.set_outbound_scid_alias(outbound_scid_alias);
+		let (mut channel_phase, message_send_event) = match msg {
+			OpenChannelMessageRef::V1(msg) => {
+				let channel = InboundV1Channel::new(
+					&self.fee_estimator, &self.entropy_source, &self.signer_provider, *counterparty_node_id,
+					&self.channel_type_features(), &peer_state.latest_features, msg, user_channel_id,
+					&self.default_configuration, best_block_height, &self.logger, /*is_0conf=*/false
+				).map_err(|e| MsgHandleErrInternal::from_chan_no_close(e, msg.common_fields.temporary_channel_id))?;
+				let message_send_event = events::MessageSendEvent::SendAcceptChannel {
+					node_id: *counterparty_node_id,
+					msg: channel.accept_inbound_channel(),
+				};
+				(ChannelPhase::UnfundedInboundV1(channel), message_send_event)
+			},
+			OpenChannelMessageRef::V2(msg) => {
+				let channel = InboundV2Channel::new(&self.fee_estimator, &self.entropy_source,
+					&self.signer_provider, *counterparty_node_id, &self.channel_type_features(),
+					&peer_state.latest_features, msg, vec![], Weight::from_wu(0), user_channel_id,
+					&self.default_configuration, best_block_height, &self.logger
+				).map_err(|e| MsgHandleErrInternal::from_chan_no_close(e, msg.common_fields.temporary_channel_id))?;
+				let message_send_event = events::MessageSendEvent::SendAcceptChannelV2 {
+					node_id: *counterparty_node_id,
+					msg: channel.accept_inbound_dual_funded_channel(),
+				};
+				(ChannelPhase::UnfundedInboundV2(channel), message_send_event)
+			},
+		};
 
-		peer_state.pending_msg_events.push(events::MessageSendEvent::SendAcceptChannel {
-			node_id: counterparty_node_id.clone(),
-			msg: channel.accept_inbound_channel(),
-		});
-		peer_state.channel_by_id.insert(channel_id, ChannelPhase::UnfundedInboundV1(channel));
+		let outbound_scid_alias = self.create_and_insert_outbound_scid_alias();
+		channel_phase.context_mut().set_outbound_scid_alias(outbound_scid_alias);
+
+		peer_state.pending_msg_events.push(message_send_event);
+		peer_state.channel_by_id.insert(channel_phase.context().channel_id(), channel_phase);
+
 		Ok(())
 	}
 
@@ -7912,7 +7982,7 @@ where
 				hash_map::Entry::Occupied(mut phase) => {
 					match phase.get_mut() {
 						ChannelPhase::UnfundedOutboundV1(chan) => {
-							try_chan_phase_entry!(self, peer_state, chan.accept_channel(&msg, &self.default_configuration.channel_handshake_limits, &peer_state.latest_features), phase);
+							try_chan_phase_entry!(self, peer_state, chan.accept_channel(msg, &self.default_configuration.channel_handshake_limits, &peer_state.latest_features), phase);
 							(chan.context.get_value_satoshis(), chan.context.get_funding_redeemscript().to_p2wsh(), chan.context.get_user_id())
 						},
 						_ => {
@@ -8090,6 +8160,145 @@ where
 			},
 			hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
 		}
+	}
+
+	fn internal_tx_msg<HandleTxMsgFn: Fn(&mut ChannelPhase<SP>) -> Result<MessageSendEvent, &'static str>>(
+		&self, counterparty_node_id: &PublicKey, channel_id: ChannelId, tx_msg_handler: HandleTxMsgFn
+	) -> Result<(), MsgHandleErrInternal> {
+		let per_peer_state = self.per_peer_state.read().unwrap();
+		let peer_state_mutex = per_peer_state.get(counterparty_node_id)
+			.ok_or_else(|| {
+				debug_assert!(false);
+				MsgHandleErrInternal::send_err_msg_no_close(
+					format!("Can't find a peer matching the passed counterparty node_id {}", counterparty_node_id),
+					channel_id)
+			})?;
+		let mut peer_state_lock = peer_state_mutex.lock().unwrap();
+		let peer_state = &mut *peer_state_lock;
+		match peer_state.channel_by_id.entry(channel_id) {
+			hash_map::Entry::Occupied(mut chan_phase_entry) => {
+				let channel_phase = chan_phase_entry.get_mut();
+				let msg_send_event = match tx_msg_handler(channel_phase) {
+					Ok(msg_send_event) => msg_send_event,
+					Err(tx_msg_str) =>  return Err(MsgHandleErrInternal::from_chan_no_close(ChannelError::Warn(
+						format!("Got a {tx_msg_str} message with no interactive transaction construction expected or in-progress")
+					), channel_id)),
+				};
+				peer_state.pending_msg_events.push(msg_send_event);
+				Ok(())
+			},
+			hash_map::Entry::Vacant(_) => {
+				Err(MsgHandleErrInternal::send_err_msg_no_close(format!(
+					"Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}",
+					counterparty_node_id), channel_id)
+				)
+			}
+		}
+	}
+
+	fn internal_tx_add_input(&self, counterparty_node_id: PublicKey, msg: &msgs::TxAddInput) -> Result<(), MsgHandleErrInternal> {
+		self.internal_tx_msg(&counterparty_node_id, msg.channel_id, |channel_phase: &mut ChannelPhase<SP>| {
+			match channel_phase {
+				ChannelPhase::UnfundedInboundV2(ref mut channel) => {
+					Ok(channel.tx_add_input(msg).into_msg_send_event(counterparty_node_id))
+				},
+				ChannelPhase::UnfundedOutboundV2(ref mut channel) => {
+					Ok(channel.tx_add_input(msg).into_msg_send_event(counterparty_node_id))
+				},
+				_ => Err("tx_add_input"),
+			}
+		})
+	}
+
+	fn internal_tx_add_output(&self, counterparty_node_id: PublicKey, msg: &msgs::TxAddOutput) -> Result<(), MsgHandleErrInternal> {
+		self.internal_tx_msg(&counterparty_node_id, msg.channel_id, |channel_phase: &mut ChannelPhase<SP>| {
+			match channel_phase {
+				ChannelPhase::UnfundedInboundV2(ref mut channel) => {
+					Ok(channel.tx_add_output(msg).into_msg_send_event(counterparty_node_id))
+				},
+				ChannelPhase::UnfundedOutboundV2(ref mut channel) => {
+					Ok(channel.tx_add_output(msg).into_msg_send_event(counterparty_node_id))
+				},
+				_ => Err("tx_add_output"),
+			}
+		})
+	}
+
+	fn internal_tx_remove_input(&self, counterparty_node_id: PublicKey, msg: &msgs::TxRemoveInput) -> Result<(), MsgHandleErrInternal> {
+		self.internal_tx_msg(&counterparty_node_id, msg.channel_id, |channel_phase: &mut ChannelPhase<SP>| {
+			match channel_phase {
+				ChannelPhase::UnfundedInboundV2(ref mut channel) => {
+					Ok(channel.tx_remove_input(msg).into_msg_send_event(counterparty_node_id))
+				},
+				ChannelPhase::UnfundedOutboundV2(ref mut channel) => {
+					Ok(channel.tx_remove_input(msg).into_msg_send_event(counterparty_node_id))
+				},
+				_ => Err("tx_remove_input"),
+			}
+		})
+	}
+
+	fn internal_tx_remove_output(&self, counterparty_node_id: PublicKey, msg: &msgs::TxRemoveOutput) -> Result<(), MsgHandleErrInternal> {
+		self.internal_tx_msg(&counterparty_node_id, msg.channel_id, |channel_phase: &mut ChannelPhase<SP>| {
+			match channel_phase {
+				ChannelPhase::UnfundedInboundV2(ref mut channel) => {
+					Ok(channel.tx_remove_output(msg).into_msg_send_event(counterparty_node_id))
+				},
+				ChannelPhase::UnfundedOutboundV2(ref mut channel) => {
+					Ok(channel.tx_remove_output(msg).into_msg_send_event(counterparty_node_id))
+				},
+				_ => Err("tx_remove_output"),
+			}
+		})
+	}
+
+	fn internal_tx_complete(&self, counterparty_node_id: PublicKey, msg: &msgs::TxComplete) -> Result<(), MsgHandleErrInternal> {
+		let per_peer_state = self.per_peer_state.read().unwrap();
+		let peer_state_mutex = per_peer_state.get(&counterparty_node_id)
+			.ok_or_else(|| {
+				debug_assert!(false);
+				MsgHandleErrInternal::send_err_msg_no_close(
+					format!("Can't find a peer matching the passed counterparty node_id {}", counterparty_node_id),
+					msg.channel_id)
+			})?;
+		let mut peer_state_lock = peer_state_mutex.lock().unwrap();
+		let peer_state = &mut *peer_state_lock;
+		match peer_state.channel_by_id.entry(msg.channel_id) {
+			hash_map::Entry::Occupied(mut chan_phase_entry) => {
+				let channel_phase = chan_phase_entry.get_mut();
+				let (msg_send_event_opt, tx_opt) = match channel_phase {
+					ChannelPhase::UnfundedInboundV2(channel) => channel.tx_complete(msg).into_msg_send_event_or_tx(counterparty_node_id),
+					ChannelPhase::UnfundedOutboundV2(channel) => channel.tx_complete(msg).into_msg_send_event_or_tx(counterparty_node_id),
+					_ => try_chan_phase_entry!(self, peer_state, Err(ChannelError::Close(
+						(
+							"Got a tx_complete message with no interactive transaction construction expected or in-progress".into(),
+							ClosureReason::HolderForceClosed { broadcasted_latest_txn: Some(false) },
+						))), chan_phase_entry)
+				};
+				if let Some(msg_send_event) = msg_send_event_opt {
+					peer_state.pending_msg_events.push(msg_send_event);
+				}
+				if let Some(tx) = tx_opt {
+					// TODO(dual_funding): Handle this unsigned transaction.
+				}
+				Ok(())
+			},
+			hash_map::Entry::Vacant(_) => {
+				Err(MsgHandleErrInternal::send_err_msg_no_close(format!("Got a message for a channel from the wrong node! No such channel for the passed counterparty_node_id {}", counterparty_node_id), msg.channel_id))
+			}
+		}
+	}
+
+	fn internal_tx_signatures(&self, counterparty_node_id: &PublicKey, msg: &msgs::TxSignatures) {
+		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
+			"Dual-funded channels not supported".to_owned(),
+			 msg.channel_id)), *counterparty_node_id);
+	}
+
+	fn internal_tx_abort(&self, counterparty_node_id: &PublicKey, msg: &msgs::TxAbort) {
+		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
+			"Dual-funded channels not supported".to_owned(),
+			 msg.channel_id)), *counterparty_node_id);
 	}
 
 	fn internal_channel_ready(&self, counterparty_node_id: &PublicKey, msg: &msgs::ChannelReady) -> Result<(), MsgHandleErrInternal> {
@@ -10838,7 +11047,7 @@ where
 		// open_channel message - pre-funded channels are never written so there should be no
 		// change to the contents.
 		let _persistence_guard = PersistenceNotifierGuard::optionally_notify(self, || {
-			let res = self.internal_open_channel(&counterparty_node_id, msg);
+			let res = self.internal_open_channel(&counterparty_node_id, OpenChannelMessageRef::V1(msg));
 			let persist = match &res {
 				Err(e) if e.closes_channel() => {
 					debug_assert!(false, "We shouldn't close a new channel");
@@ -10852,9 +11061,21 @@ where
 	}
 
 	fn handle_open_channel_v2(&self, counterparty_node_id: PublicKey, msg: &msgs::OpenChannelV2) {
-		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
-			"Dual-funded channels not supported".to_owned(),
-			msg.common_fields.temporary_channel_id.clone())), counterparty_node_id);
+		// Note that we never need to persist the updated ChannelManager for an inbound
+		// open_channel message - pre-funded channels are never written so there should be no
+		// change to the contents.
+		let _persistence_guard = PersistenceNotifierGuard::optionally_notify(self, || {
+			let res = self.internal_open_channel(&counterparty_node_id, OpenChannelMessageRef::V2(msg));
+			let persist = match &res {
+				Err(e) if e.closes_channel() => {
+					debug_assert!(false, "We shouldn't close a new channel");
+					NotifyOption::DoPersist
+				},
+				_ => NotifyOption::SkipPersistHandleEvents,
+			};
+			let _ = handle_error!(self, res, counterparty_node_id);
+			persist
+		});
 	}
 
 	fn handle_accept_channel(&self, counterparty_node_id: PublicKey, msg: &msgs::AcceptChannel) {
@@ -11384,33 +11605,53 @@ where
 	}
 
 	fn handle_tx_add_input(&self, counterparty_node_id: PublicKey, msg: &msgs::TxAddInput) {
-		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
-			"Dual-funded channels not supported".to_owned(),
-			msg.channel_id.clone())), counterparty_node_id);
+		// Note that we never need to persist the updated ChannelManager for an inbound
+		// tx_add_input message - interactive transaction construction does not need to
+		// be persisted before any signatures are exchanged.
+		let _persistence_guard = PersistenceNotifierGuard::optionally_notify(self, || {
+			let _ = handle_error!(self, self.internal_tx_add_input(counterparty_node_id, msg), counterparty_node_id);
+			NotifyOption::SkipPersistHandleEvents
+		});
 	}
 
 	fn handle_tx_add_output(&self, counterparty_node_id: PublicKey, msg: &msgs::TxAddOutput) {
-		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
-			"Dual-funded channels not supported".to_owned(),
-			msg.channel_id.clone())), counterparty_node_id);
+		// Note that we never need to persist the updated ChannelManager for an inbound
+		// tx_add_output message - interactive transaction construction does not need to
+		// be persisted before any signatures are exchanged.
+		let _persistence_guard = PersistenceNotifierGuard::optionally_notify(self, || {
+			let _ = handle_error!(self, self.internal_tx_add_output(counterparty_node_id, msg), counterparty_node_id);
+			NotifyOption::SkipPersistHandleEvents
+		});
 	}
 
 	fn handle_tx_remove_input(&self, counterparty_node_id: PublicKey, msg: &msgs::TxRemoveInput) {
-		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
-			"Dual-funded channels not supported".to_owned(),
-			msg.channel_id.clone())), counterparty_node_id);
+		// Note that we never need to persist the updated ChannelManager for an inbound
+		// tx_remove_input message - interactive transaction construction does not need to
+		// be persisted before any signatures are exchanged.
+		let _persistence_guard = PersistenceNotifierGuard::optionally_notify(self, || {
+			let _ = handle_error!(self, self.internal_tx_remove_input(counterparty_node_id, msg), counterparty_node_id);
+			NotifyOption::SkipPersistHandleEvents
+		});
 	}
 
 	fn handle_tx_remove_output(&self, counterparty_node_id: PublicKey, msg: &msgs::TxRemoveOutput) {
-		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
-			"Dual-funded channels not supported".to_owned(),
-			msg.channel_id.clone())), counterparty_node_id);
+		// Note that we never need to persist the updated ChannelManager for an inbound
+		// tx_remove_output message - interactive transaction construction does not need to
+		// be persisted before any signatures are exchanged.
+		let _persistence_guard = PersistenceNotifierGuard::optionally_notify(self, || {
+			let _ = handle_error!(self, self.internal_tx_remove_output(counterparty_node_id, msg), counterparty_node_id);
+			NotifyOption::SkipPersistHandleEvents
+		});
 	}
 
 	fn handle_tx_complete(&self, counterparty_node_id: PublicKey, msg: &msgs::TxComplete) {
-		let _: Result<(), _> = handle_error!(self, Err(MsgHandleErrInternal::send_err_msg_no_close(
-			"Dual-funded channels not supported".to_owned(),
-			msg.channel_id.clone())), counterparty_node_id);
+		// Note that we never need to persist the updated ChannelManager for an inbound
+		// tx_complete message - interactive transaction construction does not need to
+		// be persisted before any signatures are exchanged.
+		let _persistence_guard = PersistenceNotifierGuard::optionally_notify(self, || {
+			let _ = handle_error!(self, self.internal_tx_complete(counterparty_node_id, msg), counterparty_node_id);
+			NotifyOption::SkipPersistHandleEvents
+		});
 	}
 
 	fn handle_tx_signatures(&self, counterparty_node_id: PublicKey, msg: &msgs::TxSignatures) {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2600,8 +2600,14 @@ where
 	/// offer they resolve to to the given one.
 	pub testing_dnssec_proof_offer_resolution_override: Mutex<HashMap<HumanReadableName, Offer>>,
 
+	#[cfg(test)]
+	pub(super) entropy_source: ES,
+	#[cfg(not(test))]
 	entropy_source: ES,
 	node_signer: NS,
+	#[cfg(test)]
+	pub(super) signer_provider: SP,
+	#[cfg(not(test))]
 	signer_provider: SP,
 
 	logger: L,
@@ -3467,6 +3473,11 @@ where
 	/// Gets the current configuration applied to all new channels.
 	pub fn get_current_default_configuration(&self) -> &UserConfig {
 		&self.default_configuration
+	}
+
+	#[cfg(test)]
+	pub fn create_and_insert_outbound_scid_alias_for_test(&self) -> u64 {
+		self.create_and_insert_outbound_scid_alias()
 	}
 
 	fn create_and_insert_outbound_scid_alias(&self) -> u64 {
@@ -15674,9 +15685,6 @@ mod tests {
 
 		expect_pending_htlcs_forwardable!(nodes[0]);
 	}
-
-	// Dual-funding: V2 Channel Establishment Tests
-	// TODO(dual_funding): Complete these.
 }
 
 #[cfg(ldk_bench)]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3164,7 +3164,7 @@ macro_rules! handle_monitor_update_completion {
 			&mut $peer_state.pending_msg_events, $chan, updates.raa,
 			updates.commitment_update, updates.order, updates.accepted_htlcs, updates.pending_update_adds,
 			updates.funding_broadcastable, updates.channel_ready,
-			updates.announcement_sigs);
+			updates.announcement_sigs, updates.tx_signatures);
 		if let Some(upd) = channel_update {
 			$peer_state.pending_msg_events.push(upd);
 		}
@@ -7445,17 +7445,20 @@ where
 		commitment_update: Option<msgs::CommitmentUpdate>, order: RAACommitmentOrder,
 		pending_forwards: Vec<(PendingHTLCInfo, u64)>, pending_update_adds: Vec<msgs::UpdateAddHTLC>,
 		funding_broadcastable: Option<Transaction>,
-		channel_ready: Option<msgs::ChannelReady>, announcement_sigs: Option<msgs::AnnouncementSignatures>)
-	-> (Option<(u64, Option<PublicKey>, OutPoint, ChannelId, u128, Vec<(PendingHTLCInfo, u64)>)>, Option<(u64, Vec<msgs::UpdateAddHTLC>)>) {
+		channel_ready: Option<msgs::ChannelReady>, announcement_sigs: Option<msgs::AnnouncementSignatures>,
+		tx_signatures: Option<msgs::TxSignatures>
+	) -> (Option<(u64, Option<PublicKey>, OutPoint, ChannelId, u128, Vec<(PendingHTLCInfo, u64)>)>, Option<(u64, Vec<msgs::UpdateAddHTLC>)>) {
 		let logger = WithChannelContext::from(&self.logger, &channel.context, None);
-		log_trace!(logger, "Handling channel resumption for channel {} with {} RAA, {} commitment update, {} pending forwards, {} pending update_add_htlcs, {}broadcasting funding, {} channel ready, {} announcement",
+		log_trace!(logger, "Handling channel resumption for channel {} with {} RAA, {} commitment update, {} pending forwards, {} pending update_add_htlcs, {}broadcasting funding, {} channel ready, {} announcement, {} tx_signatures",
 			&channel.context.channel_id(),
 			if raa.is_some() { "an" } else { "no" },
 			if commitment_update.is_some() { "a" } else { "no" },
 			pending_forwards.len(), pending_update_adds.len(),
 			if funding_broadcastable.is_some() { "" } else { "not " },
 			if channel_ready.is_some() { "sending" } else { "without" },
-			if announcement_sigs.is_some() { "sending" } else { "without" });
+			if announcement_sigs.is_some() { "sending" } else { "without" },
+			if tx_signatures.is_some() { "sending" } else { "without" },
+		);
 
 		let counterparty_node_id = channel.context.get_counterparty_node_id();
 		let short_channel_id = channel.context.get_short_channel_id().unwrap_or(channel.context.outbound_scid_alias());
@@ -7478,6 +7481,12 @@ where
 		}
 		if let Some(msg) = announcement_sigs {
 			pending_msg_events.push(events::MessageSendEvent::SendAnnouncementSignatures {
+				node_id: counterparty_node_id,
+				msg,
+			});
+		}
+		if let Some(msg) = tx_signatures {
+			pending_msg_events.push(events::MessageSendEvent::SendTxSignatures {
 				node_id: counterparty_node_id,
 				msg,
 			});
@@ -8349,7 +8358,8 @@ where
 				let channel_phase = chan_phase_entry.get_mut();
 				match channel_phase {
 					ChannelPhase::Funded(chan) => {
-						let (tx_signatures_opt, funding_tx_opt) = try_chan_phase_entry!(self, peer_state, chan.tx_signatures(msg), chan_phase_entry);
+						let logger = WithChannelContext::from(&self.logger, &chan.context, None);
+						let (tx_signatures_opt, funding_tx_opt) = try_chan_phase_entry!(self, peer_state, chan.tx_signatures(msg, &&logger), chan_phase_entry);
 						if let Some(tx_signatures) = tx_signatures_opt {
 							peer_state.pending_msg_events.push(events::MessageSendEvent::SendTxSignatures {
 								node_id: *counterparty_node_id,
@@ -9222,7 +9232,7 @@ where
 						let need_lnd_workaround = chan.context.workaround_lnd_bug_4006.take();
 						let (htlc_forwards, decode_update_add_htlcs) = self.handle_channel_resumption(
 							&mut peer_state.pending_msg_events, chan, responses.raa, responses.commitment_update, responses.order,
-							Vec::new(), Vec::new(), None, responses.channel_ready, responses.announcement_sigs);
+							Vec::new(), Vec::new(), None, responses.channel_ready, responses.announcement_sigs, None);
 						debug_assert!(htlc_forwards.is_none());
 						debug_assert!(decode_update_add_htlcs.is_none());
 						if let Some(upd) = channel_update {

--- a/lightning/src/ln/dual_funding_tests.rs
+++ b/lightning/src/ln/dual_funding_tests.rs
@@ -1,0 +1,266 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Tests that test the creation of dual-funded channels in ChannelManager.
+
+use bitcoin::Weight;
+
+use crate::chain::chaininterface::{ConfirmationTarget, FeeEstimator, LowerBoundedFeeEstimator};
+use crate::events::{Event, MessageSendEvent, MessageSendEventsProvider};
+use crate::ln::chan_utils::{
+	make_funding_redeemscript, ChannelPublicKeys, ChannelTransactionParameters,
+	CounterpartyChannelTransactionParameters,
+};
+use crate::ln::channel::{
+	calculate_our_funding_satoshis, OutboundV2Channel, MIN_CHAN_DUST_LIMIT_SATOSHIS,
+};
+use crate::ln::channel_keys::{DelayedPaymentBasepoint, HtlcBasepoint, RevocationBasepoint};
+use crate::ln::functional_test_utils::*;
+use crate::ln::msgs::ChannelMessageHandler;
+use crate::ln::msgs::{CommitmentSigned, TxAddInput, TxAddOutput, TxComplete};
+use crate::ln::types::ChannelId;
+use crate::prelude::*;
+use crate::sign::{ChannelSigner as _, P2WPKH_WITNESS_WEIGHT};
+use crate::util::ser::TransactionU16LenLimited;
+use crate::util::test_utils;
+
+// Dual-funding: V2 Channel Establishment Tests
+struct V2ChannelEstablishmentTestSession {
+	initiator_input_value_satoshis: u64,
+}
+
+// TODO(dual_funding): Use real node and API for creating V2 channels as initiator when available,
+// instead of manually constructing messages.
+fn do_test_v2_channel_establishment(
+	session: V2ChannelEstablishmentTestSession, test_async_persist: bool,
+) {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let logger_a = test_utils::TestLogger::with_id("node a".to_owned());
+
+	// Create a funding input for the new channel along with its previous transaction.
+	let initiator_funding_inputs: Vec<_> = create_dual_funding_utxos_with_prev_txs(
+		&nodes[0],
+		&[session.initiator_input_value_satoshis],
+	)
+	.into_iter()
+	.map(|(txin, tx)| (txin, TransactionU16LenLimited::new(tx).unwrap()))
+	.collect();
+
+	// Alice creates a dual-funded channel as initiator.
+	let funding_feerate = node_cfgs[0]
+		.fee_estimator
+		.get_est_sat_per_1000_weight(ConfirmationTarget::NonAnchorChannelFee);
+	let funding_satoshis = calculate_our_funding_satoshis(
+		true,
+		&initiator_funding_inputs[..],
+		Weight::from_wu(P2WPKH_WITNESS_WEIGHT),
+		funding_feerate,
+		MIN_CHAN_DUST_LIMIT_SATOSHIS,
+	)
+	.unwrap();
+	let mut channel = OutboundV2Channel::new(
+		&LowerBoundedFeeEstimator(node_cfgs[0].fee_estimator),
+		&nodes[0].node.entropy_source,
+		&nodes[0].node.signer_provider,
+		nodes[1].node.get_our_node_id(),
+		&nodes[1].node.init_features(),
+		funding_satoshis,
+		initiator_funding_inputs.clone(),
+		42, /* user_channel_id */
+		nodes[0].node.get_current_default_configuration(),
+		nodes[0].best_block_info().1,
+		nodes[0].node.create_and_insert_outbound_scid_alias_for_test(),
+		ConfirmationTarget::NonAnchorChannelFee,
+		&logger_a,
+	)
+	.unwrap();
+	let open_channel_v2_msg = channel.get_open_channel_v2(nodes[0].chain_source.chain_hash);
+
+	nodes[1].node.handle_open_channel_v2(nodes[0].node.get_our_node_id(), &open_channel_v2_msg);
+
+	let accept_channel_v2_msg = get_event_msg!(
+		nodes[1],
+		MessageSendEvent::SendAcceptChannelV2,
+		nodes[0].node.get_our_node_id()
+	);
+	let channel_id = ChannelId::v2_from_revocation_basepoints(
+		&RevocationBasepoint::from(accept_channel_v2_msg.common_fields.revocation_basepoint),
+		&RevocationBasepoint::from(open_channel_v2_msg.common_fields.revocation_basepoint),
+	);
+
+	let tx_add_input_msg = TxAddInput {
+		channel_id,
+		serial_id: 2, // Even serial_id from initiator.
+		prevtx: initiator_funding_inputs[0].1.clone(),
+		prevtx_out: 0,
+		sequence: initiator_funding_inputs[0].0.sequence.0,
+		shared_input_txid: None,
+	};
+	let input_value =
+		tx_add_input_msg.prevtx.as_transaction().output[tx_add_input_msg.prevtx_out as usize].value;
+	assert_eq!(input_value.to_sat(), session.initiator_input_value_satoshis);
+
+	nodes[1].node.handle_tx_add_input(nodes[0].node.get_our_node_id(), &tx_add_input_msg);
+
+	let _tx_complete_msg =
+		get_event_msg!(nodes[1], MessageSendEvent::SendTxComplete, nodes[0].node.get_our_node_id());
+
+	let tx_add_output_msg = TxAddOutput {
+		channel_id,
+		serial_id: 4,
+		sats: funding_satoshis,
+		script: make_funding_redeemscript(
+			&open_channel_v2_msg.common_fields.funding_pubkey,
+			&accept_channel_v2_msg.common_fields.funding_pubkey,
+		)
+		.to_p2wsh(),
+	};
+	nodes[1].node.handle_tx_add_output(nodes[0].node.get_our_node_id(), &tx_add_output_msg);
+
+	let _tx_complete_msg =
+		get_event_msg!(nodes[1], MessageSendEvent::SendTxComplete, nodes[0].node.get_our_node_id());
+
+	let tx_complete_msg = TxComplete { channel_id };
+
+	nodes[1].node.handle_tx_complete(nodes[0].node.get_our_node_id(), &tx_complete_msg);
+	let msg_events = nodes[1].node.get_and_clear_pending_msg_events();
+	assert_eq!(msg_events.len(), 1);
+	let _msg_commitment_signed_from_1 = match msg_events[0] {
+		MessageSendEvent::UpdateHTLCs { ref node_id, ref updates } => {
+			assert_eq!(*node_id, nodes[0].node.get_our_node_id());
+			updates.commitment_signed.clone()
+		},
+		_ => panic!("Unexpected event"),
+	};
+
+	let (funding_outpoint, channel_type_features) = {
+		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
+		let peer_state =
+			per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
+		let channel_context =
+			peer_state.channel_by_id.get(&tx_complete_msg.channel_id).unwrap().context();
+		(channel_context.get_funding_txo(), channel_context.get_channel_type().clone())
+	};
+
+	let channel_transaction_parameters = ChannelTransactionParameters {
+		counterparty_parameters: Some(CounterpartyChannelTransactionParameters {
+			pubkeys: ChannelPublicKeys {
+				funding_pubkey: accept_channel_v2_msg.common_fields.funding_pubkey,
+				revocation_basepoint: RevocationBasepoint(
+					accept_channel_v2_msg.common_fields.revocation_basepoint,
+				),
+				payment_point: accept_channel_v2_msg.common_fields.payment_basepoint,
+				delayed_payment_basepoint: DelayedPaymentBasepoint(
+					accept_channel_v2_msg.common_fields.delayed_payment_basepoint,
+				),
+				htlc_basepoint: HtlcBasepoint(accept_channel_v2_msg.common_fields.htlc_basepoint),
+			},
+			selected_contest_delay: accept_channel_v2_msg.common_fields.to_self_delay,
+		}),
+		holder_pubkeys: ChannelPublicKeys {
+			funding_pubkey: open_channel_v2_msg.common_fields.funding_pubkey,
+			revocation_basepoint: RevocationBasepoint(
+				open_channel_v2_msg.common_fields.revocation_basepoint,
+			),
+			payment_point: open_channel_v2_msg.common_fields.payment_basepoint,
+			delayed_payment_basepoint: DelayedPaymentBasepoint(
+				open_channel_v2_msg.common_fields.delayed_payment_basepoint,
+			),
+			htlc_basepoint: HtlcBasepoint(open_channel_v2_msg.common_fields.htlc_basepoint),
+		},
+		holder_selected_contest_delay: open_channel_v2_msg.common_fields.to_self_delay,
+		is_outbound_from_holder: true,
+		funding_outpoint,
+		channel_type_features,
+	};
+
+	channel
+		.context
+		.get_mut_signer()
+		.as_mut_ecdsa()
+		.unwrap()
+		.provide_channel_parameters(&channel_transaction_parameters);
+
+	let msg_commitment_signed_from_0 = CommitmentSigned {
+		channel_id,
+		signature: channel
+			.context
+			.get_initial_counterparty_commitment_signature_for_test(
+				&&logger_a,
+				channel_transaction_parameters,
+				accept_channel_v2_msg.common_fields.first_per_commitment_point,
+			)
+			.unwrap(),
+		htlc_signatures: vec![],
+		batch: None,
+		#[cfg(taproot)]
+		partial_signature_with_nonce: None,
+	};
+
+	if test_async_persist {
+		chanmon_cfgs[1]
+			.persister
+			.set_update_ret(crate::chain::ChannelMonitorUpdateStatus::InProgress);
+	}
+
+	// Handle the initial commitment_signed exchange. Order is not important here.
+	nodes[1]
+		.node
+		.handle_commitment_signed(nodes[0].node.get_our_node_id(), &msg_commitment_signed_from_0);
+	check_added_monitors(&nodes[1], 1);
+
+	if test_async_persist {
+		let events = nodes[1].node.get_and_clear_pending_events();
+		assert!(events.is_empty());
+
+		chanmon_cfgs[1]
+			.persister
+			.set_update_ret(crate::chain::ChannelMonitorUpdateStatus::Completed);
+		let (outpoint, latest_update, _) = *nodes[1]
+			.chain_monitor
+			.latest_monitor_update_id
+			.lock()
+			.unwrap()
+			.get(&channel_id)
+			.unwrap();
+		nodes[1].chain_monitor.chain_monitor.force_channel_monitor_updated(outpoint, latest_update);
+	}
+
+	let events = nodes[1].node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match events[0] {
+		Event::ChannelPending { channel_id: chan_id, .. } => assert_eq!(chan_id, channel_id),
+		_ => panic!("Unexpected event"),
+	};
+
+	let tx_signatures_msg = get_event_msg!(
+		nodes[1],
+		MessageSendEvent::SendTxSignatures,
+		nodes[0].node.get_our_node_id()
+	);
+
+	assert_eq!(tx_signatures_msg.channel_id, channel_id);
+}
+
+#[test]
+fn test_v2_channel_establishment() {
+	// Only initiator contributes, no persist pending
+	do_test_v2_channel_establishment(
+		V2ChannelEstablishmentTestSession { initiator_input_value_satoshis: 100_000 },
+		false,
+	);
+	// Only initiator contributes, persist pending
+	do_test_v2_channel_establishment(
+		V2ChannelEstablishmentTestSession { initiator_input_value_satoshis: 100_000 },
+		true,
+	);
+}

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -38,17 +38,20 @@ use crate::util::test_utils;
 use crate::util::test_utils::{TestChainMonitor, TestScorer, TestKeysInterface};
 use crate::util::ser::{ReadableArgs, Writeable};
 
+use bitcoin::WPubkeyHash;
 use bitcoin::amount::Amount;
-use bitcoin::block::{Block, Header, Version};
-use bitcoin::locktime::absolute::LockTime;
-use bitcoin::transaction::{Transaction, TxIn, TxOut};
+use bitcoin::block::{Block, Header, Version as BlockVersion};
+use bitcoin::locktime::absolute::{LockTime, LOCK_TIME_THRESHOLD};
+use bitcoin::transaction::{Sequence, Transaction, TxIn, TxOut};
 use bitcoin::hash_types::{BlockHash, TxMerkleNode};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash as _;
 use bitcoin::network::Network;
 use bitcoin::pow::CompactTarget;
+use bitcoin::script::ScriptBuf;
 use bitcoin::secp256k1::{PublicKey, SecretKey};
-use bitcoin::transaction;
+use bitcoin::transaction::{self, Version as TxVersion};
+use bitcoin::witness::Witness;
 
 use alloc::rc::Rc;
 use core::cell::RefCell;
@@ -90,7 +93,7 @@ pub fn mine_transaction_without_consistency_checks<'a, 'b, 'c, 'd>(node: &'a Nod
 	let height = node.best_block_info().1 + 1;
 	let mut block = Block {
 		header: Header {
-			version: Version::NO_SOFT_FORK_SIGNALLING,
+			version: BlockVersion::NO_SOFT_FORK_SIGNALLING,
 			prev_blockhash: node.best_block_hash(),
 			merkle_root: TxMerkleNode::all_zeros(),
 			time: height,
@@ -217,7 +220,7 @@ impl ConnectStyle {
 
 pub fn create_dummy_header(prev_blockhash: BlockHash, time: u32) -> Header {
 	Header {
-		version: Version::NO_SOFT_FORK_SIGNALLING,
+		version: BlockVersion::NO_SOFT_FORK_SIGNALLING,
 		prev_blockhash,
 		merkle_root: TxMerkleNode::all_zeros(),
 		time,
@@ -1233,6 +1236,37 @@ fn internal_create_funding_transaction<'a, 'b, 'c>(node: &Node<'a, 'b, 'c>,
 		},
 		_ => panic!("Unexpected event"),
 	}
+}
+
+pub fn create_dual_funding_utxos_with_prev_txs(
+	node: &Node<'_, '_, '_>, utxo_values_in_satoshis: &[u64],
+) -> Vec<(TxIn, Transaction)> {
+	// Ensure we have unique transactions per node by using the locktime.
+	let tx = Transaction {
+		version: TxVersion::TWO,
+		lock_time: LockTime::from_height(
+			u32::from_be_bytes(node.keys_manager.get_secure_random_bytes()[0..4].try_into().unwrap()) % LOCK_TIME_THRESHOLD
+		).unwrap(),
+		input: vec![],
+		output: utxo_values_in_satoshis.iter().map(|value_satoshis| TxOut {
+			value: Amount::from_sat(*value_satoshis), script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::all_zeros()),
+		}).collect()
+	};
+
+	let mut result = vec![];
+	for i in 0..utxo_values_in_satoshis.len() {
+		result.push(
+			(TxIn {
+				previous_output: OutPoint {
+					txid: tx.compute_txid(),
+					index: i as u16,
+				}.into_bitcoin_outpoint(),
+				script_sig: ScriptBuf::new(),
+				sequence: Sequence::ZERO,
+				witness: Witness::new(),
+			}, tx.clone()));
+	}
+	result
 }
 
 pub fn sign_funding_transaction<'a, 'b, 'c>(node_a: &Node<'a, 'b, 'c>, node_b: &Node<'a, 'b, 'c>, channel_value: u64, expected_temporary_channel_id: ChannelId) -> Transaction {

--- a/lightning/src/ln/interactivetxs.rs
+++ b/lightning/src/ln/interactivetxs.rs
@@ -15,11 +15,13 @@ use bitcoin::amount::Amount;
 use bitcoin::consensus::Encodable;
 use bitcoin::constants::WITNESS_SCALE_FACTOR;
 use bitcoin::policy::MAX_STANDARD_TX_WEIGHT;
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::transaction::Version;
 use bitcoin::{OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Weight};
 
 use crate::chain::chaininterface::fee_for_weight;
 use crate::events::bump_transaction::{BASE_INPUT_WEIGHT, EMPTY_SCRIPT_SIG_WEIGHT};
+use crate::events::MessageSendEvent;
 use crate::ln::channel::TOTAL_BITCOIN_SUPPLY_SATOSHIS;
 use crate::ln::msgs;
 use crate::ln::msgs::SerialId;
@@ -27,6 +29,7 @@ use crate::ln::types::ChannelId;
 use crate::sign::{EntropySource, P2TR_KEY_PATH_WITNESS_WEIGHT, P2WPKH_WITNESS_WEIGHT};
 use crate::util::ser::TransactionU16LenLimited;
 
+use core::fmt::Display;
 use core::ops::Deref;
 
 /// The number of received `tx_add_input` messages during a negotiation at which point the
@@ -43,7 +46,7 @@ const MAX_INPUTS_OUTPUTS_COUNT: usize = 252;
 
 /// The total weight of the common fields whose fee is paid by the initiator of the interactive
 /// transaction construction protocol.
-const TX_COMMON_FIELDS_WEIGHT: u64 = (4 /* version */ + 4 /* locktime */ + 1 /* input count */ +
+pub(crate) const TX_COMMON_FIELDS_WEIGHT: u64 = (4 /* version */ + 4 /* locktime */ + 1 /* input count */ +
 	1 /* output count */) * WITNESS_SCALE_FACTOR as u64 + 2 /* segwit marker + flag */;
 
 // BOLT 3 - Lower bounds for input weights
@@ -106,6 +109,47 @@ pub(crate) enum AbortReason {
 	/// if funding output is provided by the peer this is an interop error,
 	/// if provided by the same node than internal input consistency error.
 	InvalidLowFundingOutputValue,
+}
+
+impl AbortReason {
+	pub fn into_tx_abort_msg(self, channel_id: ChannelId) -> msgs::TxAbort {
+		msgs::TxAbort { channel_id, data: self.to_string().into_bytes() }
+	}
+}
+
+impl Display for AbortReason {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.write_str(match self {
+			AbortReason::InvalidStateTransition => "State transition was invalid",
+			AbortReason::UnexpectedCounterpartyMessage => "Unexpected message",
+			AbortReason::ReceivedTooManyTxAddInputs => "Too many `tx_add_input`s received",
+			AbortReason::ReceivedTooManyTxAddOutputs => "Too many `tx_add_output`s received",
+			AbortReason::IncorrectInputSequenceValue => {
+				"Input has a sequence value greater than 0xFFFFFFFD"
+			},
+			AbortReason::IncorrectSerialIdParity => "Parity for `serial_id` was incorrect",
+			AbortReason::SerialIdUnknown => "The `serial_id` is unknown",
+			AbortReason::DuplicateSerialId => "The `serial_id` already exists",
+			AbortReason::PrevTxOutInvalid => "Invalid previous transaction output",
+			AbortReason::ExceededMaximumSatsAllowed => {
+				"Output amount exceeded total bitcoin supply"
+			},
+			AbortReason::ExceededNumberOfInputsOrOutputs => "Too many inputs or outputs",
+			AbortReason::TransactionTooLarge => "Transaction weight is too large",
+			AbortReason::BelowDustLimit => "Output amount is below the dust limit",
+			AbortReason::InvalidOutputScript => "The output script is non-standard",
+			AbortReason::InsufficientFees => "Insufficient fees paid",
+			AbortReason::OutputsValueExceedsInputsValue => {
+				"Total value of outputs exceeds total value of inputs"
+			},
+			AbortReason::InvalidTx => "The transaction is invalid",
+			AbortReason::MissingFundingOutput => "No shared funding output found",
+			AbortReason::DuplicateFundingOutput => "More than one funding output found",
+			AbortReason::InvalidLowFundingOutputValue => {
+				"Local part of funding output value is greater than the funding output value"
+			},
+		})
+	}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1048,8 +1092,9 @@ impl InteractiveTxInput {
 	}
 }
 
-pub(crate) struct InteractiveTxConstructor {
+pub(super) struct InteractiveTxConstructor {
 	state_machine: StateMachine,
+	initiator_first_message: Option<InteractiveTxMessageSend>,
 	channel_id: ChannelId,
 	inputs_to_contribute: Vec<(SerialId, TxIn, TransactionU16LenLimited)>,
 	outputs_to_contribute: Vec<(SerialId, OutputOwned)>,
@@ -1060,6 +1105,39 @@ pub(crate) enum InteractiveTxMessageSend {
 	TxAddInput(msgs::TxAddInput),
 	TxAddOutput(msgs::TxAddOutput),
 	TxComplete(msgs::TxComplete),
+}
+
+impl InteractiveTxMessageSend {
+	pub fn into_msg_send_event(self, counterparty_node_id: PublicKey) -> MessageSendEvent {
+		match self {
+			InteractiveTxMessageSend::TxAddInput(msg) => {
+				MessageSendEvent::SendTxAddInput { node_id: counterparty_node_id, msg }
+			},
+			InteractiveTxMessageSend::TxAddOutput(msg) => {
+				MessageSendEvent::SendTxAddOutput { node_id: counterparty_node_id, msg }
+			},
+			InteractiveTxMessageSend::TxComplete(msg) => {
+				MessageSendEvent::SendTxComplete { node_id: counterparty_node_id, msg }
+			},
+		}
+	}
+}
+
+pub(super) struct InteractiveTxMessageSendResult(
+	pub Result<InteractiveTxMessageSend, msgs::TxAbort>,
+);
+
+impl InteractiveTxMessageSendResult {
+	pub fn into_msg_send_event(self, counterparty_node_id: PublicKey) -> MessageSendEvent {
+		match self.0 {
+			Ok(interactive_tx_msg_send) => {
+				interactive_tx_msg_send.into_msg_send_event(counterparty_node_id)
+			},
+			Err(tx_abort_msg) => {
+				MessageSendEvent::SendTxAbort { node_id: counterparty_node_id, msg: tx_abort_msg }
+			},
+		}
+	}
 }
 
 // This macro executes a state machine transition based on a provided action.
@@ -1094,6 +1172,22 @@ pub(crate) enum HandleTxCompleteValue {
 	NegotiationComplete(ConstructedTransaction),
 }
 
+pub(super) struct HandleTxCompleteResult(pub Result<HandleTxCompleteValue, msgs::TxAbort>);
+
+pub(super) struct InteractiveTxConstructorArgs<'a, ES: Deref>
+where
+	ES::Target: EntropySource,
+{
+	pub entropy_source: &'a ES,
+	pub channel_id: ChannelId,
+	pub feerate_sat_per_kw: u32,
+	pub is_initiator: bool,
+	pub funding_tx_locktime: AbsoluteLockTime,
+	pub inputs_to_contribute: Vec<(TxIn, TransactionU16LenLimited)>,
+	pub outputs_to_contribute: Vec<OutputOwned>,
+	pub expected_remote_shared_funding_output: Option<(ScriptBuf, u64)>,
+}
+
 impl InteractiveTxConstructor {
 	/// Instantiates a new `InteractiveTxConstructor`.
 	///
@@ -1103,20 +1197,24 @@ impl InteractiveTxConstructor {
 	/// and its (local) contribution from the shared output:
 	///   0 when the whole value belongs to the remote node, or
 	///   positive if owned also by local.
-	/// Note: The local value cannot be larger that the actual shared output.
+	/// Note: The local value cannot be larger than the actual shared output.
 	///
-	/// A tuple is returned containing the newly instantiate `InteractiveTxConstructor` and optionally
-	/// an initial wrapped `Tx_` message which the holder needs to send to the counterparty.
-	pub fn new<ES: Deref>(
-		entropy_source: &ES, channel_id: ChannelId, feerate_sat_per_kw: u32, is_initiator: bool,
-		funding_tx_locktime: AbsoluteLockTime,
-		inputs_to_contribute: Vec<(TxIn, TransactionU16LenLimited)>,
-		outputs_to_contribute: Vec<OutputOwned>,
-		expected_remote_shared_funding_output: Option<(ScriptBuf, u64)>,
-	) -> Result<(Self, Option<InteractiveTxMessageSend>), AbortReason>
+	/// If the holder is the initiator, they need to send the first message which is a `TxAddInput`
+	/// message.
+	pub fn new<ES: Deref>(args: InteractiveTxConstructorArgs<ES>) -> Result<Self, AbortReason>
 	where
 		ES::Target: EntropySource,
 	{
+		let InteractiveTxConstructorArgs {
+			entropy_source,
+			channel_id,
+			feerate_sat_per_kw,
+			is_initiator,
+			funding_tx_locktime,
+			inputs_to_contribute,
+			outputs_to_contribute,
+			expected_remote_shared_funding_output,
+		} = args;
 		// Sanity check: There can be at most one shared output, local-added or remote-added
 		let mut expected_shared_funding_output: Option<(ScriptBuf, u64)> = None;
 		for output in &outputs_to_contribute {
@@ -1175,26 +1273,25 @@ impl InteractiveTxConstructor {
 				.collect();
 			// In the same manner and for the same rationale as the inputs above, we'll shuffle the outputs.
 			outputs_to_contribute.sort_unstable_by_key(|(serial_id, _)| *serial_id);
-			let mut constructor =
-				Self { state_machine, channel_id, inputs_to_contribute, outputs_to_contribute };
-			let message_send = if is_initiator {
-				match constructor.maybe_send_message() {
-					Ok(msg_send) => Some(msg_send),
-					Err(_) => {
-						debug_assert!(
-							false,
-							"We should always be able to start our state machine successfully"
-						);
-						None
-					},
-				}
-			} else {
-				None
+			let mut constructor = Self {
+				state_machine,
+				initiator_first_message: None,
+				channel_id,
+				inputs_to_contribute,
+				outputs_to_contribute,
 			};
-			Ok((constructor, message_send))
+			// We'll store the first message for the initiator.
+			if is_initiator {
+				constructor.initiator_first_message = Some(constructor.maybe_send_message()?);
+			}
+			Ok(constructor)
 		} else {
 			Err(AbortReason::MissingFundingOutput)
 		}
+	}
+
+	pub fn take_initiator_first_message(&mut self) -> Option<InteractiveTxMessageSend> {
+		self.initiator_first_message.take()
 	}
 
 	fn maybe_send_message(&mut self) -> Result<InteractiveTxMessageSend, AbortReason> {
@@ -1295,8 +1392,8 @@ mod tests {
 	use crate::ln::channel::TOTAL_BITCOIN_SUPPLY_SATOSHIS;
 	use crate::ln::interactivetxs::{
 		generate_holder_serial_id, AbortReason, HandleTxCompleteValue, InteractiveTxConstructor,
-		InteractiveTxMessageSend, MAX_INPUTS_OUTPUTS_COUNT, MAX_RECEIVED_TX_ADD_INPUT_COUNT,
-		MAX_RECEIVED_TX_ADD_OUTPUT_COUNT,
+		InteractiveTxConstructorArgs, InteractiveTxMessageSend, MAX_INPUTS_OUTPUTS_COUNT,
+		MAX_RECEIVED_TX_ADD_INPUT_COUNT, MAX_RECEIVED_TX_ADD_OUTPUT_COUNT,
 	};
 	use crate::ln::types::ChannelId;
 	use crate::sign::EntropySource;
@@ -1395,7 +1492,7 @@ mod tests {
 		ES::Target: EntropySource,
 	{
 		let channel_id = ChannelId(entropy_source.get_secure_random_bytes());
-		let tx_locktime = AbsoluteLockTime::from_height(1337).unwrap();
+		let funding_tx_locktime = AbsoluteLockTime::from_height(1337).unwrap();
 
 		// funding output sanity check
 		let shared_outputs_by_a: Vec<_> =
@@ -1448,16 +1545,16 @@ mod tests {
 			}
 		}
 
-		let (mut constructor_a, first_message_a) = match InteractiveTxConstructor::new(
+		let mut constructor_a = match InteractiveTxConstructor::new(InteractiveTxConstructorArgs {
 			entropy_source,
 			channel_id,
-			TEST_FEERATE_SATS_PER_KW,
-			true,
-			tx_locktime,
-			session.inputs_a,
-			session.outputs_a.to_vec(),
-			session.a_expected_remote_shared_output,
-		) {
+			feerate_sat_per_kw: TEST_FEERATE_SATS_PER_KW,
+			is_initiator: true,
+			funding_tx_locktime,
+			inputs_to_contribute: session.inputs_a,
+			outputs_to_contribute: session.outputs_a.to_vec(),
+			expected_remote_shared_funding_output: session.a_expected_remote_shared_output,
+		}) {
 			Ok(r) => r,
 			Err(abort_reason) => {
 				assert_eq!(
@@ -1469,16 +1566,16 @@ mod tests {
 				return;
 			},
 		};
-		let (mut constructor_b, first_message_b) = match InteractiveTxConstructor::new(
+		let mut constructor_b = match InteractiveTxConstructor::new(InteractiveTxConstructorArgs {
 			entropy_source,
 			channel_id,
-			TEST_FEERATE_SATS_PER_KW,
-			false,
-			tx_locktime,
-			session.inputs_b,
-			session.outputs_b.to_vec(),
-			session.b_expected_remote_shared_output,
-		) {
+			feerate_sat_per_kw: TEST_FEERATE_SATS_PER_KW,
+			is_initiator: false,
+			funding_tx_locktime,
+			inputs_to_contribute: session.inputs_b,
+			outputs_to_contribute: session.outputs_b.to_vec(),
+			expected_remote_shared_funding_output: session.b_expected_remote_shared_output,
+		}) {
 			Ok(r) => r,
 			Err(abort_reason) => {
 				assert_eq!(
@@ -1514,8 +1611,7 @@ mod tests {
 				}
 			};
 
-		assert!(first_message_b.is_none());
-		let mut message_send_a = first_message_a;
+		let mut message_send_a = constructor_a.take_initiator_first_message();
 		let mut message_send_b = None;
 		let mut final_tx_a = None;
 		let mut final_tx_b = None;

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -44,6 +44,9 @@ pub(crate) mod onion_utils;
 mod outbound_payment;
 pub mod wire;
 
+#[allow(dead_code)] // TODO(dual_funding): Remove once contribution to V2 channels is enabled.
+pub(crate) mod interactivetxs;
+
 pub use onion_utils::create_payment_onion;
 // Older rustc (which we support) refuses to let us call the get_payment_preimage_hash!() macro
 // without the node parameter being mut. This is incorrect, and thus newer rustcs will complain
@@ -88,7 +91,8 @@ mod async_signer_tests;
 #[cfg(test)]
 #[allow(unused_mut)]
 mod offers_tests;
-#[allow(dead_code)] // TODO(dual_funding): Remove once contribution to V2 channels is enabled.
-pub(crate) mod interactivetxs;
+#[cfg(test)]
+#[allow(unused_mut)]
+mod dual_funding_tests;
 
 pub use self::peer_channel_encryptor::LN_MAX_MSG_LEN;

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -88,6 +88,7 @@ mod async_signer_tests;
 #[cfg(test)]
 #[allow(unused_mut)]
 mod offers_tests;
+#[allow(dead_code)] // TODO(dual_funding): Remove once contribution to V2 channels is enabled.
 pub(crate) mod interactivetxs;
 
 pub use self::peer_channel_encryptor::LN_MAX_MSG_LEN;

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -88,7 +88,6 @@ mod async_signer_tests;
 #[cfg(test)]
 #[allow(unused_mut)]
 mod offers_tests;
-#[allow(dead_code)] // TODO(dual_funding): Exchange for dual_funding cfg
 pub(crate) mod interactivetxs;
 
 pub use self::peer_channel_encryptor::LN_MAX_MSG_LEN;

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -183,10 +183,10 @@ pub struct Pong {
 	pub byteslen: u16,
 }
 
-/// Contains fields that are both common to [`open_channel`] and `open_channel2` messages.
+/// Contains fields that are both common to [`open_channel`] and [`open_channel2`] messages.
 ///
 /// [`open_channel`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-open_channel-message
-// TODO(dual_funding): Add spec link for `open_channel2`.
+/// [`open_channel2`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-open_channel2-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct CommonOpenChannelFields {
 	/// The genesis hash of the blockchain where the channel is to be opened
@@ -288,11 +288,11 @@ pub struct OpenChannel {
 	pub channel_reserve_satoshis: u64,
 }
 
-/// An open_channel2 message to be sent by or received from the channel initiator.
+/// An [`open_channel2`] message to be sent by or received from the channel initiator.
 ///
 /// Used in V2 channel establishment
 ///
-// TODO(dual_funding): Add spec link for `open_channel2`.
+/// [`open_channel2`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-open_channel2-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct OpenChannelV2 {
 	/// Common fields of `open_channel(2)`-like messages
@@ -307,10 +307,10 @@ pub struct OpenChannelV2 {
 	pub require_confirmed_inputs: Option<()>,
 }
 
-/// Contains fields that are both common to [`accept_channel`] and `accept_channel2` messages.
+/// Contains fields that are both common to [`accept_channel`] and [`accept_channel2`] messages.
 ///
 /// [`accept_channel`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-accept_channel-message
-// TODO(dual_funding): Add spec link for `accept_channel2`.
+/// [`accept_channel2`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-accept_channel2-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct CommonAcceptChannelFields {
 	/// The same `temporary_channel_id` received from the initiator's `open_channel2` or `open_channel` message.
@@ -370,11 +370,11 @@ pub struct AcceptChannel {
 	pub next_local_nonce: Option<musig2::types::PublicNonce>,
 }
 
-/// An accept_channel2 message to be sent by or received from the channel accepter.
+/// An [`accept_channel2`] message to be sent by or received from the channel accepter.
 ///
 /// Used in V2 channel establishment
 ///
-// TODO(dual_funding): Add spec link for `accept_channel2`.
+/// [`accept_channel2`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-accept_channel2-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct AcceptChannelV2 {
 	/// Common fields of `accept_channel(2)`-like messages
@@ -504,9 +504,9 @@ pub struct SpliceLocked {
 	pub splice_txid: Txid,
 }
 
-/// A tx_add_input message for adding an input during interactive transaction construction
+/// A [`tx_add_input`] message for adding an input during interactive transaction construction
 ///
-// TODO(dual_funding): Add spec link for `tx_add_input`.
+/// [`tx_add_input`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_add_input-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxAddInput {
 	/// The channel ID
@@ -525,9 +525,9 @@ pub struct TxAddInput {
 	pub shared_input_txid: Option<Txid>,
 }
 
-/// A tx_add_output message for adding an output during interactive transaction construction.
+/// A [`tx_add_output`] message for adding an output during interactive transaction construction.
 ///
-// TODO(dual_funding): Add spec link for `tx_add_output`.
+/// [`tx_add_output`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_add_output-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxAddOutput {
 	/// The channel ID
@@ -541,9 +541,9 @@ pub struct TxAddOutput {
 	pub script: ScriptBuf,
 }
 
-/// A tx_remove_input message for removing an input during interactive transaction construction.
+/// A [`tx_remove_input`] message for removing an input during interactive transaction construction.
 ///
-// TODO(dual_funding): Add spec link for `tx_remove_input`.
+/// [`tx_remove_input`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_remove_input-and-tx_remove_output-messages
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxRemoveInput {
 	/// The channel ID
@@ -552,9 +552,9 @@ pub struct TxRemoveInput {
 	pub serial_id: SerialId,
 }
 
-/// A tx_remove_output message for removing an output during interactive transaction construction.
+/// A [`tx_remove_output`] message for removing an output during interactive transaction construction.
 ///
-// TODO(dual_funding): Add spec link for `tx_remove_output`.
+/// [`tx_remove_output`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_remove_input-and-tx_remove_output-messages
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxRemoveOutput {
 	/// The channel ID
@@ -563,20 +563,20 @@ pub struct TxRemoveOutput {
 	pub serial_id: SerialId,
 }
 
-/// A tx_complete message signalling the conclusion of a peer's transaction contributions during
+/// [`A tx_complete`] message signalling the conclusion of a peer's transaction contributions during
 /// interactive transaction construction.
 ///
-// TODO(dual_funding): Add spec link for `tx_complete`.
+/// [`tx_complete`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_complete-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxComplete {
 	/// The channel ID
 	pub channel_id: ChannelId,
 }
 
-/// A tx_signatures message containing the sender's signatures for a transaction constructed with
+/// A [`tx_signatures`] message containing the sender's signatures for a transaction constructed with
 /// interactive transaction construction.
 ///
-// TODO(dual_funding): Add spec link for `tx_signatures`.
+/// [`tx_signatures`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_signatures-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxSignatures {
 	/// The channel ID
@@ -589,10 +589,10 @@ pub struct TxSignatures {
 	pub shared_input_signature: Option<Signature>,
 }
 
-/// A tx_init_rbf message which initiates a replacement of the transaction after it's been
+/// A [`tx_init_rbf`] message which initiates a replacement of the transaction after it's been
 /// completed.
 ///
-// TODO(dual_funding): Add spec link for `tx_init_rbf`.
+/// [`tx_init_rbf`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_init_rbf-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxInitRbf {
 	/// The channel ID
@@ -606,10 +606,10 @@ pub struct TxInitRbf {
 	pub funding_output_contribution: Option<i64>,
 }
 
-/// A tx_ack_rbf message which acknowledges replacement of the transaction after it's been
+/// A [`tx_ack_rbf`] message which acknowledges replacement of the transaction after it's been
 /// completed.
 ///
-// TODO(dual_funding): Add spec link for `tx_ack_rbf`.
+/// [`tx_ack_rbf`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_ack_rbf-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxAckRbf {
 	/// The channel ID
@@ -619,9 +619,9 @@ pub struct TxAckRbf {
 	pub funding_output_contribution: Option<i64>,
 }
 
-/// A tx_abort message which signals the cancellation of an in-progress transaction negotiation.
+/// A [`tx_abort`] message which signals the cancellation of an in-progress transaction negotiation.
 ///
-// TODO(dual_funding): Add spec link for `tx_abort`.
+/// [`tx_abort`]: https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-tx_abort-message
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TxAbort {
 	/// The channel ID

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -340,6 +340,7 @@ impl ChannelMessageHandler for ErroringMessageHandler {
 		features.set_basic_mpp_optional();
 		features.set_wumbo_optional();
 		features.set_shutdown_any_segwit_optional();
+		features.set_dual_fund_optional();
 		features.set_channel_type_optional();
 		features.set_scid_privacy_optional();
 		features.set_zero_conf_optional();

--- a/pending_changelog/3137-accept-dual-funding-without-contributing.txt
+++ b/pending_changelog/3137-accept-dual-funding-without-contributing.txt
@@ -1,0 +1,15 @@
+# API Updates
+ * Accepting dual-funded (V2 establishment) channels (without contibuting) is now supported (#3137).
+   Some particulars to be aware of for this feature:
+   * Creating dual-funded channels is not yet supported.
+   * Contributing funds (inputs) to accepted channels is not yet supported.
+   * `Event::OpenChannelRequest::push_msat` has been replaced by the field `channel_negotiation_type` to
+     differentiate between an inbound request for a dual-funded (V2) or non-dual-funded (V1) channel to be
+     opened, with value being either of the enum variants `InboundChannelFunds::DualFunded` and
+     `InboundChannelFunds::PushMsat(u64)` corresponding to V2 and V1 channel open requests respectively.
+   * If `manually_accept_inbound_channels` is false, then V2 channels will be accepted automatically; the
+     same behaviour as V1 channels. Otherwise, `ChannelManager::accept_inbound_channel()` can also be used
+     to manually accept an inbound V2 channel.
+   * 0conf dual-funded channels are not supported.
+   * RBF of dual-funded channel funding transactions is not supported.
+


### PR DESCRIPTION
We split this out from #2302 for easier review and to address the common non-public API parts of the V2 channel establishment implementation.

This will allow the holder to be an acceptor, but not initiator of V2 channels. We also don't expose an API for contributing to an inbound channel.

The functionality to initiate V2 channels and fund inbound channels forms part of #2302.