### PR TITLE
Implement `Readable` for `Bolt12Invoice`

### DIFF
--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1160,6 +1160,13 @@ impl TryFrom<Vec<u8>> for Bolt12Invoice {
 	}
 }
 
+impl Readable for Bolt12Invoice {
+	fn read<R: io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
+		let bytes: WithoutLength<Vec<u8>> = Readable::read(reader)?;
+		Self::try_from(bytes.0).map_err(|_| DecodeError::InvalidValue)
+	}
+}
+
 tlv_stream!(InvoiceTlvStream, InvoiceTlvStreamRef, 160..240, {
 	(160, paths: (Vec<BlindedPath>, WithoutLength, Iterable<'a, BlindedPathIter<'a>, BlindedPath>)),
 	(162, blindedpay: (Vec<BlindedPayInfo>, WithoutLength, Iterable<'a, BlindedPayInfoIter<'a>, BlindedPayInfo>)),


### PR DESCRIPTION
In c13b6d814bfb5dd95f9e40f8ff07dd45c47a387e and
fc14495ac6a9dbe7dc9a6bd43c4395b599592db1 we implemented `Readable` for `Refund` and `Offer`s, but didn't do so for `Bolt12Invoice`.

Because `Bolt12Invoice`s are not serializable to strings, we generally expect users to read and write them as byte arrays, and currently expose this via `TryFrom<Vec<u8>>`. This is fine, but there's no reason to not implement `Readable` as well, and it saves having to implement `TryFrom` in bindings.