### PR TITLE
Remove usage of blockdata:: from bitcoin paths

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -19,13 +19,13 @@
 //! channel being force-closed.
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::genesis_block;
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::script::{Builder, ScriptBuf};
-use bitcoin::blockdata::transaction::{Transaction, TxOut};
+use bitcoin::constants::genesis_block;
+use bitcoin::locktime::absolute::LockTime;
 use bitcoin::network::Network;
+use bitcoin::opcodes;
+use bitcoin::script::{Builder, ScriptBuf};
 use bitcoin::transaction::Version;
+use bitcoin::transaction::{Transaction, TxOut};
 
 use bitcoin::hash_types::BlockHash;
 use bitcoin::hashes::sha256::Hash as Sha256;

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -14,11 +14,11 @@
 //! This test has been very useful, though due to its complexity good starting inputs are critical.
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::genesis_block;
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::script::{Builder, ScriptBuf};
-use bitcoin::blockdata::transaction::{Transaction, TxOut};
+use bitcoin::constants::genesis_block;
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::opcodes;
+use bitcoin::script::{Builder, ScriptBuf};
+use bitcoin::transaction::{Transaction, TxOut};
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::network::Network;
 use bitcoin::transaction::Version;

--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -1,6 +1,6 @@
 // Imports that need to be added manually
 use bech32::u5;
-use bitcoin::blockdata::script::ScriptBuf;
+use bitcoin::script::ScriptBuf;
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::RecoverableSignature;
 use bitcoin::secp256k1::schnorr;

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -8,9 +8,9 @@
 // licenses.
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::ChainHash;
-use bitcoin::blockdata::script::Builder;
-use bitcoin::blockdata::transaction::TxOut;
+use bitcoin::constants::ChainHash;
+use bitcoin::script::Builder;
+use bitcoin::transaction::TxOut;
 
 use lightning::blinded_path::{BlindedHop, BlindedPath, IntroductionNode};
 use lightning::chain::transaction::OutPoint;

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -914,9 +914,9 @@ impl Drop for BackgroundProcessor {
 #[cfg(all(feature = "std", test))]
 mod tests {
 	use bitcoin::{Amount, ScriptBuf, Txid};
-	use bitcoin::blockdata::constants::{genesis_block, ChainHash};
-	use bitcoin::blockdata::locktime::absolute::LockTime;
-	use bitcoin::blockdata::transaction::{Transaction, TxOut};
+	use bitcoin::constants::{genesis_block, ChainHash};
+	use bitcoin::locktime::absolute::LockTime;
+	use bitcoin::transaction::{Transaction, TxOut};
 	use bitcoin::hashes::Hash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::{SecretKey, PublicKey, Secp256k1};

--- a/lightning-block-sync/src/convert.rs
+++ b/lightning-block-sync/src/convert.rs
@@ -2,7 +2,7 @@ use crate::http::{BinaryResponse, JsonResponse};
 use crate::utils::hex_to_work;
 use crate::{BlockHeaderData, BlockSourceError};
 
-use bitcoin::blockdata::block::{Block, Header};
+use bitcoin::block::{Block, Header};
 use bitcoin::consensus::encode;
 use bitcoin::hash_types::{BlockHash, TxMerkleNode, Txid};
 use bitcoin::hashes::hex::FromHex;
@@ -89,7 +89,7 @@ impl TryFrom<serde_json::Value> for BlockHeaderData {
 
 		Ok(BlockHeaderData {
 			header: Header {
-				version: bitcoin::blockdata::block::Version::from_consensus(
+				version: bitcoin::block::Version::from_consensus(
 					get_field!("version", as_i64).try_into().map_err(|_| ())?
 				),
 				prev_blockhash: if let Some(hash_str) = response.get("previousblockhash") {
@@ -275,7 +275,7 @@ impl TryInto<GetUtxosResponse> for JsonResponse {
 #[cfg(test)]
 pub(crate) mod tests {
 	use super::*;
-	use bitcoin::blockdata::constants::genesis_block;
+	use bitcoin::constants::genesis_block;
 	use bitcoin::hashes::Hash;
 	use bitcoin::network::Network;
 	use hex::DisplayHex;

--- a/lightning-block-sync/src/gossip.rs
+++ b/lightning-block-sync/src/gossip.rs
@@ -4,9 +4,9 @@
 
 use crate::{AsyncBlockSourceResult, BlockData, BlockSource, BlockSourceError};
 
-use bitcoin::blockdata::block::Block;
-use bitcoin::blockdata::constants::ChainHash;
-use bitcoin::blockdata::transaction::{TxOut, OutPoint};
+use bitcoin::block::Block;
+use bitcoin::constants::ChainHash;
+use bitcoin::transaction::{TxOut, OutPoint};
 use bitcoin::hash_types::BlockHash;
 
 use lightning::ln::peer_handler::APeerManager;

--- a/lightning-block-sync/src/init.rs
+++ b/lightning-block-sync/src/init.rs
@@ -4,7 +4,7 @@
 use crate::{BlockSource, BlockSourceResult, Cache, ChainNotifier};
 use crate::poll::{ChainPoller, Validate, ValidatedBlockHeader};
 
-use bitcoin::blockdata::block::Header;
+use bitcoin::block::Header;
 use bitcoin::hash_types::BlockHash;
 use bitcoin::network::Network;
 

--- a/lightning-block-sync/src/lib.rs
+++ b/lightning-block-sync/src/lib.rs
@@ -46,7 +46,7 @@ mod utils;
 
 use crate::poll::{ChainTip, Poll, ValidatedBlockHeader};
 
-use bitcoin::blockdata::block::{Block, Header};
+use bitcoin::block::{Block, Header};
 use bitcoin::hash_types::BlockHash;
 use bitcoin::pow::Work;
 

--- a/lightning-block-sync/src/test_utils.rs
+++ b/lightning-block-sync/src/test_utils.rs
@@ -1,9 +1,9 @@
 use crate::{AsyncBlockSourceResult, BlockData, BlockHeaderData, BlockSource, BlockSourceError, UnboundedCache};
 use crate::poll::{Validate, ValidatedBlockHeader};
 
-use bitcoin::blockdata::block::{Block, Header, Version};
-use bitcoin::blockdata::constants::genesis_block;
-use bitcoin::blockdata::locktime::absolute::LockTime;
+use bitcoin::block::{Block, Header, Version};
+use bitcoin::constants::genesis_block;
+use bitcoin::locktime::absolute::LockTime;
 use bitcoin::hash_types::{BlockHash, TxMerkleNode};
 use bitcoin::network::Network;
 use bitcoin::Transaction;

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -1329,7 +1329,7 @@ mod test {
 		} else {
 			None
 		};
-		let genesis_timestamp = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Testnet).header.time as u64;
+		let genesis_timestamp = bitcoin::constants::genesis_block(bitcoin::Network::Testnet).header.time as u64;
 		let non_default_invoice_expiry_secs = 4200;
 
 		let invoice =

--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -565,7 +565,7 @@ mod tests {
 	use lightning::events::*;
 	use lightning::util::test_utils::TestNodeSigner;
 	use bitcoin::Network;
-	use bitcoin::blockdata::constants::ChainHash;
+	use bitcoin::constants::ChainHash;
 	use bitcoin::secp256k1::{Secp256k1, SecretKey, PublicKey};
 
 	use tokio::sync::mpsc;

--- a/lightning-rapid-gossip-sync/src/lib.rs
+++ b/lightning-rapid-gossip-sync/src/lib.rs
@@ -39,7 +39,7 @@
 //! from disk, which we do by calling [`RapidGossipSync::update_network_graph`]:
 //!
 //! ```
-//! use bitcoin::blockdata::constants::genesis_block;
+//! use bitcoin::constants::genesis_block;
 //! use bitcoin::Network;
 //! use lightning::routing::gossip::NetworkGraph;
 //! use lightning_rapid_gossip_sync::RapidGossipSync;

--- a/lightning-rapid-gossip-sync/src/processing.rs
+++ b/lightning-rapid-gossip-sync/src/processing.rs
@@ -2,7 +2,7 @@ use core::cmp::max;
 use core::ops::Deref;
 use core::sync::atomic::Ordering;
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::secp256k1::PublicKey;
 
 use lightning::io;

--- a/lightning-transaction-sync/tests/integration_tests.rs
+++ b/lightning-transaction-sync/tests/integration_tests.rs
@@ -12,8 +12,8 @@ use lightning_transaction_sync::ElectrumSyncClient;
 use lightning_transaction_sync::EsploraSyncClient;
 
 use bdk_macros::maybe_await;
-use bitcoin::blockdata::block::Header;
-use bitcoin::blockdata::constants::genesis_block;
+use bitcoin::block::Header;
+use bitcoin::constants::genesis_block;
 use bitcoin::network::Network;
 use bitcoin::{Amount, BlockHash, Txid};
 use bitcoind::bitcoincore_rpc::RpcApi;

--- a/lightning/src/chain/chaininterface.rs
+++ b/lightning/src/chain/chaininterface.rs
@@ -17,7 +17,7 @@ use core::{cmp, ops::Deref};
 
 use crate::prelude::*;
 
-use bitcoin::blockdata::transaction::Transaction;
+use bitcoin::transaction::Transaction;
 
 // TODO: Define typed abstraction over feerates to handle their conversions.
 pub(crate) fn compute_feerate_sat_per_1000_weight(fee_sat: u64, weight: u64) -> u32 {

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -23,7 +23,7 @@
 //! events. The remote server would make use of [`ChainMonitor`] for block processing and for
 //! servicing [`ChannelMonitor`] updates from the client.
 
-use bitcoin::blockdata::block::Header;
+use bitcoin::block::Header;
 use bitcoin::hash_types::{Txid, BlockHash};
 
 use crate::chain;

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -21,9 +21,9 @@
 //! ChannelMonitors to get out of the HSM and onto monitoring devices.
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::block::Header;
-use bitcoin::blockdata::transaction::{OutPoint as BitcoinOutPoint, TxOut, Transaction};
-use bitcoin::blockdata::script::{Script, ScriptBuf};
+use bitcoin::block::Header;
+use bitcoin::transaction::{OutPoint as BitcoinOutPoint, TxOut, Transaction};
+use bitcoin::script::{Script, ScriptBuf};
 
 use bitcoin::hashes::Hash;
 use bitcoin::hashes::sha256::Hash as Sha256;
@@ -2512,7 +2512,7 @@ macro_rules! fail_unbroadcast_htlcs {
 
 #[cfg(test)]
 pub fn deliberately_bogus_accepted_htlc_witness_program() -> Vec<u8> {
-	use bitcoin::blockdata::opcodes;
+	use bitcoin::opcodes;
 	let mut ret = [opcodes::all::OP_NOP.to_u8(); 136];
 	ret[131] = opcodes::all::OP_DROP.to_u8();
 	ret[132] = opcodes::all::OP_DROP.to_u8();
@@ -4789,11 +4789,11 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 #[cfg(test)]
 mod tests {
 	use bitcoin::amount::Amount;
-	use bitcoin::blockdata::locktime::absolute::LockTime;
-	use bitcoin::blockdata::script::{ScriptBuf, Builder};
-	use bitcoin::blockdata::opcodes;
-	use bitcoin::blockdata::transaction::{Transaction, TxIn, TxOut, Version};
-	use bitcoin::blockdata::transaction::OutPoint as BitcoinOutPoint;
+	use bitcoin::locktime::absolute::LockTime;
+	use bitcoin::script::{ScriptBuf, Builder};
+	use bitcoin::opcodes;
+	use bitcoin::transaction::{Transaction, TxIn, TxOut, Version};
+	use bitcoin::transaction::OutPoint as BitcoinOutPoint;
 	use bitcoin::sighash;
 	use bitcoin::sighash::EcdsaSighashType;
 	use bitcoin::hashes::Hash;

--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -9,9 +9,9 @@
 
 //! Structs and traits which allow other parts of rust-lightning to interact with the blockchain.
 
-use bitcoin::blockdata::block::{Block, Header};
-use bitcoin::blockdata::constants::genesis_block;
-use bitcoin::blockdata::script::{Script, ScriptBuf};
+use bitcoin::block::{Block, Header};
+use bitcoin::constants::genesis_block;
+use bitcoin::script::{Script, ScriptBuf};
 use bitcoin::hash_types::{BlockHash, Txid};
 use bitcoin::network::Network;
 use bitcoin::secp256k1::PublicKey;

--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -13,10 +13,10 @@
 //! building, tracking, bumping and notifications functions.
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::transaction::Transaction;
-use bitcoin::blockdata::transaction::OutPoint as BitcoinOutPoint;
-use bitcoin::blockdata::script::{Script, ScriptBuf};
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::transaction::Transaction;
+use bitcoin::transaction::OutPoint as BitcoinOutPoint;
+use bitcoin::script::{Script, ScriptBuf};
 use bitcoin::hashes::{Hash, HashEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hash_types::{Txid, BlockHash};

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -14,11 +14,11 @@
 
 use bitcoin::{Sequence, Witness};
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::transaction::{TxOut,TxIn, Transaction};
-use bitcoin::blockdata::transaction::OutPoint as BitcoinOutPoint;
-use bitcoin::blockdata::script::{Script, ScriptBuf};
+use bitcoin::constants::WITNESS_SCALE_FACTOR;
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::transaction::{TxOut,TxIn, Transaction};
+use bitcoin::transaction::OutPoint as BitcoinOutPoint;
+use bitcoin::script::{Script, ScriptBuf};
 use bitcoin::hash_types::Txid;
 use bitcoin::secp256k1::{SecretKey,PublicKey};
 use bitcoin::sighash::EcdsaSighashType;
@@ -1201,9 +1201,9 @@ mod tests {
 	use crate::ln::channel_keys::{DelayedPaymentBasepoint, HtlcBasepoint};
 
 	use bitcoin::amount::Amount;
-	use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
-	use bitcoin::blockdata::script::ScriptBuf;
-	use bitcoin::blockdata::transaction::OutPoint as BitcoinOutPoint;
+	use bitcoin::constants::WITNESS_SCALE_FACTOR;
+	use bitcoin::script::ScriptBuf;
+	use bitcoin::transaction::OutPoint as BitcoinOutPoint;
 
 	use bitcoin::hashes::hex::FromHex;
 

--- a/lightning/src/chain/transaction.rs
+++ b/lightning/src/chain/transaction.rs
@@ -10,8 +10,8 @@
 //! Types describing on-chain transactions.
 
 use bitcoin::hash_types::Txid;
-use bitcoin::blockdata::transaction::OutPoint as BitcoinOutPoint;
-use bitcoin::blockdata::transaction::Transaction;
+use bitcoin::transaction::OutPoint as BitcoinOutPoint;
+use bitcoin::transaction::Transaction;
 
 /// Transaction data where each item consists of a transaction reference paired with the index of
 /// the transaction within a block.
@@ -23,8 +23,8 @@ use bitcoin::blockdata::transaction::Transaction;
 /// extern crate bitcoin;
 /// extern crate lightning;
 ///
-/// use bitcoin::blockdata::block::Block;
-/// use bitcoin::blockdata::constants::genesis_block;
+/// use bitcoin::block::Block;
+/// use bitcoin::constants::genesis_block;
 /// use bitcoin::network::Network;
 /// use lightning::chain::transaction::TransactionData;
 ///
@@ -45,7 +45,7 @@ pub type TransactionData<'a> = [(usize, &'a Transaction)];
 
 /// A reference to a transaction output.
 ///
-/// Differs from bitcoin::blockdata::transaction::OutPoint as the index is a u16 instead of u32
+/// Differs from bitcoin::transaction::OutPoint as the index is a u16 instead of u32
 /// due to LN's restrictions on index values. Should reduce (possibly) unsafe conversions this way.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct OutPoint {
@@ -90,7 +90,7 @@ mod tests {
 	use crate::chain::transaction::OutPoint;
 	use crate::ln::types::ChannelId;
 
-	use bitcoin::blockdata::transaction::Transaction;
+	use bitcoin::transaction::Transaction;
 	use bitcoin::consensus::encode;
 	use bitcoin::hashes::hex::FromHex;
 

--- a/lightning/src/events/bump_transaction.rs
+++ b/lightning/src/events/bump_transaction.rs
@@ -34,8 +34,8 @@ use crate::util::logger::Logger;
 
 use bitcoin::{OutPoint, Psbt, PubkeyHash, Sequence, ScriptBuf, Transaction, TxIn, TxOut, Witness, WPubkeyHash};
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
-use bitcoin::blockdata::locktime::absolute::LockTime;
+use bitcoin::constants::WITNESS_SCALE_FACTOR;
+use bitcoin::locktime::absolute::LockTime;
 use bitcoin::consensus::Encodable;
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::{PublicKey, Secp256k1};

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -35,8 +35,8 @@ use crate::util::ser::{BigSize, FixedLengthReader, Writeable, Writer, MaybeReada
 use crate::util::string::UntrustedString;
 
 use bitcoin::{Transaction, OutPoint};
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::script::ScriptBuf;
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::script::ScriptBuf;
 use bitcoin::hashes::Hash;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::PublicKey;

--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -11,7 +11,7 @@
 //! properly with a signer implementation that asynchronously derives signatures.
 
 use bitcoin::{Transaction, TxOut, TxIn, Amount};
-use bitcoin::blockdata::locktime::absolute::LockTime;
+use bitcoin::locktime::absolute::LockTime;
 use bitcoin::transaction::Version;
 
 use crate::chain::channelmonitor::LATENCY_GRACE_PERIOD_BLOCKS;

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -12,9 +12,9 @@
 
 use bitcoin::{PubkeyHash, WPubkeyHash};
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::script::{Script, ScriptBuf, Builder};
-use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::transaction::{TxIn,TxOut,OutPoint,Transaction};
+use bitcoin::script::{Script, ScriptBuf, Builder};
+use bitcoin::opcodes;
+use bitcoin::transaction::{TxIn,TxOut,OutPoint,Transaction};
 use bitcoin::sighash;
 use bitcoin::sighash::EcdsaSighashType;
 use bitcoin::transaction::Version;
@@ -33,7 +33,7 @@ use crate::ln::msgs::DecodeError;
 use crate::util::ser::{Readable, RequiredWrapper, Writeable, Writer};
 use crate::util::transaction_utils;
 
-use bitcoin::blockdata::locktime::absolute::LockTime;
+use bitcoin::locktime::absolute::LockTime;
 use bitcoin::ecdsa::Signature as BitcoinSignature;
 use bitcoin::secp256k1::{SecretKey, PublicKey, Scalar};
 use bitcoin::secp256k1::{Secp256k1, ecdsa::Signature, Message};

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -12,7 +12,7 @@
 //! There are a bunch of these as their handling is relatively error-prone so they are split out
 //! here. See also the chanmon_fail_consistency fuzz test.
 
-use bitcoin::blockdata::constants::genesis_block;
+use bitcoin::constants::genesis_block;
 use bitcoin::hash_types::BlockHash;
 use bitcoin::network::Network;
 use crate::chain::channelmonitor::{ANTI_REORG_DELAY, ChannelMonitor};

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -8,9 +8,9 @@
 // licenses.
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::ChainHash;
-use bitcoin::blockdata::script::{Script, ScriptBuf, Builder};
-use bitcoin::blockdata::transaction::Transaction;
+use bitcoin::constants::ChainHash;
+use bitcoin::script::{Script, ScriptBuf, Builder};
+use bitcoin::transaction::Transaction;
 use bitcoin::sighash;
 use bitcoin::sighash::EcdsaSighashType;
 use bitcoin::consensus::encode;
@@ -9369,10 +9369,10 @@ impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, u32, &'c Ch
 mod tests {
 	use std::cmp;
 	use bitcoin::amount::Amount;
-	use bitcoin::blockdata::constants::ChainHash;
-	use bitcoin::blockdata::script::{ScriptBuf, Builder};
-	use bitcoin::blockdata::transaction::{Transaction, TxOut, Version};
-	use bitcoin::blockdata::opcodes;
+	use bitcoin::constants::ChainHash;
+	use bitcoin::script::{ScriptBuf, Builder};
+	use bitcoin::transaction::{Transaction, TxOut, Version};
+	use bitcoin::opcodes;
 	use bitcoin::network::Network;
 	use crate::ln::onion_utils::INVALID_ONION_BLINDING;
 	use crate::ln::types::{PaymentHash, PaymentPreimage};
@@ -9402,7 +9402,7 @@ mod tests {
 	use bitcoin::hashes::sha256::Hash as Sha256;
 	use bitcoin::hashes::Hash;
 	use bitcoin::hashes::hex::FromHex;
-	use bitcoin::blockdata::locktime::absolute::LockTime;
+	use bitcoin::locktime::absolute::LockTime;
 	use bitcoin::{WitnessProgram, WitnessVersion, WPubkeyHash};
 	use crate::prelude::*;
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -17,9 +17,9 @@
 //! on-chain transactions (it only monitors the chain to watch for any force-closes that might
 //! imply it needs to fail HTLCs/payments/channels it manages).
 
-use bitcoin::blockdata::block::Header;
-use bitcoin::blockdata::transaction::Transaction;
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::block::Header;
+use bitcoin::transaction::Transaction;
+use bitcoin::constants::ChainHash;
 use bitcoin::key::constants::SECRET_KEY_SIZE;
 use bitcoin::network::Network;
 
@@ -13582,7 +13582,7 @@ pub mod bench {
 	use crate::util::config::{UserConfig, MaxDustHTLCExposure};
 
 	use bitcoin::amount::Amount;
-	use bitcoin::blockdata::locktime::absolute::LockTime;
+	use bitcoin::locktime::absolute::LockTime;
 	use bitcoin::hashes::Hash;
 	use bitcoin::hashes::sha256::Hash as Sha256;
 	use bitcoin::{Transaction, TxOut};
@@ -13620,7 +13620,7 @@ pub mod bench {
 		// Note that this is unrealistic as each payment send will require at least two fsync
 		// calls per node.
 		let network = bitcoin::Network::Testnet;
-		let genesis_block = bitcoin::blockdata::constants::genesis_block(network);
+		let genesis_block = bitcoin::constants::genesis_block(network);
 
 		let tx_broadcaster = test_utils::TestBroadcaster::new(network);
 		let fee_estimator = test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) };

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -38,9 +38,9 @@ use crate::util::test_utils::{panicking, TestChainMonitor, TestScorer, TestKeysI
 use crate::util::ser::{ReadableArgs, Writeable};
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::block::{Block, Header, Version};
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::transaction::{Transaction, TxIn, TxOut};
+use bitcoin::block::{Block, Header, Version};
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::transaction::{Transaction, TxIn, TxOut};
 use bitcoin::hash_types::{BlockHash, TxMerkleNode};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash as _;
@@ -1507,7 +1507,7 @@ pub fn update_nodes_with_chan_announce<'a, 'b, 'c, 'd>(nodes: &'a Vec<Node<'b, '
 	}
 }
 
-pub fn do_check_spends<F: Fn(&bitcoin::blockdata::transaction::OutPoint) -> Option<TxOut>>(tx: &Transaction, get_output: F) {
+pub fn do_check_spends<F: Fn(&bitcoin::transaction::OutPoint) -> Option<TxOut>>(tx: &Transaction, get_output: F) {
 	for outp in tx.output.iter() {
 		assert!(outp.value >= outp.script_pubkey.dust_value(), "Spending tx output didn't meet dust limit");
 	}
@@ -1534,7 +1534,7 @@ macro_rules! check_spends {
 				assert!(outp.value >= outp.script_pubkey.dust_value(), "Input tx output didn't meet dust limit");
 			}
 			)*
-			let get_output = |out_point: &bitcoin::blockdata::transaction::OutPoint| {
+			let get_output = |out_point: &bitcoin::transaction::OutPoint| {
 				$(
 					if out_point.txid == $spends_txn.txid() {
 						return $spends_txn.output.get(out_point.vout as usize).cloned()
@@ -3236,7 +3236,7 @@ pub fn create_node_chanmgrs<'a, 'b>(node_count: usize, cfgs: &'a Vec<NodeCfg<'b>
 	let mut chanmgrs = Vec::new();
 	for i in 0..node_count {
 		let network = Network::Testnet;
-		let genesis_block = bitcoin::blockdata::constants::genesis_block(network);
+		let genesis_block = bitcoin::constants::genesis_block(network);
 		let params = ChainParameters {
 			network,
 			best_block: BestBlock::from_network(network),

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -38,10 +38,10 @@ use crate::util::string::UntrustedString;
 use crate::util::config::{UserConfig, MaxDustHTLCExposure};
 
 use bitcoin::hash_types::BlockHash;
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::script::{Builder, ScriptBuf};
-use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::script::{Builder, ScriptBuf};
+use bitcoin::opcodes;
+use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 use bitcoin::{Amount, Sequence, Transaction, TxIn, TxOut, Witness};
 use bitcoin::OutPoint as BitcoinOutPoint;

--- a/lightning/src/ln/interactivetxs.rs
+++ b/lightning/src/ln/interactivetxs.rs
@@ -12,7 +12,7 @@ use crate::prelude::*;
 use core::ops::Deref;
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
+use bitcoin::constants::WITNESS_SCALE_FACTOR;
 use bitcoin::consensus::Encodable;
 use bitcoin::policy::MAX_STANDARD_TX_WEIGHT;
 use bitcoin::transaction::Version;
@@ -1037,8 +1037,8 @@ mod tests {
 	use crate::util::atomic_counter::AtomicCounter;
 	use crate::util::ser::TransactionU16LenLimited;
 	use bitcoin::amount::Amount;
-	use bitcoin::blockdata::opcodes;
-	use bitcoin::blockdata::script::Builder;
+	use bitcoin::opcodes;
+	use bitcoin::script::Builder;
 	use bitcoin::hashes::Hash;
 	use bitcoin::key::UntweakedPublicKey;
 	use bitcoin::secp256k1::{Keypair, Secp256k1};

--- a/lightning/src/ln/monitor_tests.rs
+++ b/lightning/src/ln/monitor_tests.rs
@@ -25,9 +25,9 @@ use crate::util::scid_utils::block_from_scid;
 use crate::util::test_utils;
 
 use bitcoin::{Amount, PublicKey, ScriptBuf, Transaction, TxIn, TxOut, Witness};
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::script::Builder;
-use bitcoin::blockdata::opcodes;
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::script::Builder;
+use bitcoin::opcodes;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
 use bitcoin::sighash::{SighashCache, EcdsaSighashType};

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -24,11 +24,11 @@
 //! raw socket events into your non-internet-facing system and then send routing events back to
 //! track the network on the less-secure system.
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::{secp256k1, Witness};
-use bitcoin::blockdata::script::ScriptBuf;
+use bitcoin::script::ScriptBuf;
 use bitcoin::hash_types::Txid;
 
 use crate::blinded_path::payment::{BlindedPaymentTlvs, ForwardTlvs, ReceiveTlvs};
@@ -3207,9 +3207,9 @@ mod tests {
 	use bitcoin::hashes::hex::FromHex;
 	use bitcoin::address::Address;
 	use bitcoin::network::Network;
-	use bitcoin::blockdata::constants::ChainHash;
-	use bitcoin::blockdata::script::Builder;
-	use bitcoin::blockdata::opcodes;
+	use bitcoin::constants::ChainHash;
+	use bitcoin::script::Builder;
+	use bitcoin::opcodes;
 	use bitcoin::hash_types::Txid;
 	use bitcoin::locktime::absolute::LockTime;
 	use bitcoin::transaction::Version;

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -30,7 +30,7 @@ use crate::util::test_utils;
 use crate::util::config::{UserConfig, ChannelConfig, MaxDustHTLCExposure};
 use crate::util::errors::APIError;
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::hashes::{Hash, HashEngine};
 use bitcoin::hashes::hmac::{Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -15,7 +15,7 @@
 //! call into the provided message handlers (probably a ChannelManager and P2PGossipSync) with
 //! messages they should handle, and encoding/sending response messages.
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::secp256k1::{self, Secp256k1, SecretKey, PublicKey};
 
 use crate::sign::{NodeSigner, Recipient};
@@ -2713,7 +2713,7 @@ mod tests {
 	use crate::util::test_utils;
 
 	use bitcoin::Network;
-	use bitcoin::blockdata::constants::ChainHash;
+	use bitcoin::constants::ChainHash;
 	use bitcoin::secp256k1::{PublicKey, SecretKey};
 
 	use crate::sync::{Arc, Mutex};

--- a/lightning/src/ln/priv_short_conf_tests.rs
+++ b/lightning/src/ln/priv_short_conf_tests.rs
@@ -30,7 +30,7 @@ use crate::prelude::*;
 
 use crate::ln::functional_test_utils::*;
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 
 #[test]

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -21,8 +21,8 @@ use crate::util::test_utils;
 use crate::util::ser::Writeable;
 use crate::util::string::UntrustedString;
 
-use bitcoin::blockdata::script::Builder;
-use bitcoin::blockdata::opcodes;
+use bitcoin::script::Builder;
+use bitcoin::opcodes;
 use bitcoin::secp256k1::Secp256k1;
 
 use crate::prelude::*;

--- a/lightning/src/ln/script.rs
+++ b/lightning/src/ln/script.rs
@@ -1,8 +1,8 @@
 //! Abstractions for scripts used in the Lightning Network.
 
 use bitcoin::{WitnessProgram, WPubkeyHash, WScriptHash};
-use bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_0 as SEGWIT_V0;
-use bitcoin::blockdata::script::{Script, ScriptBuf};
+use bitcoin::opcodes::all::OP_PUSHBYTES_0 as SEGWIT_V0;
+use bitcoin::script::{Script, ScriptBuf};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::PublicKey;
 
@@ -170,8 +170,8 @@ mod shutdown_script_tests {
 	use super::ShutdownScript;
 
 	use bitcoin::{WitnessProgram, WitnessVersion};
-	use bitcoin::blockdata::opcodes;
-	use bitcoin::blockdata::script::{Builder, ScriptBuf};
+	use bitcoin::opcodes;
+	use bitcoin::script::{Builder, ScriptBuf};
 	use bitcoin::secp256k1::Secp256k1;
 	use bitcoin::secp256k1::{PublicKey, SecretKey};
 

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -31,9 +31,9 @@ use crate::prelude::*;
 
 use bitcoin::{Transaction, TxOut, WitnessProgram, WitnessVersion};
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::script::Builder;
-use bitcoin::blockdata::opcodes;
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::script::Builder;
+use bitcoin::opcodes;
 use bitcoin::network::Network;
 use bitcoin::transaction::Version;
 

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -103,7 +103,7 @@
 //! ```
 
 use bitcoin::{WitnessProgram, Network, WitnessVersion};
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::secp256k1::{Keypair, PublicKey, Secp256k1, self};
 use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::address::{Address, Payload};
@@ -1399,8 +1399,8 @@ mod tests {
 	use super::{Bolt12Invoice, DEFAULT_RELATIVE_EXPIRY, FallbackAddress, FullInvoiceTlvStreamRef, InvoiceTlvStreamRef, SIGNATURE_TAG, UnsignedBolt12Invoice};
 
 	use bitcoin::{WitnessProgram, WitnessVersion};
-	use bitcoin::blockdata::constants::ChainHash;
-	use bitcoin::blockdata::script::ScriptBuf;
+	use bitcoin::constants::ChainHash;
+	use bitcoin::script::ScriptBuf;
 	use bitcoin::hashes::Hash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey, XOnlyPublicKey, self};

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -57,7 +57,7 @@
 //! # }
 //! ```
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 use bitcoin::secp256k1::{Keypair, PublicKey, Secp256k1, self};
 use bitcoin::secp256k1::schnorr::Signature;
@@ -1203,7 +1203,7 @@ impl Readable for InvoiceRequestFields {
 mod tests {
 	use super::{InvoiceRequest, InvoiceRequestFields, InvoiceRequestTlvStreamRef, PAYER_NOTE_LIMIT, SIGNATURE_TAG, UnsignedInvoiceRequest};
 
-	use bitcoin::blockdata::constants::ChainHash;
+	use bitcoin::constants::ChainHash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey, self};
 	use core::num::NonZeroU64;

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -77,7 +77,7 @@
 //! [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
 //! [`ChannelManager::create_offer_builder`]: crate::ln::channelmanager::ChannelManager::create_offer_builder
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 use bitcoin::secp256k1::{Keypair, PublicKey, Secp256k1, self};
 use core::hash::{Hash, Hasher};
@@ -568,7 +568,7 @@ macro_rules! offer_accessors { ($self: ident, $contents: expr) => {
 	/// The chains that may be used when paying a requested invoice (e.g., bitcoin mainnet).
 	/// Payments must be denominated in units of the minimal lightning-payable unit (e.g., msats)
 	/// for the selected chain.
-	pub fn chains(&$self) -> Vec<bitcoin::blockdata::constants::ChainHash> {
+	pub fn chains(&$self) -> Vec<bitcoin::constants::ChainHash> {
 		$contents.chains()
 	}
 
@@ -1153,7 +1153,7 @@ mod tests {
 		super::OfferWithExplicitMetadataBuilder as OfferBuilder,
 	};
 
-	use bitcoin::blockdata::constants::ChainHash;
+	use bitcoin::constants::ChainHash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::Secp256k1;
 	use core::num::NonZeroU64;

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -82,7 +82,7 @@
 //! [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
 //! [`ChannelManager::create_refund_builder`]: crate::ln::channelmanager::ChannelManager::create_refund_builder
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, self};
 use core::hash::{Hash, Hasher};
@@ -926,7 +926,7 @@ mod tests {
 		super::RefundMaybeWithDerivedMetadataBuilder as RefundBuilder,
 	};
 
-	use bitcoin::blockdata::constants::ChainHash;
+	use bitcoin::constants::ChainHash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::{Keypair, Secp256k1, SecretKey};
 

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -29,7 +29,7 @@ use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError, ParsedMessage}
 use crate::util::ser::{Iterable, SeekReadable, WithoutLength, Writeable, Writer};
 use crate::util::string::PrintableString;
 use bitcoin::address::Address;
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::secp256k1::{self, Keypair, PublicKey, Secp256k1};
 use core::time::Duration;
@@ -573,7 +573,7 @@ mod tests {
 	use crate::offers::test_utils::*;
 	use crate::sign::KeyMaterial;
 	use crate::util::ser::{BigSize, Iterable, Writeable};
-	use bitcoin::blockdata::constants::ChainHash;
+	use bitcoin::constants::ChainHash;
 	use bitcoin::secp256k1::{self, Secp256k1};
 	use bitcoin::Network;
 	use core::time::Duration;

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -10,7 +10,7 @@
 //! The [`NetworkGraph`] stores the network gossip and [`P2PGossipSync`] fetches it from peers
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::constants::PUBLIC_KEY_SIZE;
@@ -2273,9 +2273,9 @@ pub(crate) mod tests {
 	use bitcoin::hashes::hex::FromHex;
 	use bitcoin::network::Network;
 	use bitcoin::amount::Amount;
-	use bitcoin::blockdata::constants::ChainHash;
-	use bitcoin::blockdata::script::ScriptBuf;
-	use bitcoin::blockdata::transaction::TxOut;
+	use bitcoin::constants::ChainHash;
+	use bitcoin::script::ScriptBuf;
+	use bitcoin::transaction::TxOut;
 	use bitcoin::secp256k1::{PublicKey, SecretKey};
 	use bitcoin::secp256k1::{All, Secp256k1};
 

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -3372,10 +3372,10 @@ mod tests {
 	use bitcoin::amount::Amount;
 	use bitcoin::hashes::Hash;
 	use bitcoin::network::Network;
-	use bitcoin::blockdata::constants::ChainHash;
-	use bitcoin::blockdata::script::Builder;
-	use bitcoin::blockdata::opcodes;
-	use bitcoin::blockdata::transaction::TxOut;
+	use bitcoin::constants::ChainHash;
+	use bitcoin::script::Builder;
+	use bitcoin::opcodes;
+	use bitcoin::transaction::TxOut;
 	use bitcoin::hashes::hex::FromHex;
 	use bitcoin::secp256k1::{PublicKey,SecretKey};
 	use bitcoin::secp256k1::Secp256k1;

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -2163,7 +2163,7 @@ mod tests {
 	use crate::util::ser::{ReadableArgs, Writeable};
 	use crate::util::test_utils::{self, TestLogger};
 
-	use bitcoin::blockdata::constants::ChainHash;
+	use bitcoin::constants::ChainHash;
 	use bitcoin::hashes::Hash;
 	use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 	use bitcoin::network::Network;

--- a/lightning/src/routing/test_utils.rs
+++ b/lightning/src/routing/test_utils.rs
@@ -13,7 +13,7 @@ use crate::ln::msgs::{ChannelAnnouncement, ChannelUpdate, MAX_VALUE_MSAT, NodeAn
 use crate::util::test_utils;
 use crate::util::ser::Writeable;
 
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::hashes::Hash;
 use bitcoin::hashes::hex::FromHex;

--- a/lightning/src/routing/utxo.rs
+++ b/lightning/src/routing/utxo.rs
@@ -15,7 +15,7 @@
 
 use bitcoin::TxOut;
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::constants::ChainHash;
 
 use hex::DisplayHex;
 

--- a/lightning/src/sign/ecdsa.rs
+++ b/lightning/src/sign/ecdsa.rs
@@ -1,6 +1,6 @@
 //! Defines ECDSA-specific signer types.
 
-use bitcoin::blockdata::transaction::Transaction;
+use bitcoin::transaction::Transaction;
 
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::ecdsa::Signature;

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -14,10 +14,10 @@
 
 use bitcoin::amount::Amount;
 use bitcoin::bip32::{ChildNumber, Xpriv, Xpub};
-use bitcoin::blockdata::locktime::absolute::LockTime;
-use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::script::{Builder, Script, ScriptBuf};
-use bitcoin::blockdata::transaction::{Transaction, TxIn, TxOut};
+use bitcoin::locktime::absolute::LockTime;
+use bitcoin::opcodes;
+use bitcoin::script::{Builder, Script, ScriptBuf};
+use bitcoin::transaction::{Transaction, TxIn, TxOut};
 use bitcoin::ecdsa::Signature as EcdsaSignature;
 use bitcoin::network::Network;
 use bitcoin::sighash;
@@ -2505,7 +2505,7 @@ pub fn dyn_sign() {
 #[cfg(ldk_bench)]
 pub mod benches {
 	use crate::sign::{EntropySource, KeysManager};
-	use bitcoin::blockdata::constants::genesis_block;
+	use bitcoin::constants::genesis_block;
 	use bitcoin::Network;
 	use std::sync::mpsc::TryRecvError;
 	use std::sync::{mpsc, Arc};

--- a/lightning/src/sign/taproot.rs
+++ b/lightning/src/sign/taproot.rs
@@ -1,7 +1,7 @@
 //! Defines a Taproot-specific signer type.
 
 use alloc::vec::Vec;
-use bitcoin::blockdata::transaction::Transaction;
+use bitcoin::transaction::Transaction;
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::{schnorr::Signature, PublicKey, Secp256k1, SecretKey};
 

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -10,7 +10,7 @@
 use crate::ln::types::ChannelId;
 use crate::sign::SpendableOutputDescriptor;
 
-use bitcoin::blockdata::transaction::Transaction;
+use bitcoin::transaction::Transaction;
 
 use crate::routing::router::Route;
 use crate::ln::chan_utils::HTLCClaim;

--- a/lightning/src/util/scid_utils.rs
+++ b/lightning/src/util/scid_utils.rs
@@ -71,7 +71,7 @@ pub fn scid_from_parts(block: u64, tx_index: u64, vout_index: u64) -> Result<u64
 /// 3) payments intended to be intercepted will route using a fake scid (this is typically used so
 ///    the forwarding node can open a JIT channel to the next hop)
 pub(crate) mod fake_scid {
-	use bitcoin::blockdata::constants::ChainHash;
+	use bitcoin::constants::ChainHash;
 	use bitcoin::Network;
 	use crate::sign::EntropySource;
 	use crate::crypto::chacha20::ChaCha20;
@@ -182,7 +182,7 @@ pub(crate) mod fake_scid {
 
 	#[cfg(test)]
 	mod tests {
-		use bitcoin::blockdata::constants::ChainHash;
+		use bitcoin::constants::ChainHash;
 		use bitcoin::network::Network;
 		use crate::util::scid_utils::fake_scid::{is_valid_intercept, is_valid_phantom, MAINNET_SEGWIT_ACTIVATION_HEIGHT, MAX_TX_INDEX, MAX_NAMESPACES, Namespace, NAMESPACE_ID_BITMASK, segwit_activation_height, TEST_SEGWIT_ACTIVATION_HEIGHT};
 		use crate::util::scid_utils;

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -28,9 +28,9 @@ use bitcoin::secp256k1::constants::{PUBLIC_KEY_SIZE, SECRET_KEY_SIZE, COMPACT_SI
 use bitcoin::secp256k1::ecdsa;
 use bitcoin::secp256k1::schnorr;
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::ChainHash;
-use bitcoin::blockdata::script::{self, ScriptBuf};
-use bitcoin::blockdata::transaction::{OutPoint, Transaction, TxOut};
+use bitcoin::constants::ChainHash;
+use bitcoin::script::{self, ScriptBuf};
+use bitcoin::transaction::{OutPoint, Transaction, TxOut};
 use bitcoin::{consensus, Witness};
 use bitcoin::consensus::Encodable;
 use bitcoin::hashes::sha256d::Hash as Sha256dHash;

--- a/lightning/src/util/sweep.rs
+++ b/lightning/src/util/sweep.rs
@@ -25,8 +25,8 @@ use crate::util::persist::{
 use crate::util::ser::{Readable, ReadableArgs, Writeable};
 use crate::{impl_writeable_tlv_based, log_debug, log_error};
 
-use bitcoin::blockdata::block::Header;
-use bitcoin::blockdata::locktime::absolute::LockTime;
+use bitcoin::block::Header;
+use bitcoin::locktime::absolute::LockTime;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{BlockHash, Transaction, Txid};
 

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -22,7 +22,7 @@ use core::{cmp, fmt};
 use crate::sync::{Mutex, Arc};
 #[cfg(test)] use crate::sync::MutexGuard;
 
-use bitcoin::blockdata::transaction::Transaction;
+use bitcoin::transaction::Transaction;
 use bitcoin::hashes::Hash;
 use bitcoin::sighash;
 use bitcoin::sighash::EcdsaSighashType;

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -48,12 +48,12 @@ use crate::util::ser::{Readable, ReadableArgs, Writer, Writeable};
 use crate::util::persist::KVStore;
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::constants::ChainHash;
-use bitcoin::blockdata::constants::genesis_block;
-use bitcoin::blockdata::transaction::{Transaction, TxOut};
-use bitcoin::blockdata::script::{Builder, Script, ScriptBuf};
-use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::block::Block;
+use bitcoin::constants::ChainHash;
+use bitcoin::constants::genesis_block;
+use bitcoin::transaction::{Transaction, TxOut};
+use bitcoin::script::{Builder, Script, ScriptBuf};
+use bitcoin::opcodes;
+use bitcoin::block::Block;
 use bitcoin::network::Network;
 use bitcoin::hash_types::{BlockHash, Txid};
 use bitcoin::hashes::Hash;

--- a/lightning/src/util/transaction_utils.rs
+++ b/lightning/src/util/transaction_utils.rs
@@ -8,8 +8,8 @@
 // licenses.
 
 use bitcoin::amount::Amount;
-use bitcoin::blockdata::transaction::{Transaction, TxOut};
-use bitcoin::blockdata::script::ScriptBuf;
+use bitcoin::transaction::{Transaction, TxOut};
+use bitcoin::script::ScriptBuf;
 use bitcoin::consensus::Encodable;
 use bitcoin::consensus::encode::VarInt;
 
@@ -73,9 +73,9 @@ mod tests {
 	use super::*;
 
 	use bitcoin::amount::Amount;
-	use bitcoin::blockdata::locktime::absolute::LockTime;
-	use bitcoin::blockdata::transaction::{TxIn, OutPoint, Version};
-	use bitcoin::blockdata::script::Builder;
+	use bitcoin::locktime::absolute::LockTime;
+	use bitcoin::transaction::{TxIn, OutPoint, Version};
+	use bitcoin::script::Builder;
 	use bitcoin::hash_types::Txid;
 	use bitcoin::hashes::Hash;
 	use bitcoin::hashes::hex::FromHex;


### PR DESCRIPTION
In `rust-bitcoin` the `blockdata` module is a code organisation thing, it should never have been public. One day those guys would like to remove it, so as not to be a PITA for `rust-lighting` when they do lets remove all usage of `blockdata::` now.

Internal change only, no externally visible changes.