### PR TITLE
Handle fallible commitment secret

### DIFF
--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -127,6 +127,11 @@ fn test_async_commitment_signature_for_funding_signed() {
 
 #[test]
 fn test_async_commitment_signature_for_commitment_signed() {
+	do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(0);
+	do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(1);
+}
+
+fn do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(test_case: u8) {
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
@@ -154,23 +159,33 @@ fn test_async_commitment_signature_for_commitment_signed() {
 
 	// Mark dst's signer as unavailable and handle src's commitment_signed: while dst won't yet have a
 	// `commitment_signed` of its own to offer, it should publish a `revoke_and_ack`.
+	dst.disable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::GetPerCommitmentPoint);
 	dst.disable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
 	dst.node.handle_commitment_signed(&src.node.get_our_node_id(), &payment_event.commitment_msg);
 	check_added_monitors(dst, 1);
 
-	get_event_msg!(dst, MessageSendEvent::SendRevokeAndACK, src.node.get_our_node_id());
+	if test_case == 0 {
+		// Unblock CS -> no messages should be sent, since we must send RAA first.
+		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
+		dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
+		let events = dst.node.get_and_clear_pending_msg_events();
+		assert!(events.is_empty(), "expected no message, got {}", events.len());
 
-	// Mark dst's signer as available and retry: we now expect to see dst's `commitment_signed`.
-	dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
-	dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
+		// Unblock revoke_and_ack -> we should send both RAA + CS.
+		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::GetPerCommitmentPoint);
+		dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
+		get_revoke_commit_msgs(&dst, &src.node.get_our_node_id());
+	} else if test_case == 1 {
+		// Unblock revoke_and_ack -> we should send just RAA.
+		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::GetPerCommitmentPoint);
+		dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
+		get_event_msg!(dst, MessageSendEvent::SendRevokeAndACK, src.node.get_our_node_id());
 
-	let events = dst.node.get_and_clear_pending_msg_events();
-	assert_eq!(events.len(), 1, "expected one message, got {}", events.len());
-	if let MessageSendEvent::UpdateHTLCs { ref node_id, .. } = events[0] {
-		assert_eq!(node_id, &src.node.get_our_node_id());
-	} else {
-		panic!("expected UpdateHTLCs message, not {:?}", events[0]);
-	};
+		// Unblock commitment signed -> we should send CS.
+		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
+		dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
+		get_htlc_update_msgs(dst, &src.node.get_our_node_id());
+	}
 }
 
 #[test]

--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -15,11 +15,12 @@ use bitcoin::blockdata::locktime::absolute::LockTime;
 use bitcoin::transaction::Version;
 
 use crate::chain::channelmonitor::LATENCY_GRACE_PERIOD_BLOCKS;
+use crate::chain::ChannelMonitorUpdateStatus;
 use crate::events::bump_transaction::WalletSource;
-use crate::events::{Event, MessageSendEvent, MessageSendEventsProvider, ClosureReason};
-use crate::ln::functional_test_utils::*;
+use crate::events::{ClosureReason, Event, MessageSendEvent, MessageSendEventsProvider, PaymentPurpose};
+use crate::ln::{functional_test_utils::*, msgs};
 use crate::ln::msgs::ChannelMessageHandler;
-use crate::ln::channelmanager::{PaymentId, RecipientOnionFields};
+use crate::ln::channelmanager::{PaymentId, RAACommitmentOrder, RecipientOnionFields};
 use crate::util::test_channel_signer::SignerOp;
 
 #[test]
@@ -327,6 +328,222 @@ fn test_async_commitment_signature_for_peer_disconnect() {
 			panic!("expected UpdateHTLCs message, not {:?}", events[0]);
 		};
 	}
+}
+
+#[test]
+fn test_async_commitment_signature_ordering_reestablish() {
+	do_test_async_commitment_signature_ordering(false);
+}
+
+#[test]
+fn test_async_commitment_signature_ordering_monitor_restored() {
+	do_test_async_commitment_signature_ordering(true);
+}
+
+fn do_test_async_commitment_signature_ordering(monitor_update_failure: bool) {
+	// Across disconnects we may end up in a situation where we need to send a
+	// commitment_signed and then revoke_and_ack. We need to make sure that if
+	// the signer is pending for commitment_signed but not revoke_and_ack, we don't
+	// screw up the order by sending the revoke_and_ack first.
+	//
+	// We test this for both the case where we send messages after a channel
+	// reestablish, as well as restoring a channel after persisting
+	// a monitor update.
+	//
+	// The set up for this test is based on
+	// `test_drop_messages_peer_disconnect_dual_htlc`.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, chan_id, _) = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	let (payment_preimage_1, payment_hash_1, ..) = route_payment(&nodes[0], &[&nodes[1]], 1_000_000);
+
+	// Start to send the second update_add_htlc + commitment_signed, but don't actually make it
+	// to the peer.
+	let (route, payment_hash_2, payment_preimage_2, payment_secret_2) = get_route_and_payment_hash!(nodes[0], nodes[1], 1000000);
+	nodes[0].node.send_payment_with_route(&route, payment_hash_2,
+		RecipientOnionFields::secret_only(payment_secret_2), PaymentId(payment_hash_2.0)).unwrap();
+	check_added_monitors!(nodes[0], 1);
+
+	let events_1 = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events_1.len(), 1);
+	match events_1[0] {
+		MessageSendEvent::UpdateHTLCs { .. } => {},
+		_ => panic!("Unexpected event"),
+	}
+
+	// Send back update_fulfill_htlc + commitment_signed for the first payment.
+	nodes[1].node.claim_funds(payment_preimage_1);
+	expect_payment_claimed!(nodes[1], payment_hash_1, 1_000_000);
+	check_added_monitors!(nodes[1], 1);
+
+	// Handle the update_fulfill_htlc, but fail to persist the monitor update when handling the
+	// commitment_signed.
+	let events_2 = nodes[1].node.get_and_clear_pending_msg_events();
+	assert_eq!(events_2.len(), 1);
+	match events_2[0] {
+		MessageSendEvent::UpdateHTLCs { ref node_id, updates: msgs::CommitmentUpdate { ref update_add_htlcs, ref update_fulfill_htlcs, ref update_fail_htlcs, ref update_fail_malformed_htlcs, ref update_fee, ref commitment_signed } } => {
+			assert_eq!(*node_id, nodes[0].node.get_our_node_id());
+			assert!(update_add_htlcs.is_empty());
+			assert_eq!(update_fulfill_htlcs.len(), 1);
+			assert!(update_fail_htlcs.is_empty());
+			assert!(update_fail_malformed_htlcs.is_empty());
+			assert!(update_fee.is_none());
+
+			nodes[0].node.handle_update_fulfill_htlc(&nodes[1].node.get_our_node_id(), &update_fulfill_htlcs[0]);
+			let events_3 = nodes[0].node.get_and_clear_pending_events();
+			assert_eq!(events_3.len(), 1);
+			match events_3[0] {
+				Event::PaymentSent { ref payment_preimage, ref payment_hash, .. } => {
+					assert_eq!(*payment_preimage, payment_preimage_1);
+					assert_eq!(*payment_hash, payment_hash_1);
+				},
+				_ => panic!("Unexpected event"),
+			}
+
+			if monitor_update_failure {
+				chanmon_cfgs[0].persister.set_update_ret(ChannelMonitorUpdateStatus::InProgress);
+			}
+			nodes[0].node.handle_commitment_signed(&nodes[1].node.get_our_node_id(), commitment_signed);
+			if monitor_update_failure {
+				assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
+			} else {
+				let _ = get_event_msg!(nodes[0], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id());
+			}
+			// No commitment_signed so get_event_msg's assert(len == 1) passes
+			check_added_monitors!(nodes[0], 1);
+		},
+		_ => panic!("Unexpected event"),
+	}
+
+	// Disconnect and reconnect the peers so that nodes[0] will
+	// need to re-send the commitment update *and then* revoke_and_ack.
+	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id());
+	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id());
+
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init {
+		features: nodes[1].node.init_features(), networks: None, remote_network_address: None
+	}, true).unwrap();
+	let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
+	assert_eq!(reestablish_1.len(), 1);
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init {
+		features: nodes[0].node.init_features(), networks: None, remote_network_address: None
+	}, false).unwrap();
+	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
+	assert_eq!(reestablish_2.len(), 1);
+
+	// With a fully working signer, here we would send a commitment_signed,
+	// and then revoke_and_ack. With commitment_signed disabled, since
+	// our ordering is CS then RAA, we should make sure we don't send the RAA.
+	nodes[0].disable_channel_signer_op(&nodes[1].node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
+	nodes[0].node.handle_channel_reestablish(&nodes[1].node.get_our_node_id(), &reestablish_2[0]);
+	let as_resp = handle_chan_reestablish_msgs!(nodes[0], nodes[1]);
+	assert!(as_resp.0.is_none());
+	assert!(as_resp.1.is_none());
+	assert!(as_resp.2.is_none());
+
+	if monitor_update_failure {
+		chanmon_cfgs[0].persister.set_update_ret(ChannelMonitorUpdateStatus::Completed);
+		let (outpoint, latest_update, _) = nodes[0].chain_monitor.latest_monitor_update_id.lock().unwrap().get(&chan_id).unwrap().clone();
+		nodes[0].chain_monitor.chain_monitor.force_channel_monitor_updated(outpoint, latest_update);
+		check_added_monitors!(nodes[0], 0);
+	}
+
+	// Make sure that on signer_unblocked we have the same behavior (even though RAA is ready,
+	// we don't send CS yet).
+	nodes[0].node.signer_unblocked(Some((nodes[1].node.get_our_node_id(), chan_id)));
+	let as_resp = handle_chan_reestablish_msgs!(nodes[0], nodes[1]);
+	assert!(as_resp.0.is_none());
+	assert!(as_resp.1.is_none());
+	assert!(as_resp.2.is_none());
+
+	nodes[0].enable_channel_signer_op(&nodes[1].node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
+	nodes[0].node.signer_unblocked(Some((nodes[1].node.get_our_node_id(), chan_id)));
+
+	let as_resp = handle_chan_reestablish_msgs!(nodes[0], nodes[1]);
+	nodes[1].node.handle_channel_reestablish(&nodes[0].node.get_our_node_id(), &reestablish_1[0]);
+	let bs_resp = handle_chan_reestablish_msgs!(nodes[1], nodes[0]);
+
+	assert!(as_resp.0.is_none());
+	assert!(bs_resp.0.is_none());
+
+	assert!(bs_resp.1.is_none());
+	assert!(bs_resp.2.is_none());
+
+	assert!(as_resp.3 == RAACommitmentOrder::CommitmentFirst);
+
+	// Now that everything is restored, get the CS + RAA and handle them.
+	assert_eq!(as_resp.2.as_ref().unwrap().update_add_htlcs.len(), 1);
+	assert!(as_resp.2.as_ref().unwrap().update_fulfill_htlcs.is_empty());
+	assert!(as_resp.2.as_ref().unwrap().update_fail_htlcs.is_empty());
+	assert!(as_resp.2.as_ref().unwrap().update_fail_malformed_htlcs.is_empty());
+	assert!(as_resp.2.as_ref().unwrap().update_fee.is_none());
+	nodes[1].node.handle_update_add_htlc(&nodes[0].node.get_our_node_id(), &as_resp.2.as_ref().unwrap().update_add_htlcs[0]);
+	nodes[1].node.handle_commitment_signed(&nodes[0].node.get_our_node_id(), &as_resp.2.as_ref().unwrap().commitment_signed);
+	let bs_revoke_and_ack = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[0].node.get_our_node_id());
+	// No commitment_signed so get_event_msg's assert(len == 1) passes
+	check_added_monitors!(nodes[1], 1);
+
+	nodes[1].node.handle_revoke_and_ack(&nodes[0].node.get_our_node_id(), as_resp.1.as_ref().unwrap());
+	let bs_second_commitment_signed = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
+	assert!(bs_second_commitment_signed.update_add_htlcs.is_empty());
+	assert!(bs_second_commitment_signed.update_fulfill_htlcs.is_empty());
+	assert!(bs_second_commitment_signed.update_fail_htlcs.is_empty());
+	assert!(bs_second_commitment_signed.update_fail_malformed_htlcs.is_empty());
+	assert!(bs_second_commitment_signed.update_fee.is_none());
+	check_added_monitors!(nodes[1], 1);
+
+	// The rest of this is boilerplate for resolving the previous state.
+
+	nodes[0].node.handle_revoke_and_ack(&nodes[1].node.get_our_node_id(), &bs_revoke_and_ack);
+	let as_commitment_signed = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());
+	assert!(as_commitment_signed.update_add_htlcs.is_empty());
+	assert!(as_commitment_signed.update_fulfill_htlcs.is_empty());
+	assert!(as_commitment_signed.update_fail_htlcs.is_empty());
+	assert!(as_commitment_signed.update_fail_malformed_htlcs.is_empty());
+	assert!(as_commitment_signed.update_fee.is_none());
+	check_added_monitors!(nodes[0], 1);
+
+	nodes[0].node.handle_commitment_signed(&nodes[1].node.get_our_node_id(), &bs_second_commitment_signed.commitment_signed);
+	let as_revoke_and_ack = get_event_msg!(nodes[0], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id());
+	// No commitment_signed so get_event_msg's assert(len == 1) passes
+	check_added_monitors!(nodes[0], 1);
+
+	nodes[1].node.handle_commitment_signed(&nodes[0].node.get_our_node_id(), &as_commitment_signed.commitment_signed);
+	let bs_second_revoke_and_ack = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[0].node.get_our_node_id());
+	// No commitment_signed so get_event_msg's assert(len == 1) passes
+	check_added_monitors!(nodes[1], 1);
+
+	nodes[1].node.handle_revoke_and_ack(&nodes[0].node.get_our_node_id(), &as_revoke_and_ack);
+	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
+	check_added_monitors!(nodes[1], 1);
+
+	expect_pending_htlcs_forwardable!(nodes[1]);
+
+	let events_5 = nodes[1].node.get_and_clear_pending_events();
+	assert_eq!(events_5.len(), 1);
+	match events_5[0] {
+		Event::PaymentClaimable { ref payment_hash, ref purpose, .. } => {
+			assert_eq!(payment_hash_2, *payment_hash);
+			match &purpose {
+				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
+					assert!(payment_preimage.is_none());
+					assert_eq!(payment_secret_2, *payment_secret);
+				},
+				_ => panic!("expected PaymentPurpose::Bolt11InvoicePayment")
+			}
+		},
+		_ => panic!("Unexpected event"),
+	}
+
+	nodes[0].node.handle_revoke_and_ack(&nodes[1].node.get_our_node_id(), &bs_second_revoke_and_ack);
+	assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
+	check_added_monitors!(nodes[0], 1);
+
+	expect_payment_path_successful!(nodes[0]);
+	claim_payment(&nodes[0], &[&nodes[1]], payment_preimage_2);
 }
 
 fn do_test_async_holder_signatures(anchors: bool, remote_commitment: bool) {

--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -10,6 +10,8 @@
 //! Tests for asynchronous signing. These tests verify that the channel state machine behaves
 //! properly with a signer implementation that asynchronously derives signatures.
 
+use std::collections::HashSet;
+
 use bitcoin::{Transaction, TxOut, TxIn, Amount};
 use bitcoin::blockdata::locktime::absolute::LockTime;
 use bitcoin::transaction::Version;
@@ -22,6 +24,7 @@ use crate::ln::{functional_test_utils::*, msgs};
 use crate::ln::msgs::ChannelMessageHandler;
 use crate::ln::channelmanager::{PaymentId, RAACommitmentOrder, RecipientOnionFields};
 use crate::util::test_channel_signer::SignerOp;
+use crate::util::logger::Logger;
 
 #[test]
 fn test_async_commitment_signature_for_funding_created() {
@@ -127,11 +130,17 @@ fn test_async_commitment_signature_for_funding_signed() {
 
 #[test]
 fn test_async_commitment_signature_for_commitment_signed() {
-	do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(0);
-	do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(1);
+	for i in 0..=8 {
+		let enable_signer_op_order = vec![
+			SignerOp::GetPerCommitmentPoint,
+			SignerOp::ReleaseCommitmentSecret,
+			SignerOp::SignCounterpartyCommitment,
+		].into_iter().filter(|&op| i & (1 << op as u8) != 0).collect();
+		do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(enable_signer_op_order);
+	}
 }
 
-fn do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(test_case: u8) {
+fn do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(enable_signer_op_order: Vec<SignerOp>) {
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
@@ -160,31 +169,33 @@ fn do_test_async_commitment_signature_for_commitment_signed_revoke_and_ack(test_
 	// Mark dst's signer as unavailable and handle src's commitment_signed: while dst won't yet have a
 	// `commitment_signed` of its own to offer, it should publish a `revoke_and_ack`.
 	dst.disable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::GetPerCommitmentPoint);
+	dst.disable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::ReleaseCommitmentSecret);
 	dst.disable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
 	dst.node.handle_commitment_signed(&src.node.get_our_node_id(), &payment_event.commitment_msg);
 	check_added_monitors(dst, 1);
 
-	if test_case == 0 {
-		// Unblock CS -> no messages should be sent, since we must send RAA first.
-		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
+	let mut enabled_signer_ops = HashSet::new();
+	log_trace!(dst.logger, "enable_signer_op_order={:?}", enable_signer_op_order);
+	for op in enable_signer_op_order {
+		enabled_signer_ops.insert(op);
+		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, op);
 		dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
-		let events = dst.node.get_and_clear_pending_msg_events();
-		assert!(events.is_empty(), "expected no message, got {}", events.len());
 
-		// Unblock revoke_and_ack -> we should send both RAA + CS.
-		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::GetPerCommitmentPoint);
-		dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
-		get_revoke_commit_msgs(&dst, &src.node.get_our_node_id());
-	} else if test_case == 1 {
-		// Unblock revoke_and_ack -> we should send just RAA.
-		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::GetPerCommitmentPoint);
-		dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
-		get_event_msg!(dst, MessageSendEvent::SendRevokeAndACK, src.node.get_our_node_id());
-
-		// Unblock commitment signed -> we should send CS.
-		dst.enable_channel_signer_op(&src.node.get_our_node_id(), &chan_id, SignerOp::SignCounterpartyCommitment);
-		dst.node.signer_unblocked(Some((src.node.get_our_node_id(), chan_id)));
-		get_htlc_update_msgs(dst, &src.node.get_our_node_id());
+		if enabled_signer_ops.contains(&SignerOp::GetPerCommitmentPoint) && enabled_signer_ops.contains(&SignerOp::ReleaseCommitmentSecret) {
+			// We are just able to send revoke_and_ack
+			if op == SignerOp::GetPerCommitmentPoint || op == SignerOp::ReleaseCommitmentSecret {
+				get_event_msg!(dst, MessageSendEvent::SendRevokeAndACK, src.node.get_our_node_id());
+			}
+			// We either just sent or previously sent revoke_and_ack
+			// and now we are able to send commitment_signed
+			if op == SignerOp::SignCounterpartyCommitment {
+				get_htlc_update_msgs(dst, &src.node.get_our_node_id());
+			}
+		} else {
+			// We can't send either message until RAA is unblocked
+			let events = dst.node.get_and_clear_pending_msg_events();
+			assert!(events.is_empty(), "expected no message, got {}", events.len());
+		}
 	}
 }
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1814,7 +1814,7 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 		Ok(channel_context)
 	}
 
-	fn new_for_outbound_channel<'a, ES: Deref, F: Deref>(
+	fn new_for_outbound_channel<'a, ES: Deref, F: Deref, L: Deref>(
 		fee_estimator: &'a LowerBoundedFeeEstimator<F>,
 		entropy_source: &'a ES,
 		signer_provider: &'a SP,
@@ -1831,11 +1831,13 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 		channel_keys_id: [u8; 32],
 		holder_signer: <SP::Target as SignerProvider>::EcdsaSigner,
 		pubkeys: ChannelPublicKeys,
+		logger: &L,
 	) -> Result<ChannelContext<SP>, APIError>
 		where
 			ES::Target: EntropySource,
 			F::Target: FeeEstimator,
 			SP::Target: SignerProvider,
+			L::Target: Logger,
 	{
 		// This will be updated with the counterparty contribution if this is a dual-funded channel
 		let channel_value_satoshis = funding_satoshis;
@@ -7510,13 +7512,14 @@ pub(super) struct OutboundV1Channel<SP: Deref> where SP::Target: SignerProvider 
 }
 
 impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
-	pub fn new<ES: Deref, F: Deref>(
+	pub fn new<ES: Deref, F: Deref, L: Deref>(
 		fee_estimator: &LowerBoundedFeeEstimator<F>, entropy_source: &ES, signer_provider: &SP, counterparty_node_id: PublicKey, their_features: &InitFeatures,
 		channel_value_satoshis: u64, push_msat: u64, user_id: u128, config: &UserConfig, current_chain_height: u32,
-		outbound_scid_alias: u64, temporary_channel_id: Option<ChannelId>
+		outbound_scid_alias: u64, temporary_channel_id: Option<ChannelId>, logger: &L
 	) -> Result<OutboundV1Channel<SP>, APIError>
 	where ES::Target: EntropySource,
-	      F::Target: FeeEstimator
+	      F::Target: FeeEstimator,
+	      L::Target: Logger,
 	{
 		let holder_selected_channel_reserve_satoshis = get_holder_selected_channel_reserve_satoshis(channel_value_satoshis, config);
 		if holder_selected_channel_reserve_satoshis < MIN_CHAN_DUST_LIMIT_SATOSHIS {
@@ -7548,6 +7551,7 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 				channel_keys_id,
 				holder_signer,
 				pubkeys,
+				logger,
 			)?,
 			unfunded_context: UnfundedChannelContext { unfunded_channel_age_ticks: 0 }
 		};
@@ -8120,14 +8124,15 @@ pub(super) struct OutboundV2Channel<SP: Deref> where SP::Target: SignerProvider 
 
 #[cfg(any(dual_funding, splicing))]
 impl<SP: Deref> OutboundV2Channel<SP> where SP::Target: SignerProvider {
-	pub fn new<ES: Deref, F: Deref>(
+	pub fn new<ES: Deref, F: Deref, L: Deref>(
 		fee_estimator: &LowerBoundedFeeEstimator<F>, entropy_source: &ES, signer_provider: &SP,
 		counterparty_node_id: PublicKey, their_features: &InitFeatures, funding_satoshis: u64,
 		user_id: u128, config: &UserConfig, current_chain_height: u32, outbound_scid_alias: u64,
-		funding_confirmation_target: ConfirmationTarget,
+		funding_confirmation_target: ConfirmationTarget, logger: &L,
 	) -> Result<OutboundV2Channel<SP>, APIError>
 	where ES::Target: EntropySource,
 	      F::Target: FeeEstimator,
+	      L::Target: Logger,
 	{
 		let channel_keys_id = signer_provider.generate_channel_keys_id(false, funding_satoshis, user_id);
 		let holder_signer = signer_provider.derive_channel_signer(funding_satoshis, channel_keys_id);
@@ -8159,6 +8164,7 @@ impl<SP: Deref> OutboundV2Channel<SP> where SP::Target: SignerProvider {
 				channel_keys_id,
 				holder_signer,
 				pubkeys,
+				logger,
 			)?,
 			unfunded_context: UnfundedChannelContext { unfunded_channel_age_ticks: 0 },
 			dual_funding_context: DualFundingChannelContext {
@@ -9566,11 +9572,12 @@ mod tests {
 		keys_provider.expect(OnGetShutdownScriptpubkey {
 			returns: non_v0_segwit_shutdown_script.clone(),
 		});
+		let logger = test_utils::TestLogger::new();
 
 		let secp_ctx = Secp256k1::new();
 		let node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let config = UserConfig::default();
-		match OutboundV1Channel::<&TestKeysInterface>::new(&LowerBoundedFeeEstimator::new(&TestFeeEstimator { fee_est: 253 }), &&keys_provider, &&keys_provider, node_id, &features, 10000000, 100000, 42, &config, 0, 42, None) {
+		match OutboundV1Channel::<&TestKeysInterface>::new(&LowerBoundedFeeEstimator::new(&TestFeeEstimator { fee_est: 253 }), &&keys_provider, &&keys_provider, node_id, &features, 10000000, 100000, 42, &config, 0, 42, None, &&logger) {
 			Err(APIError::IncompatibleShutdownScript { script }) => {
 				assert_eq!(script.into_inner(), non_v0_segwit_shutdown_script.into_inner());
 			},
@@ -9590,10 +9597,11 @@ mod tests {
 		let seed = [42; 32];
 		let network = Network::Testnet;
 		let keys_provider = test_utils::TestKeysInterface::new(&seed, network);
+		let logger = test_utils::TestLogger::new();
 
 		let node_a_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let config = UserConfig::default();
-		let node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&bounded_fee_estimator, &&keys_provider, &&keys_provider, node_a_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None).unwrap();
+		let node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&bounded_fee_estimator, &&keys_provider, &&keys_provider, node_a_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None, &&logger).unwrap();
 
 		// Now change the fee so we can check that the fee in the open_channel message is the
 		// same as the old fee.
@@ -9620,7 +9628,7 @@ mod tests {
 		// Create Node A's channel pointing to Node B's pubkey
 		let node_b_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let config = UserConfig::default();
-		let mut node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None).unwrap();
+		let mut node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None, &&logger).unwrap();
 
 		// Create Node B's channel by receiving Node A's open_channel message
 		// Make sure A's dust limit is as we expect.
@@ -9700,10 +9708,11 @@ mod tests {
 		let seed = [42; 32];
 		let network = Network::Testnet;
 		let keys_provider = test_utils::TestKeysInterface::new(&seed, network);
+		let logger = test_utils::TestLogger::new();
 
 		let node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let config = UserConfig::default();
-		let mut chan = OutboundV1Channel::<&TestKeysInterface>::new(&fee_est, &&keys_provider, &&keys_provider, node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None).unwrap();
+		let mut chan = OutboundV1Channel::<&TestKeysInterface>::new(&fee_est, &&keys_provider, &&keys_provider, node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None, &&logger).unwrap();
 
 		let commitment_tx_fee_0_htlcs = commit_tx_fee_msat(chan.context.feerate_per_kw, 0, chan.context.get_channel_type());
 		let commitment_tx_fee_1_htlc = commit_tx_fee_msat(chan.context.feerate_per_kw, 1, chan.context.get_channel_type());
@@ -9752,7 +9761,7 @@ mod tests {
 		// Create Node A's channel pointing to Node B's pubkey
 		let node_b_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let config = UserConfig::default();
-		let mut node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None).unwrap();
+		let mut node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None, &&logger).unwrap();
 
 		// Create Node B's channel by receiving Node A's open_channel message
 		let open_channel_msg = node_a_chan.get_open_channel(chain_hash);
@@ -9816,12 +9825,12 @@ mod tests {
 		// Test that `OutboundV1Channel::new` creates a channel with the correct value for
 		// `holder_max_htlc_value_in_flight_msat`, when configured with a valid percentage value,
 		// which is set to the lower bound + 1 (2%) of the `channel_value`.
-		let chan_1 = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&config_2_percent), 10000000, 100000, 42, &config_2_percent, 0, 42, None).unwrap();
+		let chan_1 = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&config_2_percent), 10000000, 100000, 42, &config_2_percent, 0, 42, None, &&logger).unwrap();
 		let chan_1_value_msat = chan_1.context.channel_value_satoshis * 1000;
 		assert_eq!(chan_1.context.holder_max_htlc_value_in_flight_msat, (chan_1_value_msat as f64 * 0.02) as u64);
 
 		// Test with the upper bound - 1 of valid values (99%).
-		let chan_2 = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&config_99_percent), 10000000, 100000, 42, &config_99_percent, 0, 42, None).unwrap();
+		let chan_2 = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&config_99_percent), 10000000, 100000, 42, &config_99_percent, 0, 42, None, &&logger).unwrap();
 		let chan_2_value_msat = chan_2.context.channel_value_satoshis * 1000;
 		assert_eq!(chan_2.context.holder_max_htlc_value_in_flight_msat, (chan_2_value_msat as f64 * 0.99) as u64);
 
@@ -9841,14 +9850,14 @@ mod tests {
 
 		// Test that `OutboundV1Channel::new` uses the lower bound of the configurable percentage values (1%)
 		// if `max_inbound_htlc_value_in_flight_percent_of_channel` is set to a value less than 1.
-		let chan_5 = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&config_0_percent), 10000000, 100000, 42, &config_0_percent, 0, 42, None).unwrap();
+		let chan_5 = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&config_0_percent), 10000000, 100000, 42, &config_0_percent, 0, 42, None, &&logger).unwrap();
 		let chan_5_value_msat = chan_5.context.channel_value_satoshis * 1000;
 		assert_eq!(chan_5.context.holder_max_htlc_value_in_flight_msat, (chan_5_value_msat as f64 * 0.01) as u64);
 
 		// Test that `OutboundV1Channel::new` uses the upper bound of the configurable percentage values
 		// (100%) if `max_inbound_htlc_value_in_flight_percent_of_channel` is set to a larger value
 		// than 100.
-		let chan_6 = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&config_101_percent), 10000000, 100000, 42, &config_101_percent, 0, 42, None).unwrap();
+		let chan_6 = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&config_101_percent), 10000000, 100000, 42, &config_101_percent, 0, 42, None, &&logger).unwrap();
 		let chan_6_value_msat = chan_6.context.channel_value_satoshis * 1000;
 		assert_eq!(chan_6.context.holder_max_htlc_value_in_flight_msat, chan_6_value_msat);
 
@@ -9901,7 +9910,7 @@ mod tests {
 
 		let mut outbound_node_config = UserConfig::default();
 		outbound_node_config.channel_handshake_config.their_channel_reserve_proportional_millionths = (outbound_selected_channel_reserve_perc * 1_000_000.0) as u32;
-		let chan = OutboundV1Channel::<&TestKeysInterface>::new(&&fee_est, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&outbound_node_config), channel_value_satoshis, 100_000, 42, &outbound_node_config, 0, 42, None).unwrap();
+		let chan = OutboundV1Channel::<&TestKeysInterface>::new(&&fee_est, &&keys_provider, &&keys_provider, outbound_node_id, &channelmanager::provided_init_features(&outbound_node_config), channel_value_satoshis, 100_000, 42, &outbound_node_config, 0, 42, None, &&logger).unwrap();
 
 		let expected_outbound_selected_chan_reserve = cmp::max(MIN_THEIR_CHAN_RESERVE_SATOSHIS, (chan.context.channel_value_satoshis as f64 * outbound_selected_channel_reserve_perc) as u64);
 		assert_eq!(chan.context.holder_selected_channel_reserve_satoshis, expected_outbound_selected_chan_reserve);
@@ -9938,7 +9947,7 @@ mod tests {
 		// Create Node A's channel pointing to Node B's pubkey
 		let node_b_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let config = UserConfig::default();
-		let mut node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None).unwrap();
+		let mut node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None, &&logger).unwrap();
 
 		// Create Node B's channel by receiving Node A's open_channel message
 		// Make sure A's dust limit is as we expect.
@@ -10014,7 +10023,7 @@ mod tests {
 		let config = UserConfig::default();
 		let features = channelmanager::provided_init_features(&config);
 		let mut outbound_chan = OutboundV1Channel::<&TestKeysInterface>::new(
-			&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &features, 10000000, 100000, 42, &config, 0, 42, None
+			&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &features, 10000000, 100000, 42, &config, 0, 42, None, &&logger
 		).unwrap();
 		let inbound_chan = InboundV1Channel::<&TestKeysInterface>::new(
 			&feeest, &&keys_provider, &&keys_provider, node_b_node_id, &channelmanager::provided_channel_type_features(&config),
@@ -10168,7 +10177,7 @@ mod tests {
 		let counterparty_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let mut config = UserConfig::default();
 		config.channel_handshake_config.announced_channel = false;
-		let mut chan = OutboundV1Channel::<&Keys>::new(&LowerBoundedFeeEstimator::new(&feeest), &&keys_provider, &&keys_provider, counterparty_node_id, &channelmanager::provided_init_features(&config), 10_000_000, 0, 42, &config, 0, 42, None).unwrap(); // Nothing uses their network key in this test
+		let mut chan = OutboundV1Channel::<&Keys>::new(&LowerBoundedFeeEstimator::new(&feeest), &&keys_provider, &&keys_provider, counterparty_node_id, &channelmanager::provided_init_features(&config), 10_000_000, 0, 42, &config, 0, 42, None, &logger).unwrap(); // Nothing uses their network key in this test
 		chan.context.holder_dust_limit_satoshis = 546;
 		chan.context.counterparty_selected_channel_reserve_satoshis = Some(0); // Filled in in accept_channel
 
@@ -10915,7 +10924,7 @@ mod tests {
 		let node_b_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let config = UserConfig::default();
 		let node_a_chan = OutboundV1Channel::<&TestKeysInterface>::new(&feeest, &&keys_provider, &&keys_provider,
-			node_b_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None).unwrap();
+			node_b_node_id, &channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42, None, &&logger).unwrap();
 
 		let mut channel_type_features = ChannelTypeFeatures::only_static_remote_key();
 		channel_type_features.set_zero_conf_required();
@@ -10950,7 +10959,7 @@ mod tests {
 		let channel_a = OutboundV1Channel::<&TestKeysInterface>::new(
 			&fee_estimator, &&keys_provider, &&keys_provider, node_id_b,
 			&channelmanager::provided_init_features(&UserConfig::default()), 10000000, 100000, 42,
-			&config, 0, 42, None
+			&config, 0, 42, None, &&logger
 		).unwrap();
 		assert!(!channel_a.context.channel_type.supports_anchors_zero_fee_htlc_tx());
 
@@ -10961,7 +10970,7 @@ mod tests {
 		let channel_a = OutboundV1Channel::<&TestKeysInterface>::new(
 			&fee_estimator, &&keys_provider, &&keys_provider, node_id_b,
 			&channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42,
-			None
+			None, &&logger
 		).unwrap();
 
 		let open_channel_msg = channel_a.get_open_channel(ChainHash::using_genesis_block(network));
@@ -10999,7 +11008,7 @@ mod tests {
 		let channel_a = OutboundV1Channel::<&TestKeysInterface>::new(
 			&fee_estimator, &&keys_provider, &&keys_provider, node_id_b,
 			&channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42,
-			None
+			None, &&logger
 		).unwrap();
 
 		// Set `channel_type` to `None` to force the implicit feature negotiation.
@@ -11046,7 +11055,7 @@ mod tests {
 		let channel_a = OutboundV1Channel::<&TestKeysInterface>::new(
 			&fee_estimator, &&keys_provider, &&keys_provider, node_id_b,
 			&channelmanager::provided_init_features(&config), 10000000, 100000, 42, &config, 0, 42,
-			None
+			None, &&logger
 		).unwrap();
 
 		let mut open_channel_msg = channel_a.get_open_channel(ChainHash::using_genesis_block(network));
@@ -11065,7 +11074,7 @@ mod tests {
 		// LDK.
 		let mut channel_a = OutboundV1Channel::<&TestKeysInterface>::new(
 			&fee_estimator, &&keys_provider, &&keys_provider, node_id_b, &simple_anchors_init,
-			10000000, 100000, 42, &config, 0, 42, None
+			10000000, 100000, 42, &config, 0, 42, None, &&logger
 		).unwrap();
 
 		let open_channel_msg = channel_a.get_open_channel(ChainHash::using_genesis_block(network));
@@ -11115,7 +11124,8 @@ mod tests {
 			&config,
 			0,
 			42,
-			None
+			None,
+			&&logger
 		).unwrap();
 
 		let open_channel_msg = node_a_chan.get_open_channel(ChainHash::using_genesis_block(network));

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -962,8 +962,12 @@ impl HolderCommitmentPoint {
 	{
 		HolderCommitmentPoint::Available {
 			transaction_number: INITIAL_COMMITMENT_NUMBER,
-			current: signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER, secp_ctx),
-			next: signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, secp_ctx),
+			// TODO(async_signing): remove this expect with the Uninitialized variant
+			current: signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER, secp_ctx)
+				.expect("Signer must be able to provide initial commitment point"),
+			// TODO(async_signing): remove this expect with the Uninitialized variant
+			next: signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, secp_ctx)
+				.expect("Signer must be able to provide second commitment point"),
 		}
 	}
 
@@ -1001,9 +1005,12 @@ impl HolderCommitmentPoint {
 		where SP::Target: SignerProvider, L::Target: Logger
 	{
 		if let HolderCommitmentPoint::PendingNext { transaction_number, current } = self {
-			let next = signer.as_ref().get_per_commitment_point(*transaction_number - 1, secp_ctx);
-			log_trace!(logger, "Retrieved next per-commitment point {}", *transaction_number - 1);
-			*self = HolderCommitmentPoint::Available { transaction_number: *transaction_number, current: *current, next };
+			if let Ok(next) = signer.as_ref().get_per_commitment_point(*transaction_number - 1, secp_ctx) {
+				log_trace!(logger, "Retrieved next per-commitment point {}", *transaction_number - 1);
+				*self = HolderCommitmentPoint::Available { transaction_number: *transaction_number, current: *current, next };
+			} else {
+				log_trace!(logger, "Next per-commitment point {} is pending", transaction_number);
+			}
 		}
 	}
 
@@ -5607,7 +5614,7 @@ impl<SP: Deref> Channel<SP> where
 
 		let our_commitment_transaction = INITIAL_COMMITMENT_NUMBER - self.context.holder_commitment_point.transaction_number() - 1;
 		if msg.next_remote_commitment_number > 0 {
-			let expected_point = self.context.holder_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - msg.next_remote_commitment_number + 1, &self.context.secp_ctx);
+			let expected_point = self.context.holder_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - msg.next_remote_commitment_number + 1, &self.context.secp_ctx).expect("TODO");
 			let given_secret = SecretKey::from_slice(&msg.your_last_per_commitment_secret)
 				.map_err(|_| ChannelError::close("Peer sent a garbage channel_reestablish with unparseable secret key".to_owned()))?;
 			if expected_point != PublicKey::from_secret_key(&self.context.secp_ctx, &given_secret) {
@@ -9305,14 +9312,16 @@ impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, u32, &'c Ch
 			(Some(current), Some(next)) => HolderCommitmentPoint::Available {
 				transaction_number: cur_holder_commitment_transaction_number, current, next
 			},
-			(Some(current), _) => HolderCommitmentPoint::Available {
+			(Some(current), _) => HolderCommitmentPoint::PendingNext {
 				transaction_number: cur_holder_commitment_transaction_number, current,
-				next: holder_signer.get_per_commitment_point(cur_holder_commitment_transaction_number - 1, &secp_ctx),
 			},
-			(_, _) => HolderCommitmentPoint::Available {
-				transaction_number: cur_holder_commitment_transaction_number,
-				current: holder_signer.get_per_commitment_point(cur_holder_commitment_transaction_number, &secp_ctx),
-				next: holder_signer.get_per_commitment_point(cur_holder_commitment_transaction_number - 1, &secp_ctx),
+			(_, _) => {
+				// TODO(async_signing): remove this expect with the Uninitialized variant
+				let current = holder_signer.get_per_commitment_point(cur_holder_commitment_transaction_number, &secp_ctx)
+					.expect("Must be able to derive the current commitment point upon channel restoration");
+				HolderCommitmentPoint::PendingNext {
+					transaction_number: cur_holder_commitment_transaction_number, current,
+				}
 			},
 		};
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -3473,9 +3473,6 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 						log_trace!(logger, "Counterparty commitment signature not available for funding_signed message; setting signer_pending_funding");
 						self.signer_pending_funding = true;
 					}
-				} else if self.signer_pending_funding {
-					log_trace!(logger, "Counterparty commitment signature available for funding_signed message; clearing signer_pending_funding");
-					self.signer_pending_funding = false;
 				}
 
 				// We sign "counterparty" commitment transaction, allowing them to broadcast the tx if they wish.
@@ -5377,9 +5374,13 @@ impl<SP: Deref> Channel<SP> where
 	#[cfg(async_signing)]
 	pub fn signer_maybe_unblocked<L: Deref>(&mut self, logger: &L) -> SignerResumeUpdates where L::Target: Logger {
 		let commitment_update = if self.context.signer_pending_commitment_update {
+			log_trace!(logger, "Attempting to generate pending commitment update...");
+			self.context.signer_pending_commitment_update = false;
 			self.get_last_commitment_update_for_send(logger).ok()
 		} else { None };
 		let funding_signed = if self.context.signer_pending_funding && !self.context.is_outbound() {
+			log_trace!(logger, "Attempting to generate pending funding signed...");
+			self.context.signer_pending_funding = false;
 			self.context.get_funding_signed_msg(logger).1
 		} else { None };
 		let channel_ready = if funding_signed.is_some() {
@@ -5475,10 +5476,6 @@ impl<SP: Deref> Channel<SP> where
 				&self.context.channel_id(), if update_fee.is_some() { " update_fee," } else { "" },
 				update_add_htlcs.len(), update_fulfill_htlcs.len(), update_fail_htlcs.len(), update_fail_malformed_htlcs.len());
 		let commitment_signed = if let Ok(update) = self.send_commitment_no_state_update(logger).map(|(cu, _)| cu) {
-			if self.context.signer_pending_commitment_update {
-				log_trace!(logger, "Commitment update generated: clearing signer_pending_commitment_update");
-				self.context.signer_pending_commitment_update = false;
-			}
 			update
 		} else {
 			#[cfg(not(async_signing))] {
@@ -7494,11 +7491,6 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 			_ => todo!()
 		};
 
-		if self.context.signer_pending_funding {
-			log_trace!(logger, "Counterparty commitment signature ready for funding_created message: clearing signer_pending_funding");
-			self.context.signer_pending_funding = false;
-		}
-
 		Some(msgs::FundingCreated {
 			temporary_channel_id: self.context.temporary_channel_id.unwrap(),
 			funding_txid: self.context.channel_transaction_parameters.funding_outpoint.as_ref().unwrap().txid,
@@ -7747,7 +7739,8 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 	#[cfg(async_signing)]
 	pub fn signer_maybe_unblocked<L: Deref>(&mut self, logger: &L) -> Option<msgs::FundingCreated> where L::Target: Logger {
 		if self.context.signer_pending_funding && self.context.is_outbound() {
-			log_trace!(logger, "Signer unblocked a funding_created");
+			log_trace!(logger, "Attempting to generate pending funding created...");
+			self.context.signer_pending_funding = false;
 			self.get_funding_created_msg(logger)
 		} else { None }
 	}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -906,8 +906,10 @@ pub(super) struct MonitorRestoreUpdates {
 #[allow(unused)]
 pub(super) struct SignerResumeUpdates {
 	pub commitment_update: Option<msgs::CommitmentUpdate>,
+	pub revoke_and_ack: Option<msgs::RevokeAndACK>,
 	pub funding_signed: Option<msgs::FundingSigned>,
 	pub channel_ready: Option<msgs::ChannelReady>,
+	pub order: RAACommitmentOrder,
 }
 
 /// The return value of `channel_reestablish`
@@ -1215,6 +1217,14 @@ pub(super) struct ChannelContext<SP: Deref> where SP::Target: SignerProvider {
 	monitor_pending_finalized_fulfills: Vec<HTLCSource>,
 	monitor_pending_update_adds: Vec<msgs::UpdateAddHTLC>,
 
+	/// If we went to send a revoke_and_ack but our signer was unable to give us a signature,
+	/// we should retry at some point in the future when the signer indicates it may have a
+	/// signature for us.
+	///
+	/// This may also be used to make sure we send a `revoke_and_ack` after a `commitment_signed`
+	/// if we need to maintain ordering of messages, but are pending the signer on a previous
+	/// message.
+	signer_pending_revoke_and_ack: bool,
 	/// If we went to send a commitment update (ie some messages then [`msgs::CommitmentSigned`])
 	/// but our signer (initially) refused to give us a signature, we should retry at some point in
 	/// the future when the signer indicates it may have a signature for us.
@@ -1683,6 +1693,7 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 			monitor_pending_finalized_fulfills: Vec::new(),
 			monitor_pending_update_adds: Vec::new(),
 
+			signer_pending_revoke_and_ack: false,
 			signer_pending_commitment_update: false,
 			signer_pending_funding: false,
 
@@ -1908,6 +1919,7 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 			monitor_pending_finalized_fulfills: Vec::new(),
 			monitor_pending_update_adds: Vec::new(),
 
+			signer_pending_revoke_and_ack: false,
 			signer_pending_commitment_update: false,
 			signer_pending_funding: false,
 
@@ -5373,11 +5385,6 @@ impl<SP: Deref> Channel<SP> where
 	/// blocked.
 	#[cfg(async_signing)]
 	pub fn signer_maybe_unblocked<L: Deref>(&mut self, logger: &L) -> SignerResumeUpdates where L::Target: Logger {
-		let commitment_update = if self.context.signer_pending_commitment_update {
-			log_trace!(logger, "Attempting to generate pending commitment update...");
-			self.context.signer_pending_commitment_update = false;
-			self.get_last_commitment_update_for_send(logger).ok()
-		} else { None };
 		let funding_signed = if self.context.signer_pending_funding && !self.context.is_outbound() {
 			log_trace!(logger, "Attempting to generate pending funding signed...");
 			self.context.signer_pending_funding = false;
@@ -5387,15 +5394,42 @@ impl<SP: Deref> Channel<SP> where
 			self.check_get_channel_ready(0, logger)
 		} else { None };
 
-		log_trace!(logger, "Signer unblocked with {} commitment_update, {} funding_signed and {} channel_ready",
+		let mut commitment_update = if self.context.signer_pending_commitment_update {
+			log_trace!(logger, "Attempting to generate pending commitment update...");
+			self.context.signer_pending_commitment_update = false;
+			self.get_last_commitment_update_for_send(logger).ok()
+		} else { None };
+		let mut revoke_and_ack = if self.context.signer_pending_revoke_and_ack {
+			log_trace!(logger, "Attempting to generate pending revoke and ack...");
+			self.context.signer_pending_revoke_and_ack = false;
+			Some(self.get_last_revoke_and_ack())
+		} else { None };
+
+		if self.context.resend_order == RAACommitmentOrder::CommitmentFirst
+			&& self.context.signer_pending_commitment_update && revoke_and_ack.is_some() {
+			log_trace!(logger, "Signer unblocked for revoke and ack, but unable to send due to resend order, waiting on signer for commitment update");
+			self.context.signer_pending_revoke_and_ack = true;
+			revoke_and_ack = None;
+		}
+		if self.context.resend_order == RAACommitmentOrder::RevokeAndACKFirst
+			&& self.context.signer_pending_revoke_and_ack && commitment_update.is_some() {
+			log_trace!(logger, "Signer unblocked for commitment update, but unable to send due to resend order, waiting on signer for revoke and ack");
+			self.context.signer_pending_commitment_update = true;
+			commitment_update = None;
+		}
+
+		log_trace!(logger, "Signer unblocked with {} commitment_update, {} revoke_and_ack, {} funding_signed and {} channel_ready",
 			if commitment_update.is_some() { "a" } else { "no" },
+			if revoke_and_ack.is_some() { "a" } else { "no" },
 			if funding_signed.is_some() { "a" } else { "no" },
 			if channel_ready.is_some() { "a" } else { "no" });
 
 		SignerResumeUpdates {
 			commitment_update,
+			revoke_and_ack,
 			funding_signed,
 			channel_ready,
+			order: self.context.resend_order.clone(),
 		}
 	}
 
@@ -9272,6 +9306,7 @@ impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, u32, &'c Ch
 				monitor_pending_finalized_fulfills: monitor_pending_finalized_fulfills.unwrap(),
 				monitor_pending_update_adds: monitor_pending_update_adds.unwrap_or(Vec::new()),
 
+				signer_pending_revoke_and_ack: false,
 				signer_pending_commitment_update: false,
 				signer_pending_funding: false,
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -992,6 +992,34 @@ impl HolderCommitmentPoint {
 		}
 	}
 
+	/// If we are pending the next commitment point, this method tries asking the signer again,
+	/// and transitions to the next state if successful.
+	///
+	/// This method is used for the following transitions:
+	/// - `PendingNext` -> `Available`
+	pub fn try_resolve_pending<SP: Deref, L: Deref>(&mut self, signer: &ChannelSignerType<SP>, secp_ctx: &Secp256k1<secp256k1::All>, logger: &L)
+		where SP::Target: SignerProvider, L::Target: Logger
+	{
+		if let HolderCommitmentPoint::PendingNext { transaction_number, current } = self {
+			let next = signer.as_ref().get_per_commitment_point(*transaction_number - 1, secp_ctx);
+			log_trace!(logger, "Retrieved next per-commitment point {}", *transaction_number - 1);
+			*self = HolderCommitmentPoint::Available { transaction_number: *transaction_number, current: *current, next };
+		}
+	}
+
+	/// If we are not pending the next commitment point, this method advances the commitment number
+	/// and requests the next commitment point from the signer.
+	///
+	/// If our signer is not ready to provide the next commitment point, we will remain in the
+	/// only advance to `PendingNext`, and should be tried again later in `signer_unblocked`
+	/// via `try_resolve_pending`.
+	///
+	/// If our signer is ready to provide the next commitment point, we will advance all the
+	/// way to `Available`.
+	///
+	/// This method is used for the following transitions:
+	/// - `Available` -> `PendingNext`
+	/// - `Available` -> `PendingNext` -> `Available` (in one fell swoop)
 	pub fn advance<SP: Deref, L: Deref>(&mut self, signer: &ChannelSignerType<SP>, secp_ctx: &Secp256k1<secp256k1::All>, logger: &L)
 		where SP::Target: SignerProvider, L::Target: Logger
 	{
@@ -1000,12 +1028,7 @@ impl HolderCommitmentPoint {
 				transaction_number: *transaction_number - 1,
 				current: *next,
 			};
-		}
-
-		if let HolderCommitmentPoint::PendingNext { transaction_number, current } = self {
-			let next = signer.as_ref().get_per_commitment_point(*transaction_number - 1, secp_ctx);
-			log_trace!(logger, "Retrieved next per-commitment point {}", *transaction_number - 1);
-			*self = HolderCommitmentPoint::Available { transaction_number: *transaction_number, current: *current, next };
+			self.try_resolve_pending(signer, secp_ctx, logger);
 		}
 	}
 }

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -5489,25 +5489,34 @@ impl<SP: Deref> Channel<SP> where
 
 	fn get_last_revoke_and_ack<L: Deref>(&mut self, logger: &L) -> Option<msgs::RevokeAndACK> where L::Target: Logger {
 		debug_assert!(self.context.holder_commitment_point.transaction_number() <= INITIAL_COMMITMENT_NUMBER - 2);
-		let per_commitment_secret = self.context.holder_signer.as_ref().release_commitment_secret(self.context.holder_commitment_point.transaction_number() + 2);
-		if let HolderCommitmentPoint::Available { transaction_number: _, current, next: _ } = self.context.holder_commitment_point {
-			Some(msgs::RevokeAndACK {
+		let per_commitment_secret = self.context.holder_signer.as_ref()
+			.release_commitment_secret(self.context.holder_commitment_point.transaction_number() + 2).ok();
+		if let (HolderCommitmentPoint::Available { current, .. }, Some(per_commitment_secret)) =
+			(self.context.holder_commitment_point, per_commitment_secret) {
+			return Some(msgs::RevokeAndACK {
 				channel_id: self.context.channel_id,
 				per_commitment_secret,
 				next_per_commitment_point: current,
 				#[cfg(taproot)]
 				next_local_nonce: None,
 			})
-		} else {
-			#[cfg(not(async_signing))] {
-				panic!("Holder commitment point must be Available when generating revoke_and_ack");
-			}
-			#[cfg(async_signing)] {
-				log_trace!(logger, "Last revoke-and-ack pending in channel {} for sequence {} because the next per-commitment point is not available",
-					&self.context.channel_id(), self.context.holder_commitment_point.transaction_number());
-				self.context.signer_pending_revoke_and_ack = true;
-				None
-			}
+		}
+
+		if !self.context.holder_commitment_point.is_available() {
+			log_trace!(logger, "Last revoke-and-ack pending in channel {} for sequence {} because the next per-commitment point is not available",
+				&self.context.channel_id(), self.context.holder_commitment_point.transaction_number());
+		}
+		if per_commitment_secret.is_none() {
+			log_trace!(logger, "Last revoke-and-ack pending in channel {} for sequence {} because the next per-commitment secret for {} is not available",
+				&self.context.channel_id(), self.context.holder_commitment_point.transaction_number(),
+				self.context.holder_commitment_point.transaction_number() + 2);
+		}
+		#[cfg(not(async_signing))] {
+			panic!("Holder commitment point and per commitment secret must be available when generating revoke_and_ack");
+		}
+		#[cfg(async_signing)] {
+			self.context.signer_pending_revoke_and_ack = true;
+			None
 		}
 	}
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -5310,12 +5310,18 @@ impl<SP: Deref> Channel<SP> where
 			};
 		}
 
-		let raa = if self.context.monitor_pending_revoke_and_ack {
+		let mut raa = if self.context.monitor_pending_revoke_and_ack {
 			Some(self.get_last_revoke_and_ack())
 		} else { None };
 		let commitment_update = if self.context.monitor_pending_commitment_signed {
 			self.get_last_commitment_update_for_send(logger).ok()
 		} else { None };
+		if self.context.resend_order == RAACommitmentOrder::CommitmentFirst
+			&& self.context.signer_pending_commitment_update && raa.is_some() {
+			self.context.signer_pending_revoke_and_ack = true;
+			raa = None;
+		}
+
 		if commitment_update.is_some() {
 			self.mark_awaiting_response();
 		}
@@ -5700,10 +5706,18 @@ impl<SP: Deref> Channel<SP> where
 					order: self.context.resend_order.clone(),
 				})
 			} else {
+				let commitment_update = self.get_last_commitment_update_for_send(logger).ok();
+				let raa = if self.context.resend_order == RAACommitmentOrder::CommitmentFirst
+					&& self.context.signer_pending_commitment_update && required_revoke.is_some() {
+					log_trace!(logger, "Reconnected channel {} with lost outbound RAA and lost remote commitment tx, but unable to send due to resend order, waiting on signer for commitment update", &self.context.channel_id());
+					self.context.signer_pending_revoke_and_ack = true;
+					None
+				} else {
+					required_revoke
+				};
 				Ok(ReestablishResponses {
 					channel_ready, shutdown_msg, announcement_sigs,
-					raa: required_revoke,
-					commitment_update: self.get_last_commitment_update_for_send(logger).ok(),
+					raa, commitment_update,
 					order: self.context.resend_order.clone(),
 				})
 			}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1008,7 +1008,9 @@ impl HolderCommitmentPoint {
 	}
 
 	/// If we are not pending the next commitment point, this method advances the commitment number
-	/// and requests the next commitment point from the signer.
+	/// and requests the next commitment point from the signer. Returns `Ok` if we were at
+	/// `Available` and were able to advance our commitment number (even if we are still pending
+	/// the next commitment point).
 	///
 	/// If our signer is not ready to provide the next commitment point, we will remain in the
 	/// only advance to `PendingNext`, and should be tried again later in `signer_unblocked`
@@ -1020,7 +1022,9 @@ impl HolderCommitmentPoint {
 	/// This method is used for the following transitions:
 	/// - `Available` -> `PendingNext`
 	/// - `Available` -> `PendingNext` -> `Available` (in one fell swoop)
-	pub fn advance<SP: Deref, L: Deref>(&mut self, signer: &ChannelSignerType<SP>, secp_ctx: &Secp256k1<secp256k1::All>, logger: &L)
+	pub fn advance<SP: Deref, L: Deref>(
+		&mut self, signer: &ChannelSignerType<SP>, secp_ctx: &Secp256k1<secp256k1::All>, logger: &L
+	) -> Result<(), ()>
 		where SP::Target: SignerProvider, L::Target: Logger
 	{
 		if let HolderCommitmentPoint::Available { transaction_number, next, .. } = self {
@@ -1029,7 +1033,9 @@ impl HolderCommitmentPoint {
 				current: *next,
 			};
 			self.try_resolve_pending(signer, secp_ctx, logger);
+			return Ok(());
 		}
+		Err(())
 	}
 }
 
@@ -4615,7 +4621,8 @@ impl<SP: Deref> Channel<SP> where
 			channel_id: Some(self.context.channel_id()),
 		};
 
-		self.context.holder_commitment_point.advance(&self.context.holder_signer, &self.context.secp_ctx, logger);
+		self.context.holder_commitment_point.advance(&self.context.holder_signer, &self.context.secp_ctx, logger)
+			.map_err(|_| ChannelError::close("Failed to advance our commitment point".to_owned()))?;
 		self.context.expecting_peer_commitment_signed = false;
 		// Note that if we need_commitment & !AwaitingRemoteRevoke we'll call
 		// build_commitment_no_status_check() next which will reset this to RAAFirst.
@@ -7789,7 +7796,9 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 		} else {
 			self.context.channel_state = ChannelState::AwaitingChannelReady(AwaitingChannelReadyFlags::new());
 		}
-		self.context.holder_commitment_point.advance(&self.context.holder_signer, &self.context.secp_ctx, logger);
+		if self.context.holder_commitment_point.advance(&self.context.holder_signer, &self.context.secp_ctx, logger).is_err() {
+			return Err((self, ChannelError::close("Failed to advance holder commitment point".to_owned())));
+		}
 		self.context.cur_counterparty_commitment_transaction_number -= 1;
 
 		log_info!(logger, "Received funding_signed from peer for channel {}", &self.context.channel_id());
@@ -8057,7 +8066,9 @@ impl<SP: Deref> InboundV1Channel<SP> where SP::Target: SignerProvider {
 		self.context.channel_state = ChannelState::AwaitingChannelReady(AwaitingChannelReadyFlags::new());
 		self.context.channel_id = ChannelId::v1_from_funding_outpoint(funding_txo);
 		self.context.cur_counterparty_commitment_transaction_number -= 1;
-		self.context.holder_commitment_point.advance(&self.context.holder_signer, &self.context.secp_ctx, logger);
+		if self.context.holder_commitment_point.advance(&self.context.holder_signer, &self.context.secp_ctx, logger).is_err() {
+			return Err((self, ChannelError::close("Failed to advance holder commitment point".to_owned())));
+		}
 
 		let (counterparty_initial_commitment_tx, funding_signed) = self.context.get_funding_signed_msg(logger);
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -5350,15 +5350,20 @@ impl<SP: Deref> Channel<SP> where
 		}
 
 		let mut raa = if self.context.monitor_pending_revoke_and_ack {
-			Some(self.get_last_revoke_and_ack())
+			self.get_last_revoke_and_ack(logger)
 		} else { None };
-		let commitment_update = if self.context.monitor_pending_commitment_signed {
+		let mut commitment_update = if self.context.monitor_pending_commitment_signed {
 			self.get_last_commitment_update_for_send(logger).ok()
 		} else { None };
 		if self.context.resend_order == RAACommitmentOrder::CommitmentFirst
 			&& self.context.signer_pending_commitment_update && raa.is_some() {
 			self.context.signer_pending_revoke_and_ack = true;
 			raa = None;
+		}
+		if self.context.resend_order == RAACommitmentOrder::RevokeAndACKFirst
+			&& self.context.signer_pending_revoke_and_ack {
+			self.context.signer_pending_commitment_update = true;
+			commitment_update = None;
 		}
 
 		if commitment_update.is_some() {
@@ -5430,6 +5435,10 @@ impl<SP: Deref> Channel<SP> where
 	/// blocked.
 	#[cfg(async_signing)]
 	pub fn signer_maybe_unblocked<L: Deref>(&mut self, logger: &L) -> SignerResumeUpdates where L::Target: Logger {
+		if !self.context.holder_commitment_point.is_available() {
+			log_trace!(logger, "Attempting to update holder per-commitment point...");
+			self.context.holder_commitment_point.try_resolve_pending(&self.context.holder_signer, &self.context.secp_ctx, logger);
+		}
 		let funding_signed = if self.context.signer_pending_funding && !self.context.is_outbound() {
 			log_trace!(logger, "Attempting to generate pending funding signed...");
 			self.context.signer_pending_funding = false;
@@ -5447,7 +5456,7 @@ impl<SP: Deref> Channel<SP> where
 		let mut revoke_and_ack = if self.context.signer_pending_revoke_and_ack {
 			log_trace!(logger, "Attempting to generate pending revoke and ack...");
 			self.context.signer_pending_revoke_and_ack = false;
-			Some(self.get_last_revoke_and_ack())
+			self.get_last_revoke_and_ack(logger)
 		} else { None };
 
 		if self.context.resend_order == RAACommitmentOrder::CommitmentFirst
@@ -5478,18 +5487,27 @@ impl<SP: Deref> Channel<SP> where
 		}
 	}
 
-	fn get_last_revoke_and_ack(&self) -> msgs::RevokeAndACK {
-		debug_assert!(self.context.holder_commitment_point.transaction_number() <= INITIAL_COMMITMENT_NUMBER + 2);
-		// TODO: handle non-available case when get_per_commitment_point becomes async
-		debug_assert!(self.context.holder_commitment_point.is_available());
-		let next_per_commitment_point = self.context.holder_commitment_point.current_point();
+	fn get_last_revoke_and_ack<L: Deref>(&mut self, logger: &L) -> Option<msgs::RevokeAndACK> where L::Target: Logger {
+		debug_assert!(self.context.holder_commitment_point.transaction_number() <= INITIAL_COMMITMENT_NUMBER - 2);
 		let per_commitment_secret = self.context.holder_signer.as_ref().release_commitment_secret(self.context.holder_commitment_point.transaction_number() + 2);
-		msgs::RevokeAndACK {
-			channel_id: self.context.channel_id,
-			per_commitment_secret,
-			next_per_commitment_point,
-			#[cfg(taproot)]
-			next_local_nonce: None,
+		if let HolderCommitmentPoint::Available { transaction_number: _, current, next: _ } = self.context.holder_commitment_point {
+			Some(msgs::RevokeAndACK {
+				channel_id: self.context.channel_id,
+				per_commitment_secret,
+				next_per_commitment_point: current,
+				#[cfg(taproot)]
+				next_local_nonce: None,
+			})
+		} else {
+			#[cfg(not(async_signing))] {
+				panic!("Holder commitment point must be Available when generating revoke_and_ack");
+			}
+			#[cfg(async_signing)] {
+				log_trace!(logger, "Last revoke-and-ack pending in channel {} for sequence {} because the next per-commitment point is not available",
+					&self.context.channel_id(), self.context.holder_commitment_point.transaction_number());
+				self.context.signer_pending_revoke_and_ack = true;
+				None
+			}
 		}
 	}
 
@@ -5691,7 +5709,7 @@ impl<SP: Deref> Channel<SP> where
 				self.context.monitor_pending_revoke_and_ack = true;
 				None
 			} else {
-				Some(self.get_last_revoke_and_ack())
+				self.get_last_revoke_and_ack(logger)
 			}
 		} else {
 			debug_assert!(false, "All values should have been handled in the four cases above");
@@ -5718,7 +5736,7 @@ impl<SP: Deref> Channel<SP> where
 		} else { None };
 
 		if msg.next_local_commitment_number == next_counterparty_commitment_number {
-			if required_revoke.is_some() {
+			if required_revoke.is_some() || self.context.signer_pending_revoke_and_ack {
 				log_debug!(logger, "Reconnected channel {} with only lost outbound RAA", &self.context.channel_id());
 			} else {
 				log_debug!(logger, "Reconnected channel {} with no loss", &self.context.channel_id());
@@ -5731,7 +5749,7 @@ impl<SP: Deref> Channel<SP> where
 				order: self.context.resend_order.clone(),
 			})
 		} else if msg.next_local_commitment_number == next_counterparty_commitment_number - 1 {
-			if required_revoke.is_some() {
+			if required_revoke.is_some() || self.context.signer_pending_revoke_and_ack {
 				log_debug!(logger, "Reconnected channel {} with lost outbound RAA and lost remote commitment tx", &self.context.channel_id());
 			} else {
 				log_debug!(logger, "Reconnected channel {} with only lost remote commitment tx", &self.context.channel_id());
@@ -5745,7 +5763,14 @@ impl<SP: Deref> Channel<SP> where
 					order: self.context.resend_order.clone(),
 				})
 			} else {
-				let commitment_update = self.get_last_commitment_update_for_send(logger).ok();
+				let commitment_update = if self.context.resend_order == RAACommitmentOrder::RevokeAndACKFirst
+					&& self.context.signer_pending_revoke_and_ack {
+					log_trace!(logger, "Reconnected channel {} with lost outbound RAA and lost remote commitment tx, but unable to send due to resend order, waiting on signer for revoke and ack", &self.context.channel_id());
+					self.context.signer_pending_commitment_update = true;
+					None
+				} else {
+					self.get_last_commitment_update_for_send(logger).ok()
+				};
 				let raa = if self.context.resend_order == RAACommitmentOrder::CommitmentFirst
 					&& self.context.signer_pending_commitment_update && required_revoke.is_some() {
 					log_trace!(logger, "Reconnected channel {} with lost outbound RAA and lost remote commitment tx, but unable to send due to resend order, waiting on signer for commitment update", &self.context.channel_id());

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2990,7 +2990,7 @@ where
 			let config = if override_config.is_some() { override_config.as_ref().unwrap() } else { &self.default_configuration };
 			match OutboundV1Channel::new(&self.fee_estimator, &self.entropy_source, &self.signer_provider, their_network_key,
 				their_features, channel_value_satoshis, push_msat, user_channel_id, config,
-				self.best_block.read().unwrap().height, outbound_scid_alias, temporary_channel_id)
+				self.best_block.read().unwrap().height, outbound_scid_alias, temporary_channel_id, &self.logger)
 			{
 				Ok(res) => res,
 				Err(e) => {

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -741,7 +741,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
 		 pubkeys.funding_pubkey)
 	};
-	let (remote_delayed_payment_basepoint, remote_htlc_basepoint,remote_point, remote_funding) = {
+	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
 		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
 		let remote_chan = chan_lock.channel_by_id.get(&chan.2).map(
@@ -750,7 +750,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
-		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx),
+		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx).unwrap(),
 		 pubkeys.funding_pubkey)
 	};
 
@@ -1475,7 +1475,7 @@ fn test_fee_spike_violation_fails_htlc() {
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
 		 chan_signer.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER),
-		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 2, &secp_ctx),
+		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 2, &secp_ctx).unwrap(),
 		 chan_signer.as_ref().pubkeys().funding_pubkey)
 	};
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
@@ -1487,7 +1487,7 @@ fn test_fee_spike_violation_fails_htlc() {
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
-		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx),
+		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx).unwrap(),
 		 chan_signer.as_ref().pubkeys().funding_pubkey)
 	};
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -1474,7 +1474,7 @@ fn test_fee_spike_violation_fails_htlc() {
 
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
-		 chan_signer.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER),
+		 chan_signer.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER).unwrap(),
 		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 2, &secp_ctx).unwrap(),
 		 chan_signer.as_ref().pubkeys().funding_pubkey)
 	};
@@ -7860,15 +7860,15 @@ fn test_counterparty_raa_skip_no_crash() {
 
 		// Make signer believe we got a counterparty signature, so that it allows the revocation
 		keys.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
-		per_commitment_secret = keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER);
+		per_commitment_secret = keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER).unwrap();
 
 		// Must revoke without gaps
 		keys.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
-		keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 1);
+		keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 1).unwrap();
 
 		keys.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
 		next_per_commitment_point = PublicKey::from_secret_key(&Secp256k1::new(),
-			&SecretKey::from_slice(&keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 2)).unwrap());
+			&SecretKey::from_slice(&keys.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 2).unwrap()).unwrap());
 	}
 
 	nodes[1].node.handle_revoke_and_ack(&nodes[0].node.get_our_node_id(),

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -31,7 +31,7 @@ use crate::ln::features::{ChannelFeatures, ChannelTypeFeatures, NodeFeatures};
 use crate::ln::msgs;
 use crate::ln::msgs::{ChannelMessageHandler, RoutingMessageHandler, ErrorAction};
 use crate::util::test_channel_signer::TestChannelSigner;
-use crate::util::test_utils::{self, WatchtowerPersister};
+use crate::util::test_utils::{self, TestLogger, WatchtowerPersister};
 use crate::util::errors::APIError;
 use crate::util::ser::{Writeable, ReadableArgs};
 use crate::util::string::UntrustedString;
@@ -7244,11 +7244,12 @@ fn test_user_configurable_csv_delay() {
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &user_cfgs);
 	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let logger = TestLogger::new();
 
 	// We test config.our_to_self > BREAKDOWN_TIMEOUT is enforced in OutboundV1Channel::new()
 	if let Err(error) = OutboundV1Channel::new(&LowerBoundedFeeEstimator::new(&test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) }),
 		&nodes[0].keys_manager, &nodes[0].keys_manager, nodes[1].node.get_our_node_id(), &nodes[1].node.init_features(), 1000000, 1000000, 0,
-		&low_our_to_self_config, 0, 42, None)
+		&low_our_to_self_config, 0, 42, None, &&logger)
 	{
 		match error {
 			APIError::APIMisuseError { err } => { assert!(regex::Regex::new(r"Configured with an unreasonable our_to_self_delay \(\d+\) putting user funds at risks").unwrap().is_match(err.as_str())); },

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -745,7 +745,7 @@ pub trait ChannelSigner {
 	///
 	/// Note that the commitment number starts at `(1 << 48) - 1` and counts backwards.
 	// TODO: return a Result so we can signal a validation error
-	fn release_commitment_secret(&self, idx: u64) -> [u8; 32];
+	fn release_commitment_secret(&self, idx: u64) -> Result<[u8; 32], ()>;
 
 	/// Validate the counterparty's signatures on the holder commitment transaction and HTLCs.
 	///
@@ -1354,8 +1354,8 @@ impl ChannelSigner for InMemorySigner {
 		Ok(PublicKey::from_secret_key(secp_ctx, &commitment_secret))
 	}
 
-	fn release_commitment_secret(&self, idx: u64) -> [u8; 32] {
-		chan_utils::build_commitment_secret(&self.commitment_seed, idx)
+	fn release_commitment_secret(&self, idx: u64) -> Result<[u8; 32], ()> {
+		Ok(chan_utils::build_commitment_secret(&self.commitment_seed, idx))
 	}
 
 	fn validate_holder_commitment(

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -729,8 +729,12 @@ pub trait ChannelSigner {
 	/// Gets the per-commitment point for a specific commitment number
 	///
 	/// Note that the commitment number starts at `(1 << 48) - 1` and counts backwards.
-	fn get_per_commitment_point(&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>)
-		-> PublicKey;
+	///
+	/// If the signer returns `Err`, then the user is responsible for either force-closing the channel
+	/// or retrying once the signature is ready.
+	fn get_per_commitment_point(
+		&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>,
+	) -> Result<PublicKey, ()>;
 
 	/// Gets the commitment secret for a specific commitment number as part of the revocation process
 	///
@@ -1343,11 +1347,11 @@ impl EntropySource for InMemorySigner {
 impl ChannelSigner for InMemorySigner {
 	fn get_per_commitment_point(
 		&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>,
-	) -> PublicKey {
+	) -> Result<PublicKey, ()> {
 		let commitment_secret =
 			SecretKey::from_slice(&chan_utils::build_commitment_secret(&self.commitment_seed, idx))
 				.unwrap();
-		PublicKey::from_secret_key(secp_ctx, &commitment_secret)
+		Ok(PublicKey::from_secret_key(secp_ctx, &commitment_secret))
 	}
 
 	fn release_commitment_secret(&self, idx: u64) -> [u8; 32] {

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -166,7 +166,9 @@ impl TestChannelSigner {
 }
 
 impl ChannelSigner for TestChannelSigner {
-	fn get_per_commitment_point(&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>) -> PublicKey {
+	fn get_per_commitment_point(&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<PublicKey, ()> {
+		// TODO: implement a mask in EnforcementState to let you test signatures being
+		// unavailable
 		self.inner.get_per_commitment_point(idx, secp_ctx)
 	}
 

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -167,8 +167,9 @@ impl TestChannelSigner {
 
 impl ChannelSigner for TestChannelSigner {
 	fn get_per_commitment_point(&self, idx: u64, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<PublicKey, ()> {
-		// TODO: implement a mask in EnforcementState to let you test signatures being
-		// unavailable
+		if !self.is_signer_available(SignerOp::GetPerCommitmentPoint) {
+			return Err(());
+		}
 		self.inner.get_per_commitment_point(idx, secp_ctx)
 	}
 

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -174,6 +174,9 @@ impl ChannelSigner for TestChannelSigner {
 	}
 
 	fn release_commitment_secret(&self, idx: u64) -> Result<[u8; 32], ()> {
+		if !self.is_signer_available(SignerOp::ReleaseCommitmentSecret) {
+			return Err(());
+		}
 		{
 			let mut state = self.state.lock().unwrap();
 			assert!(idx == state.last_holder_revoked_commitment || idx == state.last_holder_revoked_commitment - 1, "can only revoke the current or next unrevoked commitment - trying {}, last revoked {}", idx, state.last_holder_revoked_commitment);

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -173,7 +173,7 @@ impl ChannelSigner for TestChannelSigner {
 		self.inner.get_per_commitment_point(idx, secp_ctx)
 	}
 
-	fn release_commitment_secret(&self, idx: u64) -> [u8; 32] {
+	fn release_commitment_secret(&self, idx: u64) -> Result<[u8; 32], ()> {
 		{
 			let mut state = self.state.lock().unwrap();
 			assert!(idx == state.last_holder_revoked_commitment || idx == state.last_holder_revoked_commitment - 1, "can only revoke the current or next unrevoked commitment - trying {}, last revoked {}", idx, state.last_holder_revoked_commitment);


### PR DESCRIPTION
Builds on #3149, #3150. Most of the logic for this was added in the prerequisite PRs. Here we just set the `signer_pending_revoke_and_ack` flag if we fail to get the commitment secret.