### PR TITLE
Allow sending closing tx signatures asynchronously

### DIFF
--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -18,6 +18,7 @@ use crate::chain::channelmonitor::LATENCY_GRACE_PERIOD_BLOCKS;
 use crate::events::bump_transaction::WalletSource;
 use crate::events::{Event, MessageSendEvent, MessageSendEventsProvider, ClosureReason};
 use crate::ln::functional_test_utils::*;
+use crate::ln::channel_state::{ChannelDetails, ChannelShutdownState};
 use crate::ln::msgs::ChannelMessageHandler;
 use crate::ln::channelmanager::{PaymentId, RecipientOnionFields};
 use crate::util::test_channel_signer::SignerOp;
@@ -471,4 +472,63 @@ fn test_async_holder_signatures_anchors() {
 #[test]
 fn test_async_holder_signatures_remote_commitment_anchors() {
 	do_test_async_holder_signatures(true, true);
+}
+
+#[test]
+fn test_closing_signed() {
+	// Based off of `expect_channel_shutdown_state`.
+	// Test that we can asynchronously sign closing transactions.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+	expect_channel_shutdown_state!(nodes[0], chan_1.2, ChannelShutdownState::NotShuttingDown);
+
+	nodes[0].node.close_channel(&chan_1.2, &nodes[1].node.get_our_node_id()).unwrap();
+
+	expect_channel_shutdown_state!(nodes[0], chan_1.2, ChannelShutdownState::ShutdownInitiated);
+	expect_channel_shutdown_state!(nodes[1], chan_1.2, ChannelShutdownState::NotShuttingDown);
+
+	let node_0_shutdown = get_event_msg!(nodes[0], MessageSendEvent::SendShutdown, nodes[1].node.get_our_node_id());
+	nodes[1].node.handle_shutdown(&nodes[0].node.get_our_node_id(), &node_0_shutdown);
+
+	expect_channel_shutdown_state!(nodes[0], chan_1.2, ChannelShutdownState::ShutdownInitiated);
+	expect_channel_shutdown_state!(nodes[1], chan_1.2, ChannelShutdownState::NegotiatingClosingFee);
+
+	let node_1_shutdown = get_event_msg!(nodes[1], MessageSendEvent::SendShutdown, nodes[0].node.get_our_node_id());
+	nodes[0].disable_channel_signer_op(&nodes[1].node.get_our_node_id(), &chan_1.2, SignerOp::SignClosingTransaction);
+	nodes[0].node.handle_shutdown(&nodes[1].node.get_our_node_id(), &node_1_shutdown);
+
+	expect_channel_shutdown_state!(nodes[0], chan_1.2, ChannelShutdownState::NegotiatingClosingFee);
+	expect_channel_shutdown_state!(nodes[1], chan_1.2, ChannelShutdownState::NegotiatingClosingFee);
+
+	let events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert!(events.is_empty(), "Expected no events, got {:?}", events);
+	nodes[0].enable_channel_signer_op(&nodes[1].node.get_our_node_id(), &chan_1.2, SignerOp::SignClosingTransaction);
+	nodes[0].node.signer_unblocked(None);
+
+	let node_0_closing_signed = get_event_msg!(nodes[0], MessageSendEvent::SendClosingSigned, nodes[1].node.get_our_node_id());
+	nodes[1].disable_channel_signer_op(&nodes[0].node.get_our_node_id(), &chan_1.2, SignerOp::SignClosingTransaction);
+	nodes[1].node.handle_closing_signed(&nodes[0].node.get_our_node_id(), &node_0_closing_signed);
+
+	let events = nodes[1].node.get_and_clear_pending_msg_events();
+	assert!(events.is_empty(), "Expected no events, got {:?}", events);
+	nodes[1].enable_channel_signer_op(&nodes[0].node.get_our_node_id(), &chan_1.2, SignerOp::SignClosingTransaction);
+	nodes[1].node.signer_unblocked(None);
+
+	let node_1_closing_signed = get_event_msg!(nodes[1], MessageSendEvent::SendClosingSigned, nodes[0].node.get_our_node_id());
+	// From here we don't make any new signatures, so there's no need to test blocking the
+	// signer.
+	nodes[0].node.handle_closing_signed(&nodes[1].node.get_our_node_id(), &node_1_closing_signed);
+	let (_, node_0_2nd_closing_signed) = get_closing_signed_broadcast!(nodes[0].node, nodes[1].node.get_our_node_id());
+	nodes[1].node.handle_closing_signed(&nodes[0].node.get_our_node_id(), &node_0_2nd_closing_signed.unwrap());
+	let (_, node_1_none) = get_closing_signed_broadcast!(nodes[1].node, nodes[0].node.get_our_node_id());
+	assert!(node_1_none.is_none());
+
+	assert!(nodes[0].node.list_channels().is_empty());
+	assert!(nodes[1].node.list_channels().is_empty());
+	check_closed_event!(nodes[0], 1, ClosureReason::LocallyInitiatedCooperativeClosure, [nodes[1].node.get_our_node_id()], 100000);
+	check_closed_event!(nodes[1], 1, ClosureReason::CounterpartyInitiatedCooperativeClosure, [nodes[0].node.get_our_node_id()], 100000);
 }

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -909,6 +909,8 @@ pub(super) struct SignerResumeUpdates {
 	pub commitment_update: Option<msgs::CommitmentUpdate>,
 	pub funding_signed: Option<msgs::FundingSigned>,
 	pub channel_ready: Option<msgs::ChannelReady>,
+	pub closing_signed: Option<msgs::ClosingSigned>,
+	pub signed_closing_tx: Option<Transaction>,
 }
 
 /// The return value of `channel_reestablish`
@@ -1227,6 +1229,9 @@ pub(super) struct ChannelContext<SP: Deref> where SP::Target: SignerProvider {
 	/// [`msgs::FundingCreated`] or [`msgs::FundingSigned`] depending on if this channel is
 	/// outbound or inbound.
 	signer_pending_funding: bool,
+	/// If we attempted to sign a cooperative close transaction but the signer wasn't ready, then this
+	/// will be set to `true`.
+	signer_pending_closing: bool,
 
 	// pending_update_fee is filled when sending and receiving update_fee.
 	//
@@ -1258,7 +1263,9 @@ pub(super) struct ChannelContext<SP: Deref> where SP::Target: SignerProvider {
 	/// Max to_local and to_remote outputs in a remote-generated commitment transaction
 	counterparty_max_commitment_tx_output: Mutex<(u64, u64)>,
 
-	last_sent_closing_fee: Option<(u64, Signature)>, // (fee, holder_sig)
+	// (fee, skip_remote_output, fee_range, holder_sig)
+	last_sent_closing_fee: Option<(u64, bool, ClosingSignedFeeRange, Option<Signature>)>,
+	last_received_closing_sig: Option<Signature>,
 	target_closing_feerate_sats_per_kw: Option<u32>,
 
 	/// If our counterparty sent us a closing_signed while we were waiting for a `ChannelMonitor`
@@ -1686,6 +1693,7 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 
 			signer_pending_commitment_update: false,
 			signer_pending_funding: false,
+			signer_pending_closing: false,
 
 
 			#[cfg(debug_assertions)]
@@ -1694,6 +1702,7 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 			counterparty_max_commitment_tx_output: Mutex::new((value_to_self_msat, (channel_value_satoshis * 1000 - msg_push_msat).saturating_sub(value_to_self_msat))),
 
 			last_sent_closing_fee: None,
+			last_received_closing_sig: None,
 			pending_counterparty_closing_signed: None,
 			expecting_peer_commitment_signed: false,
 			closing_fee_limits: None,
@@ -1911,6 +1920,7 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 
 			signer_pending_commitment_update: false,
 			signer_pending_funding: false,
+			signer_pending_closing: false,
 
 			// We'll add our counterparty's `funding_satoshis` to these max commitment output assertions
 			// when we receive `accept_channel2`.
@@ -1920,6 +1930,7 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider  {
 			counterparty_max_commitment_tx_output: Mutex::new((channel_value_satoshis * 1000 - push_msat, push_msat)),
 
 			last_sent_closing_fee: None,
+			last_received_closing_sig: None,
 			pending_counterparty_closing_signed: None,
 			expecting_peer_commitment_signed: false,
 			closing_fee_limits: None,
@@ -5387,15 +5398,37 @@ impl<SP: Deref> Channel<SP> where
 			self.check_get_channel_ready(0, logger)
 		} else { None };
 
-		log_trace!(logger, "Signer unblocked with {} commitment_update, {} funding_signed and {} channel_ready",
+		let (closing_signed, signed_closing_tx) = if self.context.signer_pending_closing {
+			debug_assert!(self.context.last_sent_closing_fee.is_some());
+			if let Some((fee, skip_remote_output, fee_range, holder_sig)) = self.context.last_sent_closing_fee.clone() {
+				debug_assert!(holder_sig.is_none());
+				log_trace!(logger, "Attempting to generate pending closing_signed...");
+				self.context.signer_pending_closing = false;
+
+				let (closing_tx, fee) = self.build_closing_transaction(fee, skip_remote_output);
+				let closing_signed = self.get_closing_signed_msg(&closing_tx, skip_remote_output,
+					fee, fee_range.min_fee_satoshis, fee_range.max_fee_satoshis, logger);
+				let signed_tx = if let (Some(ClosingSigned { signature, .. }), Some(counterparty_sig)) =
+					(closing_signed.as_ref(), self.context.last_received_closing_sig) {
+					Some(self.build_signed_closing_transaction(&closing_tx, &counterparty_sig, signature))
+				} else { None };
+				(closing_signed, signed_tx)
+			} else { (None, None) }
+		} else { (None, None) };
+
+		log_trace!(logger, "Signer unblocked with {} commitment_update, {} funding_signed, {} channel_ready, {} closing_signed, and {} signed_closing_tx",
 			if commitment_update.is_some() { "a" } else { "no" },
 			if funding_signed.is_some() { "a" } else { "no" },
-			if channel_ready.is_some() { "a" } else { "no" });
+			if channel_ready.is_some() { "a" } else { "no" },
+			if closing_signed.is_some() { "a" } else { "no" },
+			if signed_closing_tx.is_some() { "a" } else { "no" });
 
 		SignerResumeUpdates {
 			commitment_update,
 			funding_signed,
 			channel_ready,
+			closing_signed,
+			signed_closing_tx,
 		}
 	}
 
@@ -5801,9 +5834,6 @@ impl<SP: Deref> Channel<SP> where
 			our_min_fee, our_max_fee, total_fee_satoshis);
 
 		let closing_signed = self.get_closing_signed_msg(&closing_tx, false, total_fee_satoshis, our_min_fee, our_max_fee, logger);
-		if closing_signed.is_none() {
-			return Err(ChannelError::close("Failed to get signature for closing transaction.".to_owned()));
-		}
 		Ok((closing_signed, None, None))
 	}
 
@@ -5963,13 +5993,17 @@ impl<SP: Deref> Channel<SP> where
 					min_fee_satoshis,
 					max_fee_satoshis,
 				};
-				let sig = ecdsa.sign_closing_transaction(closing_tx, &self.context.secp_ctx).ok()?;
+				let sig = ecdsa.sign_closing_transaction(closing_tx, &self.context.secp_ctx).ok();
+				if sig.is_none() {
+					log_trace!(logger, "Closing transaction signature unavailable, waiting on signer");
+					self.context.signer_pending_closing = true;
+				}
 
-				self.context.last_sent_closing_fee = Some((fee_satoshis, sig.clone()));
-				Some(msgs::ClosingSigned {
+				self.context.last_sent_closing_fee = Some((fee_satoshis, skip_remote_output, fee_range.clone(), sig.clone()));
+				sig.map(|signature| msgs::ClosingSigned {
 					channel_id: self.context.channel_id,
 					fee_satoshis,
-					signature: sig,
+					signature,
 					fee_range: Some(fee_range),
 				})
 			},
@@ -6039,7 +6073,7 @@ impl<SP: Deref> Channel<SP> where
 		};
 
 		assert!(self.context.shutdown_scriptpubkey.is_some());
-		if let Some((last_fee, sig)) = self.context.last_sent_closing_fee {
+		if let Some((last_fee, _, _, Some(sig))) = self.context.last_sent_closing_fee {
 			if last_fee == msg.fee_satoshis {
 				let shutdown_result = ShutdownResult {
 					closure_reason,
@@ -6072,9 +6106,6 @@ impl<SP: Deref> Channel<SP> where
 				};
 
 				let closing_signed = self.get_closing_signed_msg(&closing_tx, skip_remote_output, used_fee, our_min_fee, our_max_fee, logger);
-				if closing_signed.is_none() {
-					return Err(ChannelError::close("Failed to get signature for closing transaction.".to_owned()));
-				}
 				let (signed_tx, shutdown_result) = if $new_fee == msg.fee_satoshis {
 					let shutdown_result = ShutdownResult {
 						closure_reason,
@@ -6090,6 +6121,7 @@ impl<SP: Deref> Channel<SP> where
 					};
 					self.context.channel_state = ChannelState::ShutdownComplete;
 					self.context.update_time_counter += 1;
+					self.context.last_received_closing_sig = Some(msg.signature.clone());
 					let tx = closing_signed.as_ref().map(|ClosingSigned { signature, .. }|
 						self.build_signed_closing_transaction(&closing_tx, &msg.signature, signature));
 					(tx, Some(shutdown_result))
@@ -6127,7 +6159,7 @@ impl<SP: Deref> Channel<SP> where
 		} else {
 			// Old fee style negotiation. We don't bother to enforce whether they are complying
 			// with the "making progress" requirements, we just comply and hope for the best.
-			if let Some((last_fee, _)) = self.context.last_sent_closing_fee {
+			if let Some((last_fee, _, _, _)) = self.context.last_sent_closing_fee {
 				if msg.fee_satoshis > last_fee {
 					if msg.fee_satoshis < our_max_fee {
 						propose_fee!(msg.fee_satoshis);
@@ -9282,6 +9314,7 @@ impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, u32, &'c Ch
 
 				signer_pending_commitment_update: false,
 				signer_pending_funding: false,
+				signer_pending_closing: false,
 
 				pending_update_fee,
 				holding_cell_update_fee,
@@ -9296,6 +9329,7 @@ impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, u32, &'c Ch
 				counterparty_max_commitment_tx_output: Mutex::new((0, 0)),
 
 				last_sent_closing_fee: None,
+				last_received_closing_sig: None,
 				pending_counterparty_closing_signed: None,
 				expecting_peer_commitment_signed: false,
 				closing_fee_limits: None,

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -27,7 +27,7 @@ use bitcoin::secp256k1;
 
 use crate::ln::types::{ChannelId, PaymentPreimage, PaymentHash};
 use crate::ln::features::{ChannelTypeFeatures, InitFeatures};
-use crate::ln::msgs;
+use crate::ln::msgs::{self, ClosingSigned};
 use crate::ln::msgs::DecodeError;
 use crate::ln::script::{self, ShutdownScript};
 use crate::ln::channel_state::{ChannelShutdownState, CounterpartyForwardingInfo, InboundHTLCDetails, InboundHTLCStateDetails, OutboundHTLCDetails, OutboundHTLCStateDetails};
@@ -58,6 +58,7 @@ use crate::sync::Mutex;
 use crate::sign::type_resolver::ChannelSignerType;
 
 use super::channel_keys::{DelayedPaymentBasepoint, HtlcBasepoint, RevocationBasepoint};
+use super::msgs::ClosingSignedFeeRange;
 
 #[cfg(test)]
 pub struct ChannelValueStat {
@@ -5781,7 +5782,7 @@ impl<SP: Deref> Channel<SP> where
 
 		if !self.context.is_outbound() {
 			if let Some(msg) = &self.context.pending_counterparty_closing_signed.take() {
-				return self.closing_signed(fee_estimator, &msg);
+				return self.closing_signed(fee_estimator, &msg, logger);
 			}
 			return Ok((None, None, None));
 		}
@@ -5799,27 +5800,11 @@ impl<SP: Deref> Channel<SP> where
 		log_trace!(logger, "Proposing initial closing_signed for our counterparty with a fee range of {}-{} sat (with initial proposal {} sats)",
 			our_min_fee, our_max_fee, total_fee_satoshis);
 
-		match &self.context.holder_signer {
-			ChannelSignerType::Ecdsa(ecdsa) => {
-				let sig = ecdsa
-					.sign_closing_transaction(&closing_tx, &self.context.secp_ctx)
-					.map_err(|()| ChannelError::close("Failed to get signature for closing transaction.".to_owned()))?;
-
-				self.context.last_sent_closing_fee = Some((total_fee_satoshis, sig.clone()));
-				Ok((Some(msgs::ClosingSigned {
-					channel_id: self.context.channel_id,
-					fee_satoshis: total_fee_satoshis,
-					signature: sig,
-					fee_range: Some(msgs::ClosingSignedFeeRange {
-						min_fee_satoshis: our_min_fee,
-						max_fee_satoshis: our_max_fee,
-					}),
-				}), None, None))
-			},
-			// TODO (taproot|arik)
-			#[cfg(taproot)]
-			_ => todo!()
+		let closing_signed = self.get_closing_signed_msg(&closing_tx, false, total_fee_satoshis, our_min_fee, our_max_fee, logger);
+		if closing_signed.is_none() {
+			return Err(ChannelError::close("Failed to get signature for closing transaction.".to_owned()));
 		}
+		Ok((closing_signed, None, None))
 	}
 
 	// Marks a channel as waiting for a response from the counterparty. If it's not received
@@ -5966,10 +5951,38 @@ impl<SP: Deref> Channel<SP> where
 		tx
 	}
 
-	pub fn closing_signed<F: Deref>(
-		&mut self, fee_estimator: &LowerBoundedFeeEstimator<F>, msg: &msgs::ClosingSigned)
+	fn get_closing_signed_msg<L: Deref>(
+		&mut self, closing_tx: &ClosingTransaction, skip_remote_output: bool,
+		fee_satoshis: u64, min_fee_satoshis: u64, max_fee_satoshis: u64, logger: &L
+	) -> Option<msgs::ClosingSigned>
+		where L::Target: Logger
+	{
+		match &self.context.holder_signer {
+			ChannelSignerType::Ecdsa(ecdsa) => {
+				let fee_range = msgs::ClosingSignedFeeRange {
+					min_fee_satoshis,
+					max_fee_satoshis,
+				};
+				let sig = ecdsa.sign_closing_transaction(closing_tx, &self.context.secp_ctx).ok()?;
+
+				self.context.last_sent_closing_fee = Some((fee_satoshis, sig.clone()));
+				Some(msgs::ClosingSigned {
+					channel_id: self.context.channel_id,
+					fee_satoshis,
+					signature: sig,
+					fee_range: Some(fee_range),
+				})
+			},
+			// TODO (taproot|arik)
+			#[cfg(taproot)]
+			_ => todo!()
+		}
+	}
+
+	pub fn closing_signed<F: Deref, L: Deref>(
+		&mut self, fee_estimator: &LowerBoundedFeeEstimator<F>, msg: &msgs::ClosingSigned, logger: &L)
 		-> Result<(Option<msgs::ClosingSigned>, Option<Transaction>, Option<ShutdownResult>), ChannelError>
-		where F::Target: FeeEstimator
+		where F::Target: FeeEstimator, L::Target: Logger
 	{
 		if !self.context.channel_state.is_both_sides_shutdown() {
 			return Err(ChannelError::close("Remote end sent us a closing_signed before both sides provided a shutdown".to_owned()));
@@ -5994,7 +6007,8 @@ impl<SP: Deref> Channel<SP> where
 		}
 
 		let funding_redeemscript = self.context.get_funding_redeemscript();
-		let (mut closing_tx, used_total_fee) = self.build_closing_transaction(msg.fee_satoshis, false);
+		let mut skip_remote_output = false;
+		let (mut closing_tx, used_total_fee) = self.build_closing_transaction(msg.fee_satoshis, skip_remote_output);
 		if used_total_fee != msg.fee_satoshis {
 			return Err(ChannelError::close(format!("Remote sent us a closing_signed with a fee other than the value they can claim. Fee in message: {}. Actual closing tx fee: {}", msg.fee_satoshis, used_total_fee)));
 		}
@@ -6005,7 +6019,8 @@ impl<SP: Deref> Channel<SP> where
 			Err(_e) => {
 				// The remote end may have decided to revoke their output due to inconsistent dust
 				// limits, so check for that case by re-checking the signature here.
-				closing_tx = self.build_closing_transaction(msg.fee_satoshis, true).0;
+				skip_remote_output = true;
+				closing_tx = self.build_closing_transaction(msg.fee_satoshis, skip_remote_output).0;
 				let sighash = closing_tx.trust().get_sighash_all(&funding_redeemscript, self.context.channel_value_satoshis);
 				secp_check!(self.context.secp_ctx.verify_ecdsa(&sighash, &msg.signature, self.context.counterparty_funding_pubkey()), "Invalid closing tx signature from peer".to_owned());
 			},
@@ -6052,50 +6067,36 @@ impl<SP: Deref> Channel<SP> where
 				let (closing_tx, used_fee) = if $new_fee == msg.fee_satoshis {
 					(closing_tx, $new_fee)
 				} else {
-					self.build_closing_transaction($new_fee, false)
+					skip_remote_output = false;
+					self.build_closing_transaction($new_fee, skip_remote_output)
 				};
 
-				return match &self.context.holder_signer {
-					ChannelSignerType::Ecdsa(ecdsa) => {
-						let sig = ecdsa
-							.sign_closing_transaction(&closing_tx, &self.context.secp_ctx)
-							.map_err(|_| ChannelError::close("External signer refused to sign closing transaction".to_owned()))?;
-						let (signed_tx, shutdown_result) = if $new_fee == msg.fee_satoshis {
-							let shutdown_result = ShutdownResult {
-								closure_reason,
-								monitor_update: None,
-								dropped_outbound_htlcs: Vec::new(),
-								unbroadcasted_batch_funding_txid: self.context.unbroadcasted_batch_funding_txid(),
-								channel_id: self.context.channel_id,
-								user_channel_id: self.context.user_id,
-								channel_capacity_satoshis: self.context.channel_value_satoshis,
-								counterparty_node_id: self.context.counterparty_node_id,
-								unbroadcasted_funding_tx: self.context.unbroadcasted_funding(),
-								channel_funding_txo: self.context.get_funding_txo(),
-							};
-							self.context.channel_state = ChannelState::ShutdownComplete;
-							self.context.update_time_counter += 1;
-							let tx = self.build_signed_closing_transaction(&closing_tx, &msg.signature, &sig);
-							(Some(tx), Some(shutdown_result))
-						} else {
-							(None, None)
-						};
-
-						self.context.last_sent_closing_fee = Some((used_fee, sig.clone()));
-						Ok((Some(msgs::ClosingSigned {
-							channel_id: self.context.channel_id,
-							fee_satoshis: used_fee,
-							signature: sig,
-							fee_range: Some(msgs::ClosingSignedFeeRange {
-								min_fee_satoshis: our_min_fee,
-								max_fee_satoshis: our_max_fee,
-							}),
-						}), signed_tx, shutdown_result))
-					},
-					// TODO (taproot|arik)
-					#[cfg(taproot)]
-					_ => todo!()
+				let closing_signed = self.get_closing_signed_msg(&closing_tx, skip_remote_output, used_fee, our_min_fee, our_max_fee, logger);
+				if closing_signed.is_none() {
+					return Err(ChannelError::close("Failed to get signature for closing transaction.".to_owned()));
 				}
+				let (signed_tx, shutdown_result) = if $new_fee == msg.fee_satoshis {
+					let shutdown_result = ShutdownResult {
+						closure_reason,
+						monitor_update: None,
+						dropped_outbound_htlcs: Vec::new(),
+						unbroadcasted_batch_funding_txid: self.context.unbroadcasted_batch_funding_txid(),
+						channel_id: self.context.channel_id,
+						user_channel_id: self.context.user_id,
+						channel_capacity_satoshis: self.context.channel_value_satoshis,
+						counterparty_node_id: self.context.counterparty_node_id,
+						unbroadcasted_funding_tx: self.context.unbroadcasted_funding(),
+						channel_funding_txo: self.context.get_funding_txo(),
+					};
+					self.context.channel_state = ChannelState::ShutdownComplete;
+					self.context.update_time_counter += 1;
+					let tx = closing_signed.as_ref().map(|ClosingSigned { signature, .. }|
+						self.build_signed_closing_transaction(&closing_tx, &msg.signature, signature));
+					(tx, Some(shutdown_result))
+				} else {
+					(None, None)
+				};
+				return Ok((closing_signed, signed_tx, shutdown_result))
 			}
 		}
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8192,7 +8192,8 @@ where
 	pub fn signer_unblocked(&self, channel_opt: Option<(PublicKey, ChannelId)>) {
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 
-		let unblock_chan = |phase: &mut ChannelPhase<SP>, pending_msg_events: &mut Vec<MessageSendEvent>| {
+		// Returns whether we should remove this channel as it's just been closed.
+		let unblock_chan = |phase: &mut ChannelPhase<SP>, pending_msg_events: &mut Vec<MessageSendEvent>| -> bool {
 			let node_id = phase.context().get_counterparty_node_id();
 			match phase {
 				ChannelPhase::Funded(chan) => {
@@ -8212,6 +8213,29 @@ where
 					if let Some(msg) = msgs.channel_ready {
 						send_channel_ready!(self, pending_msg_events, chan, msg);
 					}
+					if let Some(msg) = msgs.closing_signed {
+						pending_msg_events.push(events::MessageSendEvent::SendClosingSigned {
+							node_id,
+							msg,
+						});
+					}
+					if let Some(broadcast_tx) = msgs.signed_closing_tx {
+						let channel_id = chan.context.channel_id();
+						let counterparty_node_id = chan.context.get_counterparty_node_id();
+						let logger = WithContext::from(&self.logger, Some(counterparty_node_id), Some(channel_id), None);
+						log_info!(logger, "Broadcasting closing tx {}", log_tx!(broadcast_tx));
+						self.tx_broadcaster.broadcast_transactions(&[&broadcast_tx]);
+
+						if let Ok(update) = self.get_channel_update_for_broadcast(&chan) {
+							pending_msg_events.push(events::MessageSendEvent::BroadcastChannelUpdate {
+								msg: update
+							});
+						}
+
+						// We should return true to remove the channel if we just
+						// broadcasted the closing transaction.
+						true
+					} else { false }
 				}
 				ChannelPhase::UnfundedOutboundV1(chan) => {
 					if let Some(msg) = chan.signer_maybe_unblocked(&self.logger) {
@@ -8220,8 +8244,9 @@ where
 							msg,
 						});
 					}
+					false
 				}
-				ChannelPhase::UnfundedInboundV1(_) => {},
+				ChannelPhase::UnfundedInboundV1(_) => false,
 			}
 		};
 
@@ -8230,17 +8255,25 @@ where
 			if let Some(peer_state_mutex) = per_peer_state.get(&counterparty_node_id) {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
-				if let Some(chan) = peer_state.channel_by_id.get_mut(&channel_id) {
-					unblock_chan(chan, &mut peer_state.pending_msg_events);
+				let should_remove = if let Some(chan) = peer_state.channel_by_id.get_mut(&channel_id) {
+					unblock_chan(chan, &mut peer_state.pending_msg_events)
+				} else { false };
+				if should_remove {
+					log_trace!(self.logger, "Removing channel after unblocking signer");
+					peer_state.channel_by_id.remove(&channel_id);
 				}
 			}
 		} else {
 			for (_cp_id, peer_state_mutex) in per_peer_state.iter() {
 				let mut peer_state_lock = peer_state_mutex.lock().unwrap();
 				let peer_state = &mut *peer_state_lock;
-				for (_, chan) in peer_state.channel_by_id.iter_mut() {
-					unblock_chan(chan, &mut peer_state.pending_msg_events);
-				}
+				peer_state.channel_by_id.retain(|_, chan| {
+					let should_remove = unblock_chan(chan, &mut peer_state.pending_msg_events);
+					if should_remove {
+						log_trace!(self.logger, "Removing channel after unblocking signer");
+					}
+					!should_remove
+				});
 			}
 		}
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7375,7 +7375,8 @@ where
 			match peer_state.channel_by_id.entry(msg.channel_id.clone()) {
 				hash_map::Entry::Occupied(mut chan_phase_entry) => {
 					if let ChannelPhase::Funded(chan) = chan_phase_entry.get_mut() {
-						let (closing_signed, tx, shutdown_result) = try_chan_phase_entry!(self, chan.closing_signed(&self.fee_estimator, &msg), chan_phase_entry);
+						let logger = WithChannelContext::from(&self.logger, &chan.context, None);
+						let (closing_signed, tx, shutdown_result) = try_chan_phase_entry!(self, chan.closing_signed(&self.fee_estimator, &msg, &&logger), chan_phase_entry);
 						debug_assert_eq!(shutdown_result.is_some(), chan.is_shutdown());
 						if let Some(msg) = closing_signed {
 							peer_state.pending_msg_events.push(events::MessageSendEvent::SendClosingSigned {

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -312,6 +312,9 @@ impl EcdsaChannelSigner for TestChannelSigner {
 	}
 
 	fn sign_closing_transaction(&self, closing_tx: &ClosingTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
+		if !self.is_signer_available(SignerOp::SignClosingTransaction) {
+			return Err(());
+		}
 		closing_tx.verify(self.inner.funding_outpoint().unwrap().into_bitcoin_outpoint())
 			.expect("derived different closing transaction");
 		Ok(self.inner.sign_closing_transaction(closing_tx, secp_ctx).unwrap())


### PR DESCRIPTION
Another async signing PR, this time for `sign_closing_transaction`!

If you've reviewed the other PRs, you know the drill: try to go about business as usual, if we fail to get the signature, do everything except for send the message, and mark our `signer_pending_closing` flag. The user then needs to call `signer_unblocked`, and we'll try again to get the signature, then create + send the message. In this case we not only need to send the message, but also 1. broadcast the fully signed closing tx, 2. broadcast a channel update, and 3. remove the channel from our map.

I added some additional state to track everything we need to do everything we need (rebuild the tx, fully sign, send our `closing_signed` msg, etc.) upon the signer being unblocked. This state is not persisted.