### PR TITLE
Skip incremental-mutants job for main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,7 @@ jobs:
 
   incremental-mutants:
     runs-on: ubuntu-latest
+    if: github.ref_name != 'main' # `main` has no diff with itself
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
There is no diff when running against main, so we skip incremental-mutants. Before this commit, we'd get `Error: Failed to parse diff: Line 1: Error while parsing:` as the diff file was empty.