### PR TITLE
Revert "Signal `GossipQuery` support when using `IgnoringMessagHandler`"

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -126,9 +126,7 @@ impl RoutingMessageHandler for IgnoringMessageHandler {
 	fn handle_query_short_channel_ids(&self, _their_node_id: &PublicKey, _msg: msgs::QueryShortChannelIds) -> Result<(), LightningError> { Ok(()) }
 	fn provided_node_features(&self) -> NodeFeatures { NodeFeatures::empty() }
 	fn provided_init_features(&self, _their_node_id: &PublicKey) -> InitFeatures {
-		let mut features = InitFeatures::empty();
-		features.set_gossip_queries_optional();
-		features
+		InitFeatures::empty()
 	}
 	fn processing_queue_high(&self) -> bool { false }
 }


### PR DESCRIPTION
Closes #2972.

This reverts commit 843079df72435b8a117e8b12b42492391409259f which used to fix a [small incompatibility with CLN](https://github.com/ElementsProject/lightning/pull/7174) that was fixed with CLN [24.02.2](https://github.com/ElementsProject/lightning/releases/tag/v24.02.2).