### PR TITLE
Add liquidity checks and improve payment error handling

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -67,7 +67,7 @@ use crate::offers::invoice::{Bolt12Invoice, DEFAULT_RELATIVE_EXPIRY, DerivedSign
 use crate::offers::invoice_error::InvoiceError;
 use crate::offers::invoice_request::{DerivedPayerSigningPubkey, InvoiceRequest, InvoiceRequestBuilder};
 use crate::offers::nonce::Nonce;
-use crate::offers::offer::{Offer, OfferBuilder};
+use crate::offers::offer::{Amount, Offer, OfferBuilder};
 use crate::offers::parse::Bolt12SemanticError;
 use crate::offers::refund::{Refund, RefundBuilder};
 use crate::offers::signer;
@@ -11134,6 +11134,13 @@ where
 					Some(responder) => responder,
 					None => return None,
 				};
+
+				if let Some(amount) = invoice_request.amount() {
+					if let Amount::Currency { .. } = amount {
+						let error = Bolt12SemanticError::UnsupportedCurrency;
+						return Some((OffersMessage::InvoiceError(error.into()), responder.respond()));
+					}
+				}
 
 				let nonce = match context {
 					None if invoice_request.metadata().is_some() => None,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1946,12 +1946,13 @@ where
 /// ```
 /// # use core::time::Duration;
 /// # use lightning::events::{Event, EventsProvider};
-/// # use lightning::ln::channelmanager::{AChannelManager, Bolt12CreationError, PaymentId, RecentPaymentDetails, Retry};
+/// # use lightning::ln::channelmanager::{AChannelManager, PaymentId, RecentPaymentDetails, Retry};
+/// # use lightning::offers::parse::Bolt12SemanticError;
 /// #
 /// # fn example<T: AChannelManager>(
 /// #     channel_manager: T, amount_msats: u64, absolute_expiry: Duration, retry: Retry,
 /// #     max_total_routing_fee_msat: Option<u64>
-/// # ) -> Result<(), Bolt12CreationError> {
+/// # ) -> Result<(), Bolt12SemanticError> {
 /// # let channel_manager = channel_manager.get_cm();
 /// let payment_id = PaymentId([42; 32]);
 /// let refund = channel_manager
@@ -2688,10 +2689,6 @@ pub enum RecentPaymentDetails {
 pub enum Bolt12CreationError {
     /// Error from  BOLT 12 semantic checks.
     InvalidSemantics(Bolt12SemanticError),
-    /// The payment id for a refund or request is already in use.
-    DuplicatePaymentId,
-    /// There is insufficient liquidity to complete the payment.
-    InsufficientLiquidity,
     /// Failed to create a blinded path.
     BlindedPathCreationFailed,
 }
@@ -9205,7 +9202,7 @@ macro_rules! create_refund_builder { ($self: ident, $builder: ty) => {
 	pub fn create_refund_builder(
 		&$self, amount_msats: u64, absolute_expiry: Duration, payment_id: PaymentId,
 		retry_strategy: Retry, max_total_routing_fee_msat: Option<u64>
-	) -> Result<$builder, Bolt12CreationError> {
+	) -> Result<$builder, Bolt12SemanticError> {
 		let node_id = $self.get_our_node_id();
 		let expanded_key = &$self.inbound_payment_key;
 		let entropy = &*$self.entropy_source;
@@ -9215,7 +9212,7 @@ macro_rules! create_refund_builder { ($self: ident, $builder: ty) => {
 		let context = OffersContext::OutboundPayment { payment_id, nonce, hmac: None };
 		let path = $self.create_blinded_paths_using_absolute_expiry(context, Some(absolute_expiry))
 			.and_then(|paths| paths.into_iter().next().ok_or(()))
-			.map_err(|()| Bolt12CreationError::BlindedPathCreationFailed)?;
+			.map_err(|_| Bolt12SemanticError::MissingPaths)?;
 
 		let builder = RefundBuilder::deriving_signing_pubkey(
 			node_id, expanded_key, nonce, secp_ctx, amount_msats, payment_id
@@ -9231,7 +9228,7 @@ macro_rules! create_refund_builder { ($self: ident, $builder: ty) => {
 			.add_new_awaiting_invoice(
 				payment_id, expiration, retry_strategy, max_total_routing_fee_msat, None,
 			)
-			.map_err(|()| Bolt12CreationError::DuplicatePaymentId)?;
+			.map_err(|_| Bolt12SemanticError::DuplicatePaymentId)?;
 
 		Ok(builder.into())
 	}
@@ -9323,7 +9320,7 @@ where
 		&self, offer: &Offer, quantity: Option<u64>, amount_msats: Option<u64>,
 		payer_note: Option<String>, payment_id: PaymentId, retry_strategy: Retry,
 		max_total_routing_fee_msat: Option<u64>
-	) -> Result<(), Bolt12CreationError> {
+	) -> Result<(), Bolt12SemanticError> {
 		let expanded_key = &self.inbound_payment_key;
 		let entropy = &*self.entropy_source;
 		let secp_ctx = &self.secp_ctx;
@@ -9353,7 +9350,7 @@ where
 			OffersContext::OutboundPayment { payment_id, nonce, hmac: Some(hmac) }
 		);
 		let reply_paths = self.create_blinded_paths(context)
-			.map_err(|()| Bolt12CreationError::BlindedPathCreationFailed)?;
+			.map_err(|_| Bolt12SemanticError::MissingPaths)?;
 
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 
@@ -9367,7 +9364,7 @@ where
 				payment_id, expiration, retry_strategy, max_total_routing_fee_msat,
 				Some(retryable_invoice_request)
 			)
-			.map_err(|()| Bolt12CreationError::DuplicatePaymentId)?;
+			.map_err(|_| Bolt12SemanticError::DuplicatePaymentId)?;
 
 		self.enqueue_invoice_request(invoice_request, reply_paths)?;
 		Ok(())

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -48,7 +48,7 @@ use crate::blinded_path::message::BlindedMessagePath;
 use crate::blinded_path::payment::{Bolt12OfferContext, Bolt12RefundContext, PaymentContext};
 use crate::blinded_path::message::{MessageContext, OffersContext};
 use crate::events::{ClosureReason, Event, MessageSendEventsProvider, PaymentFailureReason, PaymentPurpose};
-use crate::ln::channelmanager::{Bolt12CreationError, Bolt12PaymentError, MAX_SHORT_LIVED_RELATIVE_EXPIRY, PaymentId, RecentPaymentDetails, Retry, self};
+use crate::ln::channelmanager::{Bolt12CreationError, Bolt12PaymentError, Bolt12RequestError, MAX_SHORT_LIVED_RELATIVE_EXPIRY, PaymentId, RecentPaymentDetails, Retry, self};
 use crate::ln::features::Bolt12InvoiceFeatures;
 use crate::ln::functional_test_utils::*;
 use crate::ln::inbound_payment::ExpandedKey;
@@ -1697,7 +1697,7 @@ fn fails_creating_or_paying_for_offer_without_connected_peers() {
 
 	match david.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12SemanticError::MissingPaths),
+		Err(e) => assert_eq!(e, Bolt12RequestError::BlindedPathCreationFailed),
 	}
 
 	assert!(nodes[0].node.list_recent_payments().is_empty());
@@ -1755,7 +1755,7 @@ fn fails_creating_refund_or_sending_invoice_without_connected_peers() {
 		10_000_000, absolute_expiry, payment_id, Retry::Attempts(0), None
 	) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12SemanticError::MissingPaths),
+		Err(e) => assert_eq!(e, Bolt12RequestError::BlindedPathCreationFailed),
 	}
 
 	let mut args = ReconnectArgs::new(charlie, david);
@@ -1801,7 +1801,7 @@ fn fails_creating_invoice_request_for_unsupported_chain() {
 	let payment_id = PaymentId([1; 32]);
 	match bob.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12SemanticError::UnsupportedChain),
+		Err(e) => assert_eq!(e, Bolt12RequestError::InvalidSemantics(Bolt12SemanticError::UnsupportedChain)),
 	}
 }
 
@@ -1860,7 +1860,7 @@ fn fails_creating_invoice_request_without_blinded_reply_path() {
 
 	match david.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12SemanticError::MissingPaths),
+		Err(e) => assert_eq!(e, Bolt12RequestError::BlindedPathCreationFailed),
 	}
 
 	assert!(nodes[0].node.list_recent_payments().is_empty());
@@ -1900,7 +1900,7 @@ fn fails_creating_invoice_request_with_duplicate_payment_id() {
 
 	match david.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12SemanticError::DuplicatePaymentId),
+		Err(e) => assert_eq!(e, Bolt12RequestError::DuplicatePaymentId),
 	}
 
 	expect_recent_payment!(david, RecentPaymentDetails::AwaitingInvoice, payment_id);
@@ -1928,7 +1928,7 @@ fn fails_creating_refund_with_duplicate_payment_id() {
 		10_000, absolute_expiry, payment_id, Retry::Attempts(0), None
 	) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12SemanticError::DuplicatePaymentId),
+		Err(e) => assert_eq!(e, Bolt12RequestError::DuplicatePaymentId),
 	}
 
 	expect_recent_payment!(nodes[0], RecentPaymentDetails::AwaitingInvoice, payment_id);
@@ -2337,4 +2337,3 @@ fn no_double_pay_with_stale_channelmanager() {
 	// generated in response to the duplicate invoice.
 	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
 }
-

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -1697,7 +1697,7 @@ fn fails_creating_or_paying_for_offer_without_connected_peers() {
 
 	match david.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12CreationError::BlindedPathCreationFailed),
+		Err(e) => assert_eq!(e, Bolt12SemanticError::MissingPaths),
 	}
 
 	assert!(nodes[0].node.list_recent_payments().is_empty());
@@ -1755,7 +1755,7 @@ fn fails_creating_refund_or_sending_invoice_without_connected_peers() {
 		10_000_000, absolute_expiry, payment_id, Retry::Attempts(0), None
 	) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12CreationError::BlindedPathCreationFailed),
+		Err(e) => assert_eq!(e, Bolt12SemanticError::MissingPaths),
 	}
 
 	let mut args = ReconnectArgs::new(charlie, david);
@@ -1801,7 +1801,7 @@ fn fails_creating_invoice_request_for_unsupported_chain() {
 	let payment_id = PaymentId([1; 32]);
 	match bob.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12CreationError::InvalidSemantics(Bolt12SemanticError::UnsupportedChain)),
+		Err(e) => assert_eq!(e, Bolt12SemanticError::UnsupportedChain),
 	}
 }
 
@@ -1860,7 +1860,7 @@ fn fails_creating_invoice_request_without_blinded_reply_path() {
 
 	match david.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12CreationError::BlindedPathCreationFailed),
+		Err(e) => assert_eq!(e, Bolt12SemanticError::MissingPaths),
 	}
 
 	assert!(nodes[0].node.list_recent_payments().is_empty());
@@ -1900,7 +1900,7 @@ fn fails_creating_invoice_request_with_duplicate_payment_id() {
 
 	match david.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12CreationError::DuplicatePaymentId),
+		Err(e) => assert_eq!(e, Bolt12SemanticError::DuplicatePaymentId),
 	}
 
 	expect_recent_payment!(david, RecentPaymentDetails::AwaitingInvoice, payment_id);
@@ -1928,7 +1928,7 @@ fn fails_creating_refund_with_duplicate_payment_id() {
 		10_000, absolute_expiry, payment_id, Retry::Attempts(0), None
 	) {
 		Ok(_) => panic!("Expected error"),
-		Err(e) => assert_eq!(e, Bolt12CreationError::DuplicatePaymentId),
+		Err(e) => assert_eq!(e, Bolt12SemanticError::DuplicatePaymentId),
 	}
 
 	expect_recent_payment!(nodes[0], RecentPaymentDetails::AwaitingInvoice, payment_id);

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1381,11 +1381,23 @@ impl TryFrom<PartialInvoiceTlvStream> for InvoiceContents {
 			let refund = RefundContents::try_from(
 				(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream)
 			)?;
+
+			if amount_msats != refund.amount_msats() {
+				return Err(Bolt12SemanticError::InvalidAmount);
+			}
+
 			Ok(InvoiceContents::ForRefund { refund, fields })
 		} else {
 			let invoice_request = InvoiceRequestContents::try_from(
 				(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream)
 			)?;
+
+			if let Some(requested_amount_msats) = invoice_request.amount_msats() {
+				if amount_msats != requested_amount_msats {
+					return Err(Bolt12SemanticError::InvalidAmount);
+				}
+			}
+
 			Ok(InvoiceContents::ForOffer { invoice_request, fields })
 		}
 	}

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -270,6 +270,11 @@ macro_rules! invoice_request_builder_methods { (
 	/// Sets the [`InvoiceRequest::amount_msats`] for paying an invoice. Errors if `amount_msats` is
 	/// not at least the expected invoice amount (i.e., [`Offer::amount`] times [`quantity`]).
 	///
+	/// When the [`Offer`] specifies a currency, this method allows setting the `amount_msats` in the
+	/// `InvoiceRequest`. The issuer of the Offer will validate this amount and must set a matching
+	/// amount in the final invoice. If the issuer disagrees with the specfified amount, the invoice
+	/// request will be rejected. This is also useful if the Offer doesn't specify an amount.
+	///
 	/// Successive calls to this method will override the previous setting.
 	///
 	/// [`quantity`]: Self::quantity

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -71,7 +71,7 @@ use crate::ln::inbound_payment::{ExpandedKey, IV_LEN};
 use crate::ln::msgs::DecodeError;
 use crate::offers::merkle::{SignError, SignFn, SignatureTlvStream, SignatureTlvStreamRef, TaggedHash, self};
 use crate::offers::nonce::Nonce;
-use crate::offers::offer::{Amount, Offer, OfferContents, OfferId, OfferTlvStream, OfferTlvStreamRef};
+use crate::offers::offer::{Offer, OfferContents, OfferId, OfferTlvStream, OfferTlvStreamRef};
 use crate::offers::parse::{Bolt12ParseError, ParsedMessage, Bolt12SemanticError};
 use crate::offers::payer::{PayerContents, PayerTlvStream, PayerTlvStreamRef};
 use crate::offers::signer::{Metadata, MetadataMaterial};
@@ -1163,14 +1163,6 @@ impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 		};
 		let offer = OfferContents::try_from(offer_tlv_stream)?;
 
-		match offer.amount() {
-			Some(Amount::Currency {..}) => return Err(Bolt12SemanticError::UnsupportedCurrency),
-			_ => {
-				offer.check_amount_msats_for_quantity(amount, quantity)?;
-				offer.check_quantity(quantity)?;
-			},
-		};
-
 		if !offer.supports_chain(chain.unwrap_or_else(|| offer.implied_chain())) {
 			return Err(Bolt12SemanticError::UnsupportedChain);
 		}
@@ -1178,6 +1170,9 @@ impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 		if offer.amount().is_none() && amount.is_none() {
 			return Err(Bolt12SemanticError::MissingAmount);
 		}
+
+		offer.check_quantity(quantity)?;
+		offer.check_amount_msats_for_quantity(amount, quantity)?;
 
 		let features = features.unwrap_or_else(InvoiceRequestFeatures::empty);
 
@@ -2048,11 +2043,8 @@ mod tests {
 		let mut buffer = Vec::new();
 		invoice_request.write(&mut buffer).unwrap();
 
-		match InvoiceRequest::try_from(buffer) {
-			Ok(_) => panic!("expected error"),
-			Err(e) => {
-				assert_eq!(e, Bolt12ParseError::InvalidSemantics(Bolt12SemanticError::UnsupportedCurrency));
-			},
+		if let Err(e) = InvoiceRequest::try_from(buffer) {
+			panic!("error parsing invoice_request: {:?}", e);
 		}
 
 		let invoice_request = OfferBuilder::new(recipient_pubkey())

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1737,6 +1737,29 @@ mod tests {
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
 		}
+
+		let invoice_request = OfferBuilder::new(recipient_pubkey())
+			.amount(Amount::Currency { iso4217_code: *b"USD", amount: 1000 })
+			.build_unchecked()
+			.request_invoice(vec![1; 32], payer_pubkey()).unwrap()
+			.build().unwrap()
+			.sign(payer_sign).unwrap();
+		let (_, _, tlv_stream, _) = invoice_request.as_tlv_stream();
+		assert_eq!(invoice_request.amount(), Some(Amount::Currency { iso4217_code: *b"USD", amount: 1000 }));
+		assert_eq!(invoice_request.amount_msats(), None);
+		assert_eq!(tlv_stream.amount, None);
+
+		let invoice_request = OfferBuilder::new(recipient_pubkey())
+			.amount(Amount::Currency { iso4217_code: *b"USD", amount: 100 })
+			.build_unchecked()
+			.request_invoice(vec![1; 32], payer_pubkey()).unwrap()
+			.amount_msats(150_000_000)
+			.unwrap()
+			.build().unwrap()
+			.sign(payer_sign).unwrap();
+		let (_, _, tlv_stream, _) = invoice_request.as_tlv_stream();
+		assert_eq!(invoice_request.amount_msats(), Some(150_000_000));
+		assert_eq!(tlv_stream.amount, Some(150_000_000));
 	}
 
 	#[test]

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -873,9 +873,8 @@ impl OfferContents {
 		&self, amount_msats: Option<u64>, quantity: Option<u64>
 	) -> Result<(), Bolt12SemanticError> {
 		let offer_amount_msats = match self.amount {
-			None => 0,
 			Some(Amount::Bitcoin { amount_msats }) => amount_msats,
-			Some(Amount::Currency { .. }) => return Err(Bolt12SemanticError::UnsupportedCurrency),
+			_ => 0,
 		};
 
 		if !self.expects_quantity() || quantity.is_some() {

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -180,6 +180,8 @@ pub enum Bolt12SemanticError {
 	MissingPayerSigningPubkey,
 	/// A payer id was expected but was missing.
 	MissingPayerId,
+	/// The payment id for a refund or request is already in use.
+	DuplicatePaymentId,
 	/// Blinded paths were expected but were missing.
 	MissingPaths,
 	/// Blinded paths were provided but were not expected.

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -147,6 +147,9 @@ pub enum Bolt12SemanticError {
 	/// An amount was expected but was missing.
 	MissingAmount,
 	/// The amount exceeded the total bitcoin supply.
+	///
+	/// This error can also occur if the amount in an invoice does not match the expected
+	/// amount specified in the associated `InvoiceRequest` or `Refund`.
 	InvalidAmount,
 	/// An amount was provided but was not sufficient in value.
 	InsufficientAmount,

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -180,8 +180,6 @@ pub enum Bolt12SemanticError {
 	MissingPayerSigningPubkey,
 	/// A payer id was expected but was missing.
 	MissingPayerId,
-	/// The payment id for a refund or request is already in use.
-	DuplicatePaymentId,
 	/// Blinded paths were expected but were missing.
 	MissingPaths,
 	/// Blinded paths were provided but were not expected.

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -178,8 +178,8 @@ pub enum Bolt12SemanticError {
 	MissingPayerMetadata,
 	/// A payer signing pubkey was expected but was missing.
 	MissingPayerSigningPubkey,
-	/// The payment id for a refund or request is already in use.
-	DuplicatePaymentId,
+	/// A payer id was expected but was missing.
+	MissingPayerId,
 	/// Blinded paths were expected but were missing.
 	MissingPaths,
 	/// Blinded paths were provided but were not expected.


### PR DESCRIPTION
This PR introduces a few improvements including liquidity checks in the `pay_for_offer` and `create_refund_builder`,  updated error handling, and support for fiat-denominated offers.
#### Changes:
* Liquidity Checks:
    * Added early aborts in `pay_for_offer` and `create_refund_builder` if channel liquidity is insufficient.
    * Added tests to validate the new liquidity checks.
* Error Handling:
    * Introduced `Bolt12RequestError` for errors related to BOLT12 payment/refund requests.
    * Introduced `Bolt12CreationError` for errors occurring during the creation of BOLT12 offers/refunds.
* Fiat-Denominated Offers:
    * Improved support for offers specifying an amount in fiat currencies.
    * Added tests for `InvoiceRequest` creation with currency-based amounts.
* Docs updates:
    * Updated the docs for `InvoiceRequestBuilder::amount_msats` to clarify behavior when handling currency-based offers.
    * Updated the docs for `Bolt12SemanticError::InvalidAmount` to include cases where the invoice amount does not match the expected amount.

Fixes #3174 