### PR TITLE
Drop unnecessary `strict` feature from `lightning-invoice`

### DIFF
--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["std"]
 no-std = ["lightning/no-std"]
 std = ["bitcoin/std", "lightning/std", "bech32/std"]
-strict = []
 
 [dependencies]
 bech32 = { version = "0.9.1", default-features = false }

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#![cfg_attr(feature = "strict", deny(warnings))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 //! This crate provides data structures to represent


### PR DESCRIPTION
99aa6e27f616c96dda2b49d09bafbc0b982251e0 detected that we had an undefined feature in `lightning-invoice` called `strict`, which was used to turn on `deny(warnings)`. It resolved that by adding the feature to the `Cargo.toml`, but we actually don't need it - our CI already builds with `-Dwarnings`, so any warnings should be rejected during CI and there's not a lot of value in having a (public) feature to do the same.