### PR TITLE
Clarify maximum length of an invoice description

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -1511,8 +1511,8 @@ impl TaggedField {
 
 impl Description {
 
-	/// Creates a new `Description` if `description` is at most 1023 __bytes__ long,
-	/// returns [`CreationError::DescriptionTooLong`] otherwise
+	/// Creates a new `Description` if `description` is at most 1023 * 5 bits (i.e., 639 bytes)
+	/// long, and returns [`CreationError::DescriptionTooLong`] otherwise.
 	///
 	/// Please note that single characters may use more than one byte due to UTF8 encoding.
 	pub fn new(description: String) -> Result<Description, CreationError> {


### PR DESCRIPTION
We previously stated in the docs that the invoice description can be at most `1023` bytes long, which is wrong. According to BOLT 11 it's at most 1023*5 bits (639 bytes) long.