### PR TITLE
lightning-invoice: Add `Description::as_inner`

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -1526,6 +1526,11 @@ impl Description {
 	pub fn into_inner(self) -> UntrustedString {
 		self.0
 	}
+
+	/// Get a reference to the underlying description [`UntrustedString`]
+	pub fn as_inner(&self) -> &UntrustedString {
+		&self.0
+	}
 }
 
 impl Display for Description {


### PR DESCRIPTION
v0.0.119 introduced a `lightning_invoice::Description` newtype which doesn't allow accessing the inner `UntrustedString` without cloning the entire `Description`. Adds a quick `fn Description::as_inner -> &UntrustedString` which users can use to get the underlying `&str` if needed.