### PR TITLE
Re-export bech32

### DIFF
--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -62,6 +62,7 @@ compile_error!("Tests will always fail with cfg=fuzzing");
 #[macro_use]
 extern crate alloc;
 pub extern crate bitcoin;
+pub extern crate bech32;
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 


### PR DESCRIPTION
In the upgrade to rust-bitcoin 0.31, bech32 is no longer re-exported. This is needed for the u5 type by the NodeSigner for the sign_invoice function. This just re-exports the bech32 crate to handle this.