### PR TITLE
Upgrade `rust-bitcoin`

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,7 +23,6 @@ lightning-invoice = { path = "../lightning-invoice" }
 lightning-rapid-gossip-sync = { path = "../lightning-rapid-gossip-sync" }
 bech32 = "0.9.1"
 bitcoin = { version = "0.31.2", features = ["secp-lowmemory"] }
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 
 afl = { version = "0.12", optional = true }
 honggfuzz = { version = "0.5", optional = true, default-features = false }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,7 +22,7 @@ lightning = { path = "../lightning", features = ["regex", "hashbrown", "_test_ut
 lightning-invoice = { path = "../lightning-invoice" }
 lightning-rapid-gossip-sync = { path = "../lightning-rapid-gossip-sync" }
 bech32 = "0.9.1"
-bitcoin = { version = "0.31.2", features = ["secp-lowmemory"] }
+bitcoin = { version = "0.32.2", features = ["secp-lowmemory"] }
 
 afl = { version = "0.12", optional = true }
 honggfuzz = { version = "0.5", optional = true, default-features = false }

--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -16,12 +16,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 futures = [ ]
 std = ["bitcoin/std", "lightning/std", "lightning-rapid-gossip-sync/std"]
-no-std = ["bitcoin/no-std", "lightning/no-std", "lightning-rapid-gossip-sync/no-std"]
+no-std = ["lightning/no-std", "lightning-rapid-gossip-sync/no-std"]
 
 default = ["std"]
 
 [dependencies]
-bitcoin = { version = "0.31.2", default-features = false }
+bitcoin = { version = "0.32.2", default-features = false }
 lightning = { version = "0.0.123-beta", path = "../lightning", default-features = false }
 lightning-rapid-gossip-sync = { version = "0.0.123-beta", path = "../lightning-rapid-gossip-sync", default-features = false }
 

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -19,7 +19,6 @@ rpc-client = [ "serde_json", "chunked_transfer" ]
 
 [dependencies]
 bitcoin = "0.31.2"
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 lightning = { version = "0.0.123-beta", path = "../lightning" }
 tokio = { version = "1.35", features = [ "io-util", "net", "time", "rt" ], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -18,7 +18,7 @@ rest-client = [ "serde_json", "chunked_transfer" ]
 rpc-client = [ "serde_json", "chunked_transfer" ]
 
 [dependencies]
-bitcoin = "0.31.2"
+bitcoin = "0.32.2"
 lightning = { version = "0.0.123-beta", path = "../lightning" }
 tokio = { version = "1.35", features = [ "io-util", "net", "time", "rt" ], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/lightning-block-sync/src/convert.rs
+++ b/lightning-block-sync/src/convert.rs
@@ -294,8 +294,8 @@ pub(crate) mod tests {
 	use super::*;
 	use bitcoin::blockdata::constants::genesis_block;
 	use bitcoin::hashes::Hash;
+	use bitcoin::hex::DisplayHex;
 	use bitcoin::network::Network;
-	use hex::DisplayHex;
 	use serde_json::value::Number;
 	use serde_json::Value;
 

--- a/lightning-custom-message/Cargo.toml
+++ b/lightning-custom-message/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-bitcoin = "0.31.2"
+bitcoin = "0.32.2"
 lightning = { version = "0.0.123-beta", path = "../lightning" }
 
 [lints]

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ bech32 = { version = "0.9.1", default-features = false }
 lightning = { version = "0.0.123-beta", path = "../lightning", default-features = false }
 secp256k1 = { version = "0.28.0", default-features = false, features = ["recovery", "alloc"] }
 serde = { version = "1.0.118", optional = true }
-bitcoin = { version = "0.31.2", default-features = false }
+bitcoin = { version = "0.32.2", default-features = false }
 
 [dev-dependencies]
 lightning = { version = "0.0.123-beta", path = "../lightning", default-features = false, features = ["_test_utils"] }

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-bitcoin = "0.31.2"
+bitcoin = "0.32.2"
 lightning = { version = "0.0.123-beta", path = "../lightning" }
 tokio = { version = "1.35", features = [ "rt", "sync", "net", "time" ] }
 

--- a/lightning-persister/Cargo.toml
+++ b/lightning-persister/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-bitcoin = "0.31.2"
+bitcoin = "0.32.2"
 lightning = { version = "0.0.123-beta", path = "../lightning" }
 
 [target.'cfg(windows)'.dependencies]
@@ -25,7 +25,7 @@ criterion = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 lightning = { version = "0.0.123-beta", path = "../lightning", features = ["_test_utils"] }
-bitcoin = { version = "0.31.2", default-features = false }
+bitcoin = { version = "0.32.2", default-features = false }
 
 [lints]
 workspace = true

--- a/lightning-rapid-gossip-sync/Cargo.toml
+++ b/lightning-rapid-gossip-sync/Cargo.toml
@@ -16,7 +16,7 @@ std = ["lightning/std"]
 
 [dependencies]
 lightning = { version = "0.0.123-beta", path = "../lightning", default-features = false }
-bitcoin = { version = "0.31.2", default-features = false }
+bitcoin = { version = "0.32.2", default-features = false }
 
 [target.'cfg(ldk_bench)'.dependencies]
 criterion = { version = "0.4", optional = true, default-features = false }

--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -24,7 +24,7 @@ async-interface = []
 
 [dependencies]
 lightning = { version = "0.0.123-beta", path = "../lightning", default-features = false, features = ["std"] }
-bitcoin = { version = "0.31.2", default-features = false }
+bitcoin = { version = "0.32.2", default-features = false }
 bdk-macros = "0.6"
 futures = { version = "0.3", optional = true }
 esplora-client = { version = "0.7", default-features = false, optional = true }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -45,7 +45,6 @@ bitcoin = { version = "0.31.2", default-features = false, features = ["secp-reco
 
 hashbrown = { version = "0.13", optional = true, default-features = false }
 possiblyrandom = { version = "0.2", optional = true, default-features = false }
-hex = { package = "hex-conservative", version = "0.1.1", default-features = false }
 regex = { version = "1.5.6", optional = true }
 backtrace = { version = "0.3", optional = true }
 

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -31,7 +31,7 @@ unsafe_revoked_tx_signing = []
 # Override signing to not include randomness when generating signatures for test vectors.
 _test_vectors = []
 
-no-std = ["hashbrown", "possiblyrandom", "bitcoin/no-std", "core2/alloc", "libm"]
+no-std = ["hashbrown", "possiblyrandom", "core2/alloc", "libm"]
 std = ["bitcoin/std", "bech32/std"]
 
 # Generates low-r bitcoin signatures, which saves 1 byte in 50% of the cases
@@ -41,7 +41,7 @@ default = ["std", "grind_signatures"]
 
 [dependencies]
 bech32 = { version = "0.9.1", default-features = false }
-bitcoin = { version = "0.31.2", default-features = false, features = ["secp-recovery"] }
+bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 hashbrown = { version = "0.13", optional = true, default-features = false }
 possiblyrandom = { version = "0.2", optional = true, default-features = false }
@@ -55,7 +55,7 @@ libm = { version = "0.2", optional = true, default-features = false }
 regex = "1.5.6"
 
 [dev-dependencies.bitcoin]
-version = "0.31.2"
+version = "0.32.2"
 default-features = false
 features = ["bitcoinconsensus", "secp-recovery"]
 

--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -85,12 +85,8 @@ pub mod events;
 
 pub(crate) mod crypto;
 
-#[cfg(feature = "std")]
-/// Re-export of either `core2::io` or `std::io`, depending on the `std` feature flag.
-pub use std::io;
-#[cfg(not(feature = "std"))]
-/// Re-export of either `core2::io` or `std::io`, depending on the `std` feature flag.
-pub use core2::io;
+/// Re-export the `bitcoin_io` crate.
+pub use bitcoin::io;
 
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
@@ -98,30 +94,6 @@ pub use core2::io;
 ///
 /// This is not exported to bindings users as it is not intended for public consumption.
 pub mod io_extras {
-	use core2::io::{self, Read, Write};
-
-	/// A writer which will move data into the void.
-	pub struct Sink {
-		_priv: (),
-	}
-
-	/// Creates an instance of a writer which will successfully consume all data.
-	pub const fn sink() -> Sink {
-		Sink { _priv: () }
-	}
-
-	impl core2::io::Write for Sink {
-		#[inline]
-		fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
-			Ok(buf.len())
-		}
-
-		#[inline]
-		fn flush(&mut self) -> core2::io::Result<()> {
-			Ok(())
-		}
-	}
-
 	pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> Result<u64, io::Error>
 		where
 		R: Read,
@@ -141,19 +113,11 @@ pub mod io_extras {
 		Ok(count)
 	}
 
-	pub fn read_to_end<D: io::Read>(mut d: D) -> Result<alloc::vec::Vec<u8>, io::Error> {
-		let mut result = vec![];
-		let mut buf = [0u8; 64];
-		loop {
-			match d.read(&mut buf) {
-				Ok(0) => break,
-				Ok(n) => result.extend_from_slice(&buf[0..n]),
-				Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {},
-				Err(e) => return Err(e.into()),
-			};
-		}
-		Ok(result)
-	}
+        pub fn read_to_end<D: io::Read>(mut d: D) -> Result<alloc::vec::Vec<u8>, io::Error> {
+                let mut buf = Vec::new();
+                d.take(u64::MAX).read_to_end(&mut buf)?;
+                Ok(buf)
+        }
 }
 
 #[cfg(feature = "std")]
@@ -162,13 +126,13 @@ pub mod io_extras {
 ///
 /// This is not exported to bindings users as it is not intended for public consumption.
 mod io_extras {
-	pub fn read_to_end<D: ::std::io::Read>(mut d: D) -> Result<Vec<u8>, ::std::io::Error> {
-		let mut buf = Vec::new();
-		d.read_to_end(&mut buf)?;
-		Ok(buf)
-	}
+       pub fn read_to_end<D: ::std::io::Read>(mut d: D) -> Result<Vec<u8>, ::std::io::Error> {
+               let mut buf = Vec::new();
+               d.read_to_end(&mut buf)?;
+               Ok(buf)
+       }
 
-	pub use std::io::{copy, sink};
+       pub use std::io::{copy, sink};
 }
 
 mod prelude {

--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -65,7 +65,6 @@ pub extern crate bitcoin;
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 
-extern crate hex;
 #[cfg(any(test, feature = "_test_utils"))] extern crate regex;
 
 #[cfg(not(feature = "std"))] extern crate core2;

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -736,7 +736,7 @@ pub fn build_htlc_input_witness(
 	let mut witness = Witness::new();
 	// First push the multisig dummy, note that due to BIP147 (NULLDUMMY) it must be a zero-length element.
 	witness.push(vec![]);
-	witness.push_ecdsa_signature(&BitcoinSignature { sig: *remote_sig, hash_ty: remote_sighash_type });
+	witness.push_ecdsa_signature(&BitcoinSignature { signature: *remote_sig, sighash_type: remote_sighash_type });
 	witness.push_ecdsa_signature(&BitcoinSignature::sighash_all(*local_sig));
 	if let Some(preimage) = preimage {
 		witness.push(preimage.0.to_vec());
@@ -1840,11 +1840,10 @@ mod tests {
 	use bitcoin::secp256k1::{PublicKey, SecretKey, Secp256k1};
 	use crate::util::test_utils;
 	use crate::sign::{ChannelSigner, SignerProvider};
-	use bitcoin::{Network, Txid, ScriptBuf};
+	use bitcoin::{Address, KnownHrp, Network, Txid, ScriptBuf};
 	use bitcoin::hashes::Hash;
 	use bitcoin::hashes::hex::FromHex;
 	use crate::ln::types::PaymentHash;
-	use bitcoin::address::Payload;
 	use bitcoin::PublicKey as BitcoinPublicKey;
 	use crate::ln::features::ChannelTypeFeatures;
 
@@ -1913,11 +1912,12 @@ mod tests {
 	#[test]
 	fn test_anchors() {
 		let mut builder = TestCommitmentTxBuilder::new();
+                let hrp = KnownHrp::Testnets;
 
 		// Generate broadcaster and counterparty outputs
 		let tx = builder.build(1000, 2000);
 		assert_eq!(tx.built.transaction.output.len(), 2);
-		assert_eq!(tx.built.transaction.output[1].script_pubkey, Payload::p2wpkh(&BitcoinPublicKey::new(builder.counterparty_pubkeys.payment_point)).unwrap().script_pubkey());
+		assert_eq!(tx.built.transaction.output[1].script_pubkey, Address::p2wpkh(&BitcoinPublicKey::new(builder.counterparty_pubkeys.payment_point), hrp).unwrap().script_pubkey());
 
 		// Generate broadcaster and counterparty outputs as well as two anchors
 		builder.channel_parameters.channel_type_features = ChannelTypeFeatures::anchors_zero_htlc_fee_and_dependencies();

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -10274,6 +10274,7 @@ mod tests {
 		use bitcoin::sighash::EcdsaSighashType;
 		use bitcoin::hashes::hex::FromHex;
 		use bitcoin::hash_types::Txid;
+		use bitcoin::hex::DisplayHex;
 		use bitcoin::secp256k1::Message;
 		use crate::sign::{ChannelDerivationParameters, HTLCDescriptor, ecdsa::EcdsaChannelSigner};
 		use crate::ln::PaymentPreimage;
@@ -10283,7 +10284,6 @@ mod tests {
 		use crate::util::logger::Logger;
 		use crate::sync::Arc;
 		use core::str::FromStr;
-		use hex::DisplayHex;
 
 		// Test vectors from BOLT 3 Appendices C and F (anchors):
 		let feeest = TestFeeEstimator{fee_est: 15000};

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -3232,7 +3232,7 @@ impl_writeable_msg!(GossipTimestampFilter, {
 #[cfg(test)]
 mod tests {
 	use bitcoin::{Amount, Transaction, TxIn, ScriptBuf, Sequence, Witness, TxOut};
-	use hex::DisplayHex;
+	use bitcoin::hex::DisplayHex;
 	use crate::ln::types::{ChannelId, PaymentPreimage, PaymentHash, PaymentSecret};
 	use crate::ln::features::{ChannelFeatures, ChannelTypeFeatures, InitFeatures, NodeFeatures};
 	use crate::ln::msgs::{self, FinalOnionHopData, OnionErrorPacket, CommonOpenChannelFields, CommonAcceptChannelFields, TrampolineOnionPacket};

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -51,7 +51,6 @@ use std::net::SocketAddr;
 use core::fmt::Display;
 use crate::io::{self, Cursor, Read};
 use crate::io_extras::read_to_end;
-
 use crate::events::MessageSendEventsProvider;
 use crate::crypto::streams::ChaChaPolyReadAdapter;
 use crate::util::logger;
@@ -2884,7 +2883,7 @@ impl Readable for UnsignedChannelAnnouncement {
 			node_id_2: Readable::read(r)?,
 			bitcoin_key_1: Readable::read(r)?,
 			bitcoin_key_2: Readable::read(r)?,
-			excess_data: read_to_end(r)?,
+			excess_data: r.read_to_end()?,
 		})
 	}
 }

--- a/lightning/src/ln/peer_channel_encryptor.rs
+++ b/lightning/src/ln/peer_channel_encryptor.rs
@@ -17,12 +17,12 @@ use crate::ln::wire;
 use bitcoin::hashes::{Hash, HashEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
 
+use bitcoin::hex::DisplayHex;
+
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::secp256k1::{PublicKey,SecretKey};
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1;
-
-use hex::DisplayHex;
 
 use crate::crypto::chacha20poly1305rfc::ChaCha20Poly1305RFC;
 use crate::crypto::utils::hkdf_extract_expand_twice;

--- a/lightning/src/ln/types.rs
+++ b/lightning/src/ln/types.rs
@@ -200,7 +200,7 @@ mod tests {
 		sha256::Hash as Sha256,
 	};
 	use bitcoin::secp256k1::PublicKey;
-	use hex::DisplayHex;
+	use bitcoin::hex::DisplayHex;
 
 	use super::ChannelId;
 	use crate::ln::channel_keys::RevocationBasepoint;

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -19,6 +19,7 @@ use bitcoin::secp256k1::{PublicKey, Verification};
 
 use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::hashes::Hash;
+use bitcoin::hex;
 use bitcoin::network::Network;
 
 use crate::events::{MessageSendEvent, MessageSendEventsProvider};

--- a/lightning/src/routing/utxo.rs
+++ b/lightning/src/routing/utxo.rs
@@ -17,7 +17,7 @@ use bitcoin::TxOut;
 use bitcoin::amount::Amount;
 use bitcoin::blockdata::constants::ChainHash;
 
-use hex::DisplayHex;
+use bitcoin::hex::DisplayHex;
 
 use crate::events::MessageSendEvent;
 use crate::ln::chan_utils::make_funding_redeemscript_from_slices;

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -1327,8 +1327,8 @@ impl InMemorySigner {
 				.unwrap()[..]
 		);
 		let local_delayedsig = EcdsaSignature {
-			sig: sign_with_aux_rand(secp_ctx, &sighash, &delayed_payment_key, &self),
-			hash_ty: EcdsaSighashType::All,
+			signature: sign_with_aux_rand(secp_ctx, &sighash, &delayed_payment_key, &self),
+			sighash_type: EcdsaSighashType::All,
 		};
 		let payment_script =
 			bitcoin::Address::p2wsh(&witness_script, Network::Bitcoin).script_pubkey();

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -14,8 +14,8 @@
 //! [`ChannelMonitor`]: crate::chain::channelmonitor::ChannelMonitor
 
 use crate::prelude::*;
-use crate::io::{self, Read, Seek, Write};
-use crate::io_extras::{copy, sink};
+use crate::io_extras::copy;
+use crate::io::{self, sink, Read, Write};
 use core::hash::Hash;
 use crate::sync::{Mutex, RwLock};
 use core::cmp;

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -1591,8 +1591,8 @@ impl WalletSource for TestWalletSource {
 				let sighash = SighashCache::new(&tx)
 					.legacy_signature_hash(i, &utxo.output.script_pubkey, EcdsaSighashType::All as u32)
 					.map_err(|_| ())?;
-				let sig = self.secp.sign_ecdsa(&secp256k1::Message::from_digest(sighash.to_byte_array()), &self.secret_key);
-				let bitcoin_sig = bitcoin::ecdsa::Signature { sig, hash_ty: EcdsaSighashType::All };
+				let signature = self.secp.sign_ecdsa(&secp256k1::Message::from_digest(sighash.to_byte_array()), &self.secret_key);
+				let bitcoin_sig = bitcoin::ecdsa::Signature { signature, sighash_type: EcdsaSighashType::All };
 				tx.input[i].script_sig = Builder::new()
 					.push_slice(&bitcoin_sig.serialize())
 					.push_slice(&self.secret_key.public_key(&self.secp).serialize())

--- a/lightning/src/util/transaction_utils.rs
+++ b/lightning/src/util/transaction_utils.rs
@@ -16,7 +16,7 @@ use bitcoin::consensus::encode::VarInt;
 #[allow(unused_imports)]
 use crate::prelude::*;
 
-use crate::io_extras::sink;
+use crate::io::sink;
 use core::cmp::Ordering;
 
 pub fn sort_outputs<T, C : Fn(&T, &T) -> Ordering>(outputs: &mut Vec<(TxOut, T)>, tie_breaker: C) {


### PR DESCRIPTION
Draft because WIP still until we resolve `Seek`. Also on top of #3210.

Nothing too surprising here, upgrade the `rust-bitcoin` dependency to the latest version. Includes:
    
- Use new `bitcoin_io` crate
- Use new `Address` API (remove `Payload`, use `KnownHrp`)
- Use renamed signature struct fields

Does not yet include fix of lint warnings for deprecated functions (eg `txid` was renamed to `compute_txid`).
