### PR TITLE
Fix clippy errors: resolve always-return-zero operations

### DIFF
--- a/lightning/src/crypto/chacha20.rs
+++ b/lightning/src/crypto/chacha20.rs
@@ -62,7 +62,7 @@ mod real_chacha {
 		fn from_bytes(bytes: &[u8]) -> Self {
 			assert_eq!(bytes.len(), 4*4);
 			Self (
-				u32::from_le_bytes(bytes[0*4..1*4].try_into().expect("len is 4")),
+				u32::from_le_bytes(bytes[0..1*4].try_into().expect("len is 4")),
 				u32::from_le_bytes(bytes[1*4..2*4].try_into().expect("len is 4")),
 				u32::from_le_bytes(bytes[2*4..3*4].try_into().expect("len is 4")),
 				u32::from_le_bytes(bytes[3*4..4*4].try_into().expect("len is 4")),

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -1829,7 +1829,7 @@ pub fn get_commitment_transaction_number_obscure_factor(
 		| ((res[28] as u64) << 3 * 8)
 		| ((res[29] as u64) << 2 * 8)
 		| ((res[30] as u64) << 1 * 8)
-		| ((res[31] as u64) << 0 * 8)
+		| (res[31] as u64)
 }
 
 #[cfg(test)]

--- a/lightning/src/util/byte_utils.rs
+++ b/lightning/src/util/byte_utils.rs
@@ -14,7 +14,7 @@ pub fn slice_to_be48(v: &[u8]) -> u64 {
 	((v[2] as u64) << 8*3) |
 	((v[3] as u64) << 8*2) |
 	((v[4] as u64) << 8*1) |
-	((v[5] as u64) << 8*0)
+	(v[5] as u64)
 }
 #[inline]
 pub fn be48_to_array(u: u64) -> [u8; 6] {
@@ -25,7 +25,7 @@ pub fn be48_to_array(u: u64) -> [u8; 6] {
 	v[2] = ((u >> 8*3) & 0xff) as u8;
 	v[3] = ((u >> 8*2) & 0xff) as u8;
 	v[4] = ((u >> 8*1) & 0xff) as u8;
-	v[5] = ((u >> 8*0) & 0xff) as u8;
+	v[5] = (u & 0xff) as u8;
 	v
 }
 


### PR DESCRIPTION
Fix clippy "error: this operation will always return zero".

Error described in https://rust-lang.github.io/rust-clippy/master/index.html#erasing_op