### PR TITLE
Don't depend on `bitcoinconsensus` in fuzzing

### DIFF
--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Internal test utilities exposed to other repo crates
-_test_utils = ["regex", "bitcoin/bitcoinconsensus"]
+_test_utils = ["regex"]
 # Unlog messages superior at targeted level.
 max_level_off = []
 max_level_error = []
@@ -65,6 +65,10 @@ criterion = { version = "0.4", optional = true, default-features = false }
 
 [target.'cfg(taproot)'.dependencies]
 musig2 = { git = "https://github.com/arik-so/rust-musig2", rev = "739533fc" }
+
+[target.'cfg(all(feature = "_test_utils", not(fuzzing)))'.dependencies.bitcoin]
+version = "0.31.2"
+features = ["bitcoinconsensus"]
 
 [lints]
 workspace = true

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1538,6 +1538,10 @@ pub fn do_check_spends<F: Fn(&bitcoin::blockdata::transaction::OutPoint) -> Opti
 	let min_fee = (tx.weight().to_wu() as u64 + 3) / 4; // One sat per vbyte (ie per weight/4, rounded up)
 	// Input amount - output amount = fee, so check that out + min_fee is smaller than input
 	assert!(total_value_out + min_fee <= total_value_in);
+
+	// If we're fuzzing, we shouldn't ever get here, but transactions won't validate anyway (as
+	// we're not using valid signatures) so just skip the bitcoinconsensus step
+	#[cfg(not(fuzzing))]
 	tx.verify(get_output).unwrap();
 }
 


### PR DESCRIPTION
Its a bit annoying to deal with the C++ dependency in some fuzz build modes, and there's no reason for it, so we skip it here.