### PR TITLE
Experimental offer TLVs

### DIFF
--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1716,7 +1716,9 @@ mod tests {
 					message_paths: None,
 				},
 				SignatureTlvStreamRef { signature: Some(&invoice.signature()) },
-				ExperimentalOfferTlvStreamRef {},
+				ExperimentalOfferTlvStreamRef {
+					experimental_foo: None,
+				},
 			),
 		);
 
@@ -1810,7 +1812,9 @@ mod tests {
 					message_paths: None,
 				},
 				SignatureTlvStreamRef { signature: Some(&invoice.signature()) },
-				ExperimentalOfferTlvStreamRef {},
+				ExperimentalOfferTlvStreamRef {
+					experimental_foo: None,
+				},
 			),
 		);
 
@@ -1904,6 +1908,7 @@ mod tests {
 		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
 			.amount_msats(1000)
 			.path(blinded_path)
+			.experimental_foo(42)
 			.build().unwrap();
 		let invoice_request = offer.request_invoice(vec![1; 32], payer_pubkey()).unwrap()
 			.build().unwrap()
@@ -1925,6 +1930,7 @@ mod tests {
 		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
 			.amount_msats(1000)
 			// Omit the path so that node_id is used for the signing pubkey instead of deriving it
+			.experimental_foo(42)
 			.build().unwrap();
 		let invoice_request = offer.request_invoice(vec![1; 32], payer_pubkey()).unwrap()
 			.build().unwrap()
@@ -1946,6 +1952,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 
 		let refund = RefundBuilder::new(vec![1; 32], payer_pubkey(), 1000).unwrap()
+			.experimental_foo(42)
 			.build().unwrap();
 
 		if let Err(e) = refund

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1237,7 +1237,7 @@ impl TryFrom<Vec<u8>> for Bolt12Invoice {
 /// Valid type range for invoice TLV records.
 pub(super) const INVOICE_TYPES: core::ops::Range<u64> = 160..240;
 
-tlv_stream!(InvoiceTlvStream, InvoiceTlvStreamRef, INVOICE_TYPES, {
+tlv_stream!(InvoiceTlvStream, InvoiceTlvStreamRef<'a>, INVOICE_TYPES, {
 	(160, paths: (Vec<BlindedPath>, WithoutLength, Iterable<'a, BlindedPathIter<'a>, BlindedPath>)),
 	(162, blindedpay: (Vec<BlindedPayInfo>, WithoutLength, Iterable<'a, BlindedPayInfoIter<'a>, BlindedPayInfo>)),
 	(164, created_at: (u64, HighZeroBytesDroppedBigSize)),

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1274,12 +1274,7 @@ impl TryFrom<Vec<u8>> for UnsignedBolt12Invoice {
 	fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
 		let invoice = ParsedMessage::<PartialInvoiceTlvStream>::try_from(bytes)?;
 		let ParsedMessage { mut bytes, tlv_stream } = invoice;
-		let (
-			payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream, invoice_tlv_stream,
-		) = tlv_stream;
-		let contents = InvoiceContents::try_from(
-			(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream, invoice_tlv_stream)
-		)?;
+		let contents = InvoiceContents::try_from(tlv_stream)?;
 
 		let tagged_hash = TaggedHash::from_valid_tlv_stream_bytes(SIGNATURE_TAG, &bytes);
 

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1738,7 +1738,9 @@ mod tests {
 				ExperimentalOfferTlvStreamRef {
 					experimental_foo: None,
 				},
-				ExperimentalInvoiceRequestTlvStreamRef {},
+				ExperimentalInvoiceRequestTlvStreamRef {
+					experimental_bar: None,
+				},
 			),
 		);
 
@@ -1835,7 +1837,9 @@ mod tests {
 				ExperimentalOfferTlvStreamRef {
 					experimental_foo: None,
 				},
-				ExperimentalInvoiceRequestTlvStreamRef {},
+				ExperimentalInvoiceRequestTlvStreamRef {
+					experimental_bar: None,
+				},
 			),
 		);
 

--- a/lightning/src/offers/invoice_macros.rs
+++ b/lightning/src/offers/invoice_macros.rs
@@ -95,6 +95,11 @@ macro_rules! invoice_builder_methods_test { (
 		$return_value
 	}
 
+	#[cfg_attr(c_bindings, allow(dead_code))]
+	pub(super) fn experimental_baz($($self_mut)* $self: $self_type, experimental_baz: u64) -> $return_type {
+		$invoice_fields.experimental_baz = Some(experimental_baz);
+		$return_value
+	}
 } }
 
 macro_rules! invoice_accessors_common { ($self: ident, $contents: expr, $invoice_type: ty) => {

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1061,7 +1061,7 @@ pub(super) const INVOICE_REQUEST_PAYER_ID_TYPE: u64 = 88;
 
 // This TLV stream is used for both InvoiceRequest and Refund, but not all TLV records are valid for
 // InvoiceRequest as noted below.
-tlv_stream!(InvoiceRequestTlvStream, InvoiceRequestTlvStreamRef, INVOICE_REQUEST_TYPES, {
+tlv_stream!(InvoiceRequestTlvStream, InvoiceRequestTlvStreamRef<'a>, INVOICE_REQUEST_TYPES, {
 	(80, chain: ChainHash),
 	(82, amount: (u64, HighZeroBytesDroppedBigSize)),
 	(84, features: (InvoiceRequestFeatures, WithoutLength)),

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1565,7 +1565,7 @@ mod tests {
 		let (
 			payer_tlv_stream, offer_tlv_stream, mut invoice_request_tlv_stream,
 			mut invoice_tlv_stream, mut signature_tlv_stream, experimental_offer_tlv_stream,
-			experimental_invoice_request_tlv_stream,
+			experimental_invoice_request_tlv_stream, experimental_invoice_tlv_stream,
 		) = invoice.as_tlv_stream();
 		invoice_request_tlv_stream.amount = Some(2000);
 		invoice_tlv_stream.amount = Some(2000);
@@ -1574,6 +1574,7 @@ mod tests {
 			(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream, invoice_tlv_stream);
 		let experimental_tlv_stream = (
 			experimental_offer_tlv_stream, experimental_invoice_request_tlv_stream,
+			experimental_invoice_tlv_stream,
 		);
 		let mut bytes = Vec::new();
 		(&tlv_stream, &experimental_tlv_stream).write(&mut bytes).unwrap();
@@ -1594,7 +1595,7 @@ mod tests {
 		let (
 			mut payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream, invoice_tlv_stream,
 			mut signature_tlv_stream, experimental_offer_tlv_stream,
-			experimental_invoice_request_tlv_stream,
+			experimental_invoice_request_tlv_stream, experimental_invoice_tlv_stream,
 		) = invoice.as_tlv_stream();
 		let metadata = payer_tlv_stream.metadata.unwrap().iter().copied().rev().collect();
 		payer_tlv_stream.metadata = Some(&metadata);
@@ -1603,6 +1604,7 @@ mod tests {
 			(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream, invoice_tlv_stream);
 		let experimental_tlv_stream = (
 			experimental_offer_tlv_stream, experimental_invoice_request_tlv_stream,
+			experimental_invoice_tlv_stream,
 		);
 		let mut bytes = Vec::new();
 		(&tlv_stream, &experimental_tlv_stream).write(&mut bytes).unwrap();
@@ -1652,7 +1654,7 @@ mod tests {
 		let (
 			payer_tlv_stream, offer_tlv_stream, mut invoice_request_tlv_stream,
 			mut invoice_tlv_stream, mut signature_tlv_stream, experimental_offer_tlv_stream,
-			experimental_invoice_request_tlv_stream,
+			experimental_invoice_request_tlv_stream, experimental_invoice_tlv_stream,
 		) = invoice.as_tlv_stream();
 		invoice_request_tlv_stream.amount = Some(2000);
 		invoice_tlv_stream.amount = Some(2000);
@@ -1661,6 +1663,7 @@ mod tests {
 			(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream, invoice_tlv_stream);
 		let experimental_tlv_stream = (
 			experimental_offer_tlv_stream, experimental_invoice_request_tlv_stream,
+			experimental_invoice_tlv_stream,
 		);
 		let mut bytes = Vec::new();
 		(&tlv_stream, &experimental_tlv_stream).write(&mut bytes).unwrap();
@@ -1683,7 +1686,7 @@ mod tests {
 		let (
 			payer_tlv_stream, offer_tlv_stream, mut invoice_request_tlv_stream, invoice_tlv_stream,
 			mut signature_tlv_stream, experimental_offer_tlv_stream,
-			experimental_invoice_request_tlv_stream,
+			experimental_invoice_request_tlv_stream, experimental_invoice_tlv_stream,
 		) = invoice.as_tlv_stream();
 		let payer_id = pubkey(1);
 		invoice_request_tlv_stream.payer_id = Some(&payer_id);
@@ -1692,6 +1695,7 @@ mod tests {
 			(payer_tlv_stream, offer_tlv_stream, invoice_request_tlv_stream, invoice_tlv_stream);
 		let experimental_tlv_stream = (
 			experimental_offer_tlv_stream, experimental_invoice_request_tlv_stream,
+			experimental_invoice_tlv_stream,
 		);
 		let mut bytes = Vec::new();
 		(&tlv_stream, &experimental_tlv_stream).write(&mut bytes).unwrap();

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1434,7 +1434,9 @@ mod tests {
 					paths: None,
 				},
 				SignatureTlvStreamRef { signature: Some(&invoice_request.signature()) },
-				ExperimentalOfferTlvStreamRef {},
+				ExperimentalOfferTlvStreamRef {
+					experimental_foo: None,
+				},
 			),
 		);
 
@@ -1482,6 +1484,7 @@ mod tests {
 
 		let offer = OfferBuilder::new(recipient_pubkey())
 			.amount_msats(1000)
+			.experimental_foo(42)
 			.build().unwrap();
 		let invoice_request = offer
 			.request_invoice_deriving_metadata(signing_pubkey, &expanded_key, nonce, payment_id)
@@ -1565,6 +1568,7 @@ mod tests {
 
 		let offer = OfferBuilder::new(recipient_pubkey())
 			.amount_msats(1000)
+			.experimental_foo(42)
 			.build().unwrap();
 		let invoice_request = offer
 			.request_invoice_deriving_signing_pubkey(&expanded_key, nonce, &secp_ctx, payment_id)

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1551,6 +1551,7 @@ mod tests {
 
 		let invoice = invoice_request.respond_with_no_std(payment_paths(), payment_hash(), now())
 			.unwrap()
+			.experimental_baz(42)
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 		match invoice.verify_using_metadata(&expanded_key, &secp_ctx) {
@@ -1643,6 +1644,7 @@ mod tests {
 
 		let invoice = invoice_request.respond_with_no_std(payment_paths(), payment_hash(), now())
 			.unwrap()
+			.experimental_baz(42)
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 		assert!(invoice.verify_using_metadata(&expanded_key, &secp_ctx).is_err());

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1242,7 +1242,7 @@ impl Readable for InvoiceRequestFields {
 
 #[cfg(test)]
 mod tests {
-	use super::{InvoiceRequest, InvoiceRequestFields, InvoiceRequestTlvStreamRef, PAYER_NOTE_LIMIT, SIGNATURE_TAG, UnsignedInvoiceRequest};
+	use super::{INVOICE_REQUEST_TYPES, InvoiceRequest, InvoiceRequestFields, InvoiceRequestTlvStreamRef, PAYER_NOTE_LIMIT, SIGNATURE_TAG, UnsignedInvoiceRequest};
 
 	use bitcoin::constants::ChainHash;
 	use bitcoin::network::Network;
@@ -2294,7 +2294,72 @@ mod tests {
 	}
 
 	#[test]
-	fn fails_parsing_invoice_request_with_extra_tlv_records() {
+	fn parses_invoice_request_with_unknown_tlv_records() {
+		const UNKNOWN_ODD_TYPE: u64 = INVOICE_REQUEST_TYPES.end - 1;
+		assert!(UNKNOWN_ODD_TYPE % 2 == 1);
+
+		let secp_ctx = Secp256k1::new();
+		let keys = Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
+		let mut unsigned_invoice_request = OfferBuilder::new(keys.public_key())
+			.amount_msats(1000)
+			.build().unwrap()
+			.request_invoice(vec![1; 32], keys.public_key()).unwrap()
+			.build().unwrap();
+
+		BigSize(UNKNOWN_ODD_TYPE).write(&mut unsigned_invoice_request.bytes).unwrap();
+		BigSize(32).write(&mut unsigned_invoice_request.bytes).unwrap();
+		[42u8; 32].write(&mut unsigned_invoice_request.bytes).unwrap();
+
+		unsigned_invoice_request.tagged_hash =
+			TaggedHash::from_valid_tlv_stream_bytes(SIGNATURE_TAG, &unsigned_invoice_request.bytes);
+
+		let invoice_request = unsigned_invoice_request
+			.sign(|message: &UnsignedInvoiceRequest|
+				Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+			)
+			.unwrap();
+
+		let mut encoded_invoice_request = Vec::new();
+		invoice_request.write(&mut encoded_invoice_request).unwrap();
+
+		match InvoiceRequest::try_from(encoded_invoice_request.clone()) {
+			Ok(invoice_request) => assert_eq!(invoice_request.bytes, encoded_invoice_request),
+			Err(e) => panic!("error parsing invoice_request: {:?}", e),
+		}
+
+		const UNKNOWN_EVEN_TYPE: u64 = INVOICE_REQUEST_TYPES.end - 2;
+		assert!(UNKNOWN_EVEN_TYPE % 2 == 0);
+
+		let mut unsigned_invoice_request = OfferBuilder::new(keys.public_key())
+			.amount_msats(1000)
+			.build().unwrap()
+			.request_invoice(vec![1; 32], keys.public_key()).unwrap()
+			.build().unwrap();
+
+		BigSize(UNKNOWN_EVEN_TYPE).write(&mut unsigned_invoice_request.bytes).unwrap();
+		BigSize(32).write(&mut unsigned_invoice_request.bytes).unwrap();
+		[42u8; 32].write(&mut unsigned_invoice_request.bytes).unwrap();
+
+		unsigned_invoice_request.tagged_hash =
+			TaggedHash::from_valid_tlv_stream_bytes(SIGNATURE_TAG, &unsigned_invoice_request.bytes);
+
+		let invoice_request = unsigned_invoice_request
+			.sign(|message: &UnsignedInvoiceRequest|
+				Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+			)
+			.unwrap();
+
+		let mut encoded_invoice_request = Vec::new();
+		invoice_request.write(&mut encoded_invoice_request).unwrap();
+
+		match InvoiceRequest::try_from(encoded_invoice_request) {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12ParseError::Decode(DecodeError::UnknownRequiredFeature)),
+		}
+	}
+
+	#[test]
+	fn fails_parsing_invoice_request_with_out_of_range_tlv_records() {
 		let secp_ctx = Secp256k1::new();
 		let keys = Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 		let invoice_request = OfferBuilder::new(keys.public_key())

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -249,7 +249,6 @@ impl<'a> TlvStream<'a> {
 }
 
 /// A slice into a [`TlvStream`] for a record.
-#[derive(Eq, PartialEq)]
 pub(super) struct TlvRecord<'a> {
 	pub(super) r#type: u64,
 	type_bytes: &'a [u8],

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -21,7 +21,7 @@ use crate::prelude::*;
 /// Valid type range for signature TLV records.
 const SIGNATURE_TYPES: core::ops::RangeInclusive<u64> = 240..=1000;
 
-tlv_stream!(SignatureTlvStream, SignatureTlvStreamRef, SIGNATURE_TYPES, {
+tlv_stream!(SignatureTlvStream, SignatureTlvStreamRef<'a>, SIGNATURE_TYPES, {
 	(240, signature: Signature),
 });
 

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -963,7 +963,9 @@ impl OfferContents {
 						OFFER_ISSUER_ID_TYPE => !metadata.derives_recipient_keys(),
 						_ => true,
 					}
-				});
+				})
+				.chain(TlvStream::new(bytes).range(EXPERIMENTAL_OFFER_TYPES));
+
 				let signing_pubkey = match self.issuer_signing_pubkey() {
 					Some(signing_pubkey) => signing_pubkey,
 					None => return Err(()),

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -1077,7 +1077,7 @@ const OFFER_METADATA_TYPE: u64 = 4;
 /// TLV record type for [`Offer::issuer_signing_pubkey`].
 const OFFER_ISSUER_ID_TYPE: u64 = 22;
 
-tlv_stream!(OfferTlvStream, OfferTlvStreamRef, OFFER_TYPES, {
+tlv_stream!(OfferTlvStream, OfferTlvStreamRef<'a>, OFFER_TYPES, {
 	(2, chains: (Vec<ChainHash>, WithoutLength)),
 	(OFFER_METADATA_TYPE, metadata: (Vec<u8>, WithoutLength)),
 	(6, currency: CurrencyCode),

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -1091,6 +1091,9 @@ tlv_stream!(OfferTlvStream, OfferTlvStreamRef<'a>, OFFER_TYPES, {
 	(OFFER_ISSUER_ID_TYPE, issuer_id: PublicKey),
 });
 
+/// Valid type range for experimental offer TLV records.
+pub(super) const EXPERIMENTAL_OFFER_TYPES: core::ops::Range<u64> = 1_000_000_000..2_000_000_000;
+
 impl Bech32Encode for Offer {
 	const BECH32_HRP: &'static str = "lno";
 }

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -90,7 +90,7 @@ use crate::ln::channelmanager::PaymentId;
 use crate::ln::features::OfferFeatures;
 use crate::ln::inbound_payment::{ExpandedKey, IV_LEN};
 use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
-use crate::offers::merkle::{TaggedHash, TlvStream};
+use crate::offers::merkle::{TaggedHash, TlvRecord, TlvStream};
 use crate::offers::nonce::Nonce;
 use crate::offers::parse::{Bech32Encode, Bolt12ParseError, Bolt12SemanticError, ParsedMessage};
 use crate::offers::signer::{Metadata, MetadataMaterial, self};
@@ -128,7 +128,7 @@ impl OfferId {
 	}
 
 	fn from_valid_invreq_tlv_stream(bytes: &[u8]) -> Self {
-		let tlv_stream = TlvStream::new(bytes).range(OFFER_TYPES);
+		let tlv_stream = Offer::tlv_stream_iter(bytes);
 		let tagged_hash = TaggedHash::from_tlv_stream(Self::ID_TAG, tlv_stream);
 		Self(tagged_hash.to_bytes())
 	}
@@ -685,6 +685,12 @@ impl Offer {
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	pub fn expects_quantity(&self) -> bool {
 		self.contents.expects_quantity()
+	}
+
+	pub(super) fn tlv_stream_iter<'a>(
+		bytes: &'a [u8]
+	) -> impl core::iter::Iterator<Item = TlvRecord<'a>> {
+		TlvStream::new(bytes).range(OFFER_TYPES)
 	}
 
 	#[cfg(async_payments)]

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -2084,6 +2084,9 @@ mod bolt12_tests {
 
 			// unknown odd field
 			"lno1pgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxfppf5x2mrvdamk7unvvs",
+
+			// unknown odd experimental field
+			"lno1pgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvx078wdv5gg2dpjkcmr0wahhymry",
 		];
 		for encoded_offer in &offers {
 			if let Err(e) = encoded_offer.parse::<Offer>() {
@@ -2223,6 +2226,18 @@ mod bolt12_tests {
 		// Contains type >= 80
 		assert_eq!(
 			"lno1pgz5znzfgdz3vggzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgp9qgr0u2xq4dh3kdevrf4zg6hx8a60jv0gxe0ptgyfc6xkryqqqqqqqq".parse::<Offer>(),
+			Err(Bolt12ParseError::Decode(DecodeError::InvalidValue)),
+		);
+
+		// Contains type > 1999999999
+		assert_eq!(
+			"lno1pgz5znzfgdz3vggzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgp06ae4jsq9qgr0u2xq4dh3kdevrf4zg6hx8a60jv0gxe0ptgyfc6xkryqqqqqqqq".parse::<Offer>(),
+			Err(Bolt12ParseError::Decode(DecodeError::InvalidValue)),
+		);
+
+		// Contains unknown even type (1000000002)
+		assert_eq!(
+			"lno1pgz5znzfgdz3vggzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgp06wu6egp9qgr0u2xq4dh3kdevrf4zg6hx8a60jv0gxe0ptgyfc6xkryqqqqqqqq".parse::<Offer>(),
 			Err(Bolt12ParseError::Decode(DecodeError::InvalidValue)),
 		);
 

--- a/lightning/src/offers/payer.rs
+++ b/lightning/src/offers/payer.rs
@@ -30,6 +30,6 @@ pub(super) struct PayerContents(pub Metadata);
 /// [`Refund::payer_metadata`]: crate::offers::refund::Refund::payer_metadata
 pub(super) const PAYER_METADATA_TYPE: u64 = 0;
 
-tlv_stream!(PayerTlvStream, PayerTlvStreamRef, 0..1, {
+tlv_stream!(PayerTlvStream, PayerTlvStreamRef<'a>, 0..1, {
 	(PAYER_METADATA_TYPE, metadata: (Vec<u8>, WithoutLength)),
 });

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -178,6 +178,8 @@ macro_rules! refund_explicit_metadata_builder_methods { () => {
 				quantity: None, payer_signing_pubkey: signing_pubkey, payer_note: None, paths: None,
 				#[cfg(test)]
 				experimental_foo: None,
+				#[cfg(test)]
+				experimental_bar: None,
 			},
 			secp_ctx: None,
 		})
@@ -222,6 +224,8 @@ macro_rules! refund_builder_methods { (
 				quantity: None, payer_signing_pubkey: node_id, payer_note: None, paths: None,
 				#[cfg(test)]
 				experimental_foo: None,
+				#[cfg(test)]
+				experimental_bar: None,
 			},
 			secp_ctx: Some(secp_ctx),
 		})
@@ -368,6 +372,12 @@ macro_rules! refund_builder_test_methods { (
 		$self.refund.experimental_foo = Some(experimental_foo);
 		$return_value
 	}
+
+	#[cfg_attr(c_bindings, allow(dead_code))]
+	pub(super) fn experimental_bar($($self_mut)* $self: $self_type, experimental_bar: u64) -> $return_type {
+		$self.refund.experimental_bar = Some(experimental_bar);
+		$return_value
+	}
 } }
 
 impl<'a> RefundBuilder<'a, secp256k1::SignOnly> {
@@ -449,6 +459,8 @@ pub(super) struct RefundContents {
 	paths: Option<Vec<BlindedMessagePath>>,
 	#[cfg(test)]
 	experimental_foo: Option<u64>,
+	#[cfg(test)]
+	experimental_bar: Option<u64>,
 }
 
 impl Refund {
@@ -787,7 +799,10 @@ impl RefundContents {
 			experimental_foo: self.experimental_foo,
 		};
 
-		let experimental_invoice_request = ExperimentalInvoiceRequestTlvStreamRef {};
+		let experimental_invoice_request = ExperimentalInvoiceRequestTlvStreamRef {
+			#[cfg(test)]
+			experimental_bar: self.experimental_bar,
+		};
 
 		(payer, offer, invoice_request, experimental_offer, experimental_invoice_request)
 	}
@@ -879,7 +894,10 @@ impl TryFrom<RefundTlvStream> for RefundContents {
 				#[cfg(test)]
 				experimental_foo,
 			},
-			ExperimentalInvoiceRequestTlvStream {},
+			ExperimentalInvoiceRequestTlvStream {
+				#[cfg(test)]
+				experimental_bar,
+			},
 		) = tlv_stream;
 
 		let payer = match payer_metadata {
@@ -942,6 +960,8 @@ impl TryFrom<RefundTlvStream> for RefundContents {
 			payer_signing_pubkey, payer_note, paths,
 			#[cfg(test)]
 			experimental_foo,
+			#[cfg(test)]
+			experimental_bar,
 		})
 	}
 }
@@ -1050,7 +1070,9 @@ mod tests {
 				ExperimentalOfferTlvStreamRef {
 					experimental_foo: None,
 				},
-				ExperimentalInvoiceRequestTlvStreamRef {},
+				ExperimentalInvoiceRequestTlvStreamRef {
+					experimental_bar: None,
+				},
 			),
 		);
 
@@ -1080,6 +1102,7 @@ mod tests {
 			::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx, 1000, payment_id)
 			.unwrap()
 			.experimental_foo(42)
+			.experimental_bar(42)
 			.build().unwrap();
 		assert_eq!(refund.payer_signing_pubkey(), node_id);
 
@@ -1148,6 +1171,7 @@ mod tests {
 			.unwrap()
 			.path(blinded_path)
 			.experimental_foo(42)
+			.experimental_bar(42)
 			.build().unwrap();
 		assert_ne!(refund.payer_signing_pubkey(), node_id);
 

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -1110,6 +1110,7 @@ mod tests {
 		let invoice = refund
 			.respond_with_no_std(payment_paths(), payment_hash(), recipient_pubkey(), now())
 			.unwrap()
+			.experimental_baz(42)
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 		match invoice.verify_using_metadata(&expanded_key, &secp_ctx) {
@@ -1178,6 +1179,7 @@ mod tests {
 		let invoice = refund
 			.respond_with_no_std(payment_paths(), payment_hash(), recipient_pubkey(), now())
 			.unwrap()
+			.experimental_baz(42)
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 		assert!(invoice.verify_using_metadata(&expanded_key, &secp_ctx).is_err());

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -997,7 +997,7 @@ mod tests {
 	use crate::ln::features::{InvoiceRequestFeatures, OfferFeatures};
 	use crate::ln::inbound_payment::ExpandedKey;
 	use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
-	use crate::offers::invoice_request::{ExperimentalInvoiceRequestTlvStreamRef, INVOICE_REQUEST_TYPES, InvoiceRequestTlvStreamRef};
+	use crate::offers::invoice_request::{EXPERIMENTAL_INVOICE_REQUEST_TYPES, ExperimentalInvoiceRequestTlvStreamRef, INVOICE_REQUEST_TYPES, InvoiceRequestTlvStreamRef};
 	use crate::offers::nonce::Nonce;
 	use crate::offers::offer::{ExperimentalOfferTlvStreamRef, OfferTlvStreamRef};
 	use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError};
@@ -1622,6 +1622,43 @@ mod tests {
 	}
 
 	#[test]
+	fn parses_refund_with_experimental_tlv_records() {
+		const UNKNOWN_ODD_TYPE: u64 = EXPERIMENTAL_INVOICE_REQUEST_TYPES.start + 1;
+		assert!(UNKNOWN_ODD_TYPE % 2 == 1);
+
+		let refund = RefundBuilder::new(vec![1; 32], payer_pubkey(), 1000).unwrap()
+			.build().unwrap();
+
+		let mut encoded_refund = Vec::new();
+		refund.write(&mut encoded_refund).unwrap();
+		BigSize(UNKNOWN_ODD_TYPE).write(&mut encoded_refund).unwrap();
+		BigSize(32).write(&mut encoded_refund).unwrap();
+		[42u8; 32].write(&mut encoded_refund).unwrap();
+
+		match Refund::try_from(encoded_refund.clone()) {
+			Ok(refund) => assert_eq!(refund.bytes, encoded_refund),
+			Err(e) => panic!("error parsing refund: {:?}", e),
+		}
+
+		const UNKNOWN_EVEN_TYPE: u64 = EXPERIMENTAL_INVOICE_REQUEST_TYPES.start;
+		assert!(UNKNOWN_EVEN_TYPE % 2 == 0);
+
+		let refund = RefundBuilder::new(vec![1; 32], payer_pubkey(), 1000).unwrap()
+			.build().unwrap();
+
+		let mut encoded_refund = Vec::new();
+		refund.write(&mut encoded_refund).unwrap();
+		BigSize(UNKNOWN_EVEN_TYPE).write(&mut encoded_refund).unwrap();
+		BigSize(32).write(&mut encoded_refund).unwrap();
+		[42u8; 32].write(&mut encoded_refund).unwrap();
+
+		match Refund::try_from(encoded_refund) {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12ParseError::Decode(DecodeError::UnknownRequiredFeature)),
+		}
+	}
+
+	#[test]
 	fn fails_parsing_refund_with_out_of_range_tlv_records() {
 		let secp_ctx = Secp256k1::new();
 		let keys = Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
@@ -1631,6 +1668,17 @@ mod tests {
 		let mut encoded_refund = Vec::new();
 		refund.write(&mut encoded_refund).unwrap();
 		BigSize(1002).write(&mut encoded_refund).unwrap();
+		BigSize(32).write(&mut encoded_refund).unwrap();
+		[42u8; 32].write(&mut encoded_refund).unwrap();
+
+		match Refund::try_from(encoded_refund) {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12ParseError::Decode(DecodeError::InvalidValue)),
+		}
+
+		let mut encoded_refund = Vec::new();
+		refund.write(&mut encoded_refund).unwrap();
+		BigSize(EXPERIMENTAL_INVOICE_REQUEST_TYPES.end).write(&mut encoded_refund).unwrap();
 		BigSize(32).write(&mut encoded_refund).unwrap();
 		[42u8; 32].write(&mut encoded_refund).unwrap();
 

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -388,12 +388,10 @@ impl StaticInvoice {
 	}
 
 	pub(crate) fn from_same_offer(&self, invreq: &InvoiceRequest) -> bool {
-		let invoice_offer_tlv_stream = TlvStream::new(&self.bytes)
-			.range(OFFER_TYPES)
-			.map(|tlv_record| tlv_record.record_bytes);
-		let invreq_offer_tlv_stream = TlvStream::new(invreq.bytes())
-			.range(OFFER_TYPES)
-			.map(|tlv_record| tlv_record.record_bytes);
+		let invoice_offer_tlv_stream =
+			Offer::tlv_stream_iter(&self.bytes).map(|tlv_record| tlv_record.record_bytes);
+		let invreq_offer_tlv_stream =
+			Offer::tlv_stream_iter(invreq.bytes()).map(|tlv_record| tlv_record.record_bytes);
 		invoice_offer_tlv_stream.eq(invreq_offer_tlv_stream)
 	}
 }

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -1488,6 +1488,30 @@ impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable, E: Writeable, F: Wr
 	}
 }
 
+impl<A: Readable, B: Readable, C: Readable, D: Readable, E: Readable, F: Readable, G: Readable> Readable for (A, B, C, D, E, F, G) {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+		let a: A = Readable::read(r)?;
+		let b: B = Readable::read(r)?;
+		let c: C = Readable::read(r)?;
+		let d: D = Readable::read(r)?;
+		let e: E = Readable::read(r)?;
+		let f: F = Readable::read(r)?;
+		let g: G = Readable::read(r)?;
+		Ok((a, b, c, d, e, f, g))
+	}
+}
+impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable, E: Writeable, F: Writeable, G: Writeable> Writeable for (A, B, C, D, E, F, G) {
+	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+		self.0.write(w)?;
+		self.1.write(w)?;
+		self.2.write(w)?;
+		self.3.write(w)?;
+		self.4.write(w)?;
+		self.5.write(w)?;
+		self.6.write(w)
+	}
+}
+
 impl Writeable for () {
 	fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
 		Ok(())

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -1398,119 +1398,38 @@ impl<T: Writeable> Writeable for RwLock<T> {
 	}
 }
 
-impl<A: Readable, B: Readable> Readable for (A, B) {
-	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
-		let a: A = Readable::read(r)?;
-		let b: B = Readable::read(r)?;
-		Ok((a, b))
-	}
-}
-impl<A: Writeable, B: Writeable> Writeable for (A, B) {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
-		self.0.write(w)?;
-		self.1.write(w)
+macro_rules! impl_tuple_ser {
+	($($i: ident : $type: tt),*) => {
+		impl<$($type),*> Readable for ($($type),*)
+		where $(
+			$type: Readable,
+		)*
+		{
+			fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+				Ok(($(<$type as Readable>::read(r)?),*))
+			}
+		}
+
+		impl<$($type),*> Writeable for ($($type),*)
+		where $(
+			$type: Writeable,
+		)*
+		{
+			fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+				let ($($i),*) = self;
+				$($i.write(w)?;)*
+				Ok(())
+			}
+		}
 	}
 }
 
-impl<A: Readable, B: Readable, C: Readable> Readable for (A, B, C) {
-	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
-		let a: A = Readable::read(r)?;
-		let b: B = Readable::read(r)?;
-		let c: C = Readable::read(r)?;
-		Ok((a, b, c))
-	}
-}
-impl<A: Writeable, B: Writeable, C: Writeable> Writeable for (A, B, C) {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
-		self.0.write(w)?;
-		self.1.write(w)?;
-		self.2.write(w)
-	}
-}
-
-impl<A: Readable, B: Readable, C: Readable, D: Readable> Readable for (A, B, C, D) {
-	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
-		let a: A = Readable::read(r)?;
-		let b: B = Readable::read(r)?;
-		let c: C = Readable::read(r)?;
-		let d: D = Readable::read(r)?;
-		Ok((a, b, c, d))
-	}
-}
-impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable> Writeable for (A, B, C, D) {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
-		self.0.write(w)?;
-		self.1.write(w)?;
-		self.2.write(w)?;
-		self.3.write(w)
-	}
-}
-
-impl<A: Readable, B: Readable, C: Readable, D: Readable, E: Readable> Readable for (A, B, C, D, E) {
-	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
-		let a: A = Readable::read(r)?;
-		let b: B = Readable::read(r)?;
-		let c: C = Readable::read(r)?;
-		let d: D = Readable::read(r)?;
-		let e: E = Readable::read(r)?;
-		Ok((a, b, c, d, e))
-	}
-}
-impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable, E: Writeable> Writeable for (A, B, C, D, E) {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
-		self.0.write(w)?;
-		self.1.write(w)?;
-		self.2.write(w)?;
-		self.3.write(w)?;
-		self.4.write(w)
-	}
-}
-
-impl<A: Readable, B: Readable, C: Readable, D: Readable, E: Readable, F: Readable> Readable for (A, B, C, D, E, F) {
-	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
-		let a: A = Readable::read(r)?;
-		let b: B = Readable::read(r)?;
-		let c: C = Readable::read(r)?;
-		let d: D = Readable::read(r)?;
-		let e: E = Readable::read(r)?;
-		let f: F = Readable::read(r)?;
-		Ok((a, b, c, d, e, f))
-	}
-}
-impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable, E: Writeable, F: Writeable> Writeable for (A, B, C, D, E, F) {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
-		self.0.write(w)?;
-		self.1.write(w)?;
-		self.2.write(w)?;
-		self.3.write(w)?;
-		self.4.write(w)?;
-		self.5.write(w)
-	}
-}
-
-impl<A: Readable, B: Readable, C: Readable, D: Readable, E: Readable, F: Readable, G: Readable> Readable for (A, B, C, D, E, F, G) {
-	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
-		let a: A = Readable::read(r)?;
-		let b: B = Readable::read(r)?;
-		let c: C = Readable::read(r)?;
-		let d: D = Readable::read(r)?;
-		let e: E = Readable::read(r)?;
-		let f: F = Readable::read(r)?;
-		let g: G = Readable::read(r)?;
-		Ok((a, b, c, d, e, f, g))
-	}
-}
-impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable, E: Writeable, F: Writeable, G: Writeable> Writeable for (A, B, C, D, E, F, G) {
-	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
-		self.0.write(w)?;
-		self.1.write(w)?;
-		self.2.write(w)?;
-		self.3.write(w)?;
-		self.4.write(w)?;
-		self.5.write(w)?;
-		self.6.write(w)
-	}
-}
+impl_tuple_ser!(a: A, b: B);
+impl_tuple_ser!(a: A, b: B, c: C);
+impl_tuple_ser!(a: A, b: B, c: C, d: D);
+impl_tuple_ser!(a: A, b: B, c: C, d: D, e: E);
+impl_tuple_ser!(a: A, b: B, c: C, d: D, e: E, f: F);
+impl_tuple_ser!(a: A, b: B, c: C, d: D, e: E, f: F, g: G);
 
 impl Writeable for () {
 	fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -1446,6 +1446,26 @@ impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable> Writeable for (A, B
 	}
 }
 
+impl<A: Readable, B: Readable, C: Readable, D: Readable, E: Readable> Readable for (A, B, C, D, E) {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+		let a: A = Readable::read(r)?;
+		let b: B = Readable::read(r)?;
+		let c: C = Readable::read(r)?;
+		let d: D = Readable::read(r)?;
+		let e: E = Readable::read(r)?;
+		Ok((a, b, c, d, e))
+	}
+}
+impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable, E: Writeable> Writeable for (A, B, C, D, E) {
+	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+		self.0.write(w)?;
+		self.1.write(w)?;
+		self.2.write(w)?;
+		self.3.write(w)?;
+		self.4.write(w)
+	}
+}
+
 impl Writeable for () {
 	fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
 		Ok(())

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -1466,6 +1466,28 @@ impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable, E: Writeable> Write
 	}
 }
 
+impl<A: Readable, B: Readable, C: Readable, D: Readable, E: Readable, F: Readable> Readable for (A, B, C, D, E, F) {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+		let a: A = Readable::read(r)?;
+		let b: B = Readable::read(r)?;
+		let c: C = Readable::read(r)?;
+		let d: D = Readable::read(r)?;
+		let e: E = Readable::read(r)?;
+		let f: F = Readable::read(r)?;
+		Ok((a, b, c, d, e, f))
+	}
+}
+impl<A: Writeable, B: Writeable, C: Writeable, D: Writeable, E: Writeable, F: Writeable> Writeable for (A, B, C, D, E, F) {
+	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+		self.0.write(w)?;
+		self.1.write(w)?;
+		self.2.write(w)?;
+		self.3.write(w)?;
+		self.4.write(w)?;
+		self.5.write(w)
+	}
+}
+
 impl Writeable for () {
 	fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
 		Ok(())

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -952,7 +952,7 @@ macro_rules! impl_writeable_tlv_based {
 /// [`Readable`]: crate::util::ser::Readable
 /// [`Writeable`]: crate::util::ser::Writeable
 macro_rules! tlv_stream {
-	($name:ident, $nameref:ident, $range:expr, {
+	($name:ident, $nameref:ident $(<$lifetime:lifetime>)?, $range:expr, {
 		$(($type:expr, $field:ident : $fieldty:tt)),* $(,)*
 	}) => {
 		#[derive(Debug)]
@@ -964,13 +964,13 @@ macro_rules! tlv_stream {
 
 		#[cfg_attr(test, derive(PartialEq))]
 		#[derive(Debug)]
-		pub(crate) struct $nameref<'a> {
+		pub(crate) struct $nameref<$($lifetime)*> {
 			$(
 				pub(super) $field: Option<tlv_record_ref_type!($fieldty)>,
 			)*
 		}
 
-		impl<'a> $crate::util::ser::Writeable for $nameref<'a> {
+		impl<$($lifetime)*> $crate::util::ser::Writeable for $nameref<$($lifetime)*> {
 			fn write<W: $crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), $crate::io::Error> {
 				encode_tlv_stream!(writer, {
 					$(($type, self.$field, (option, encoding: $fieldty))),*


### PR DESCRIPTION
The BOLT12 spec defines experimental TLV ranges that are allowed in messages. Allow this range when parsing those messages and include those bytes in subsequent messages (i.e., experimental `offer` TLVs are included in an `invreq` after the signature). Account for these bytes when computing metadata, verifying messages, and constructing `OfferId`s.

~~Based on #3218.~~
Fixes #3168.