### PR TITLE
Disallow skipping tx-sync tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
             echo "ELECTRS_EXE=$( pwd )/bin/electrs-${{ runner.os }}-${{ runner.arch }}" >> "$GITHUB_ENV"
       - name: Run CI script
         shell: bash # Default on Winblows is powershell
-        run: CI_MINIMIZE_DISK_USAGE=1 ./ci/ci-tests.sh
+        run: CI_ENV=1 CI_MINIMIZE_DISK_USAGE=1 ./ci/ci-tests.sh
 
   coverage:
     strategy:

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -44,22 +44,24 @@ cargo check --verbose --color always --features rpc-client,rest-client,tokio
 popd
 
 if [[ "$HOST_PLATFORM" != *windows* ]]; then
-	if [ -z "$BITCOIND_EXE" ] || [ -z "$ELECTRS_EXE" ]; then
-		echo -e "\n\nSkipping testing Transaction Sync Clients due to BITCOIND_EXE or ELECTRS_EXE being unset."
-	else
-		echo -e "\n\nBuilding and testing Transaction Sync Clients with features"
-		pushd lightning-transaction-sync
+	pushd lightning-transaction-sync
+	echo -e "\n\nChecking Transaction Sync Clients with features."
+	cargo check --verbose --color always --features esplora-blocking
+	cargo check --verbose --color always --features esplora-async
+	cargo check --verbose --color always --features esplora-async-https
+	cargo check --verbose --color always --features electrum
 
+	if [ -z "$CI_ENV" ] && [[ -z "$BITCOIND_EXE" || -z "$ELECTRS_EXE" ]]; then
+		echo -e "\n\nSkipping testing Transaction Sync Clients due to BITCOIND_EXE or ELECTRS_EXE being unset."
+		cargo check --tests
+	else
+		echo -e "\n\nTesting Transaction Sync Clients with features."
 		cargo test --verbose --color always --features esplora-blocking
-		cargo check --verbose --color always --features esplora-blocking
 		cargo test --verbose --color always --features esplora-async
-		cargo check --verbose --color always --features esplora-async
 		cargo test --verbose --color always --features esplora-async-https
-		cargo check --verbose --color always --features esplora-async-https
 		cargo test --verbose --color always --features electrum
-		cargo check --verbose --color always --features electrum
-		popd
 	fi
+	popd
 fi
 
 echo -e "\n\nTest futures builds"


### PR DESCRIPTION
Minor follow-up to #3020.

Previously, we'd always skip tx-sync tests if the
`BITCOIND_EXE`/`ELECTRS_EXE` environment variables would be unset. While this is especially fine for local testing, we still want to enforce tests failing if somehow the `bitcoind`/`electrs` downloading or caching in CI stops working. Here, we therefore add a `CI_ENV` variable that indicates we're indeed running in CI, and only skip if it's unset.