### PR TITLE
Return slices, rather than `Vec` references, in addresses

### DIFF
--- a/lightning-rapid-gossip-sync/src/processing.rs
+++ b/lightning-rapid-gossip-sync/src/processing.rs
@@ -178,7 +178,7 @@ where
 							synthetic_node_announcement.features = info.features().clone();
 							synthetic_node_announcement.rgb = info.rgb().clone();
 							synthetic_node_announcement.alias = info.alias().clone();
-							synthetic_node_announcement.addresses = info.addresses().clone();
+							synthetic_node_announcement.addresses = info.addresses().to_vec();
 						});
 
 					if has_address_details {

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -595,7 +595,7 @@ where
 
 			match node_details {
 				Some((features, addresses)) if features.supports_onion_messages() && addresses.len() > 0 => {
-					let first_node_addresses = Some(addresses.clone());
+					let first_node_addresses = Some(addresses.to_vec());
 					Ok(OnionMessagePath {
 						intermediate_nodes: vec![], destination, first_node_addresses
 					})

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -1308,7 +1308,7 @@ impl NodeAnnouncementInfo {
 	}
 
 	/// Internet-level addresses via which one can connect to the node
-	pub fn addresses(&self) -> &Vec<SocketAddress> {
+	pub fn addresses(&self) -> &[SocketAddress] {
 		match self {
 			NodeAnnouncementInfo::Relayed(relayed) => {
 				&relayed.contents.addresses


### PR DESCRIPTION
Its a bit strange to return a reference to a `Vec` in Rust, when a slice is really intended as the way to do so. Worse, the bindings don't know how to map a reference to a `Vec` (but do have code to map a slice of `Clone`able objects).

Here, we move `NodeAnnouncementInfo::addresses` to return a slice, though to do so we have to adapt the `WithoutLength` `Writeable` impl to support slices as well.