### PR TITLE
Upgrade bech32 dependency

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ stdin_fuzz = []
 lightning = { path = "../lightning", features = ["regex", "hashbrown", "_test_utils"] }
 lightning-invoice = { path = "../lightning-invoice" }
 lightning-rapid-gossip-sync = { path = "../lightning-rapid-gossip-sync" }
-bech32 = "0.9.1"
+bech32 = "0.11.0"
 bitcoin = { version = "0.32.2", features = ["secp-lowmemory"] }
 
 afl = { version = "0.12", optional = true }

--- a/fuzz/src/bolt11_deser.rs
+++ b/fuzz/src/bolt11_deser.rs
@@ -8,10 +8,11 @@
 // licenses.
 
 use crate::utils::test_logger;
-use bech32::{u5, FromBase32, ToBase32};
+use bech32::Fe32;
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
 use lightning_invoice::{
-	Bolt11Invoice, RawBolt11Invoice, RawDataPart, RawHrp, RawTaggedField, TaggedField,
+	Bolt11Invoice, FromBase32, RawBolt11Invoice, RawDataPart, RawHrp, RawTaggedField, TaggedField,
+	ToBase32,
 };
 use std::str::FromStr;
 
@@ -25,7 +26,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 			Err(_) => return,
 		};
 		let bech32 =
-			data.iter().skip(hrp_len).map(|x| u5::try_from_u8(x % 32).unwrap()).collect::<Vec<_>>();
+			data.iter().skip(hrp_len).map(|x| Fe32::try_from(x % 32).unwrap()).collect::<Vec<_>>();
 		let invoice_data = match RawDataPart::from_base32(&bech32) {
 			Ok(invoice) => invoice,
 			Err(_) => return,

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 std = []
 
 [dependencies]
-bech32 = { version = "0.9.1", default-features = false }
+bech32 = { version = "0.11.0", default-features = false }
 lightning-types = { version = "0.1.0-beta", path = "../lightning-types", default-features = false }
 serde = { version = "1.0.118", optional = true }
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -33,7 +33,8 @@ extern crate serde;
 #[cfg(feature = "std")]
 use std::time::SystemTime;
 
-use bech32::{FromBase32, u5};
+use bech32::Fe32;
+use bech32::primitives::decode::CheckedHrpstringError;
 use bitcoin::{Address, Network, PubkeyHash, ScriptHash, WitnessProgram, WitnessVersion};
 use bitcoin::hashes::{Hash, sha256};
 use lightning_types::features::Bolt11InvoiceFeatures;
@@ -76,12 +77,59 @@ mod prelude {
 
 use crate::prelude::*;
 
+/// Interface to write `Fe32`s into a sink
+pub trait WriteBase32 {
+	/// Write error
+	type Err: fmt::Debug;
+
+	/// Write a `Fe32` slice
+	fn write(&mut self, data: &Vec<Fe32>) -> Result<(), Self::Err> {
+		for b in data {
+			self.write_fe32(*b)?;
+		}
+		Ok(())
+	}
+
+	/// Write a single `Fe32`
+	fn write_fe32(&mut self, data: Fe32) -> Result<(), Self::Err>;
+}
+
+/// A trait for converting a value to a type `T` that represents a `Fe32` slice.
+pub trait ToBase32 {
+	/// Convert `Self` to base32 vector
+	fn to_base32(&self) -> Vec<Fe32> {
+		let mut vec = Vec::new();
+		self.write_base32(&mut vec).unwrap();
+		vec
+	}
+
+	/// Encode as base32 and write it to the supplied writer
+	/// Implementations shouldn't allocate.
+	fn write_base32<W: WriteBase32>(&self, writer: &mut W) -> Result<(), <W as WriteBase32>::Err>;
+}
+
+/// Interface to calculate the length of the base32 representation before actually serializing
+pub trait Base32Len: ToBase32 {
+	/// Calculate the base32 serialized length
+	fn base32_len(&self) -> usize;
+}
+
+/// Trait for paring/converting base32 slice. It is the reciprocal of `ToBase32`.
+pub trait FromBase32: Sized {
+	/// The associated error which can be returned from parsing (e.g. because of bad padding).
+	type Err;
+
+	/// Convert a base32 slice to `Self`.
+	fn from_base32(b32: &[Fe32]) -> Result<Self, Self::Err>;
+}
+
 /// Errors that indicate what is wrong with the invoice. They have some granularity for debug
 /// reasons, but should generally result in an "invalid BOLT11 invoice" message for the user.
 #[allow(missing_docs)]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Bolt11ParseError {
-	Bech32Error(bech32::Error),
+	Bech32Error(CheckedHrpstringError),
+	GenericBech32Error,
 	ParseAmountError(ParseIntError),
 	MalformedSignature(bitcoin::secp256k1::Error),
 	BadPrefix,
@@ -404,12 +452,30 @@ impl From<Currency> for Network {
 /// Tagged field which may have an unknown tag
 ///
 /// This is not exported to bindings users as we don't currently support TaggedField
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum RawTaggedField {
 	/// Parsed tagged field with known tag
 	KnownSemantics(TaggedField),
 	/// tagged field which was not parsed due to an unknown tag or undefined field semantics
-	UnknownSemantics(Vec<u5>),
+	UnknownSemantics(Vec<Fe32>),
+}
+
+impl PartialOrd for RawTaggedField {
+	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+/// Note: `Ord `cannot be simply derived because of `Fe32`.
+impl Ord for RawTaggedField {
+	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+		match (self, other) {
+			(RawTaggedField::KnownSemantics(ref a), RawTaggedField::KnownSemantics(ref b)) => a.cmp(b),
+			(RawTaggedField::UnknownSemantics(ref a), RawTaggedField::UnknownSemantics(ref b)) => a.iter().map(|a| a.to_u8()).cmp(b.iter().map(|b| b.to_u8())),
+			(RawTaggedField::KnownSemantics(..), RawTaggedField::UnknownSemantics(..)) => core::cmp::Ordering::Less,
+			(RawTaggedField::UnknownSemantics(..), RawTaggedField::KnownSemantics(..)) => core::cmp::Ordering::Greater,
+		}
+	}
 }
 
 /// Tagged field with known tag
@@ -957,18 +1023,18 @@ macro_rules! find_all_extract {
 #[allow(missing_docs)]
 impl RawBolt11Invoice {
 	/// Hash the HRP as bytes and signatureless data part.
-	fn hash_from_parts(hrp_bytes: &[u8], data_without_signature: &[u5]) -> [u8; 32] {
+	fn hash_from_parts(hrp_bytes: &[u8], data_without_signature: &[Fe32]) -> [u8; 32] {
 		let mut preimage = Vec::<u8>::from(hrp_bytes);
 
 		let mut data_part = Vec::from(data_without_signature);
 		let overhang = (data_part.len() * 5) % 8;
 		if overhang > 0 {
 			// add padding if data does not end at a byte boundary
-			data_part.push(u5::try_from_u8(0).unwrap());
+			data_part.push(Fe32::try_from(0).unwrap());
 
-			// if overhang is in (1..3) we need to add u5(0) padding two times
+			// if overhang is in (1..3) we need to add Fe32(0) padding two times
 			if overhang < 3 {
-				data_part.push(u5::try_from_u8(0).unwrap());
+				data_part.push(Fe32::try_from(0).unwrap());
 			}
 		}
 
@@ -982,8 +1048,6 @@ impl RawBolt11Invoice {
 
 	/// Calculate the hash of the encoded `RawBolt11Invoice` which should be signed.
 	pub fn signable_hash(&self) -> [u8; 32] {
-		use bech32::ToBase32;
-
 		RawBolt11Invoice::hash_from_parts(
 			self.hrp.to_string().as_bytes(),
 			&self.data.to_base32()
@@ -1493,7 +1557,7 @@ impl From<TaggedField> for RawTaggedField {
 
 impl TaggedField {
 	/// Numeric representation of the field's tag
-	pub fn tag(&self) -> u5 {
+	pub fn tag(&self) -> Fe32 {
 		let tag = match *self {
 			TaggedField::PaymentHash(_) => constants::TAG_PAYMENT_HASH,
 			TaggedField::Description(_) => constants::TAG_DESCRIPTION,
@@ -1508,7 +1572,7 @@ impl TaggedField {
 			TaggedField::Features(_) => constants::TAG_FEATURES,
 		};
 
-		u5::try_from_u8(tag).expect("all tags defined are <32")
+		Fe32::try_from(tag).expect("all tags defined are <32")
 	}
 }
 
@@ -2242,5 +2306,33 @@ mod test {
 		assert_eq!(invoice, deserialized_invoice);
 		assert_eq!(invoice_str, deserialized_invoice.to_string().as_str());
 		assert_eq!(invoice_str, serialized_invoice.as_str().trim_matches('\"'));
+	}
+
+	#[test]
+	fn raw_tagged_field_ordering() {
+		use crate::{Description, Fe32, RawTaggedField, TaggedField, Sha256, sha256, UntrustedString};
+
+		let field10 = RawTaggedField::KnownSemantics(
+			TaggedField::PaymentHash(Sha256(sha256::Hash::from_str(
+				"0001020304050607080900010203040506070809000102030405060708090102"
+			).unwrap()))
+		);
+		let field11 = RawTaggedField::KnownSemantics(
+			TaggedField::Description(Description(UntrustedString("Description".to_string())))
+		);
+		let field20 = RawTaggedField::UnknownSemantics(vec![Fe32::Q]);
+		let field21 = RawTaggedField::UnknownSemantics(vec![Fe32::R]);
+
+		assert!(field10 < field20);
+		assert!(field20 > field10);
+		assert_eq!(field10.cmp(&field20), std::cmp::Ordering::Less);
+		assert_eq!(field20.cmp(&field10), std::cmp::Ordering::Greater);
+		assert_eq!(field10.cmp(&field10), std::cmp::Ordering::Equal);
+		assert_eq!(field20.cmp(&field20), std::cmp::Ordering::Equal);
+		assert_eq!(field10.partial_cmp(&field20).unwrap(), std::cmp::Ordering::Less);
+		assert_eq!(field20.partial_cmp(&field10).unwrap(), std::cmp::Ordering::Greater);
+
+		assert_eq!(field10.partial_cmp(&field11).unwrap(), std::cmp::Ordering::Less);
+		assert_eq!(field20.partial_cmp(&field21).unwrap(), std::cmp::Ordering::Less);
 	}
 }

--- a/lightning-invoice/src/test_ser_de.rs
+++ b/lightning-invoice/src/test_ser_de.rs
@@ -1,7 +1,7 @@
 use crate::{
-	sha256, FromBase32, PayeePubKey, PaymentSecret, PositiveTimestamp, RawDataPart, Sha256,
+	sha256, Base32Len, FromBase32, PayeePubKey, PaymentSecret, PositiveTimestamp, RawDataPart,
+	Sha256, ToBase32,
 };
-use bech32::{Base32Len, ToBase32};
 
 use core::fmt::Debug;
 use std::str::FromStr;

--- a/lightning-invoice/tests/ser_de.rs
+++ b/lightning-invoice/tests/ser_de.rs
@@ -410,19 +410,21 @@ fn invoice_deserialize() {
 
 #[test]
 fn test_bolt_invalid_invoices() {
+	use bech32::primitives::decode::{CharError, ChecksumError, CheckedHrpstringError, UncheckedHrpstringError};
+
 	// Tests the BOLT 11 invalid invoice test vectors
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqqsgqtqyx5vggfcsll4wu246hz02kp85x4katwsk9639we5n5yngc3yhqkm35jnjw4len8vrnqnf5ejh0mzj9n3vz2px97evektfm2l6wqccp3y7372"
 		), Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::InvalidFeatures)));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrnt"
-		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(bech32::Error::InvalidChecksum))));
+		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(CheckedHrpstringError::Checksum(ChecksumError::InvalidResidue)))));
 	assert_eq!(Bolt11Invoice::from_str(
 		"pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrny"
-		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(bech32::Error::MissingSeparator))));
+		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(CheckedHrpstringError::Parse(UncheckedHrpstringError::Char(CharError::MissingSeparator))))));
 	assert_eq!(Bolt11Invoice::from_str(
 		"LNBC2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpuyk0sg5g70me25alkluzd2x62aysf2pyy8edtjeevuv4p2d5p76r4zkmneet7uvyakky2zr4cusd45tftc9c5fh0nnqpnl2jfll544esqchsrny"
-		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(bech32::Error::MixedCase))));
+		), Err(ParseOrSemanticError::ParseError(Bolt11ParseError::Bech32Error(CheckedHrpstringError::Parse(UncheckedHrpstringError::Char(CharError::MixedCase))))));
 	assert_eq!(Bolt11Invoice::from_str(
 		"lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgqwgt7mcn5yqw3yx0w94pswkpq6j9uh6xfqqqtsk4tnarugeektd4hg5975x9am52rz4qskukxdmjemg92vvqz8nvmsye63r5ykel43pgz7zq0g2"
 		), Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::InvalidSignature)));

--- a/lightning-types/Cargo.toml
+++ b/lightning-types/Cargo.toml
@@ -19,7 +19,7 @@ _test_utils = []
 bitcoin = { version = "0.32.2", default-features = false }
 # TODO: Once we switch to bitcoin 0.32 drop this explicit dep:
 hex-conservative = { version = "0.2", default-features = false }
-bech32 = { version = "0.9", default-features = false }
+bech32 = { version = "0.11.0", default-features = false }
 
 [lints]
 workspace = true

--- a/lightning-types/src/features.rs
+++ b/lightning-types/src/features.rs
@@ -82,10 +82,7 @@ use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 use core::{cmp, fmt};
 
-use alloc::vec;
 use alloc::vec::Vec;
-
-use bech32::{u5, Base32Len, FromBase32, ToBase32, WriteBase32};
 
 mod sealed {
 	use super::*;
@@ -775,73 +772,6 @@ impl ChannelTypeFeatures {
 	}
 }
 
-impl ToBase32 for Bolt11InvoiceFeatures {
-	fn write_base32<W: WriteBase32>(&self, writer: &mut W) -> Result<(), <W as WriteBase32>::Err> {
-		// Explanation for the "4": the normal way to round up when dividing is to add the divisor
-		// minus one before dividing
-		let length_u5s = (self.flags.len() * 8 + 4) / 5 as usize;
-		let mut res_u5s: Vec<u5> = vec![u5::try_from_u8(0).unwrap(); length_u5s];
-		for (byte_idx, byte) in self.flags.iter().enumerate() {
-			let bit_pos_from_left_0_indexed = byte_idx * 8;
-			let new_u5_idx = length_u5s - (bit_pos_from_left_0_indexed / 5) as usize - 1;
-			let new_bit_pos = bit_pos_from_left_0_indexed % 5;
-			let shifted_chunk_u16 = (*byte as u16) << new_bit_pos;
-			let curr_u5_as_u8 = res_u5s[new_u5_idx].to_u8();
-			res_u5s[new_u5_idx] =
-				u5::try_from_u8(curr_u5_as_u8 | ((shifted_chunk_u16 & 0x001f) as u8)).unwrap();
-			if new_u5_idx > 0 {
-				let curr_u5_as_u8 = res_u5s[new_u5_idx - 1].to_u8();
-				res_u5s[new_u5_idx - 1] =
-					u5::try_from_u8(curr_u5_as_u8 | (((shifted_chunk_u16 >> 5) & 0x001f) as u8))
-						.unwrap();
-			}
-			if new_u5_idx > 1 {
-				let curr_u5_as_u8 = res_u5s[new_u5_idx - 2].to_u8();
-				res_u5s[new_u5_idx - 2] =
-					u5::try_from_u8(curr_u5_as_u8 | (((shifted_chunk_u16 >> 10) & 0x001f) as u8))
-						.unwrap();
-			}
-		}
-		// Trim the highest feature bits.
-		while !res_u5s.is_empty() && res_u5s[0] == u5::try_from_u8(0).unwrap() {
-			res_u5s.remove(0);
-		}
-		writer.write(&res_u5s)
-	}
-}
-
-impl Base32Len for Bolt11InvoiceFeatures {
-	fn base32_len(&self) -> usize {
-		self.to_base32().len()
-	}
-}
-
-impl FromBase32 for Bolt11InvoiceFeatures {
-	type Err = bech32::Error;
-
-	fn from_base32(field_data: &[u5]) -> Result<Bolt11InvoiceFeatures, bech32::Error> {
-		// Explanation for the "7": the normal way to round up when dividing is to add the divisor
-		// minus one before dividing
-		let length_bytes = (field_data.len() * 5 + 7) / 8 as usize;
-		let mut res_bytes: Vec<u8> = vec![0; length_bytes];
-		for (u5_idx, chunk) in field_data.iter().enumerate() {
-			let bit_pos_from_right_0_indexed = (field_data.len() - u5_idx - 1) * 5;
-			let new_byte_idx = (bit_pos_from_right_0_indexed / 8) as usize;
-			let new_bit_pos = bit_pos_from_right_0_indexed % 8;
-			let chunk_u16 = chunk.to_u8() as u16;
-			res_bytes[new_byte_idx] |= ((chunk_u16 << new_bit_pos) & 0xff) as u8;
-			if new_byte_idx != length_bytes - 1 {
-				res_bytes[new_byte_idx + 1] |= ((chunk_u16 >> (8 - new_bit_pos)) & 0xff) as u8;
-			}
-		}
-		// Trim the highest feature bits.
-		while !res_bytes.is_empty() && res_bytes[res_bytes.len() - 1] == 0 {
-			res_bytes.pop();
-		}
-		Ok(Bolt11InvoiceFeatures::from_le_bytes(res_bytes))
-	}
-}
-
 impl<T: sealed::Context> Features<T> {
 	/// Create a blank Features with no features set
 	pub fn empty() -> Self {
@@ -1291,37 +1221,6 @@ mod tests {
 		assert!(features.set_required_custom_bit(257).is_ok());
 		assert!(features.set_required_custom_bit(258).is_ok());
 		assert_eq!(features.flags[32], 0b00000101);
-	}
-
-	#[test]
-	fn invoice_features_encoding() {
-		let features_as_u5s = vec![
-			u5::try_from_u8(6).unwrap(),
-			u5::try_from_u8(10).unwrap(),
-			u5::try_from_u8(25).unwrap(),
-			u5::try_from_u8(1).unwrap(),
-			u5::try_from_u8(10).unwrap(),
-			u5::try_from_u8(0).unwrap(),
-			u5::try_from_u8(20).unwrap(),
-			u5::try_from_u8(2).unwrap(),
-			u5::try_from_u8(0).unwrap(),
-			u5::try_from_u8(6).unwrap(),
-			u5::try_from_u8(0).unwrap(),
-			u5::try_from_u8(16).unwrap(),
-			u5::try_from_u8(1).unwrap(),
-		];
-		let features = Bolt11InvoiceFeatures::from_le_bytes(vec![1, 2, 3, 4, 5, 42, 100, 101]);
-
-		// Test length calculation.
-		assert_eq!(features.base32_len(), 13);
-
-		// Test serialization.
-		let features_serialized = features.to_base32();
-		assert_eq!(features_as_u5s, features_serialized);
-
-		// Test deserialization.
-		let features_deserialized = Bolt11InvoiceFeatures::from_base32(&features_as_u5s).unwrap();
-		assert_eq!(features, features_deserialized);
 	}
 
 	#[test]

--- a/lightning-types/src/payment.rs
+++ b/lightning-types/src/payment.rs
@@ -9,8 +9,6 @@
 
 //! Types which describe payments in lightning.
 
-use alloc::vec::Vec;
-
 use core::borrow::Borrow;
 
 use bitcoin::hashes::{sha256::Hash as Sha256, Hash as _};
@@ -79,34 +77,5 @@ impl Borrow<[u8]> for PaymentSecret {
 impl_fmt_traits! {
 	impl fmt_traits for PaymentSecret {
 		const LENGTH: usize = 32;
-	}
-}
-
-use bech32::{u5, Base32Len, FromBase32, ToBase32, WriteBase32};
-
-impl FromBase32 for PaymentSecret {
-	type Err = bech32::Error;
-
-	fn from_base32(field_data: &[u5]) -> Result<PaymentSecret, bech32::Error> {
-		if field_data.len() != 52 {
-			return Err(bech32::Error::InvalidLength);
-		} else {
-			let data_bytes = Vec::<u8>::from_base32(field_data)?;
-			let mut payment_secret = [0; 32];
-			payment_secret.copy_from_slice(&data_bytes);
-			Ok(PaymentSecret(payment_secret))
-		}
-	}
-}
-
-impl ToBase32 for PaymentSecret {
-	fn write_base32<W: WriteBase32>(&self, writer: &mut W) -> Result<(), <W as WriteBase32>::Err> {
-		(&self.0[..]).write_base32(writer)
-	}
-}
-
-impl Base32Len for PaymentSecret {
-	fn base32_len(&self) -> usize {
-		52
 	}
 }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -41,7 +41,7 @@ default = ["std", "grind_signatures"]
 lightning-types = { version = "0.1.0-beta", path = "../lightning-types", default-features = false }
 lightning-invoice = { version = "0.32.0-beta", path = "../lightning-invoice", default-features = false }
 
-bech32 = { version = "0.9.1", default-features = false }
+bech32 = { version = "0.11.0", default-features = false }
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 hashbrown = { version = "0.13", optional = true, default-features = false }


### PR DESCRIPTION
Reopening of #3181 . Fixes #3176 .

Changes summary:

- Upgraded `bech32` dependency to `0.11.0` (from `0.9`)
- Crates affected: `lightning/types`, `lightning-invoice` and `lightning`
- The previously used type `bech32::u5` can be replaced by `bech32::Fe32`, mostly as a drop-in replacement.
- `u5::try_from_u8` is now `Fe32::try_from`
- `bech32::Error` is mostly replaced by `bech32::primitives::decode::CheckedHrpstringError`
- To/FromBase32 traits are discontinued in `bech32`, they have been taken over to `lighning-invoice` crate. The implementations (for Bolt11InvoiceFeatures and Payment*) have been moved to `lightning-invoice` crate (as the trait is defined there)

Here are some minor issues identified

- Hrp/checksum parsing has changed (uses new iterative API)
- `Fe32` does not have `Ord`, so it had to be explicitly implemented for `RawTaggedField`
- `Fe32` does not have `Default`, for which some workaround was needed. This will be added in next `bech32 0.12` release (see https://github.com/rust-bitcoin/rust-bech32/pull/186)
- Conversions of `bech32` error types are not always optimal
- Parsing of tagged values in an invoice stays own implementation (not supported by `bech32` crate)

TODO:

- [x] fix `fuzz` target
- [x] fix fmt
- [x] squash
- [ ] Incremental-mutants, add tests for ToBase32/FromBase32