### PR TITLE
Refactor `BlindedPath` construction utils

### DIFF
--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -386,6 +386,8 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 		.map(|next_hop| ControlTlvs::Forward(ForwardTlvs { next_hop, next_blinding_override: None }))
 		.chain(core::iter::once(ControlTlvs::Receive(ReceiveTlvs{ context: Some(context) })));
 
-	utils::construct_blinded_hops(secp_ctx, pks, tlvs, session_priv)
+	let path = pks.zip(tlvs);
+
+	utils::construct_blinded_hops(secp_ctx, path, session_priv)
 }
 

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -374,14 +374,14 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<T>, intermediate_nodes: &[ForwardNode], recipient_node_id: PublicKey,
 	context: MessageContext, session_priv: &SecretKey
 ) -> Result<Vec<BlindedHop>, secp256k1::Error> {
-	let pks = intermediate_nodes.iter().map(|node| &node.node_id)
-		.chain(core::iter::once(&recipient_node_id));
+	let pks = intermediate_nodes.iter().map(|node| node.node_id)
+		.chain(core::iter::once(recipient_node_id));
 	let tlvs = pks.clone()
 		.skip(1) // The first node's TLVs contains the next node's pubkey
 		.zip(intermediate_nodes.iter().map(|node| node.short_channel_id))
 		.map(|(pubkey, scid)| match scid {
 			Some(scid) => NextMessageHop::ShortChannelId(scid),
-			None => NextMessageHop::NodeId(*pubkey),
+			None => NextMessageHop::NodeId(pubkey),
 		})
 		.map(|next_hop| ControlTlvs::Forward(ForwardTlvs { next_hop, next_blinding_override: None }))
 		.chain(core::iter::once(ControlTlvs::Receive(ReceiveTlvs{ context: Some(context) })));

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -466,7 +466,10 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 		.chain(core::iter::once(payee_node_id));
 	let tlvs = intermediate_nodes.iter().map(|node| BlindedPaymentTlvsRef::Forward(&node.tlvs))
 		.chain(core::iter::once(BlindedPaymentTlvsRef::Receive(&payee_tlvs)));
-	utils::construct_blinded_hops(secp_ctx, pks, tlvs, session_priv)
+
+	let path = pks.zip(tlvs);
+
+	utils::construct_blinded_hops(secp_ctx, path, session_priv)
 }
 
 /// `None` if underflow occurs.

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -462,8 +462,8 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<T>, intermediate_nodes: &[ForwardNode],
 	payee_node_id: PublicKey, payee_tlvs: ReceiveTlvs, session_priv: &SecretKey
 ) -> Result<Vec<BlindedHop>, secp256k1::Error> {
-	let pks = intermediate_nodes.iter().map(|node| &node.node_id)
-		.chain(core::iter::once(&payee_node_id));
+	let pks = intermediate_nodes.iter().map(|node| node.node_id)
+		.chain(core::iter::once(payee_node_id));
 	let tlvs = intermediate_nodes.iter().map(|node| BlindedPaymentTlvsRef::Forward(&node.tlvs))
 		.chain(core::iter::once(BlindedPaymentTlvsRef::Receive(&payee_tlvs)));
 	utils::construct_blinded_hops(secp_ctx, pks, tlvs, session_priv)

--- a/lightning/src/blinded_path/utils.rs
+++ b/lightning/src/blinded_path/utils.rs
@@ -88,7 +88,7 @@ macro_rules! build_keys_helper {
 }}
 
 #[inline]
-pub(crate) fn construct_keys_callback<'a, T, I, F>(
+pub(crate) fn construct_keys_for_onion_message<'a, T, I, F>(
 	secp_ctx: &Secp256k1<T>, unblinded_path: I, destination: Destination, session_priv: &SecretKey,
 	mut callback: F,
 ) -> Result<(), secp256k1::Error>
@@ -116,7 +116,7 @@ where
 }
 
 #[inline]
-pub(super) fn construct_keys_callback_for_blinded_path<'a, T, I, F, H>(
+pub(super) fn construct_keys_for_blinded_path<'a, T, I, F, H>(
 	secp_ctx: &Secp256k1<T>, unblinded_path: I, session_priv: &SecretKey, mut callback: F,
 ) -> Result<(), secp256k1::Error>
 where
@@ -153,7 +153,7 @@ where
 	W: Writeable
 {
 	let mut blinded_hops = Vec::with_capacity(unblinded_path.size_hint().0);
-	construct_keys_callback_for_blinded_path(
+	construct_keys_for_blinded_path(
 		secp_ctx, unblinded_path.map(|(pubkey, tlvs)| PublicKeyWithTlvs { pubkey, tlvs }), session_priv,
 		|blinded_node_id, _, _, encrypted_payload_rho, unblinded_hop_data, _| {
 			blinded_hops.push(BlindedHop {

--- a/lightning/src/blinded_path/utils.rs
+++ b/lightning/src/blinded_path/utils.rs
@@ -89,8 +89,8 @@ macro_rules! build_keys_helper {
 
 #[inline]
 pub(crate) fn construct_keys_callback<'a, T, I, F>(
-	secp_ctx: &Secp256k1<T>, unblinded_path: I, destination: Option<Destination>,
-	session_priv: &SecretKey, mut callback: F
+	secp_ctx: &Secp256k1<T>, unblinded_path: I, destination: Destination, session_priv: &SecretKey,
+	mut callback: F,
 ) -> Result<(), secp256k1::Error>
 where
 	T: secp256k1::Signing + secp256k1::Verification,
@@ -102,17 +102,15 @@ where
 	for pk in unblinded_path {
 		build_keys_in_loop!(pk, false, None);
 	}
-	if let Some(dest) = destination {
-		match dest {
-			Destination::Node(pk) => {
-				build_keys!(pk, false, None);
-			},
-			Destination::BlindedPath(BlindedMessagePath(BlindedPath { blinded_hops, .. })) => {
-				for hop in blinded_hops {
-					build_keys_in_loop!(hop.blinded_node_id, true, Some(hop.encrypted_payload));
-				}
-			},
-		}
+	match destination {
+		Destination::Node(pk) => {
+			build_keys!(pk, false, None);
+		},
+		Destination::BlindedPath(BlindedMessagePath(BlindedPath { blinded_hops, .. })) => {
+			for hop in blinded_hops {
+				build_keys_in_loop!(hop.blinded_node_id, true, Some(hop.encrypted_payload));
+			}
+		},
 	}
 	Ok(())
 }

--- a/lightning/src/blinded_path/utils.rs
+++ b/lightning/src/blinded_path/utils.rs
@@ -91,13 +91,13 @@ pub(crate) fn construct_keys_callback<'a, T, I, F>(
 ) -> Result<(), secp256k1::Error>
 where
 	T: secp256k1::Signing + secp256k1::Verification,
-	I: Iterator<Item=&'a PublicKey>,
+	I: Iterator<Item=PublicKey>,
 	F: FnMut(PublicKey, SharedSecret, PublicKey, [u8; 32], Option<PublicKey>, Option<Vec<u8>>),
 {
 	build_keys_helper!(session_priv, secp_ctx, callback);
 
 	for pk in unblinded_path {
-		build_keys_in_loop!(*pk, false, None);
+		build_keys_in_loop!(pk, false, None);
 	}
 	if let Some(dest) = destination {
 		match dest {
@@ -120,7 +120,7 @@ pub(crate) fn construct_blinded_hops<'a, T, I1, I2>(
 ) -> Result<Vec<BlindedHop>, secp256k1::Error>
 where
 	T: secp256k1::Signing + secp256k1::Verification,
-	I1: Iterator<Item=&'a PublicKey>,
+	I1: Iterator<Item=PublicKey>,
 	I2: Iterator,
 	I2::Item: Writeable
 {

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -1392,19 +1392,17 @@ fn route_blinding_spec_test_vector() {
 	let blinding_override = PublicKey::from_secret_key(&secp_ctx, &dave_eve_session_priv);
 	assert_eq!(blinding_override, pubkey_from_hex("031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"));
 	// Can't use the public API here as the encrypted payloads contain unknown TLVs.
+	let path = [(dave_node_id, WithoutLength(&dave_unblinded_tlvs)), (eve_node_id, WithoutLength(&eve_unblinded_tlvs))];
 	let mut dave_eve_blinded_hops = blinded_path::utils::construct_blinded_hops(
-		&secp_ctx, [dave_node_id, eve_node_id].iter(),
-		&mut [WithoutLength(&dave_unblinded_tlvs), WithoutLength(&eve_unblinded_tlvs)].iter(),
-		&dave_eve_session_priv
+		&secp_ctx, path.into_iter(), &dave_eve_session_priv
 	).unwrap();
 
 	// Concatenate an additional Bob -> Carol blinded path to the Eve -> Dave blinded path.
 	let bob_carol_session_priv = secret_from_hex("0202020202020202020202020202020202020202020202020202020202020202");
 	let bob_blinding_point = PublicKey::from_secret_key(&secp_ctx, &bob_carol_session_priv);
+	let path = [(bob_node_id, WithoutLength(&bob_unblinded_tlvs)), (carol_node_id, WithoutLength(&carol_unblinded_tlvs))];
 	let bob_carol_blinded_hops = blinded_path::utils::construct_blinded_hops(
-		&secp_ctx, [bob_node_id, carol_node_id].iter(),
-		&mut [WithoutLength(&bob_unblinded_tlvs), WithoutLength(&carol_unblinded_tlvs)].iter(),
-		&bob_carol_session_priv
+		&secp_ctx, path.into_iter(), &bob_carol_session_priv
 	).unwrap();
 
 	let mut blinded_hops = bob_carol_blinded_hops;

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -1809,7 +1809,7 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 	let mut blinded_path_idx = 0;
 	let mut prev_control_tlvs_ss = None;
 	let mut final_control_tlvs = None;
-	utils::construct_keys_callback(
+	utils::construct_keys_for_onion_message(
 		secp_ctx, unblinded_path.into_iter(), destination, session_priv,
 		|_, onion_packet_ss, ephemeral_pubkey, control_tlvs_ss, unblinded_pk_opt, enc_payload_opt| {
 			if num_unblinded_hops != 0 && unblinded_path_idx < num_unblinded_hops {

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -925,7 +925,7 @@ where
 		}
 	};
 	let (packet_payloads, packet_keys) = packet_payloads_and_keys(
-		&secp_ctx, &intermediate_nodes, destination, contents, reply_path, &blinding_secret
+		&secp_ctx, intermediate_nodes, destination, contents, reply_path, &blinding_secret
 	)?;
 
 	let prng_seed = entropy_source.get_secure_random_bytes();
@@ -1784,7 +1784,7 @@ pub type SimpleRefOnionMessenger<
 /// Construct onion packet payloads and keys for sending an onion message along the given
 /// `unblinded_path` to the given `destination`.
 fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + secp256k1::Verification>(
-	secp_ctx: &Secp256k1<S>, unblinded_path: &[PublicKey], destination: Destination, message: T,
+	secp_ctx: &Secp256k1<S>, unblinded_path: Vec<PublicKey>, destination: Destination, message: T,
 	mut reply_path: Option<BlindedMessagePath>, session_priv: &SecretKey
 ) -> Result<(Vec<(Payload<T>, [u8; 32])>, Vec<onion_utils::OnionKeys>), SendError> {
 	let num_hops = unblinded_path.len() + destination.num_hops();
@@ -1809,7 +1809,8 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 	let mut blinded_path_idx = 0;
 	let mut prev_control_tlvs_ss = None;
 	let mut final_control_tlvs = None;
-	utils::construct_keys_callback(secp_ctx, unblinded_path.iter(), Some(destination), session_priv,
+	utils::construct_keys_callback(
+		secp_ctx, unblinded_path.into_iter(), Some(destination), session_priv,
 		|_, onion_packet_ss, ephemeral_pubkey, control_tlvs_ss, unblinded_pk_opt, enc_payload_opt| {
 			if num_unblinded_hops != 0 && unblinded_path_idx < num_unblinded_hops {
 				if let Some(ss) = prev_control_tlvs_ss.take() {

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -1810,7 +1810,7 @@ fn packet_payloads_and_keys<T: OnionMessageContents, S: secp256k1::Signing + sec
 	let mut prev_control_tlvs_ss = None;
 	let mut final_control_tlvs = None;
 	utils::construct_keys_callback(
-		secp_ctx, unblinded_path.into_iter(), Some(destination), session_priv,
+		secp_ctx, unblinded_path.into_iter(), destination, session_priv,
 		|_, onion_packet_ss, ephemeral_pubkey, control_tlvs_ss, unblinded_pk_opt, enc_payload_opt| {
 			if num_unblinded_hops != 0 && unblinded_path_idx < num_unblinded_hops {
 				if let Some(ss) = prev_control_tlvs_ss.take() {


### PR DESCRIPTION
When constructing a `BlindedPath`, the `construct_blinded_hops` utility function requires two iterators: one for public keys and another for TLVs. The first is used by the `construct_keys_callback` function while the second is used in a callback passed to that function.

There are few disadvantages to this:
- The iterators are assumed to be the same length otherwise there will be a panic.
- Iterators over the same data cannot have one be over mutable references.
- The `Option<Destination>` parameter is not relevant as it is only used for constructing the full onion.

This PR refactors the utility functions such that only a single iterator is used. This is useful as an iterator over mutable TLVs can be used to add padding, in particular for payment paths when adding dummy hops. See https://github.com/lightningdevkit/rust-lightning/pull/3177#discussion_r1716295422.