### PR TITLE
Re-export `lightning_types` in top-level `lightning` modules

### DIFF
--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -62,7 +62,7 @@ compile_error!("Tests will always fail with cfg=fuzzing");
 #[macro_use]
 extern crate alloc;
 
-extern crate lightning_types;
+pub extern crate lightning_types as types;
 
 pub extern crate bitcoin;
 #[cfg(any(test, feature = "std"))]

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -11,6 +11,10 @@
 //!
 //! See [`lightning_types::features`] for the list of features currently supported.
 //!
+//! Note that the use of types via this module is deprecated and will be removed in a future
+//! version. Instead, use feature objects via [`lightning::types::features`].
+//!
+//! [`lightning::types::features`]: crate::types::features
 //! [BOLT #9]: https://github.com/lightning/bolts/blob/master/09-features.md
 
 pub use lightning_types::features::Features;

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -8,6 +8,12 @@
 // licenses.
 
 //! Implementations of various parts of the Lightning protocol are in this module.
+//!
+//! Note that the re-exports of [`PaymentHash`], [`PaymentPreimage`], and [`PaymentSecret`] here
+//! are deprecated and will be removed in a future version. Instead, use them via
+//! [`lightning::types::payment`].
+//!
+//! [`lightning::types::payment`]: crate::types::payment
 
 #[cfg(any(test, feature = "_test_utils"))]
 #[macro_use]

--- a/lightning/src/ln/types.rs
+++ b/lightning/src/ln/types.rs
@@ -8,6 +8,12 @@
 // licenses.
 
 //! Various wrapper types (most around 32-byte arrays) for use in lightning.
+//!
+//! Note that the re-exports of [`PaymentHash`], [`PaymentPreimage`], and [`PaymentSecret`] here
+//! are deprecated and will be removed in a future version. Instead, use them via
+//! [`lightning::types::payment`].
+//!
+//! [`lightning::types::payment`]: crate::types::payment
 
 use crate::chain::transaction::OutPoint;
 use crate::io;


### PR DESCRIPTION
Since we now have many types in one place, it makes sense to export them in that place. Further, doing so finally somewhat starts to reduce our `lightning::ln` module size, which historically is the dumping ground for everything when most things really should be top-level modules in `lightning`.

Here we take a step in the right direction by exporting `lightning_types` as `lightning::types` and encouraging users to use those paths directly rather than the ones in `lightning::ln`.