### PR TITLE
Correct `peer_handler::test_process_events_multithreaded`

### DIFF
--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -759,8 +759,13 @@ pub struct TestChannelMessageHandler {
 	pub pending_events: Mutex<Vec<events::MessageSendEvent>>,
 	expected_recv_msgs: Mutex<Option<Vec<wire::Message<()>>>>,
 	connected_peers: Mutex<HashSet<PublicKey>>,
-	pub message_fetch_counter: AtomicUsize,
 	chain_hash: ChainHash,
+}
+
+impl TestChannelMessageHandler {
+	thread_local! {
+		pub static MESSAGE_FETCH_COUNTER: AtomicUsize = AtomicUsize::new(0);
+	}
 }
 
 impl TestChannelMessageHandler {
@@ -769,7 +774,6 @@ impl TestChannelMessageHandler {
 			pending_events: Mutex::new(Vec::new()),
 			expected_recv_msgs: Mutex::new(None),
 			connected_peers: Mutex::new(new_hash_set()),
-			message_fetch_counter: AtomicUsize::new(0),
 			chain_hash,
 		}
 	}
@@ -940,7 +944,7 @@ impl msgs::ChannelMessageHandler for TestChannelMessageHandler {
 
 impl events::MessageSendEventsProvider for TestChannelMessageHandler {
 	fn get_and_clear_pending_msg_events(&self) -> Vec<events::MessageSendEvent> {
-		self.message_fetch_counter.fetch_add(1, Ordering::AcqRel);
+		Self::MESSAGE_FETCH_COUNTER.with(|val| val.fetch_add(1, Ordering::AcqRel));
 		let mut pending_events = self.pending_events.lock().unwrap();
 		let mut ret = Vec::new();
 		mem::swap(&mut ret, &mut *pending_events);


### PR DESCRIPTION
This test was added some time ago in
0c034e9a82e4339fb32af9da63832ac2a64abb0b, but never made any sense. `PeerManager::process_events` will go around its loop as many times is required to ensure we've always processed all events which were pending prior to a `process_events` call, so having a test that checks that we never go around more than twice is obviously broken.

And, indeed, in CI this tests fails with some regularity.

Instead, the test here is changed to ensure that we detectably go around the loop again at least once.

Fixes #2385