### PR TITLE
Consistently pass `DefaultRouter::new` `Default` scoring parameters

### DIFF
--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -130,7 +130,7 @@ impl<'a> TestRouter<'a> {
 	) -> Self {
 		let entropy_source = Arc::new(RandomBytes::new([42; 32]));
 		Self {
-			router: DefaultRouter::new(network_graph.clone(), logger, entropy_source, scorer, ()),
+			router: DefaultRouter::new(network_graph.clone(), logger, entropy_source, scorer, Default::default()),
 			network_graph,
 			next_routes: Mutex::new(VecDeque::new()),
 			next_blinded_payment_paths: Mutex::new(Vec::new()),


### PR DESCRIPTION
In 26c1639ab69d6780c97a118f09e42cb42304088a (and later in 50c55dcf32466e3ccf17acea50697fc664950deb and
fb693ecbf81be0146a81cc7fd95342c403eacaa9) we switched to using `Default::default()` to initialize `()` for scoring parameters in tests. One `()`s slipped back in recently, which we replace here.