### PR TITLE
Bound `Persister`'s `WriteableScore` by `Deref`

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -764,7 +764,7 @@ where
 	F::Target: 'static + FeeEstimator,
 	L::Target: 'static + Logger,
 	P::Target: 'static + Persist<<CM::Target as AChannelManager>::Signer>,
-	PS::Target: 'static + Persister<'a, CM, L, SC>,
+	PS::Target: 'static + Persister<'a, CM, L, S>,
 	CM::Target: AChannelManager + Send + Sync,
 	OM::Target: AOnionMessenger + Send + Sync,
 	PM::Target: APeerManager + Send + Sync,
@@ -786,7 +786,7 @@ where
 				if let Some(duration_since_epoch) = fetch_time() {
 					if update_scorer(scorer, &event, duration_since_epoch) {
 						log_trace!(logger, "Persisting scorer after update");
-						if let Err(e) = persister.persist_scorer(&scorer) {
+						if let Err(e) = persister.persist_scorer(&*scorer) {
 							log_error!(logger, "Error: Failed to persist scorer, check your disk and permissions {}", e);
 							// We opt not to abort early on persistence failure here as persisting
 							// the scorer is non-critical and we still hope that it will have
@@ -935,7 +935,7 @@ impl BackgroundProcessor {
 		F::Target: 'static + FeeEstimator,
 		L::Target: 'static + Logger,
 		P::Target: 'static + Persist<<CM::Target as AChannelManager>::Signer>,
-		PS::Target: 'static + Persister<'a, CM, L, SC>,
+		PS::Target: 'static + Persister<'a, CM, L, S>,
 		CM::Target: AChannelManager + Send + Sync,
 		OM::Target: AOnionMessenger + Send + Sync,
 		PM::Target: APeerManager + Send + Sync,

--- a/lightning/src/util/persist.rs
+++ b/lightning/src/util/persist.rs
@@ -157,10 +157,11 @@ pub trait KVStore {
 /// Trait that handles persisting a [`ChannelManager`], [`NetworkGraph`], and [`WriteableScore`] to disk.
 ///
 /// [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
-pub trait Persister<'a, CM: Deref, L: Deref, S: WriteableScore<'a>>
+pub trait Persister<'a, CM: Deref, L: Deref, S: Deref>
 where
 	CM::Target: 'static + AChannelManager,
 	L::Target: 'static + Logger,
+	S::Target: WriteableScore<'a>,
 {
 	/// Persist the given ['ChannelManager'] to disk, returning an error if persistence failed.
 	///
@@ -175,10 +176,11 @@ where
 }
 
 
-impl<'a, A: KVStore + ?Sized, CM: Deref, L: Deref, S: WriteableScore<'a>> Persister<'a, CM, L, S> for A
+impl<'a, A: KVStore + ?Sized, CM: Deref, L: Deref, S: Deref> Persister<'a, CM, L, S> for A
 where
 	CM::Target: 'static + AChannelManager,
 	L::Target: 'static + Logger,
+	S::Target: WriteableScore<'a>,
 {
 	fn persist_manager(&self, channel_manager: &CM) -> Result<(), io::Error> {
 		self.write(CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,


### PR DESCRIPTION
This makes the trait marginally more flexible, but more importantly matches our normal structure which makes the bindings generator a bit happier.