### PR TITLE
Parameterize the `OnionMessageContents` in message handler traits

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -10747,6 +10747,8 @@ where
 	R::Target: Router,
 	L::Target: Logger,
 {
+	type ResponseType = OffersMessage;
+
 	fn handle_message(
 		&self, message: OffersMessage, context: Option<OffersContext>, responder: Option<Responder>,
 	) -> ResponseInstruction<OffersMessage> {
@@ -10954,9 +10956,11 @@ where
 	R::Target: Router,
 	L::Target: Logger,
 {
+	type ResponseType = AsyncPaymentsMessage;
+
 	fn held_htlc_available(
 		&self, _message: HeldHtlcAvailable, _responder: Option<Responder>
-	) -> ResponseInstruction<ReleaseHeldHtlc> {
+	) -> ResponseInstruction<AsyncPaymentsMessage> {
 		ResponseInstruction::NoResponse
 	}
 

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -29,7 +29,7 @@ use crate::util::ser::{VecWriter, Writeable, Writer};
 use crate::ln::peer_channel_encryptor::{PeerChannelEncryptor, NextNoiseStep, MessageBuf, MSG_BUF_ALLOC_SIZE};
 use crate::ln::wire;
 use crate::ln::wire::{Encode, Type};
-use crate::onion_message::async_payments::{AsyncPaymentsMessageHandler, HeldHtlcAvailable, ReleaseHeldHtlc};
+use crate::onion_message::async_payments::{AsyncPaymentsMessage, AsyncPaymentsMessageHandler, HeldHtlcAvailable, ReleaseHeldHtlc};
 use crate::onion_message::messenger::{CustomOnionMessageHandler, PendingOnionMessage, Responder, ResponseInstruction};
 use crate::onion_message::offers::{OffersMessage, OffersMessageHandler};
 use crate::onion_message::packet::OnionMessageContents;
@@ -144,14 +144,16 @@ impl OnionMessageHandler for IgnoringMessageHandler {
 }
 
 impl OffersMessageHandler for IgnoringMessageHandler {
+	type ResponseType = OffersMessage;
 	fn handle_message(&self, _message: OffersMessage, _context: Option<OffersContext>, _responder: Option<Responder>) -> ResponseInstruction<OffersMessage> {
 		ResponseInstruction::NoResponse
 	}
 }
 impl AsyncPaymentsMessageHandler for IgnoringMessageHandler {
+	type ResponseType = AsyncPaymentsMessage;
 	fn held_htlc_available(
 		&self, _message: HeldHtlcAvailable, _responder: Option<Responder>,
-	) -> ResponseInstruction<ReleaseHeldHtlc> {
+	) -> ResponseInstruction<AsyncPaymentsMessage> {
 		ResponseInstruction::NoResponse
 	}
 	fn release_held_htlc(&self, _message: ReleaseHeldHtlc) {}

--- a/lightning/src/onion_message/async_payments.rs
+++ b/lightning/src/onion_message/async_payments.rs
@@ -26,11 +26,15 @@ const RELEASE_HELD_HTLC_TLV_TYPE: u64 = 74;
 ///
 /// [`OnionMessage`]: crate::ln::msgs::OnionMessage
 pub trait AsyncPaymentsMessageHandler {
+	/// The message type for messages which are sent in response to [`Self::held_htlc_available`]
+	/// or sent via [`Self::release_pending_messages`].
+	type ResponseType: OnionMessageContents;
+
 	/// Handle a [`HeldHtlcAvailable`] message. A [`ReleaseHeldHtlc`] should be returned to release
 	/// the held funds.
 	fn held_htlc_available(
 		&self, message: HeldHtlcAvailable, responder: Option<Responder>,
-	) -> ResponseInstruction<ReleaseHeldHtlc>;
+	) -> ResponseInstruction<Self::ResponseType>;
 
 	/// Handle a [`ReleaseHeldHtlc`] message. If authentication of the message succeeds, an HTLC
 	/// should be released to the corresponding payee.
@@ -41,7 +45,7 @@ pub trait AsyncPaymentsMessageHandler {
 	/// Typically, this is used for messages initiating an async payment flow rather than in response
 	/// to another message.
 	#[cfg(not(c_bindings))]
-	fn release_pending_messages(&self) -> Vec<PendingOnionMessage<AsyncPaymentsMessage>> {
+	fn release_pending_messages(&self) -> Vec<PendingOnionMessage<Self::ResponseType>> {
 		vec![]
 	}
 

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -19,7 +19,7 @@ use crate::routing::test_utils::{add_channel, add_or_update_node};
 use crate::sign::{NodeSigner, Recipient};
 use crate::util::ser::{FixedLengthReader, LengthReadable, Writeable, Writer};
 use crate::util::test_utils;
-use super::async_payments::{AsyncPaymentsMessageHandler, HeldHtlcAvailable, ReleaseHeldHtlc};
+use super::async_payments::{AsyncPaymentsMessage, AsyncPaymentsMessageHandler, HeldHtlcAvailable, ReleaseHeldHtlc};
 use super::messenger::{CustomOnionMessageHandler, DefaultMessageRouter, Destination, OnionMessagePath, OnionMessenger, PendingOnionMessage, Responder, ResponseInstruction, SendError, SendSuccess};
 use super::offers::{OffersMessage, OffersMessageHandler};
 use super::packet::{OnionMessageContents, Packet};
@@ -76,6 +76,7 @@ impl Drop for MessengerNode {
 struct TestOffersMessageHandler {}
 
 impl OffersMessageHandler for TestOffersMessageHandler {
+	type ResponseType = OffersMessage;
 	fn handle_message(&self, _message: OffersMessage, _context: Option<OffersContext>, _responder: Option<Responder>) -> ResponseInstruction<OffersMessage> {
 		ResponseInstruction::NoResponse
 	}
@@ -84,9 +85,10 @@ impl OffersMessageHandler for TestOffersMessageHandler {
 struct TestAsyncPaymentsMessageHandler {}
 
 impl AsyncPaymentsMessageHandler for TestAsyncPaymentsMessageHandler {
+	type ResponseType = AsyncPaymentsMessage;
 	fn held_htlc_available(
 		&self, _message: HeldHtlcAvailable, _responder: Option<Responder>,
-	) -> ResponseInstruction<ReleaseHeldHtlc> {
+	) -> ResponseInstruction<AsyncPaymentsMessage> {
 		ResponseInstruction::NoResponse
 	}
 	fn release_held_htlc(&self, _message: ReleaseHeldHtlc) {}

--- a/lightning/src/onion_message/offers.rs
+++ b/lightning/src/onion_message/offers.rs
@@ -39,6 +39,10 @@ const STATIC_INVOICE_TLV_TYPE: u64 = 70;
 ///
 /// [`OnionMessage`]: crate::ln::msgs::OnionMessage
 pub trait OffersMessageHandler {
+	/// The message type for messages which are sent in response to [`Self::handle_message`] or
+	/// sent via [`Self::release_pending_messages`].
+	type ResponseType: OnionMessageContents;
+
 	/// Handles the given message by either responding with an [`Bolt12Invoice`], sending a payment,
 	/// or replying with an error.
 	///
@@ -47,14 +51,14 @@ pub trait OffersMessageHandler {
 	/// [`OnionMessenger`]: crate::onion_message::messenger::OnionMessenger
 	fn handle_message(
 		&self, message: OffersMessage, context: Option<OffersContext>, responder: Option<Responder>,
-	) -> ResponseInstruction<OffersMessage>;
+	) -> ResponseInstruction<Self::ResponseType>;
 
 	/// Releases any [`OffersMessage`]s that need to be sent.
 	///
 	/// Typically, this is used for messages initiating a payment flow rather than in response to
 	/// another message. The latter should use the return value of [`Self::handle_message`].
 	#[cfg(not(c_bindings))]
-	fn release_pending_messages(&self) -> Vec<PendingOnionMessage<OffersMessage>> { vec![] }
+	fn release_pending_messages(&self) -> Vec<PendingOnionMessage<Self::ResponseType>> { vec![] }
 
 	/// Releases any [`OffersMessage`]s that need to be sent.
 	///


### PR DESCRIPTION
Our onion message handlers generally have one or more methods which return either a `ResponseInstruction` or a `PendingOnionMessage` parameterized with the expected message type (enum) of the message handler. This is generally fine, there's not much reason for a message handler of one type to return a response of a different type, but there's also not much reason to restrict it from doing so, either.

Sadly, that restriction is also impossible to represent in our bindings - our bindings concretize all structs, enums, and traits into a single concrete instance with generics set to our concrete trait instances (which hold a jump table). This prevents us from having multiple instances of `ResponseInstruction` or `PendingOnionMessage` structs for different message types.

Instead, we simply add an associated type to our onion message handlers, allowing them to return any type they want (or for the bindings to make them dynamic on the internal jump table but static at compile-time).