### PR TITLE
Disambiguate blinded path `ForwardNode`s between payment + message

### DIFF
--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -11,8 +11,8 @@ use crate::utils::test_logger;
 use bitcoin::secp256k1::{self, Keypair, Parity, PublicKey, Secp256k1, SecretKey};
 use core::convert::TryFrom;
 use lightning::blinded_path::payment::{
-	BlindedPaymentPath, Bolt12OfferContext, ForwardNode, ForwardTlvs, PaymentConstraints,
-	PaymentContext, PaymentRelay, ReceiveTlvs,
+	BlindedPaymentPath, Bolt12OfferContext, ForwardTlvs, PaymentConstraints, PaymentContext,
+	PaymentForwardNode, PaymentRelay, ReceiveTlvs,
 };
 use lightning::ln::channelmanager::MIN_FINAL_CLTV_EXPIRY_DELTA;
 use lightning::ln::features::BlindedHopFeatures;
@@ -100,7 +100,7 @@ fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
 		},
 		payment_context,
 	};
-	let intermediate_nodes = [ForwardNode {
+	let intermediate_nodes = [PaymentForwardNode {
 		tlvs: ForwardTlvs {
 			short_channel_id: 43,
 			payment_relay: PaymentRelay {

--- a/fuzz/src/refund_deser.rs
+++ b/fuzz/src/refund_deser.rs
@@ -11,8 +11,8 @@ use crate::utils::test_logger;
 use bitcoin::secp256k1::{self, Keypair, PublicKey, Secp256k1, SecretKey};
 use core::convert::TryFrom;
 use lightning::blinded_path::payment::{
-	BlindedPaymentPath, Bolt12RefundContext, ForwardNode, ForwardTlvs, PaymentConstraints,
-	PaymentContext, PaymentRelay, ReceiveTlvs,
+	BlindedPaymentPath, Bolt12RefundContext, ForwardTlvs, PaymentConstraints, PaymentContext,
+	PaymentForwardNode, PaymentRelay, ReceiveTlvs,
 };
 use lightning::ln::channelmanager::MIN_FINAL_CLTV_EXPIRY_DELTA;
 use lightning::ln::features::BlindedHopFeatures;
@@ -78,7 +78,7 @@ fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
 		},
 		payment_context,
 	};
-	let intermediate_nodes = [ForwardNode {
+	let intermediate_nodes = [PaymentForwardNode {
 		tlvs: ForwardTlvs {
 			short_channel_id: 43,
 			payment_relay: PaymentRelay {

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -12,7 +12,7 @@ use bitcoin::secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey, schnorr};
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::ecdsa::{RecoverableSignature, Signature};
 use crate::blinded_path;
-use crate::blinded_path::payment::{BlindedPaymentPath, ForwardNode, ForwardTlvs, PaymentConstraints, PaymentContext, PaymentRelay, ReceiveTlvs};
+use crate::blinded_path::payment::{BlindedPaymentPath, PaymentForwardNode, ForwardTlvs, PaymentConstraints, PaymentContext, PaymentRelay, ReceiveTlvs};
 use crate::events::{Event, HTLCDestination, MessageSendEvent, MessageSendEventsProvider, PaymentFailureReason};
 use crate::ln::types::{ChannelId, PaymentHash, PaymentSecret};
 use crate::ln::channelmanager;
@@ -44,7 +44,7 @@ fn blinded_payment_path(
 	let mut intro_node_min_htlc_opt = Some(intro_node_min_htlc);
 	let mut intro_node_max_htlc_opt = Some(intro_node_max_htlc);
 	for (idx, (node_id, chan_upd)) in node_ids.iter().zip(channel_upds).enumerate() {
-		intermediate_nodes.push(ForwardNode {
+		intermediate_nodes.push(PaymentForwardNode {
 			node_id: *node_id,
 			tlvs: ForwardTlvs {
 				short_channel_id: chan_upd.short_channel_id,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -34,7 +34,7 @@ use bitcoin::{secp256k1, Sequence};
 
 use crate::blinded_path::message::{MessageContext, OffersContext};
 use crate::blinded_path::NodeIdLookUp;
-use crate::blinded_path::message::{BlindedMessagePath, ForwardNode};
+use crate::blinded_path::message::{BlindedMessagePath, MessageForwardNode};
 use crate::blinded_path::payment::{BlindedPaymentPath, Bolt12OfferContext, Bolt12RefundContext, PaymentConstraints, PaymentContext, ReceiveTlvs};
 use crate::chain;
 use crate::chain::{Confirm, ChannelMonitorUpdateStatus, Watch, BestBlock};
@@ -9354,7 +9354,7 @@ where
 			.map(|(node_id, peer_state)| (node_id, peer_state.lock().unwrap()))
 			.filter(|(_, peer)| peer.is_connected)
 			.filter(|(_, peer)| peer.latest_features.supports_onion_messages())
-			.map(|(node_id, peer)| ForwardNode {
+			.map(|(node_id, peer)| MessageForwardNode {
 				node_id: *node_id,
 				short_channel_id: peer.channel_by_id
 					.iter()

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -10,7 +10,7 @@
 //! Onion message testing and test utilities live here.
 
 use crate::blinded_path::EmptyNodeIdLookUp;
-use crate::blinded_path::message::{BlindedMessagePath, ForwardNode, MessageContext, OffersContext};
+use crate::blinded_path::message::{BlindedMessagePath, MessageForwardNode, MessageContext, OffersContext};
 use crate::events::{Event, EventsProvider};
 use crate::ln::features::{ChannelFeatures, InitFeatures};
 use crate::ln::msgs::{self, DecodeError, OnionMessageHandler};
@@ -386,7 +386,7 @@ fn two_unblinded_two_blinded() {
 	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
-	let intermediate_nodes = [ForwardNode { node_id: nodes[3].node_id, short_channel_id: None }];
+	let intermediate_nodes = [MessageForwardNode { node_id: nodes[3].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let blinded_path = BlindedMessagePath::new(&intermediate_nodes, nodes[4].node_id, context, &*nodes[4].entropy_source, &secp_ctx).unwrap();
 	let path = OnionMessagePath {
@@ -407,8 +407,8 @@ fn three_blinded_hops() {
 
 	let secp_ctx = Secp256k1::new();
 	let intermediate_nodes = [
-		ForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
-		ForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let blinded_path = BlindedMessagePath::new(&intermediate_nodes, nodes[3].node_id, context, &*nodes[3].entropy_source, &secp_ctx).unwrap();
@@ -548,8 +548,8 @@ fn we_are_intro_node() {
 
 	let secp_ctx = Secp256k1::new();
 	let intermediate_nodes = [
-		ForwardNode { node_id: nodes[0].node_id, short_channel_id: None },
-		ForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[0].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let blinded_path = BlindedMessagePath::new(&intermediate_nodes, nodes[2].node_id, context, &*nodes[2].entropy_source, &secp_ctx).unwrap();
@@ -560,7 +560,7 @@ fn we_are_intro_node() {
 	pass_along_path(&nodes);
 
 	// Try with a two-hop blinded path where we are the introduction node.
-	let intermediate_nodes = [ForwardNode { node_id: nodes[0].node_id, short_channel_id: None }];
+	let intermediate_nodes = [MessageForwardNode { node_id: nodes[0].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let blinded_path = BlindedMessagePath::new(&intermediate_nodes, nodes[1].node_id, context, &*nodes[1].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
@@ -577,7 +577,7 @@ fn invalid_blinded_path_error() {
 	let test_msg = TestCustomMessage::Pong;
 
 	let secp_ctx = Secp256k1::new();
-	let intermediate_nodes = [ForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
+	let intermediate_nodes = [MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let mut blinded_path = BlindedMessagePath::new(&intermediate_nodes, nodes[2].node_id, context, &*nodes[2].entropy_source, &secp_ctx).unwrap();
 	blinded_path.clear_blinded_hops();
@@ -599,8 +599,8 @@ fn reply_path() {
 		first_node_addresses: None,
 	};
 	let intermediate_nodes = [
-		ForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
-		ForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let reply_path = BlindedMessagePath::new(&intermediate_nodes, nodes[0].node_id, context, &*nodes[0].entropy_source, &secp_ctx).unwrap();
@@ -614,15 +614,15 @@ fn reply_path() {
 
 	// Destination::BlindedPath
 	let intermediate_nodes = [
-		ForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
-		ForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let blinded_path = BlindedMessagePath::new(&intermediate_nodes, nodes[3].node_id, context, &*nodes[3].entropy_source, &secp_ctx).unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let intermediate_nodes = [
-		ForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
-		ForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
+		MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None },
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let reply_path = BlindedMessagePath::new(&intermediate_nodes, nodes[0].node_id, context, &*nodes[0].entropy_source, &secp_ctx).unwrap();
@@ -705,7 +705,7 @@ fn requests_peer_connection_for_buffered_messages() {
 	let secp_ctx = Secp256k1::new();
 	add_channel_to_graph(&nodes[0], &nodes[1], &secp_ctx, 42);
 
-	let intermediate_nodes = [ForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
+	let intermediate_nodes = [MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let blinded_path = BlindedMessagePath::new(
 		&intermediate_nodes, nodes[2].node_id, context, &*nodes[0].entropy_source, &secp_ctx
@@ -744,7 +744,7 @@ fn drops_buffered_messages_waiting_for_peer_connection() {
 	let secp_ctx = Secp256k1::new();
 	add_channel_to_graph(&nodes[0], &nodes[1], &secp_ctx, 42);
 
-	let intermediate_nodes = [ForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
+	let intermediate_nodes = [MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let blinded_path = BlindedMessagePath::new(
 		&intermediate_nodes, nodes[2].node_id, context, &*nodes[0].entropy_source, &secp_ctx
@@ -795,7 +795,7 @@ fn intercept_offline_peer_oms() {
 
 	let message = TestCustomMessage::Pong;
 	let secp_ctx = Secp256k1::new();
-	let intermediate_nodes = [ForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
+	let intermediate_nodes = [MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let blinded_path = BlindedMessagePath::new(
 		&intermediate_nodes, nodes[2].node_id, context, &*nodes[2].entropy_source, &secp_ctx

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -12,8 +12,8 @@
 use bitcoin::secp256k1::{PublicKey, Secp256k1, self};
 
 use crate::blinded_path::{BlindedHop, Direction, IntroductionNode};
-use crate::blinded_path::message::{self, BlindedMessagePath, MessageContext};
-use crate::blinded_path::payment::{BlindedPaymentPath, ForwardTlvs, PaymentConstraints, PaymentRelay, ReceiveTlvs, self};
+use crate::blinded_path::message::{BlindedMessagePath, MessageContext, MessageForwardNode};
+use crate::blinded_path::payment::{BlindedPaymentPath, ForwardTlvs, PaymentConstraints, PaymentForwardNode, PaymentRelay, ReceiveTlvs};
 use crate::ln::{PaymentHash, PaymentPreimage};
 use crate::ln::channel_state::ChannelDetails;
 use crate::ln::channelmanager::{PaymentId, MIN_FINAL_CLTV_EXPIRY_DELTA, RecipientOnionFields};
@@ -146,7 +146,7 @@ impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref, S: Deref, SP: Size
 					max_cltv_expiry: tlvs.payment_constraints.max_cltv_expiry + cltv_expiry_delta,
 					htlc_minimum_msat: details.inbound_htlc_minimum_msat.unwrap_or(0),
 				};
-				Some(payment::ForwardNode {
+				Some(PaymentForwardNode {
 					tlvs: ForwardTlvs {
 						short_channel_id,
 						payment_relay,
@@ -205,7 +205,7 @@ impl< G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref, S: Deref, SP: Siz
 	fn create_compact_blinded_paths<
 		T: secp256k1::Signing + secp256k1::Verification
 	> (
-		&self, recipient: PublicKey, context: MessageContext, peers: Vec<message::ForwardNode>, secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, context: MessageContext, peers: Vec<MessageForwardNode>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		DefaultMessageRouter::create_compact_blinded_paths(&self.network_graph, recipient, context, peers, &self.entropy_source, secp_ctx)
 	}

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -8,7 +8,7 @@
 // licenses.
 
 use crate::blinded_path::message::MessageContext;
-use crate::blinded_path::message::{BlindedMessagePath, ForwardNode};
+use crate::blinded_path::message::{BlindedMessagePath, MessageForwardNode};
 use crate::blinded_path::payment::{BlindedPaymentPath, ReceiveTlvs};
 use crate::chain;
 use crate::chain::WatchedOutput;
@@ -278,7 +278,7 @@ impl<'a> MessageRouter for TestRouter<'a> {
 		T: secp256k1::Signing + secp256k1::Verification
 	>(
 		&self, recipient: PublicKey, context: MessageContext,
-		peers: Vec<ForwardNode>, secp_ctx: &Secp256k1<T>,
+		peers: Vec<MessageForwardNode>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		self.router.create_compact_blinded_paths(recipient, context, peers, secp_ctx)
 	}
@@ -321,7 +321,7 @@ impl<'a> MessageRouter for TestMessageRouter<'a> {
 
 	fn create_compact_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
 		&self, recipient: PublicKey, context: MessageContext,
-		peers: Vec<ForwardNode>, secp_ctx: &Secp256k1<T>,
+		peers: Vec<MessageForwardNode>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		self.inner.create_compact_blinded_paths(recipient, context, peers, secp_ctx)
 	}


### PR DESCRIPTION
We currently have two structs with identical names in our public API - `blinded_path::message::ForwardNode` and
`blinded_path::payment::ForwardNode`. This makes the API somewhat awkward to use - users have to try (and fail) to import `ForwardNode` twice only to then have to change their imports.

More importantly, however, this makes the API very hard to use in some bindings languages where rename-imports or module imports aren't available.

Thus, here, we rename both to give them context.