### PR TITLE
Update RGS stats for August 2024.

### DIFF
--- a/lightning-rapid-gossip-sync/README.md
+++ b/lightning-rapid-gossip-sync/README.md
@@ -125,20 +125,22 @@ Given the primary purpose of this utility is a faster graph sync, we thought it 
 provide some examples of various delta sets. These examples were calculated as of August 2024
 with a network graph comprised of 80,000 channel announcements and 160,000 directed channel updates.
 
+The processing times were averaged over 100 iterations on an iPhone 15 Pro.
+
 | Full sync                   |        |
 |-----------------------------|--------|
 | Message Length              | 3.3 MB |
 | Gzipped Message Length      | 1.5 MB |
-| Client-side Processing Time | 1.4 s  |
+| Client-side Processing Time | 407 ms |
 
 | Week-old sync               |        |
 |-----------------------------|--------|
 | Message Length              | 1.7 MB |
 | Gzipped Message Length      | 566 kB |
-| Client-side Processing Time | 907 ms |
+| Client-side Processing Time | 283 ms |
 
 | Day-old sync                |        |
 |-----------------------------|--------|
 | Message Length              | 210 kB |
 | Gzipped Message Length      | 99 kB  |
-| Client-side Processing Time | 196 ms |
+| Client-side Processing Time | 26 ms  |


### PR DESCRIPTION
This updates the RGS metrics to the latest measurements for V2 gossip.