### PR TITLE
Return owned `String`s for onion message message types

### DIFF
--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -87,7 +87,9 @@ cargo test -p lightning --verbose --color always --no-default-features --feature
 cargo test -p lightning --verbose --color always --features no-std
 
 echo -e "\n\nTesting c_bindings builds"
-RUSTFLAGS="$RUSTFLAGS --cfg=c_bindings" cargo test --verbose --color always
+# Note that because `$RUSTFLAGS` is not passed through to doctest builds we cannot selectively
+# disable doctests in `c_bindings` so we skip doctests entirely here.
+RUSTFLAGS="$RUSTFLAGS --cfg=c_bindings" cargo test --verbose --color always --lib --bins --tests
 
 for DIR in lightning-invoice lightning-rapid-gossip-sync; do
 	# check if there is a conflict between no-std and the c_bindings cfg
@@ -95,9 +97,9 @@ for DIR in lightning-invoice lightning-rapid-gossip-sync; do
 done
 
 # Note that because `$RUSTFLAGS` is not passed through to doctest builds we cannot selectively
-# disable tests in `c_bindings` so we skip doctests entirely here.
+# disable doctests in `c_bindings` so we skip doctests entirely here.
 RUSTFLAGS="$RUSTFLAGS --cfg=c_bindings" cargo test -p lightning-background-processor --verbose --color always --features futures --no-default-features --lib --bins --tests
-RUSTFLAGS="$RUSTFLAGS --cfg=c_bindings" cargo test -p lightning --verbose --color always --no-default-features --features=no-std
+RUSTFLAGS="$RUSTFLAGS --cfg=c_bindings" cargo test -p lightning --verbose --color always --no-default-features --features=no-std --lib --bins --tests
 
 echo -e "\n\nTesting other crate-specific builds"
 # Note that outbound_commitment_test only runs in this mode because of hardcoded signature values

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -170,6 +170,9 @@ impl CustomOnionMessageHandler for IgnoringMessageHandler {
 
 impl OnionMessageContents for Infallible {
 	fn tlv_type(&self) -> u64 { unreachable!(); }
+	#[cfg(c_bindings)]
+	fn msg_type(&self) -> String { unreachable!(); }
+	#[cfg(not(c_bindings))]
 	fn msg_type(&self) -> &'static str { unreachable!(); }
 }
 

--- a/lightning/src/onion_message/async_payments.rs
+++ b/lightning/src/onion_message/async_payments.rs
@@ -77,6 +77,11 @@ impl OnionMessageContents for ReleaseHeldHtlc {
 	fn tlv_type(&self) -> u64 {
 		RELEASE_HELD_HTLC_TLV_TYPE
 	}
+	#[cfg(c_bindings)]
+	fn msg_type(&self) -> String {
+		"Release Held HTLC".to_string()
+	}
+	#[cfg(not(c_bindings))]
 	fn msg_type(&self) -> &'static str {
 		"Release Held HTLC"
 	}
@@ -107,6 +112,14 @@ impl OnionMessageContents for AsyncPaymentsMessage {
 			Self::ReleaseHeldHtlc(msg) => msg.tlv_type(),
 		}
 	}
+	#[cfg(c_bindings)]
+	fn msg_type(&self) -> String {
+		match &self {
+			Self::HeldHtlcAvailable(_) => "Held HTLC Available".to_string(),
+			Self::ReleaseHeldHtlc(msg) => msg.msg_type(),
+		}
+	}
+	#[cfg(not(c_bindings))]
 	fn msg_type(&self) -> &'static str {
 		match &self {
 			Self::HeldHtlcAvailable(_) => "Held HTLC Available",

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -108,6 +108,11 @@ impl OnionMessageContents for TestCustomMessage {
 			TestCustomMessage::Pong => CUSTOM_PONG_MESSAGE_TYPE,
 		}
 	}
+	#[cfg(c_bindings)]
+	fn msg_type(&self) -> String {
+		"Custom Message".to_string()
+	}
+	#[cfg(not(c_bindings))]
 	fn msg_type(&self) -> &'static str {
 		"Custom Message"
 	}
@@ -656,6 +661,11 @@ fn invalid_custom_message_type() {
 			// Onion message contents must have a TLV >= 64.
 			63
 		}
+		#[cfg(c_bindings)]
+		fn msg_type(&self) -> String {
+			"Invalid Message".to_string()
+		}
+		#[cfg(not(c_bindings))]
 		fn msg_type(&self) -> &'static str {
 			"Invalid Message"
 		}

--- a/lightning/src/onion_message/offers.rs
+++ b/lightning/src/onion_message/offers.rs
@@ -99,6 +99,16 @@ impl OffersMessage {
 			_ => Err(Bolt12ParseError::Decode(DecodeError::InvalidValue)),
 		}
 	}
+
+	fn get_msg_type(&self) -> &'static str {
+		match &self {
+			OffersMessage::InvoiceRequest(_) => "Invoice Request",
+			OffersMessage::Invoice(_) => "Invoice",
+			#[cfg(async_payments)]
+			OffersMessage::StaticInvoice(_) => "Static Invoice",
+			OffersMessage::InvoiceError(_) => "Invoice Error",
+		}
+	}
 }
 
 impl fmt::Debug for OffersMessage {
@@ -131,14 +141,13 @@ impl OnionMessageContents for OffersMessage {
 			OffersMessage::InvoiceError(_) => INVOICE_ERROR_TLV_TYPE,
 		}
 	}
+	#[cfg(c_bindings)]
+	fn msg_type(&self) -> String {
+		self.get_msg_type().to_string()
+	}
+	#[cfg(not(c_bindings))]
 	fn msg_type(&self) -> &'static str {
-		match &self {
-			OffersMessage::InvoiceRequest(_) => "Invoice Request",
-			OffersMessage::Invoice(_) => "Invoice",
-			#[cfg(async_payments)]
-			OffersMessage::StaticInvoice(_) => "Static Invoice",
-			OffersMessage::InvoiceError(_) => "Invoice Error",
-		}
+		self.get_msg_type()
 	}
 }
 

--- a/lightning/src/onion_message/packet.rs
+++ b/lightning/src/onion_message/packet.rs
@@ -148,6 +148,16 @@ impl<T: OnionMessageContents> OnionMessageContents for ParsedOnionMessageContent
 			&ParsedOnionMessageContents::Custom(ref msg) => msg.tlv_type(),
 		}
 	}
+	#[cfg(c_bindings)]
+	fn msg_type(&self) -> String {
+		match self {
+			ParsedOnionMessageContents::Offers(ref msg) => msg.msg_type(),
+			#[cfg(async_payments)]
+			ParsedOnionMessageContents::AsyncPayments(ref msg) => msg.msg_type(),
+			ParsedOnionMessageContents::Custom(ref msg) => msg.msg_type(),
+		}
+	}
+	#[cfg(not(c_bindings))]
 	fn msg_type(&self) -> &'static str {
 		match self {
 			ParsedOnionMessageContents::Offers(ref msg) => msg.msg_type(),
@@ -174,6 +184,11 @@ pub trait OnionMessageContents: Writeable + core::fmt::Debug {
 	/// Returns the TLV type identifying the message contents. MUST be >= 64.
 	fn tlv_type(&self) -> u64;
 
+	#[cfg(c_bindings)]
+	/// Returns the message type
+	fn msg_type(&self) -> String;
+
+	#[cfg(not(c_bindings))]
 	/// Returns the message type
 	fn msg_type(&self) -> &'static str;
 }


### PR DESCRIPTION
Returning a reference from a trait method is relatively difficult to map in bindings and is currently handled by storing the object in the trait instance, returning a reference to the local field.

This is fine when the object we're returning only needs to live as long as the trait, but when it needs to be `'static` (as is the case for onion message `msg_type`s), there's not really a good way to map them at all.

Instead, here, condition on `#[cfg(c_bindings)]` we return a fully owned `String`. This is obviously relatively less effecient, but the extra allocation and `memcpy` isn't the end of the world, especially given it should be released relatively quickly.