### PR TITLE
Correct handling of added `OP_RETURN` outputs

### DIFF
--- a/lightning/src/events/bump_transaction.rs
+++ b/lightning/src/events/bump_transaction.rs
@@ -670,7 +670,7 @@ where
 
 			let package_fee = total_input_amount -
 				anchor_psbt.unsigned_tx.output.iter().map(|output| output.value).sum();
-			let package_weight = unsigned_tx_weight + total_satisfaction_weight + commitment_tx.weight().to_wu();
+			let package_weight = unsigned_tx_weight + 2 /* wit marker */ + total_satisfaction_weight + commitment_tx.weight().to_wu();
 			if package_fee.to_sat() * 1000 / package_weight < package_target_feerate_sat_per_1000_weight.into() {
 				// On the first iteration of the loop, we may undershoot the target feerate because
 				// we had to add an OP_RETURN output in `process_coin_selection` which we didn't
@@ -695,7 +695,7 @@ where
 
 			#[cfg(debug_assertions)] {
 				let signed_tx_weight = anchor_tx.weight().to_wu();
-				let expected_signed_tx_weight = unsigned_tx_weight + total_satisfaction_weight;
+				let expected_signed_tx_weight = unsigned_tx_weight + 2 /* wit marker */ + total_satisfaction_weight;
 				// Our estimate should be within a 1% error margin of the actual weight and we should
 				// never underestimate.
 				assert!(expected_signed_tx_weight >= signed_tx_weight &&

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -68,7 +68,12 @@ pub(crate) const MIN_ACCEPTED_HTLC_SCRIPT_WEIGHT: usize = 136;
 pub const MAX_ACCEPTED_HTLC_SCRIPT_WEIGHT: usize = 143;
 
 /// The upper bound weight of an anchor input.
-pub const ANCHOR_INPUT_WITNESS_WEIGHT: u64 = 116;
+#[cfg(feature = "grind_signatures")]
+pub const ANCHOR_INPUT_WITNESS_WEIGHT: u64 = 114;
+/// The upper bound weight of an anchor input.
+#[cfg(not(feature = "grind_signatures"))]
+pub const ANCHOR_INPUT_WITNESS_WEIGHT: u64 = 115;
+
 /// The upper bound weight of an HTLC timeout input from a commitment transaction with anchor
 /// outputs.
 pub const HTLC_TIMEOUT_INPUT_ANCHOR_WITNESS_WEIGHT: u64 = 288;


### PR DESCRIPTION
This fixes two bugs in handling of coin selections that don't contain change, both of them pretty minor (in part cause we'll always re-select soon anyway and that selection might well contain change) but also important.