### PR TITLE
[Splicing] Signer extended with method to sign prev funding transaction input

### DIFF
--- a/lightning/src/sign/ecdsa.rs
+++ b/lightning/src/sign/ecdsa.rs
@@ -209,4 +209,18 @@ pub trait EcdsaChannelSigner: ChannelSigner {
 	fn sign_channel_announcement_with_funding_key(
 		&self, msg: &UnsignedChannelAnnouncement, secp_ctx: &Secp256k1<secp256k1::All>,
 	) -> Result<Signature, ()>;
+
+	/// Signs the input of a splicing funding transaction with our funding key.
+	///
+	/// In splicing, the previous funding transaction output is spent as the input of
+	/// the new funding transaction, and is a 2-of-2 multisig.
+	///
+	/// `input_index`: The index of the input within the new funding transaction `tx`,
+	///    spending the previous funding transaction's output
+	///
+	/// `input_value`: The value of the previous funding transaction output.
+	fn sign_splicing_funding_input(
+		&self, tx: &Transaction, input_index: usize, input_value: u64,
+		secp_ctx: &Secp256k1<secp256k1::All>,
+	) -> Result<Signature, ()>;
 }

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -353,6 +353,13 @@ impl EcdsaChannelSigner for TestChannelSigner {
 	) -> Result<Signature, ()> {
 		self.inner.sign_channel_announcement_with_funding_key(msg, secp_ctx)
 	}
+
+	fn sign_splicing_funding_input(
+		&self, tx: &Transaction, input_index: usize, input_value: u64,
+		secp_ctx: &Secp256k1<secp256k1::All>,
+	) -> Result<Signature, ()> {
+		self.inner.sign_splicing_funding_input(tx, input_index, input_value, secp_ctx)
+	}
 }
 
 #[cfg(taproot)]


### PR DESCRIPTION
Fixes #3312 . (#1621 )

New method to sign an input of a transaction with our funding key.
Used for splicing, when signing the previous funding transaction. The previous funding transaction becomes an input to the new funding transaction, and it is a multisig, which we also need to sign.