### PR TITLE
Allow Asynchronously responding to Invoice Request

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -823,17 +823,28 @@ pub enum Event {
 		addresses: Vec<msgs::SocketAddress>,
 	},
 
-	/// Event triggered when manual handling is enabled, and an invoice request is received.
+	/// Event triggered when manual handling is enabled and an invoice request is received.
+	///
+	/// Indicates that an [`InvoiceRequest`] for an [`Offer`] created by us has been received.
+	///
+	/// This event will only be generated if [`UserConfig::manually_handle_bolt12_messages`] is set.
+	/// Use [`ChannelManager::send_invoice_request_response`] to respond with an appropriate
+	/// response to the received invoice request. Use [`ChannelManager::reject_invoice_request`] to
+	/// reject the invoice request and respond with an [`InvoiceError`]. See the docs for further details.
+	///
+	/// [`Offer`]: crate::offers::offer::Offer
+	/// [`UserConfig::manually_handle_bolt12_messages`]: crate::util::config::UserConfig::manually_handle_bolt12_messages
+	/// [`ChannelManager::send_invoice_request_response`]: crate::ln::channelmanager::ChannelManager::send_invoice_request_response
+	/// [`ChannelManager::reject_invoice_request`]: crate::ln::channelmanager::ChannelManager::reject_invoice_request
+	/// [`InvoiceError`]: crate::offers::invoice_error::InvoiceError
 	InvoiceRequestReceived {
-		/// The invoice request to pay.
+		/// The received invoice request to respond to.
 		invoice_request: InvoiceRequest,
 		/// The context of the [`BlindedMessagePath`] used to send the invoice request.
 		///
 		/// [`BlindedMessagePath`]: crate::blinded_path::message::BlindedMessagePath
 		context: Option<OffersContext>,
 		/// A responder for replying with an [`InvoiceError`] if needed.
-		///
-		/// `None` if the invoice wasn't sent with a reply path.
 		///
 		/// [`InvoiceError`]: crate::offers::invoice_error::InvoiceError
 		responder: Responder,

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -824,7 +824,7 @@ pub enum Event {
 	/// Indicates a [`Bolt12Invoice`] in response to an [`InvoiceRequest`] or a [`Refund`] was
 	/// received.
 	///
-	/// This event will only be generated if [`UserConfig::manually_handle_bolt12_invoices`] is set.
+	/// This event will only be generated if [`UserConfig::manually_handle_bolt12_messages`] is set.
 	/// Use [`ChannelManager::send_payment_for_bolt12_invoice`] to pay the invoice or
 	/// [`ChannelManager::abandon_payment`] to abandon the associated payment. See those docs for
 	/// further details.
@@ -835,7 +835,7 @@ pub enum Event {
 	///
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	/// [`Refund`]: crate::offers::refund::Refund
-	/// [`UserConfig::manually_handle_bolt12_invoices`]: crate::util::config::UserConfig::manually_handle_bolt12_invoices
+	/// [`UserConfig::manually_handle_bolt12_messages`]: crate::util::config::UserConfig::manually_handle_bolt12_messages
 	/// [`ChannelManager::send_payment_for_bolt12_invoice`]: crate::ln::channelmanager::ChannelManager::send_payment_for_bolt12_invoice
 	/// [`ChannelManager::abandon_payment`]: crate::ln::channelmanager::ChannelManager::abandon_payment
 	InvoiceReceived {

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -836,7 +836,7 @@ pub enum Event {
 		/// `None` if the invoice wasn't sent with a reply path.
 		///
 		/// [`InvoiceError`]: crate::offers::invoice_error::InvoiceError
-		responder: Option<Responder>,
+		responder: Responder,
 	},
 
 	/// Indicates a [`Bolt12Invoice`] in response to an [`InvoiceRequest`] or a [`Refund`] was
@@ -1764,7 +1764,7 @@ impl Writeable for Event {
 				write_tlv_fields!(writer, {
 					(0, invoice_request, required),
 					(2, context, option),
-					(4, responder, option),
+					(4, responder, required),
 				});
 			},
 			// Note that, going forward, all new events must only write data inside of
@@ -2266,12 +2266,12 @@ impl MaybeReadable for Event {
 					_init_and_read_len_prefixed_tlv_fields!(reader, {
 						(0, invoice_request, required),
 						(2, context, option),
-						(4, responder, option),
+						(4, responder, required),
 					});
 					Ok(Some(Event::InvoiceRequestReceived {
 						invoice_request: invoice_request.0.unwrap(),
 						context,
-						responder,
+						responder: responder.0.unwrap(),
 					}))
 				};
 				f()

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2614,6 +2614,17 @@ pub enum RecentPaymentDetails {
 	},
 }
 
+/// Error during responding to Bolt12 Messages.
+pub enum Bolt12ResponseError {
+	/// Error from  BOLT 12 semantic checks.
+	SemanticError(Bolt12SemanticError),
+	/// Error from failed verification of received [`OffersMessage`]
+	VerificationError,
+	/// Error generated when custom amount is provided when [`InvoiceRequest`] already
+	/// contains amount.
+	UnexpectedAmount
+}
+
 /// Route hints used in constructing invoices for [phantom node payents].
 ///
 /// [phantom node payments]: crate::sign::PhantomKeysManager

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11038,6 +11038,14 @@ where
 
 		match message {
 			OffersMessage::InvoiceRequest(invoice_request) => {
+				if self.default_configuration.manually_handle_bolt12_messages {
+					let event = Event::InvoiceRequestReceived {
+						invoice_request, context, responder,
+					};
+					self.pending_events.lock().unwrap().push_back((event, None));
+					return None;
+				}
+
 				let responder = match responder {
 					Some(responder) => responder,
 					None => return None,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4548,6 +4548,18 @@ where
 		Ok(())
 	}
 
+	/// Signals that the received [`InvoiceRequest`] must be rejected, and the corresponding
+	/// [`InvoiceError`], must be sent back to the counterparty.
+	pub fn reject_invoice_request(&self, reason: Bolt12SemanticError, responder: Responder) {
+		let mut pending_offers_message = self.pending_offers_messages.lock().unwrap();
+		let error = InvoiceError::from(reason);
+
+		let instructions = responder.respond().into_instructions();
+		let message = OffersMessage::InvoiceError(error);
+
+		pending_offers_message.push((message, instructions))
+	}
+
 	#[cfg(async_payments)]
 	fn initiate_async_payment(
 		&self, invoice: &StaticInvoice, payment_id: PaymentId

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11154,7 +11154,7 @@ where
 					&self.logger, None, None, Some(invoice.payment_hash()),
 				);
 
-				if self.default_configuration.manually_handle_bolt12_invoices {
+				if self.default_configuration.manually_handle_bolt12_messages {
 					let event = Event::InvoiceReceived {
 						payment_id, invoice, context, responder,
 					};

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11083,7 +11083,7 @@ where
 
 
 				let amount_msats = match InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(
-					&invoice_request.inner
+					&invoice_request.inner, None
 				) {
 					Ok(amount_msats) => amount_msats,
 					Err(error) => return Some((OffersMessage::InvoiceError(error.into()), responder.respond())),
@@ -11122,11 +11122,11 @@ where
 				let response = if invoice_request.keys.is_some() {
 					#[cfg(feature = "std")]
 					let builder = invoice_request.respond_using_derived_keys(
-						payment_paths, payment_hash
+						payment_paths, payment_hash, None
 					);
 					#[cfg(not(feature = "std"))]
 					let builder = invoice_request.respond_using_derived_keys_no_std(
-						payment_paths, payment_hash, created_at
+						payment_paths, payment_hash, created_at, None
 					);
 					builder
 						.map(InvoiceBuilder::<DerivedSigningPubkey>::from)

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11038,14 +11038,6 @@ where
 
 		match message {
 			OffersMessage::InvoiceRequest(invoice_request) => {
-				if self.default_configuration.manually_handle_bolt12_messages {
-					let event = Event::InvoiceRequestReceived {
-						invoice_request, context, responder,
-					};
-					self.pending_events.lock().unwrap().push_back((event, None));
-					return None;
-				}
-
 				let responder = match responder {
 					Some(responder) => responder,
 					None => return None,
@@ -11069,6 +11061,15 @@ where
 						Err(()) => return None,
 					},
 				};
+
+				if self.default_configuration.manually_handle_bolt12_messages {
+					let event = Event::InvoiceRequestReceived {
+						invoice_request: invoice_request.inner, context, responder,
+					};
+					self.pending_events.lock().unwrap().push_back((event, None));
+					return None;
+				}
+
 
 				let amount_msats = match InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(
 					&invoice_request.inner

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -2223,7 +2223,7 @@ fn fails_paying_invoice_with_unknown_required_features() {
 	let created_at = alice.node.duration_since_epoch();
 	let invoice = invoice_request
 		.verify_using_recipient_data(nonce, &expanded_key, &secp_ctx).unwrap()
-		.respond_using_derived_keys_no_std(payment_paths, payment_hash, created_at).unwrap()
+		.respond_using_derived_keys_no_std(payment_paths, payment_hash, created_at, None).unwrap()
 		.features_unchecked(Bolt12InvoiceFeatures::unknown())
 		.build_and_sign(&secp_ctx).unwrap();
 

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -1147,7 +1147,7 @@ fn creates_and_pays_for_offer_with_retry() {
 #[test]
 fn pays_bolt12_invoice_asynchronously() {
 	let mut manually_pay_cfg = test_default_channel_config();
-	manually_pay_cfg.manually_handle_bolt12_invoices = true;
+	manually_pay_cfg.manually_handle_bolt12_messages = true;
 
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -1227,6 +1227,78 @@ fn pays_bolt12_invoice_asynchronously() {
 	);
 }
 
+#[test]
+fn send_invoice_request_response_asynchronously() {
+	let mut manually_respond_cfg = test_default_channel_config();
+	manually_respond_cfg.manually_handle_bolt12_messages = true;
+
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[Some(manually_respond_cfg), None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 10_000_000, 1_000_000_000);
+
+	let alice = &nodes[0];
+	let alice_id = alice.node.get_our_node_id();
+	let bob = &nodes[1];
+	let bob_id = bob.node.get_our_node_id();
+
+	let offer = alice.node
+		.create_offer_builder(None).unwrap()
+		.amount_msats(10_000_000)
+		.build().unwrap();
+
+	let payment_id = PaymentId([1; 32]);
+	bob.node.pay_for_offer(&offer, None, None, None, payment_id, Retry::Attempts(0), None).unwrap();
+	expect_recent_payment!(bob, RecentPaymentDetails::AwaitingInvoice, payment_id);
+
+	let onion_message = bob.onion_messenger.next_onion_message_for_peer(alice_id).unwrap();
+	alice.onion_messenger.handle_onion_message(bob_id, &onion_message);
+
+	let (invoice_request, context, responder) = match get_event!(alice, Event::InvoiceRequestReceived) {
+		Event::InvoiceRequestReceived { invoice_request, context, responder } => {
+			(invoice_request, context, responder)
+		}
+		_ => panic!("No Event::InvoiceReceived"),
+	};
+
+	let payment_context = PaymentContext::Bolt12Offer(Bolt12OfferContext {
+		offer_id: offer.id(),
+		invoice_request: InvoiceRequestFields {
+			payer_signing_pubkey: invoice_request.payer_signing_pubkey(),
+			quantity: None,
+			payer_note_truncated: None,
+		},
+	});
+
+	assert_eq!(invoice_request.amount_msats(), None);
+	assert_ne!(invoice_request.payer_signing_pubkey(), bob_id);
+	assert_eq!(responder.reply_path.introduction_node(), &IntroductionNode::NodeId(bob_id));
+
+	match alice.node.send_invoice_request_response(invoice_request, context, None, responder) {
+		Ok(()) => (),
+		Err(_) => panic!("Unexpected Error.")
+	}
+
+	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
+	bob.onion_messenger.handle_onion_message(alice_id, &onion_message);
+
+	let (invoice, _) = extract_invoice(bob, &onion_message);
+	assert_eq!(invoice.amount_msats(), 10_000_000);
+	assert_ne!(invoice.signing_pubkey(), alice_id);
+	assert!(!invoice.payment_paths().is_empty());
+	for path in invoice.payment_paths() {
+		assert_eq!(path.introduction_node(), &IntroductionNode::NodeId(alice_id));
+	}
+
+	route_bolt12_payment(bob, &[alice], &invoice);
+	expect_recent_payment!(bob, RecentPaymentDetails::Pending, payment_id);
+
+	claim_bolt12_payment(bob, &[alice], payment_context);
+	expect_recent_payment!(bob, RecentPaymentDetails::Fulfilled, payment_id);
+}
+
 /// Checks that an offer can be created using an unannounced node as a blinded path's introduction
 /// node. This is only preferred if there are no other options which may indicated either the offer
 /// is intended for the unannounced node or that the node is actually announced (e.g., an LSP) but

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -1017,7 +1017,7 @@ impl OutboundPayments {
 						abandon_with_entry!(entry, PaymentFailureReason::UnknownRequiredFeatures);
 						return Err(Bolt12PaymentError::UnknownRequiredFeatures)
 					}
-					let amount_msat = match InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(invreq) {
+					let amount_msat = match InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(invreq, None) {
 						Ok(amt) => amt,
 						Err(_) => {
 							// We check this during invoice request parsing, when constructing the invreq's

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -342,7 +342,12 @@ macro_rules! invoice_builder_methods { (
 	pub(crate) fn amount_msats(
 		invoice_request: &InvoiceRequest, custom_amount_msats: Option<u64>
 	) -> Result<u64, Bolt12SemanticError> {
-		if invoice_request.amount_msats().is_some() && custom_amount_msats.is_some() {
+		let invoice_request_amount = invoice_request.amount_msats();
+		let offer_amount = invoice_request.contents.inner.offer.amount();
+
+		// custom_amount_msats should only be provided for the case when the offer is denominated
+		// in Currency (and not Bitcoin) and when Invoice Request doesn't contain an amount.
+		if (!matches!(offer_amount, Some(Amount::Currency { .. })) || invoice_request_amount.is_some()) && custom_amount_msats.is_some() {
 			return Err(Bolt12SemanticError::UnexpectedAmount);
 		}
 

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -595,7 +595,6 @@ impl AsRef<TaggedHash> for UnsignedInvoiceRequest {
 /// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 /// [`Offer`]: crate::offers::offer::Offer
 #[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
 pub struct InvoiceRequest {
 	pub(super) bytes: Vec<u8>,
 	pub(super) contents: InvoiceRequestContents,
@@ -1144,6 +1143,14 @@ impl TryFrom<Vec<u8>> for InvoiceRequest {
 		Ok(InvoiceRequest { bytes, contents, signature })
 	}
 }
+
+impl PartialEq for InvoiceRequest {
+	fn eq(&self, other: &Self) -> bool {
+		self.bytes.eq(&other.bytes)
+	}
+}
+
+impl Eq for InvoiceRequest {}
 
 impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 	type Error = Bolt12SemanticError;

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -883,13 +883,13 @@ macro_rules! invoice_request_respond_with_derived_signing_pubkey_methods { (
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	#[cfg(feature = "std")]
 	pub fn respond_using_derived_keys(
-		&$self, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash
+		&$self, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash, custom_amount_msats: Option<u64>
 	) -> Result<$builder, Bolt12SemanticError> {
 		let created_at = std::time::SystemTime::now()
 			.duration_since(std::time::SystemTime::UNIX_EPOCH)
 			.expect("SystemTime::now() should come after SystemTime::UNIX_EPOCH");
 
-		$self.respond_using_derived_keys_no_std(payment_paths, payment_hash, created_at)
+		$self.respond_using_derived_keys_no_std(payment_paths, payment_hash, created_at, custom_amount_msats)
 	}
 
 	/// Creates an [`InvoiceBuilder`] for the request using the given required fields and that uses
@@ -901,7 +901,7 @@ macro_rules! invoice_request_respond_with_derived_signing_pubkey_methods { (
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	pub fn respond_using_derived_keys_no_std(
 		&$self, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
-		created_at: core::time::Duration
+		created_at: core::time::Duration, custom_amount_msats: Option<u64>
 	) -> Result<$builder, Bolt12SemanticError> {
 		if $self.inner.invoice_request_features().requires_unknown_bits() {
 			return Err(Bolt12SemanticError::UnknownRequiredFeatures);
@@ -918,7 +918,7 @@ macro_rules! invoice_request_respond_with_derived_signing_pubkey_methods { (
 		}
 
 		<$builder>::for_offer_using_keys(
-			&$self.inner, payment_paths, created_at, payment_hash, keys
+			&$self.inner, payment_paths, created_at, payment_hash, keys, custom_amount_msats
 		)
 	}
 } }

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -394,7 +394,7 @@ pub struct ResponseInstruction {
 }
 
 impl ResponseInstruction {
-	fn into_instructions(self) -> MessageSendInstructions {
+	pub(crate) fn into_instructions(self) -> MessageSendInstructions {
 		MessageSendInstructions::ForReply { instructions: self }
 	}
 }

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -347,7 +347,7 @@ impl OnionMessageRecipient {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Responder {
 	/// The path along which a response can be sent.
-	reply_path: BlindedMessagePath,
+	pub(crate) reply_path: BlindedMessagePath,
 }
 
 impl_writeable_tlv_based!(Responder, {

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -859,7 +859,7 @@ pub struct UserConfig {
 	/// [`Event::InvoiceReceived`]: crate::events::Event::InvoiceReceived
 	/// [`ChannelManager::send_payment_for_bolt12_invoice`]: crate::ln::channelmanager::ChannelManager::send_payment_for_bolt12_invoice
 	/// [`ChannelManager::abandon_payment`]: crate::ln::channelmanager::ChannelManager::abandon_payment
-	pub manually_handle_bolt12_invoices: bool,
+	pub manually_handle_bolt12_messages: bool,
 }
 
 impl Default for UserConfig {
@@ -873,7 +873,7 @@ impl Default for UserConfig {
 			manually_accept_inbound_channels: false,
 			accept_intercept_htlcs: false,
 			accept_mpp_keysend: false,
-			manually_handle_bolt12_invoices: false,
+			manually_handle_bolt12_messages: false,
 		}
 	}
 }
@@ -893,7 +893,7 @@ impl Readable for UserConfig {
 			manually_accept_inbound_channels: Readable::read(reader)?,
 			accept_intercept_htlcs: Readable::read(reader)?,
 			accept_mpp_keysend: Readable::read(reader)?,
-			manually_handle_bolt12_invoices: Readable::read(reader)?,
+			manually_handle_bolt12_messages: Readable::read(reader)?,
 		})
 	}
 }


### PR DESCRIPTION
Introduce a new event and set of supporting functions to allow flexibility in responding asynchronously to a received invoice request.

This PR provides foundational work for further improvements in future. For example, this allows supporting Offers created in currency denomination, as a user can do appropriate pre-processing for a received InvoiceRequest, before sending an Invoice for it.