### PR TITLE
Fix silent rebase conflict that broke tests

### DIFF
--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -2287,7 +2287,7 @@ fn no_double_pay_with_stale_channelmanager() {
 		.clear_paths()
 		.amount_msats(amt_msat)
 		.build().unwrap();
-	assert_eq!(offer.signing_pubkey(), Some(bob_id));
+	assert_eq!(offer.issuer_signing_pubkey(), Some(bob_id));
 	assert!(offer.paths().is_empty());
 
 	let payment_id = PaymentId([1; 32]);


### PR DESCRIPTION
429cbe1a060a5ee7abb421c65d2cf5e503909215 merged a PR that renamed `Offer::signing_pubkey` to `Offer::issuer_signing_pubkey`. However, there was a silent rebase conflict and a test added as part of 1059f5ffc55d3c21bf4d3ae82fe185f588a53116 did not get the memo and used the old method name, breaking the test build.