### PR TITLE
Calculate Trampoline onion packet sizes dynamically.

### DIFF
--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -427,12 +427,30 @@ pub(super) fn construct_onion_packet(
 #[allow(unused)]
 pub(super) fn construct_trampoline_onion_packet(
 	payloads: Vec<msgs::OutboundTrampolinePayload>, onion_keys: Vec<OnionKeys>,
-	prng_seed: [u8; 32], associated_data: &PaymentHash, length: u16,
+	prng_seed: [u8; 32], associated_data: &PaymentHash, length: Option<u16>,
 ) -> Result<msgs::TrampolineOnionPacket, ()> {
-	let mut packet_data = vec![0u8; length as usize];
+	let minimum_packet_length = payloads.iter().map(|p| p.serialized_length() + 32).sum();
 
+	debug_assert!(
+		minimum_packet_length < ONION_DATA_LEN,
+		"Trampoline onion packet must be smaller than outer onion"
+	);
+	if minimum_packet_length >= ONION_DATA_LEN {
+		return Err(());
+	}
+
+	let packet_length = length.map(|l| usize::from(l)).unwrap_or(minimum_packet_length);
+	debug_assert!(
+		packet_length >= minimum_packet_length,
+		"Packet length cannot be smaller than the payloads require."
+	);
+	if packet_length < minimum_packet_length {
+		return Err(());
+	}
+
+	let mut packet_data = vec![0u8; packet_length];
 	let mut chacha = ChaCha20::new(&prng_seed, &[0; 8]);
-	chacha.process(&vec![0u8; length as usize], &mut packet_data);
+	chacha.process_in_place(&mut packet_data);
 
 	construct_onion_packet_with_init_noise::<_, _>(
 		payloads,


### PR DESCRIPTION
Given that Trampoline onion sizes will be variable, this obviates the need to pass the onion size a priori.

Builds on top of #3446.