### PR TITLE
Introduce ManualRoutingParameters

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -53,7 +53,7 @@ use crate::ln::channel_state::ChannelDetails;
 use crate::ln::features::{Bolt12InvoiceFeatures, ChannelFeatures, ChannelTypeFeatures, InitFeatures, NodeFeatures};
 #[cfg(any(feature = "_test_utils", test))]
 use crate::ln::features::Bolt11InvoiceFeatures;
-use crate::routing::router::{BlindedTail, InFlightHtlcs, Path, Payee, PaymentParameters, Route, RouteParameters, Router};
+use crate::routing::router::{BlindedTail, InFlightHtlcs, ManualRoutingParameters, Path, Payee, PaymentParameters, Route, RouteParameters, Router};
 use crate::ln::onion_payment::{check_incoming_htlc_cltv, create_recv_pending_htlc_info, create_fwd_pending_htlc_info, decode_incoming_update_add_htlc_onion, InboundHTLCErr, NextPacketDetails};
 use crate::ln::msgs;
 use crate::ln::onion_utils;
@@ -1893,10 +1893,11 @@ where
 /// # use lightning::events::{Event, EventsProvider};
 /// # use lightning::ln::channelmanager::{AChannelManager, PaymentId, RecentPaymentDetails, Retry};
 /// # use lightning::offers::offer::Offer;
+/// # use lightning::routing::router::ManualRoutingParameters;
 /// #
 /// # fn example<T: AChannelManager>(
 /// #     channel_manager: T, offer: &Offer, quantity: Option<u64>, amount_msats: Option<u64>,
-/// #     payer_note: Option<String>, retry: Retry, max_total_routing_fee_msat: Option<u64>
+/// #     payer_note: Option<String>, retry: Retry, max_total_routing_fee_msat: Option<ManualRoutingParameters>
 /// # ) {
 /// # let channel_manager = channel_manager.get_cm();
 /// let payment_id = PaymentId([42; 32]);
@@ -9207,10 +9208,15 @@ macro_rules! create_refund_builder { ($self: ident, $builder: ty) => {
 
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop($self);
 
+		let manual_routing_params = max_total_routing_fee_msat.map(
+			|fee_msat| ManualRoutingParameters::new()
+				.with_max_total_routing_fee_msat(fee_msat)
+		);
+
 		let expiration = StaleExpiration::AbsoluteTimeout(absolute_expiry);
 		$self.pending_outbound_payments
 			.add_new_awaiting_invoice(
-				payment_id, expiration, retry_strategy, max_total_routing_fee_msat, None,
+				payment_id, expiration, retry_strategy, manual_routing_params, None,
 			)
 			.map_err(|_| Bolt12SemanticError::DuplicatePaymentId)?;
 
@@ -9303,7 +9309,7 @@ where
 	pub fn pay_for_offer(
 		&self, offer: &Offer, quantity: Option<u64>, amount_msats: Option<u64>,
 		payer_note: Option<String>, payment_id: PaymentId, retry_strategy: Retry,
-		max_total_routing_fee_msat: Option<u64>
+		manual_routing_params: Option<ManualRoutingParameters>
 	) -> Result<(), Bolt12SemanticError> {
 		let expanded_key = &self.inbound_payment_key;
 		let entropy = &*self.entropy_source;
@@ -9345,7 +9351,7 @@ where
 		};
 		self.pending_outbound_payments
 			.add_new_awaiting_invoice(
-				payment_id, expiration, retry_strategy, max_total_routing_fee_msat,
+				payment_id, expiration, retry_strategy, manual_routing_params,
 				Some(retryable_invoice_request)
 			)
 			.map_err(|_| Bolt12SemanticError::DuplicatePaymentId)?;

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -1598,13 +1598,9 @@ impl OutboundPayments {
 
 	pub(super) fn add_new_awaiting_invoice(
 		&self, payment_id: PaymentId, expiration: StaleExpiration, retry_strategy: Retry,
-		max_total_routing_fee_msat: Option<u64>, retryable_invoice_request: Option<RetryableInvoiceRequest>
+		manual_routing_params: Option<ManualRoutingParameters>, retryable_invoice_request: Option<RetryableInvoiceRequest>
 	) -> Result<(), ()> {
 		let mut pending_outbounds = self.pending_outbound_payments.lock().unwrap();
-		let manual_routing_params = max_total_routing_fee_msat.map(
-			|fee_msats| ManualRoutingParameters::new()
-				.with_max_total_routing_fee_msat(fee_msats)
-		);
 		match pending_outbounds.entry(payment_id) {
 			hash_map::Entry::Occupied(_) => Err(()),
 			hash_map::Entry::Vacant(entry) => {
@@ -2281,7 +2277,7 @@ mod tests {
 	use crate::offers::offer::OfferBuilder;
 	use crate::offers::test_utils::*;
 	use crate::routing::gossip::NetworkGraph;
-	use crate::routing::router::{InFlightHtlcs, Path, PaymentParameters, Route, RouteHop, RouteParameters};
+	use crate::routing::router::{InFlightHtlcs, ManualRoutingParameters, Path, PaymentParameters, Route, RouteHop, RouteParameters};
 	use crate::sync::{Arc, Mutex, RwLock};
 	use crate::util::errors::APIError;
 	use crate::util::hash_tables::new_hash_map;
@@ -2695,10 +2691,12 @@ mod tests {
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 
+		let manual_routing_params = ManualRoutingParameters::new().with_max_total_routing_fee_msat(invoice.amount_msats() / 100 + 50_000);
+
 		assert!(
 			outbound_payments.add_new_awaiting_invoice(
 				payment_id, expiration, Retry::Attempts(0),
-				Some(invoice.amount_msats() / 100 + 50_000), None,
+				Some(manual_routing_params), None,
 			).is_ok()
 		);
 		assert!(outbound_payments.has_pending_payments());
@@ -2796,9 +2794,11 @@ mod tests {
 		assert!(!outbound_payments.has_pending_payments());
 		assert!(pending_events.lock().unwrap().is_empty());
 
+		let manual_routing_params = ManualRoutingParameters::new().with_max_total_routing_fee_msat(1234);
+
 		assert!(
 			outbound_payments.add_new_awaiting_invoice(
-				payment_id, expiration, Retry::Attempts(0), Some(1234), None,
+				payment_id, expiration, Retry::Attempts(0), Some(manual_routing_params), None,
 			).is_ok()
 		);
 		assert!(outbound_payments.has_pending_payments());

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -962,6 +962,43 @@ impl PaymentParameters {
 	}
 }
 
+/// Information manually provided by the user to route the payment
+#[derive(Clone, Copy)]
+pub struct ManualRoutingParameters {
+	/// Same as [`RouteParameters::max_total_routing_fee_msat`]
+	pub max_total_routing_fee_msat: Option<u64>,
+	/// Same as [`PaymentParameters::max_total_cltv_expiry_delta`]
+	pub max_total_cltv_expiry_delta: Option<u32>,
+	/// Same as [`PaymentParameters::max_path_count`]
+	pub max_path_count: Option<u8>,
+	/// Same as [`PaymentParameters::max_channel_saturation_power_of_half`]
+	pub max_channel_saturation_power_of_half: Option<u8>,
+}
+
+impl_writeable_tlv_based!(ManualRoutingParameters, {
+	(1, max_total_routing_fee_msat, option),
+	(3, max_total_cltv_expiry_delta, option),
+	(5, max_path_count, option),
+	(7, max_channel_saturation_power_of_half, option),
+});
+
+impl ManualRoutingParameters {
+	/// Initates an empty set of [`ManualRoutingParameters`]
+	pub fn new() -> Self {
+		Self {
+			max_total_routing_fee_msat: None,
+			max_total_cltv_expiry_delta: None,
+			max_path_count: None,
+			max_channel_saturation_power_of_half: None,
+		}
+	}
+
+	/// Creates a new set of [`ManualRoutingParameters`] with the updated `max_total_routing_fee_msat`.
+	pub fn with_max_total_routing_fee_msat(self, fee_msat: u64) -> Self {
+		Self { max_total_routing_fee_msat: Some(fee_msat), ..self }
+	}
+}
+
 /// The recipient of a payment, differing based on whether they've hidden their identity with route
 /// blinding.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -607,6 +607,24 @@ impl RouteParameters {
 		Self { payment_params, final_value_msat, max_total_routing_fee_msat: Some(final_value_msat / 100 + 50_000) }
 	}
 
+	/// Constructs [`RouteParameters`] from the given [`PaymentParameters`], a payment amount,
+	/// and from the provided [`ManualRoutingParameters`].
+	/// 
+	/// [`Self::max_total_routing_fee_msat`] defaults to 1% of the payment amount + 50 sats
+	pub fn from_payment_and_manual_params(mut payment_params: PaymentParameters, final_value_msat: u64, manual_routing_params: ManualRoutingParameters) -> Self {
+		manual_routing_params.max_total_cltv_expiry_delta.map(|v| payment_params.max_total_cltv_expiry_delta = v);
+		manual_routing_params.max_path_count.map(|v| payment_params.max_path_count = v);
+		manual_routing_params.max_channel_saturation_power_of_half.map(|v| payment_params.max_channel_saturation_power_of_half = v);
+
+		let mut route_params = RouteParameters::from_payment_params_and_value(payment_params, final_value_msat);
+
+		manual_routing_params.max_total_routing_fee_msat.map(
+			|fee_msat| route_params.max_total_routing_fee_msat = Some(fee_msat)
+		);
+
+		route_params
+	}
+
 	/// Sets the maximum number of hops that can be included in a payment path, based on the provided
 	/// [`RecipientOnionFields`] and blinded paths.
 	pub fn set_max_path_length(


### PR DESCRIPTION
Partially addresses #3262 

- Introduce a new struct `ManualRoutingParameters` that optionally takes the parameter to set for routing.
- Pass it to `pay_for_offer` to use it along with the invoice's payment parameter to set route parameters.