### PR TITLE
Bump `esplora-client` to 0.11

### DIFF
--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["time"]
 time = []
-esplora-async = ["async-interface", "esplora-client/async", "futures"]
+esplora-async = ["async-interface", "esplora-client/async", "esplora-client/tokio", "futures"]
 esplora-async-https = ["esplora-async", "esplora-client/async-https-rustls"]
 esplora-blocking = ["esplora-client/blocking"]
 electrum = ["electrum-client"]
@@ -27,7 +27,7 @@ lightning = { version = "0.0.124", path = "../lightning", default-features = fal
 lightning-macros = { version = "0.1", path = "../lightning-macros", default-features = false }
 bitcoin = { version = "0.32.2", default-features = false }
 futures = { version = "0.3", optional = true }
-esplora-client = { version = "0.9", default-features = false, optional = true }
+esplora-client = { version = "0.11", default-features = false, optional = true }
 electrum-client = { version = "0.21.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
 Bump `esplora-client` to 0.11
.. the most-recent release, which also dropped the `async-std` dependency in favor of a default sleeper implementation using `tokio`.

This is needed for compatibility with upcoming BDK versions.