### PR TITLE
`lightning-block-sync`: Fix `synchronize_listeners` always calling default implementation

### DIFF
--- a/lightning-block-sync/src/init.rs
+++ b/lightning-block-sync/src/init.rs
@@ -239,8 +239,6 @@ impl<'a, L: chain::Listen + ?Sized> chain::Listen for DynamicChainListener<'a, L
 struct ChainListenerSet<'a, L: chain::Listen + ?Sized>(Vec<(u32, &'a L)>);
 
 impl<'a, L: chain::Listen + ?Sized> chain::Listen for ChainListenerSet<'a, L> {
-	// Needed to differentiate test expectations.
-	#[cfg(test)]
 	fn block_connected(&self, block: &bitcoin::Block, height: u32) {
 		for (starting_height, chain_listener) in self.0.iter() {
 			if height > *starting_height {


### PR DESCRIPTION
Previously, the `ChainListenerSet` `Listen` implementation wouldn't forward to the listeners `block_connected` implementation outside of tests. This would result in the default implementation of `Listen::block_connected` being used and the listeners implementation never being called.