### PR TITLE
Skip MSRV on Windows in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
         toolchain: [ stable, beta, 1.63.0 ] # 1.63.0 is the MSRV for all crates.
+        exclude:
+          - platform: windows-latest
+            toolchain: 1.63.0
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code


### PR DESCRIPTION
Despite the compilation fixes in #3357, upstream dependencies continued having excessive issues, so this PR is meant to either entirely supplant #3357 or, if the compilation fixes are worth preserving, build on it.