### PR TITLE
[Splicing] Preserve funding_transaction for the later lifecycle of the channel, simple solution

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -5486,7 +5486,8 @@ impl<SP: Deref> Channel<SP> where
 				(matches!(self.context.channel_state, ChannelState::AwaitingChannelReady(flags) if !flags.is_set(AwaitingChannelReadyFlags::WAITING_FOR_BATCH)) ||
 				matches!(self.context.channel_state, ChannelState::ChannelReady(_)))
 			{
-				self.context.funding_transaction.take()
+				// Take the funding transaction, do not clear the field
+				self.context.funding_transaction.clone()
 			} else { None };
 		// That said, if the funding transaction is already confirmed (ie we're active with a
 		// minimum_depth over 0) don't bother re-broadcasting the confirmed funding tx.
@@ -7893,6 +7894,7 @@ impl<SP: Deref> OutboundV1Channel<SP> where SP::Target: SignerProvider {
 			self.context.minimum_depth = Some(COINBASE_MATURITY);
 		}
 
+		debug_assert!(self.context.funding_transaction.is_none());
 		self.context.funding_transaction = Some(funding_transaction);
 		self.context.is_batch_funding = Some(()).filter(|_| is_batch_funding);
 

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -891,7 +891,7 @@ fn do_test_completed_payment_not_retryable_on_reload(use_dust: bool) {
 	nodes[0].node.timer_tick_occurred();
 	assert!(nodes[0].node.list_channels().is_empty());
 	assert!(nodes[0].node.has_pending_payments());
-	assert_eq!(nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap().split_off(0).len(), 1);
+	assert_eq!(nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap().split_off(0).len(), 4);
 	check_added_monitors!(nodes[0], 1);
 
 	nodes[0].node.peer_connected(nodes[1].node.get_our_node_id(), &msgs::Init {


### PR DESCRIPTION
Fixes #3300

In splicing, the funding transaction (not just the ID) is needed during splice negotiation.
Funding transaction is kept in field `ChannelContext.funding_transaction`.
However, the way it is currently used is that it is cleared when the tx is broadcast, and this fact is used in some logic.

This change:
- does not clear `ChannelContext.funding_transaction` when tx is broadcast, but it's preserved (it's never reset)
- adjust on test case (`close_on_unfunded_channel`)

Note that in some cases the funding transaction may get broadcasted more than once, which is a change in behavior.

Alternative is to preserve behavior, with some extra field, #3317 .