### PR TITLE
Add additional test coverage of `NetworkGraph` counters

### DIFF
--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -2089,6 +2089,10 @@ where
 			};
 		}
 
+		core::mem::drop(nodes);
+		core::mem::drop(channels);
+		self.test_node_counter_consistency();
+
 		Ok(())
 	}
 


### PR DESCRIPTION
This would have caught the bug fixed in 0c0cb6fccbb426924f21915053b in our tests.

Suggested by @valentinewallace.