### PR TITLE
Drop broken debug assertion on peer buffer lengths

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -1365,7 +1365,6 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, OM: Deref, L: Deref, CM
 	/// Append a message to a peer's pending outbound/write gossip broadcast buffer
 	fn enqueue_encoded_gossip_broadcast(&self, peer: &mut Peer, encoded_message: MessageBuf) {
 		peer.msgs_sent_since_pong += 1;
-		debug_assert!(peer.gossip_broadcast_buffer.len() <= OUTBOUND_BUFFER_LIMIT_DROP_GOSSIP);
 		peer.gossip_broadcast_buffer.push_back(encoded_message);
 	}
 


### PR DESCRIPTION
1b711ed15f426ce40f1aa6be83d930a01ab530ba changed it so that we can enqueue broadcast gossip messages to peers even though their buffer is full as long as its our `ChannelMessageHandler` doing it. This broke a debug assertion that the buffer isn't too large when appending the broadcast message which is simply dropped here.

Found by the `full_stack_target` fuzzer.