### PR TITLE
Pin `indexmap` back to account for `hashbrown` MSRV bump

### DIFF
--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -18,6 +18,9 @@ function PIN_RELEASE_DEPS {
 	# Here we opt to keep using unicode-rs by pinning idna_adapter as described here: https://docs.rs/crate/idna_adapter/1.2.0
 	[ "$RUSTC_MINOR_VERSION" -lt 67 ] && cargo update -p idna_adapter --precise "1.1.0" --verbose
 
+	# indexmap 2.6.0 upgraded to hashbrown 0.15, which unfortunately bumped their MSRV to rustc 1.65 with the 0.15.1 release
+	[ "$RUSTC_MINOR_VERSION" -lt 65 ] && cargo update -p indexmap@2.6.0 --precise "2.5.0" --verbose
+
 	return 0 # Don't fail the script if our rustc is higher than the last check
 }
 


### PR DESCRIPTION
... here we go again.

`indexmap` 2.6.0 upgraded to `hashbrown` 0.15, which unfortunately bumped their MSRV to rustc 1.65 with the 0.15.1 release. So we pin `indexmap` to 2.5.0 to fix our MSRV CI.