### PR TITLE
Support async signing for V2 channel establishment

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -8879,14 +8879,12 @@ impl<SP: Deref> OutboundV2Channel<SP> where SP::Target: SignerProvider {
 		}
 	}
 
-	pub fn into_channel(self) -> Result<Channel<SP>, ChannelError>{
+	pub fn into_channel(self) -> Channel<SP> {
 		debug_assert!(self.signing_session.is_some());
-		let channel = Channel {
+		Channel {
 			context: self.context,
 			interactive_tx_signing_session: self.signing_session,
-		};
-
-		Ok(channel)
+		}
 	}
 }
 
@@ -9076,14 +9074,12 @@ impl<SP: Deref> InboundV2Channel<SP> where SP::Target: SignerProvider {
 		self.generate_accept_channel_v2_message()
 	}
 
-	pub fn into_channel(self) -> Result<Channel<SP>, ChannelError>{
+	pub fn into_channel(self) -> Channel<SP> {
 		debug_assert!(self.signing_session.is_some());
-		let channel = Channel {
+		Channel {
 			context: self.context,
 			interactive_tx_signing_session: self.signing_session,
-		};
-
-		Ok(channel)
+		}
 	}
 }
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8330,8 +8330,8 @@ where
 
 					let (channel_id, channel_phase) = chan_phase_entry.remove_entry();
 					let channel = match channel_phase {
-						ChannelPhase::UnfundedOutboundV2(chan) => chan.into_channel(),
-						ChannelPhase::UnfundedInboundV2(chan) => chan.into_channel(),
+						ChannelPhase::UnfundedOutboundV2(chan) => Ok(chan.into_channel()),
+						ChannelPhase::UnfundedInboundV2(chan) => Ok(chan.into_channel()),
 						_ => {
 							debug_assert!(false); // It cannot be another variant as we are in the `Ok` branch of the above match.
 							Err(ChannelError::Warn(

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -6915,7 +6915,6 @@ where
 		let mut prev_total_msat = None;
 		let mut expected_amt_msat = None;
 		let mut valid_mpp = true;
-		let mut errs = Vec::new();
 		let per_peer_state = self.per_peer_state.read().unwrap();
 		for htlc in sources.iter() {
 			if prev_total_msat.is_some() && prev_total_msat != Some(htlc.total_msat) {
@@ -7001,12 +7000,6 @@ where
 				self.fail_htlc_backwards_internal(&source, &payment_hash, &reason, receiver);
 			}
 			self.claimable_payments.lock().unwrap().pending_claiming_payments.remove(&payment_hash);
-		}
-
-		// Now we can handle any errors which were generated.
-		for (counterparty_node_id, err) in errs.drain(..) {
-			let res: Result<(), _> = Err(err);
-			let _ = handle_error!(self, res, counterparty_node_id);
 		}
 	}
 

--- a/lightning/src/ln/interactivetxs.rs
+++ b/lightning/src/ln/interactivetxs.rs
@@ -327,7 +327,7 @@ impl InteractiveTxSigningSession {
 		if self.remote_inputs_count() != tx_signatures.witnesses.len() {
 			return Err(());
 		}
-		self.unsigned_tx.add_remote_witnesses(tx_signatures.witnesses.clone());
+		self.unsigned_tx.add_remote_witnesses(tx_signatures.witnesses);
 		self.counterparty_sent_tx_signatures = true;
 
 		let holder_tx_signatures = if !self.holder_sends_tx_signatures_first {
@@ -360,7 +360,7 @@ impl InteractiveTxSigningSession {
 		self.holder_tx_signatures = Some(TxSignatures {
 			channel_id,
 			tx_hash: self.unsigned_tx.compute_txid(),
-			witnesses: witnesses.into_iter().collect(),
+			witnesses,
 			shared_input_signature: None,
 		});
 		if self.received_commitment_signed


### PR DESCRIPTION
When handling a `tx_complete` message, allow signers to return an error indicating that the signer has not yet complete. This will leave the `ChannelPhase` in an unfunded variant until the signer becomes unblocked. The user calls `ChannelManager::signer_unblocked` to indicate that signing is complete, which will attempt to finish handling the `tx_complete` message again.

Based on #3137.
Fixes #3404.