### PR TITLE
Fix expected-cfg-checks for logging features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,4 +65,5 @@ check-cfg = [
     "cfg(require_route_graph_test)",
     "cfg(splicing)",
     "cfg(async_payments)",
+    'cfg(feature, values("max_level_off","max_level_error","max_level_warn","max_level_info","max_level_debug","max_level_trace"))'
 ]


### PR DESCRIPTION
Fixes #3424.

Rustc 1.84 (nightly) introduced that the `unexpected_cfg`s lint will now be reported for external macros (see
https://github.com/rust-lang/rust/pull/132577), leading to some of our builds failing due to our `level = "forbid"` config of unexpected cfg flags.

Here, we add the logging features to the expected features of the workspace to mitigiate this issue and fix builds.