### PR TITLE
Drop log-limiting features

### DIFF
--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -106,11 +106,6 @@ cargo test -p lightning-custom-message --verbose --color always
 echo -e "\n\nTest backtrace-debug builds"
 cargo test -p lightning --verbose --color always --features backtrace
 
-echo -e "\n\nBuilding with all Log-Limiting features"
-grep '^max_level_' lightning/Cargo.toml | awk '{ print $1 }'| while read -r FEATURE; do
-	RUSTFLAGS="$RUSTFLAGS -A unused_variables -A unused_macros -A unused_imports -A dead_code" cargo check -p lightning --verbose --color always --features "$FEATURE"
-done
-
 echo -e "\n\nTesting no_std builds"
 for DIR in lightning-invoice lightning-rapid-gossip-sync; do
 	cargo test -p $DIR --verbose --color always --no-default-features

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -18,13 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 # Internal test utilities exposed to other repo crates
 _test_utils = ["regex", "bitcoin/bitcoinconsensus", "lightning-types/_test_utils"]
-# Unlog messages superior at targeted level.
-max_level_off = []
-max_level_error = []
-max_level_warn = []
-max_level_info = []
-max_level_debug = []
-max_level_trace = []
+
 # Allow signing of local transactions that may have been revoked or will be revoked, for functional testing (e.g. justice tx handling).
 # This is unsafe to use in production because it may result in the counterparty publishing taking our funds.
 unsafe_revoked_tx_signing = []

--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -28,13 +28,6 @@
 //!
 //! * `std`
 //! * `grind_signatures`
-//! * Skip logging of messages at levels below the given log level:
-//!     * `max_level_off`
-//!     * `max_level_error`
-//!     * `max_level_warn`
-//!     * `max_level_info`
-//!     * `max_level_debug`
-//!     * `max_level_trace`
 
 #![cfg_attr(not(any(test, fuzzing, feature = "_test_utils")), deny(missing_docs))]
 #![cfg_attr(not(any(test, feature = "_test_utils")), forbid(unsafe_code))]

--- a/lightning/src/util/logger.rs
+++ b/lightning/src/util/logger.rs
@@ -10,9 +10,8 @@
 //! Log traits live here, which are called throughout the library to provide useful information for
 //! debugging purposes.
 //!
-//! There is currently 2 ways to filter log messages. First one, by using compilation features, e.g "max_level_off".
-//! The second one, client-side by implementing check against Record Level field.
-//! Each module may have its own Logger or share one.
+//! Log messages should be filtered client-side by implementing check against a given [`Record`]'s
+//! [`Level`] field. Each module may have its own Logger or share one.
 
 use bitcoin::secp256k1::PublicKey;
 

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -173,36 +173,9 @@ macro_rules! log_spendable {
 /// but it needs to be exported so `log_trace` etc can use it in external crates.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! log_internal {
-	($logger: expr, $lvl:expr, $($arg:tt)+) => (
-		$logger.log($crate::util::logger::Record::new($lvl, None, None, format_args!($($arg)+), module_path!(), file!(), line!(), None))
-	);
-}
-
-/// Logs an entry at the given level.
-#[doc(hidden)]
-#[macro_export]
 macro_rules! log_given_level {
 	($logger: expr, $lvl:expr, $($arg:tt)+) => (
-		match $lvl {
-			#[cfg(not(any(feature = "max_level_off")))]
-			$crate::util::logger::Level::Error => $crate::log_internal!($logger, $lvl, $($arg)*),
-			#[cfg(not(any(feature = "max_level_off", feature = "max_level_error")))]
-			$crate::util::logger::Level::Warn => $crate::log_internal!($logger, $lvl, $($arg)*),
-			#[cfg(not(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn")))]
-			$crate::util::logger::Level::Info => $crate::log_internal!($logger, $lvl, $($arg)*),
-			#[cfg(not(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn", feature = "max_level_info")))]
-			$crate::util::logger::Level::Debug => $crate::log_internal!($logger, $lvl, $($arg)*),
-			#[cfg(not(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn", feature = "max_level_info", feature = "max_level_debug")))]
-			$crate::util::logger::Level::Trace => $crate::log_internal!($logger, $lvl, $($arg)*),
-			#[cfg(not(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn", feature = "max_level_info", feature = "max_level_debug", feature = "max_level_trace")))]
-			$crate::util::logger::Level::Gossip => $crate::log_internal!($logger, $lvl, $($arg)*),
-
-			#[cfg(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn", feature = "max_level_info", feature = "max_level_debug", feature = "max_level_trace"))]
-			_ => {
-				// The level is disabled at compile-time
-			},
-		}
+		$logger.log($crate::util::logger::Record::new($lvl, None, None, format_args!($($arg)+), module_path!(), file!(), line!(), None))
 	);
 }
 


### PR DESCRIPTION
Fixes #3424.

Previously, LDK offered two ways to limit log outputs: filtering during runtime client-side by matching on any given `Record`'s `Level` value, as well as at compile time through the `max_level_*` feature flags.

It turns out the latter approach was always broken when used outside of the `lightning` crate. Here, we therefore simply drop the feature-based filtering.