### PR TITLE
Take circular `GossipVerifier` reference by `Arc`

### DIFF
--- a/lightning-block-sync/src/gossip.rs
+++ b/lightning-block-sync/src/gossip.rs
@@ -144,7 +144,7 @@ pub struct GossipVerifier<
 {
 	source: Blocks,
 	peer_manager_wake: Arc<dyn Fn() + Send + Sync>,
-	gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Self, L>>,
+	gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Arc<Self>, L>>,
 	spawn: S,
 	block_cache: Arc<Mutex<VecDeque<(u32, Block)>>>,
 }
@@ -162,7 +162,7 @@ where
 	/// This is expected to be given to a [`P2PGossipSync`] (initially constructed with `None` for
 	/// the UTXO lookup) via [`P2PGossipSync::add_utxo_lookup`].
 	pub fn new<APM: Deref + Send + Sync + Clone + 'static>(
-		source: Blocks, spawn: S, gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Self, L>>,
+		source: Blocks, spawn: S, gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Arc<Self>, L>>,
 		peer_manager: APM,
 	) -> Self
 	where


### PR DESCRIPTION
Closes #3369.

Our current architecture requires `GossipVerifier`'s type signature to include a circular reference to itself. Previously, we directly gave that as `Self`, which however did not work when setting it dynamically under all circumstances. Here we take `Self` by `Arc` mitigate this issue.


This change was proposed by @TheBlueMatt  in https://github.com/lightningdevkit/rust-lightning/issues/3369#issuecomment-2444828993, I have yet to confirm it works as expected myself.