### PR TITLE
Drop elided lifetime name from `get_best_block`

### DIFF
--- a/lightning-block-sync/src/lib.rs
+++ b/lightning-block-sync/src/lib.rs
@@ -78,7 +78,7 @@ pub trait BlockSource: Sync + Send {
 	/// to allow for a more efficient lookup.
 	///
 	/// [`get_header`]: Self::get_header
-	fn get_best_block<'a>(&'a self) -> AsyncBlockSourceResult<(BlockHash, Option<u32>)>;
+	fn get_best_block(&self) -> AsyncBlockSourceResult<(BlockHash, Option<u32>)>;
 }
 
 /// Result type for `BlockSource` requests.


### PR DESCRIPTION
.. which recently started to yield a warning on the `beta` channel of rustc.