### PR TITLE
Support receiving async payments

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -127,7 +127,7 @@ impl Router for FuzzRouter {
 
 	fn create_blinded_payment_paths<T: secp256k1::Signing + secp256k1::Verification>(
 		&self, _recipient: PublicKey, _first_hops: Vec<ChannelDetails>, _tlvs: ReceiveTlvs,
-		_amount_msats: u64, _secp_ctx: &Secp256k1<T>,
+		_amount_msats: Option<u64>, _secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPaymentPath>, ()> {
 		unreachable!()
 	}

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -162,7 +162,7 @@ impl Router for FuzzRouter {
 
 	fn create_blinded_payment_paths<T: secp256k1::Signing + secp256k1::Verification>(
 		&self, _recipient: PublicKey, _first_hops: Vec<ChannelDetails>, _tlvs: ReceiveTlvs,
-		_amount_msats: u64, _secp_ctx: &Secp256k1<T>,
+		_amount_msats: Option<u64>, _secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPaymentPath>, ()> {
 		unreachable!()
 	}

--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -121,7 +121,8 @@ struct TestAsyncPaymentsMessageHandler {}
 
 impl AsyncPaymentsMessageHandler for TestAsyncPaymentsMessageHandler {
 	fn handle_held_htlc_available(
-		&self, _message: HeldHtlcAvailable, responder: Option<Responder>,
+		&self, _message: HeldHtlcAvailable, _context: AsyncPaymentsContext,
+		responder: Option<Responder>,
 	) -> Option<(ReleaseHeldHtlc, ResponseInstruction)> {
 		let responder = match responder {
 			Some(resp) => resp,

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -25,6 +25,7 @@ use crate::ln::msgs::DecodeError;
 use crate::ln::onion_utils;
 use crate::types::payment::PaymentHash;
 use crate::offers::nonce::Nonce;
+use crate::offers::offer::OfferId;
 use crate::onion_message::packet::ControlTlvs;
 use crate::routing::gossip::{NodeId, ReadOnlyNetworkGraph};
 use crate::sign::{EntropySource, NodeSigner, Recipient};
@@ -402,6 +403,28 @@ pub enum AsyncPaymentsContext {
 		/// containing the expected [`PaymentId`].
 		hmac: Hmac<Sha256>,
 	},
+	/// Context contained within the [`BlindedMessagePath`]s we put in static invoices, provided back
+	/// to us in corresponding [`HeldHtlcAvailable`] messages.
+	///
+	/// [`HeldHtlcAvailable`]: crate::onion_message::async_payments::HeldHtlcAvailable
+	InboundPayment {
+		/// The ID of the [`Offer`] that this [`BlindedMessagePath`]'s static invoice corresponds to.
+		/// Useful to authenticate that this blinded path was created by us for asynchronously paying
+		/// one of our offers.
+		///
+		/// [`Offer`]: crate::offers::offer::Offer
+		offer_id: OfferId,
+		/// A nonce used for authenticating that a [`HeldHtlcAvailable`] message is valid for a
+		/// preceding static invoice.
+		///
+		/// [`HeldHtlcAvailable`]: crate::onion_message::async_payments::HeldHtlcAvailable
+		nonce: Nonce,
+		/// Authentication code for the [`OfferId`].
+		///
+		/// Prevents the recipient from being able to deanonymize us by creating a blinded path to us
+		/// containing the expected [`OfferId`].
+		hmac: Hmac<Sha256>,
+	},
 }
 
 impl_writeable_tlv_based_enum!(MessageContext,
@@ -430,6 +453,11 @@ impl_writeable_tlv_based_enum!(OffersContext,
 impl_writeable_tlv_based_enum!(AsyncPaymentsContext,
 	(0, OutboundPayment) => {
 		(0, payment_id, required),
+		(2, nonce, required),
+		(4, hmac, required),
+	},
+	(1, InboundPayment) => {
+		(0, offer_id, required),
 		(2, nonce, required),
 		(4, hmac, required),
 	},

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -22,6 +22,7 @@ use crate::types::features::BlindedHopFeatures;
 use crate::ln::msgs::DecodeError;
 use crate::ln::onion_utils;
 use crate::offers::invoice_request::InvoiceRequestFields;
+use crate::offers::nonce::Nonce;
 use crate::offers::offer::OfferId;
 use crate::routing::gossip::{NodeId, ReadOnlyNetworkGraph};
 use crate::sign::{EntropySource, NodeSigner, Recipient};
@@ -318,6 +319,11 @@ pub enum PaymentContext {
 	/// [`Offer`]: crate::offers::offer::Offer
 	Bolt12Offer(Bolt12OfferContext),
 
+	/// The payment was made for a static invoice requested from a BOLT 12 [`Offer`].
+	///
+	/// [`Offer`]: crate::offers::offer::Offer
+	AsyncBolt12Offer(AsyncBolt12OfferContext),
+
 	/// The payment was made for an invoice sent for a BOLT 12 [`Refund`].
 	///
 	/// [`Refund`]: crate::offers::refund::Refund
@@ -349,6 +355,22 @@ pub struct Bolt12OfferContext {
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	pub invoice_request: InvoiceRequestFields,
+}
+
+/// The context of a payment made for a static invoice requested from a BOLT 12 [`Offer`].
+///
+/// [`Offer`]: crate::offers::offer::Offer
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AsyncBolt12OfferContext {
+	/// The identifier of the [`Offer`].
+	///
+	/// [`Offer`]: crate::offers::offer::Offer
+	pub offer_id: OfferId,
+	/// The [`Nonce`] used to verify that an inbound [`InvoiceRequest`] corresponds to this static
+	/// invoice's offer.
+	///
+	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+	pub offer_nonce: Nonce,
 }
 
 /// The context of a payment made for an invoice sent for a BOLT 12 [`Refund`].
@@ -590,6 +612,7 @@ impl_writeable_tlv_based_enum_legacy!(PaymentContext,
 	(0, Unknown),
 	(1, Bolt12Offer),
 	(2, Bolt12Refund),
+	(3, AsyncBolt12Offer),
 );
 
 impl<'a> Writeable for PaymentContextRef<'a> {
@@ -624,6 +647,11 @@ impl Readable for UnknownPaymentContext {
 impl_writeable_tlv_based!(Bolt12OfferContext, {
 	(0, offer_id, required),
 	(2, invoice_request, required),
+});
+
+impl_writeable_tlv_based!(AsyncBolt12OfferContext, {
+	(0, offer_id, required),
+	(2, offer_nonce, required),
 });
 
 impl_writeable_tlv_based!(Bolt12RefundContext, {});

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -203,6 +203,15 @@ impl PaymentPurpose {
 					payment_context: context,
 				}
 			},
+			Some(PaymentContext::AsyncBolt12Offer(_context)) => {
+				debug_assert!(false, "Receiving async payments is not yet supported");
+				// This code will change to return Self::Bolt12OfferPayment when we add support for async
+				// receive.
+				PaymentPurpose::Bolt11InvoicePayment {
+					payment_preimage,
+					payment_secret,
+				}
+			},
 		}
 	}
 }

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -28,6 +28,7 @@ use crate::ln::msgs;
 use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentPreimage, PaymentHash, PaymentSecret};
 use crate::offers::invoice::Bolt12Invoice;
+use crate::offers::invoice_request::InvoiceRequestFields;
 use crate::onion_message::messenger::Responder;
 use crate::routing::gossip::NetworkUpdate;
 use crate::routing::router::{BlindedTail, Path, RouteHop, RouteParameters};
@@ -180,7 +181,7 @@ impl PaymentPurpose {
 
 	pub(crate) fn from_parts(
 		payment_preimage: Option<PaymentPreimage>, payment_secret: PaymentSecret,
-		payment_context: Option<PaymentContext>,
+		payment_context: Option<PaymentContext>, invreq_fields: Option<InvoiceRequestFields>,
 	) -> Result<Self, ()> {
 		match payment_context {
 			Some(PaymentContext::Unknown(_)) | None => {
@@ -203,11 +204,18 @@ impl PaymentPurpose {
 					payment_context: context,
 				})
 			},
-			Some(PaymentContext::AsyncBolt12Offer(_context)) => {
-				// This code will change to return Self::Bolt12OfferPayment when we add support for async
-				// receive.
-				Err(())
-			},
+			Some(PaymentContext::AsyncBolt12Offer(context)) => {
+				let invoice_request = invreq_fields.ok_or(())?;
+				if payment_preimage.is_none() { return Err(()) }
+				Ok(PaymentPurpose::Bolt12OfferPayment {
+					payment_preimage,
+					payment_secret,
+					payment_context: Bolt12OfferContext {
+						offer_id: context.offer_id,
+						invoice_request,
+					},
+				})
+			}
 		}
 	}
 }
@@ -1841,7 +1849,7 @@ impl MaybeReadable for Event {
 						(13, payment_id, option),
 					});
 					let purpose = match payment_secret {
-						Some(secret) => PaymentPurpose::from_parts(payment_preimage, secret, payment_context)
+						Some(secret) => PaymentPurpose::from_parts(payment_preimage, secret, payment_context, None)
 							.map_err(|()| msgs::DecodeError::InvalidValue)?,
 						None if payment_preimage.is_some() => PaymentPurpose::SpontaneousPayment(payment_preimage.unwrap()),
 						None => return Err(msgs::DecodeError::InvalidValue),

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -181,36 +181,32 @@ impl PaymentPurpose {
 	pub(crate) fn from_parts(
 		payment_preimage: Option<PaymentPreimage>, payment_secret: PaymentSecret,
 		payment_context: Option<PaymentContext>,
-	) -> Self {
+	) -> Result<Self, ()> {
 		match payment_context {
 			Some(PaymentContext::Unknown(_)) | None => {
-				PaymentPurpose::Bolt11InvoicePayment {
+				Ok(PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage,
 					payment_secret,
-				}
+				})
 			},
 			Some(PaymentContext::Bolt12Offer(context)) => {
-				PaymentPurpose::Bolt12OfferPayment {
+				Ok(PaymentPurpose::Bolt12OfferPayment {
 					payment_preimage,
 					payment_secret,
 					payment_context: context,
-				}
+				})
 			},
 			Some(PaymentContext::Bolt12Refund(context)) => {
-				PaymentPurpose::Bolt12RefundPayment {
+				Ok(PaymentPurpose::Bolt12RefundPayment {
 					payment_preimage,
 					payment_secret,
 					payment_context: context,
-				}
+				})
 			},
 			Some(PaymentContext::AsyncBolt12Offer(_context)) => {
-				debug_assert!(false, "Receiving async payments is not yet supported");
 				// This code will change to return Self::Bolt12OfferPayment when we add support for async
 				// receive.
-				PaymentPurpose::Bolt11InvoicePayment {
-					payment_preimage,
-					payment_secret,
-				}
+				Err(())
 			},
 		}
 	}
@@ -1845,7 +1841,8 @@ impl MaybeReadable for Event {
 						(13, payment_id, option),
 					});
 					let purpose = match payment_secret {
-						Some(secret) => PaymentPurpose::from_parts(payment_preimage, secret, payment_context),
+						Some(secret) => PaymentPurpose::from_parts(payment_preimage, secret, payment_context)
+							.map_err(|()| msgs::DecodeError::InvalidValue)?,
 						None if payment_preimage.is_some() => PaymentPurpose::SpontaneousPayment(payment_preimage.unwrap()),
 						None => return Err(msgs::DecodeError::InvalidValue),
 					};

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -17,7 +17,7 @@ use crate::events::{Event, HTLCDestination, MessageSendEvent, MessageSendEventsP
 use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentHash, PaymentSecret};
 use crate::ln::channelmanager;
-use crate::ln::channelmanager::{HTLCFailureMsg, PaymentId, RecipientOnionFields};
+use crate::ln::channelmanager::{HTLCFailureMsg, PaymentId, RecipientOnionFields, Verification};
 use crate::types::features::{BlindedHopFeatures, ChannelFeatures, NodeFeatures};
 use crate::ln::functional_test_utils::*;
 use crate::ln::msgs;
@@ -37,8 +37,8 @@ use lightning_invoice::RawBolt11Invoice;
 #[cfg(async_payments)] use {
 	crate::blinded_path::BlindedHop,
 	crate::blinded_path::message::{AsyncPaymentsContext, BlindedMessagePath, OffersContext},
-	crate::ln::channelmanager::Verification,
 	crate::ln::inbound_payment,
+	crate::ln::inbound_payment::ExpandedKey,
 	crate::ln::msgs::OnionMessageHandler,
 	crate::offers::nonce::Nonce,
 	crate::onion_message::async_payments::{AsyncPaymentsMessage, AsyncPaymentsMessageHandler, ReleaseHeldHtlc},
@@ -1871,4 +1871,208 @@ fn route_blinding_spec_test_vector() {
 		Err(HTLCFailureMsg::Malformed(msg)) => assert_eq!(msg.failure_code, INVALID_ONION_BLINDING),
 		_ => panic!("Unexpected error")
 	}
+}
+
+#[cfg(async_payments)]
+#[test]
+fn async_receive_flow_success() {
+	// Test that an always-online sender can successfully pay an async receiver.
+	let secp_ctx = Secp256k1::new();
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let mut allow_priv_chan_fwds_cfg = test_default_channel_config();
+	allow_priv_chan_fwds_cfg.accept_forwards_to_priv_channels = true;
+	let mut mpp_keysend_config = test_default_channel_config();
+	mpp_keysend_config.accept_mpp_keysend = true;
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, Some(allow_priv_chan_fwds_cfg), Some(mpp_keysend_config)]);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	create_unannounced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0);
+
+	let dummy_blinded_path_to_always_online_node = BlindedMessagePath::from_raw(
+		nodes[1].node.get_our_node_id(), test_utils::pubkey(42),
+		vec![BlindedHop { blinded_node_id: test_utils::pubkey(42), encrypted_payload: vec![42; 32] }]
+	);
+	let (offer_builder, offer_nonce) = nodes[2].node.create_async_receive_offer_builder(vec![dummy_blinded_path_to_always_online_node]).unwrap();
+	let offer = offer_builder.build().unwrap();
+	let static_invoice = nodes[2].node.create_static_invoice_builder_for_async_receive_offer(&offer, offer_nonce, None).unwrap().build_and_sign(&secp_ctx).unwrap();
+
+	// Check that we won't pay static invoices that aren't expected.
+	if nodes[0].node.handle_message(
+		OffersMessage::StaticInvoice(static_invoice.clone()),
+		Some(OffersContext::OutboundPayment { payment_id: PaymentId([0; 32]), nonce: offer_nonce, hmac: None }), None
+	).is_some() { panic!() }
+
+	let amt_msat = 5000;
+	let payment_id = PaymentId([1; 32]);
+	nodes[0].node.pay_for_offer(&offer, None, Some(amt_msat), None, payment_id, Retry::Attempts(0), None).unwrap();
+	let _invreq_om = nodes[0].onion_messenger.next_onion_message_for_peer(nodes[1].node.get_our_node_id()).unwrap();
+
+	// Don't forward the invreq since we don't support retrieving the static invoice from the
+	// recipient's LSP yet, instead just provide the invoice directly to the payer.
+	let hardcoded_random_bytes = [42; 32];
+	let keysend_preimage = PaymentPreimage(hardcoded_random_bytes);
+	*nodes[0].keys_manager.override_random_bytes.lock().unwrap() = Some(hardcoded_random_bytes);
+	let expanded_key = ExpandedKey::new(&nodes[0].keys_manager.get_inbound_payment_key_material());
+	let hmac = Some(payment_id.hmac_for_offer_payment(offer_nonce, &expanded_key));
+	assert!(nodes[0].node.handle_message(
+		OffersMessage::StaticInvoice(static_invoice.clone()),
+		Some(OffersContext::OutboundPayment { payment_id, nonce: offer_nonce, hmac }), None
+	).is_none());
+
+	let held_htlc_available_om_0_1 = nodes[0].onion_messenger.next_onion_message_for_peer(nodes[1].node.get_our_node_id()).unwrap();
+
+	// Check that receiving a duplicate static invoice won't cause us to generate another
+	// held_htlc_available message.
+	assert!(nodes[0].node.handle_message(
+		OffersMessage::StaticInvoice(static_invoice),
+		Some(OffersContext::OutboundPayment { payment_id, nonce: offer_nonce, hmac }), None
+	).is_none());
+	assert!(nodes[0].onion_messenger.next_onion_message_for_peer(nodes[1].node.get_our_node_id()).is_none());
+
+	nodes[1].onion_messenger.handle_onion_message(nodes[0].node.get_our_node_id(), &held_htlc_available_om_0_1);
+	let held_htlc_available_om_1_2 = nodes[1].onion_messenger.next_onion_message_for_peer(nodes[2].node.get_our_node_id()).unwrap();
+	nodes[2].onion_messenger.handle_onion_message(nodes[1].node.get_our_node_id(), &held_htlc_available_om_1_2);
+
+	let release_held_htlc_om_2_0 = nodes[2].onion_messenger.next_onion_message_for_peer(nodes[0].node.get_our_node_id()).unwrap();
+	nodes[0].onion_messenger.handle_onion_message(nodes[2].node.get_our_node_id(), &release_held_htlc_om_2_0);
+	check_added_monitors(&nodes[0], 1);
+
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let ev = remove_first_msg_event_to_node(&nodes[1].node.get_our_node_id(), &mut events);
+	let payment_hash = if let MessageSendEvent::UpdateHTLCs {
+		updates: msgs::CommitmentUpdate { ref update_add_htlcs, .. }, ..
+	} = ev {
+		update_add_htlcs[0].payment_hash
+	} else { panic!() };
+
+	let route: &[&[&Node]] = &[&[&nodes[1], &nodes[2]]];
+	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
+		.with_payment_preimage(keysend_preimage);
+	do_pass_along_path(args);
+	claim_payment_along_route(ClaimAlongRouteArgs::new(&nodes[0], route, keysend_preimage));
+}
+
+#[cfg(async_payments)]
+#[test]
+fn retry_async_payment() {
+	// Test that we can successfully retry async payments.
+	let secp_ctx = Secp256k1::new();
+	let chanmon_cfgs = create_chanmon_cfgs(4);
+	let mut allow_priv_chan_fwds_cfg = test_default_channel_config();
+	allow_priv_chan_fwds_cfg.accept_forwards_to_priv_channels = true;
+	// Make one blinded path's fees slightly higher so they are tried in a deterministic order.
+	let mut higher_fee_chan_cfg = test_default_channel_config();
+	higher_fee_chan_cfg.channel_config.forwarding_fee_base_msat += 5000;
+	higher_fee_chan_cfg.accept_forwards_to_priv_channels = true;
+	let mut mpp_keysend_config = test_default_channel_config();
+	mpp_keysend_config.accept_mpp_keysend = true;
+	let node_cfgs = create_node_cfgs(4, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(4, &node_cfgs, &[None, Some(allow_priv_chan_fwds_cfg), Some(higher_fee_chan_cfg), Some(mpp_keysend_config)]);
+	let mut nodes = create_network(4, &node_cfgs, &node_chanmgrs);
+
+	// Create this network topology so nodes[0] has a blinded route hint to retry over.
+	//      n1
+	//    /    \
+	// n0       n3
+	//    \    /
+	//      n2
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 2, 1_000_000, 0);
+	let _chan_1_3 = create_unannounced_chan_between_nodes_with_value(&nodes, 1, 3, 1_000_000, 0);
+	let _chan_2_3 = create_unannounced_chan_between_nodes_with_value(&nodes, 2, 3, 1_000_000, 0);
+
+	let dummy_path_to_always_online_node = BlindedMessagePath::from_raw(
+		nodes[1].node.get_our_node_id(), test_utils::pubkey(42),
+		vec![BlindedHop { blinded_node_id: test_utils::pubkey(42), encrypted_payload: vec![42; 32] }]
+	);
+	let (offer_builder, offer_nonce) = nodes[3].node.create_async_receive_offer_builder(vec![dummy_path_to_always_online_node]).unwrap();
+	let offer = offer_builder.build().unwrap();
+	let static_invoice = nodes[3].node.create_static_invoice_builder_for_async_receive_offer(&offer, offer_nonce, None).unwrap().build_and_sign(&secp_ctx).unwrap();
+
+	let amt_msat = 5000;
+	let payment_id = PaymentId([1; 32]);
+	nodes[0].node.pay_for_offer(&offer, None, Some(amt_msat), None, payment_id, Retry::Attempts(1), None).unwrap();
+	let _invreq_om = nodes[0].onion_messenger.next_onion_message_for_peer(nodes[1].node.get_our_node_id()).unwrap();
+
+	// Don't forward the invreq since we don't support retrieving the static invoice from the
+	// recipient's LSP yet, instead just provide the invoice directly to the payer.
+	let hardcoded_random_bytes = [42; 32];
+	let keysend_preimage = PaymentPreimage(hardcoded_random_bytes);
+	*nodes[0].keys_manager.override_random_bytes.lock().unwrap() = Some(hardcoded_random_bytes);
+	let expanded_key = ExpandedKey::new(&nodes[0].keys_manager.get_inbound_payment_key_material());
+	let hmac = Some(payment_id.hmac_for_offer_payment(offer_nonce, &expanded_key));
+	assert!(nodes[0].node.handle_message(
+			OffersMessage::StaticInvoice(static_invoice.clone()),
+			Some(OffersContext::OutboundPayment { payment_id, nonce: offer_nonce, hmac }), None
+	).is_none());
+
+	let held_htlc_available_om_0_3 = nodes[0].onion_messenger.next_onion_message_for_peer(nodes[3].node.get_our_node_id()).unwrap();
+	nodes[3].onion_messenger.handle_onion_message(nodes[0].node.get_our_node_id(), &held_htlc_available_om_0_3);
+	let release_held_htlc_om_3_0 = nodes[3].onion_messenger.next_onion_message_for_peer(nodes[0].node.get_our_node_id()).unwrap();
+	nodes[0].onion_messenger.handle_onion_message(nodes[3].node.get_our_node_id(), &release_held_htlc_om_3_0);
+	check_added_monitors(&nodes[0], 1);
+
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let ev = remove_first_msg_event_to_node(&nodes[1].node.get_our_node_id(), &mut events);
+	let payment_hash = if let MessageSendEvent::UpdateHTLCs {
+		updates: msgs::CommitmentUpdate { ref update_add_htlcs, .. }, ..
+	} = ev {
+		update_add_htlcs[0].payment_hash
+	} else { panic!() };
+
+	let route: &[&[&Node]] = &[&[&nodes[1], &nodes[3]]];
+	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
+		.with_payment_preimage(keysend_preimage);
+	do_pass_along_path(args);
+
+	// Fail the payment back to trigger the retry.
+	nodes[3].node.fail_htlc_backwards(&payment_hash);
+	expect_pending_htlcs_forwardable_conditions(
+		nodes[3].node.get_and_clear_pending_events(), &[HTLCDestination::FailedPayment { payment_hash }]
+	);
+	nodes[3].node.process_pending_htlc_forwards();
+	check_added_monitors!(nodes[3], 1);
+
+	let updates = get_htlc_update_msgs!(nodes[3], nodes[1].node.get_our_node_id());
+	assert_eq!(updates.update_fail_malformed_htlcs.len(), 1);
+	let update_malformed = &updates.update_fail_malformed_htlcs[0];
+	assert_eq!(update_malformed.sha256_of_onion, [0; 32]);
+	assert_eq!(update_malformed.failure_code, INVALID_ONION_BLINDING);
+	nodes[1].node.handle_update_fail_malformed_htlc(nodes[3].node.get_our_node_id(), update_malformed);
+	do_commitment_signed_dance(&nodes[1], &nodes[3], &updates.commitment_signed, true, false);
+
+	let updates =  get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
+	assert_eq!(updates.update_fail_htlcs.len(), 1);
+	nodes[0].node.handle_update_fail_htlc(nodes[1].node.get_our_node_id(), &updates.update_fail_htlcs[0]);
+	do_commitment_signed_dance(&nodes[0], &nodes[1], &updates.commitment_signed, false, false);
+
+	let mut events = nodes[0].node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 2);
+	match events[0] {
+		Event::PaymentPathFailed { payment_hash: ev_payment_hash, payment_failed_permanently, ..  } => {
+			assert_eq!(payment_hash, ev_payment_hash);
+			assert_eq!(payment_failed_permanently, false);
+		},
+		_ => panic!("Unexpected event"),
+	}
+	match events[1] {
+		Event::PendingHTLCsForwardable { .. } => {},
+		_ => panic!("Unexpected event"),
+	}
+	nodes[0].node.process_pending_htlc_forwards();
+	check_added_monitors(&nodes[0], 1);
+
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let ev = remove_first_msg_event_to_node(&nodes[2].node.get_our_node_id(), &mut events);
+
+	let route: &[&[&Node]] = &[&[&nodes[2], &nodes[3]]];
+	let args = PassAlongPathArgs::new(&nodes[0], route[0], amt_msat, payment_hash, ev)
+		.with_payment_preimage(keysend_preimage);
+	do_pass_along_path(args);
+	claim_payment_along_route(ClaimAlongRouteArgs::new(&nodes[0], route, keysend_preimage));
+	// TODO: check that the payment context is as expected
 }

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -35,7 +35,15 @@ use crate::util::ser::WithoutLength;
 use crate::util::test_utils;
 use lightning_invoice::RawBolt11Invoice;
 #[cfg(async_payments)] use {
+	crate::blinded_path::BlindedHop,
+	crate::blinded_path::message::{AsyncPaymentsContext, BlindedMessagePath, OffersContext},
+	crate::ln::channelmanager::Verification,
 	crate::ln::inbound_payment,
+	crate::ln::msgs::OnionMessageHandler,
+	crate::offers::nonce::Nonce,
+	crate::onion_message::async_payments::{AsyncPaymentsMessage, AsyncPaymentsMessageHandler, ReleaseHeldHtlc},
+	crate::onion_message::offers::{OffersMessage, OffersMessageHandler},
+	crate::types::features::Bolt12InvoiceFeatures,
 	crate::types::payment::PaymentPreimage,
 };
 
@@ -1414,6 +1422,209 @@ fn custom_tlvs_to_blinded_path() {
 		ClaimAlongRouteArgs::new(&nodes[0], &[&[&nodes[1]]], payment_preimage)
 			.with_custom_tlvs(recipient_onion_fields.custom_tlvs.clone())
 	);
+}
+
+#[test]
+#[cfg(async_payments)]
+fn static_invoice_unknown_required_features() {
+	// Test that we will fail to pay a static invoice with unsupported required features.
+	let secp_ctx = Secp256k1::new();
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	create_unannounced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0);
+
+	// Use a dummy blinded path because we don't support retrieving the static invoice from the
+	// recipient's LSP yet.
+	let dummy_blinded_path_to_always_online_node = BlindedMessagePath::from_raw(
+		nodes[1].node.get_our_node_id(), test_utils::pubkey(42),
+		vec![BlindedHop { blinded_node_id: test_utils::pubkey(42), encrypted_payload: vec![42; 32] }]
+	);
+	let (offer_builder, nonce) = nodes[2].node.create_async_receive_offer_builder(vec![dummy_blinded_path_to_always_online_node]).unwrap();
+	let offer = offer_builder.build().unwrap();
+	let static_invoice_unknown_req_features = nodes[2].node.create_static_invoice_builder_for_async_receive_offer(
+		&offer, nonce, None
+	)
+		.unwrap()
+		.features_unchecked(Bolt12InvoiceFeatures::unknown())
+		.build_and_sign(&secp_ctx).unwrap();
+
+	let amt_msat = 5000;
+	let payment_id = PaymentId([1; 32]);
+	// Set the random bytes so we can predict the offer outbound payment context nonce.
+	*nodes[0].keys_manager.override_random_bytes.lock().unwrap() = Some([42; 32]);
+	nodes[0].node.pay_for_offer(&offer, None, Some(amt_msat), None, payment_id, Retry::Attempts(0), None).unwrap();
+
+	// Don't forward the invreq since we don't support retrieving the static invoice from the
+	// recipient's LSP yet, instead just provide the invoice directly to the payer.
+	let _invreq_om = nodes[0].onion_messenger.next_onion_message_for_peer(nodes[1].node.get_our_node_id()).unwrap();
+
+	let inbound_payment_key = inbound_payment::ExpandedKey::new(
+		&nodes[0].keys_manager.get_inbound_payment_key_material()
+	);
+	let offer_outbound_context_nonce = Nonce::from_entropy_source(nodes[0].keys_manager);
+	let hmac = payment_id.hmac_for_offer_payment(offer_outbound_context_nonce, &inbound_payment_key);
+	if nodes[0].node.handle_message(
+		OffersMessage::StaticInvoice(static_invoice_unknown_req_features),
+		Some(OffersContext::OutboundPayment { payment_id, nonce: offer_outbound_context_nonce, hmac: Some(hmac) }), None
+	).is_some() { panic!() }
+
+	let events = nodes[0].node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match events[0] {
+		Event::PaymentFailed { payment_hash, payment_id: ev_payment_id, reason } => {
+			assert_eq!(payment_hash, None);
+			assert_eq!(payment_id, ev_payment_id);
+			assert_eq!(reason, Some(PaymentFailureReason::UnknownRequiredFeatures));
+		},
+		_ => panic!()
+	}
+}
+
+#[test]
+#[cfg(async_payments)]
+fn ignore_unexpected_static_invoice() {
+	// Test that we'll ignore unexpected static invoices, invoices that don't match our invoice
+	// request, and duplicate invoices.
+	let secp_ctx = Secp256k1::new();
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	create_unannounced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0);
+
+	// Initiate payment to the sender's intended offer.
+	let dummy_blinded_path_to_always_online_node = BlindedMessagePath::from_raw(
+		nodes[1].node.get_our_node_id(), test_utils::pubkey(42),
+		vec![BlindedHop { blinded_node_id: test_utils::pubkey(42), encrypted_payload: vec![42; 32] }]
+	);
+	let (offer_builder, offer_nonce) = nodes[2].node.create_async_receive_offer_builder(vec![dummy_blinded_path_to_always_online_node.clone()]).unwrap();
+	let offer = offer_builder.build().unwrap();
+	let amt_msat = 5000;
+	let payment_id = PaymentId([1; 32]);
+	// Set the random bytes so we can predict the offer outbound payment context nonce.
+	*nodes[0].keys_manager.override_random_bytes.lock().unwrap() = Some([42; 32]);
+	nodes[0].node.pay_for_offer(&offer, None, Some(amt_msat), None, payment_id, Retry::Attempts(0), None).unwrap();
+
+	// Don't forward the invreq since we don't support retrieving the static invoice from the
+	// recipient's LSP yet, instead just provide the invoice directly to the payer.
+	let _invreq_om = nodes[0].onion_messenger.next_onion_message_for_peer(nodes[1].node.get_our_node_id()).unwrap();
+
+	// Create a static invoice with the same payment_id but corresponding to a different offer.
+	let unexpected_static_invoice = {
+		let (offer_builder, nonce) = nodes[2].node.create_async_receive_offer_builder(vec![dummy_blinded_path_to_always_online_node]).unwrap();
+		let sender_unintended_offer = offer_builder.build().unwrap();
+
+		nodes[2].node.create_static_invoice_builder_for_async_receive_offer(
+			&sender_unintended_offer, nonce, None
+		).unwrap().build_and_sign(&secp_ctx).unwrap()
+	};
+
+	// Check that we'll ignore the unexpected static invoice.
+	let inbound_payment_key = inbound_payment::ExpandedKey::new(
+		&nodes[0].keys_manager.get_inbound_payment_key_material()
+	);
+	let offer_outbound_context_nonce = Nonce::from_entropy_source(nodes[0].keys_manager);
+	let hmac = payment_id.hmac_for_offer_payment(offer_outbound_context_nonce, &inbound_payment_key);
+	assert!(nodes[0].node.handle_message(
+		OffersMessage::StaticInvoice(unexpected_static_invoice),
+		Some(OffersContext::OutboundPayment { payment_id, nonce: offer_outbound_context_nonce, hmac: Some(hmac) }), None
+	).is_none());
+	let async_pmts_msgs = AsyncPaymentsMessageHandler::release_pending_messages(nodes[0].node);
+	assert!(async_pmts_msgs.is_empty());
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+
+	// A valid static invoice corresponding to the correct offer will succeed and cause us to send a
+	// held_htlc_available onion message.
+	let valid_static_invoice = nodes[2].node.create_static_invoice_builder_for_async_receive_offer(
+		&offer, offer_nonce, None
+	).unwrap().build_and_sign(&secp_ctx).unwrap();
+
+	assert!(nodes[0].node.handle_message(
+		OffersMessage::StaticInvoice(valid_static_invoice.clone()),
+		Some(OffersContext::OutboundPayment { payment_id, nonce: offer_outbound_context_nonce, hmac: Some(hmac) }), None
+	).is_none());
+	let async_pmts_msgs = AsyncPaymentsMessageHandler::release_pending_messages(nodes[0].node);
+	assert!(!async_pmts_msgs.is_empty());
+	assert!(async_pmts_msgs.into_iter().all(|(msg, _)| matches!(msg, AsyncPaymentsMessage::HeldHtlcAvailable(_))));
+
+	// Receiving a duplicate invoice will have no effect.
+	assert!(nodes[0].node.handle_message(
+		OffersMessage::StaticInvoice(valid_static_invoice),
+		Some(OffersContext::OutboundPayment { payment_id, nonce: offer_outbound_context_nonce, hmac: Some(hmac) }), None
+	).is_none());
+	let async_pmts_msgs = AsyncPaymentsMessageHandler::release_pending_messages(nodes[0].node);
+	assert!(async_pmts_msgs.is_empty());
+}
+
+#[test]
+#[cfg(async_payments)]
+fn pays_static_invoice() {
+	// Test that we support the async payments flow up to and including sending the actual payment.
+	// Async receive is not yet supported so we don't complete the payment yet.
+	let secp_ctx = Secp256k1::new();
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	create_unannounced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0);
+
+	let dummy_blinded_path_to_always_online_node = BlindedMessagePath::from_raw(
+		nodes[1].node.get_our_node_id(), test_utils::pubkey(42),
+		vec![BlindedHop { blinded_node_id: test_utils::pubkey(42), encrypted_payload: vec![42; 32] }]
+	);
+	let (offer_builder, offer_nonce) = nodes[2].node.create_async_receive_offer_builder(vec![dummy_blinded_path_to_always_online_node.clone()]).unwrap();
+	let offer = offer_builder.build().unwrap();
+	let amt_msat = 5000;
+	let payment_id = PaymentId([1; 32]);
+	// Set the random bytes so we can predict the offer outbound payment context nonce.
+	*nodes[0].keys_manager.override_random_bytes.lock().unwrap() = Some([42; 32]);
+	nodes[0].node.pay_for_offer(&offer, None, Some(amt_msat), None, payment_id, Retry::Attempts(0), None).unwrap();
+
+	// Don't forward the invreq since we don't support retrieving the static invoice from the
+	// recipient's LSP yet, instead just provide the invoice directly to the payer.
+	let _invreq_om = nodes[0].onion_messenger.next_onion_message_for_peer(nodes[1].node.get_our_node_id()).unwrap();
+
+	let inbound_payment_key = inbound_payment::ExpandedKey::new(
+		&nodes[0].keys_manager.get_inbound_payment_key_material()
+	);
+	let offer_outbound_context_nonce = Nonce::from_entropy_source(nodes[0].keys_manager);
+	let hmac = payment_id.hmac_for_offer_payment(offer_outbound_context_nonce, &inbound_payment_key);
+
+	let static_invoice = nodes[2].node.create_static_invoice_builder_for_async_receive_offer(
+		&offer, offer_nonce, None
+	).unwrap().build_and_sign(&secp_ctx).unwrap();
+
+	assert!(nodes[0].node.handle_message(
+			OffersMessage::StaticInvoice(static_invoice),
+			Some(OffersContext::OutboundPayment { payment_id, nonce: offer_outbound_context_nonce, hmac: Some(hmac) }), None
+	).is_none());
+	let async_pmts_msgs = AsyncPaymentsMessageHandler::release_pending_messages(nodes[0].node);
+	assert!(!async_pmts_msgs.is_empty());
+	assert!(async_pmts_msgs.into_iter().all(|(msg, _)| matches!(msg, AsyncPaymentsMessage::HeldHtlcAvailable(_))));
+
+	// Manually create the message and context releasing the HTLC since the recipient doesn't support
+	// responding themselves yet.
+	let outbound_async_payment_context_nonce = Nonce::from_entropy_source(nodes[0].keys_manager);
+	let outbound_async_payment_context = AsyncPaymentsContext::OutboundPayment {
+		payment_id,
+		nonce: outbound_async_payment_context_nonce,
+		hmac: payment_id.hmac_for_async_payment(outbound_async_payment_context_nonce, &inbound_payment_key),
+	};
+	nodes[0].node.handle_release_held_htlc(ReleaseHeldHtlc {}, outbound_async_payment_context.clone());
+
+	// Check that we've queued the HTLCs of the async keysend payment.
+	let htlc_updates = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());
+	assert_eq!(htlc_updates.update_add_htlcs.len(), 1);
+	check_added_monitors!(nodes[0], 1);
+
+	// Receiving a duplicate release_htlc message doesn't result in duplicate payment.
+	nodes[0].node.handle_release_held_htlc(ReleaseHeldHtlc {}, outbound_async_payment_context.clone());
+	assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
 }
 
 fn secret_from_hex(hex: &str) -> SecretKey {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -235,6 +235,13 @@ pub enum PendingHTLCRouting {
 		/// [`PaymentSecret`] and should verify it using our
 		/// [`NodeSigner::get_inbound_payment_key_material`].
 		has_recipient_created_payment_secret: bool,
+		/// The [`InvoiceRequest`] associated with the [`Offer`] corresponding to this payment.
+		invoice_request: Option<InvoiceRequest>,
+		/// The context of the payment included by the recipient in a blinded path, or `None` if a
+		/// blinded path was not used.
+		///
+		/// Used in part to determine the [`events::PaymentPurpose`].
+		payment_context: Option<PaymentContext>,
 	},
 }
 
@@ -5883,8 +5890,8 @@ where
 											true)
 									},
 									PendingHTLCRouting::ReceiveKeysend {
-										payment_data, payment_preimage, payment_metadata,
-										incoming_cltv_expiry, custom_tlvs, requires_blinded_error: _,
+										payment_data, payment_preimage, payment_metadata, incoming_cltv_expiry,
+										custom_tlvs, invoice_request: _, payment_context: _, requires_blinded_error: _,
 										has_recipient_created_payment_secret,
 									} => {
 										let onion_fields = RecipientOnionFields {
@@ -12030,6 +12037,8 @@ impl_writeable_tlv_based_enum!(PendingHTLCRouting,
 		(4, payment_data, option), // Added in 0.0.116
 		(5, custom_tlvs, optional_vec),
 		(7, has_recipient_created_payment_secret, (default_value, false)),
+		(9, invoice_request, option),
+		(11, payment_context, option),
 	},
 );
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -6092,6 +6092,7 @@ where
 											payment_preimage,
 											payment_data.payment_secret,
 											payment_context,
+											None,
 										) {
 											Ok(purpose) => purpose,
 											Err(()) => {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -9612,6 +9612,7 @@ where
 			let retryable_invoice_request = RetryableInvoiceRequest {
 				invoice_request: invoice_request.clone(),
 				nonce,
+				needs_retry: true,
 			};
 			self.pending_outbound_payments
 				.add_new_awaiting_invoice(
@@ -11452,7 +11453,7 @@ where
 			.pending_outbound_payments
 			.release_invoice_requests_awaiting_invoice()
 		{
-			let RetryableInvoiceRequest { invoice_request, nonce } = retryable_invoice_request;
+			let RetryableInvoiceRequest { invoice_request, nonce, .. } = retryable_invoice_request;
 			let hmac = payment_id.hmac_for_offer_payment(nonce, &self.inbound_payment_key);
 			let context = MessageContext::Offers(OffersContext::OutboundPayment {
 				payment_id,
@@ -11787,6 +11788,7 @@ where
 								let retryable_invoice_request = RetryableInvoiceRequest {
 									invoice_request: invoice_request.clone(),
 									nonce,
+									needs_retry: true,
 								};
 								self.pending_outbound_payments
 									.received_offer(payment_id, Some(retryable_invoice_request))

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11746,7 +11746,12 @@ where
 
 	fn handle_release_held_htlc(&self, _message: ReleaseHeldHtlc, _context: AsyncPaymentsContext) {
 		#[cfg(async_payments)] {
-			let AsyncPaymentsContext::OutboundPayment { payment_id, hmac, nonce } = _context;
+			let (payment_id, nonce, hmac) = match _context {
+				AsyncPaymentsContext::OutboundPayment { payment_id, hmac, nonce } => {
+					(payment_id, nonce, hmac)
+				},
+				_ => return
+			};
 			if payment_id.verify_for_async_payment(hmac, nonce, &self.inbound_payment_key).is_err() { return }
 			if let Err(e) = self.send_payment_for_static_invoice(payment_id) {
 				log_trace!(

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11830,7 +11830,8 @@ where
 	L::Target: Logger,
 {
 	fn handle_held_htlc_available(
-		&self, _message: HeldHtlcAvailable, _responder: Option<Responder>
+		&self, _message: HeldHtlcAvailable, _context: AsyncPaymentsContext,
+		_responder: Option<Responder>
 	) -> Option<(ReleaseHeldHtlc, ResponseInstruction)> {
 		None
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11833,7 +11833,22 @@ where
 		&self, _message: HeldHtlcAvailable, _context: AsyncPaymentsContext,
 		_responder: Option<Responder>
 	) -> Option<(ReleaseHeldHtlc, ResponseInstruction)> {
-		None
+		#[cfg(async_payments)] {
+			match _context {
+				AsyncPaymentsContext::InboundPayment { offer_id, nonce, hmac } => {
+					if let Err(()) = offer_id.verify_for_static_invoice_payment(
+						hmac, nonce, &self.inbound_payment_key
+					) { return None }
+				},
+				_ => return None
+			}
+			return _responder.map(|responder| {
+				let message = ReleaseHeldHtlc {};
+				(message, responder.respond())
+			})
+		}
+		#[cfg(not(async_payments))]
+		return None
 	}
 
 	fn handle_release_held_htlc(&self, _message: ReleaseHeldHtlc, _context: AsyncPaymentsContext) {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -9560,8 +9560,8 @@ where
 	/// Create an offer for receiving async payments as an often-offline recipient.
 	///
 	/// Because we may be offline when the payer attempts to request an invoice, you MUST:
-	/// 1. Provide at least 1 [`BlindedPath`] for onion messages terminating at an always-online node
-	///    that will serve the [`StaticInvoice`] created from this offer on our behalf.
+	/// 1. Provide at least 1 [`BlindedMessagePath`] terminating at an always-online node that will
+	///    serve the [`StaticInvoice`] created from this offer on our behalf.
 	/// 2. Use [`Self::create_static_invoice_builder_for_async_receive_offer`] to create a
 	///    [`StaticInvoice`] from this [`Offer`] plus the returned [`Nonce`], and provide the static
 	///    invoice to the aforementioned always-online node.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -36,7 +36,7 @@ use crate::events::FundingInfo;
 use crate::blinded_path::message::{AsyncPaymentsContext, MessageContext, OffersContext};
 use crate::blinded_path::NodeIdLookUp;
 use crate::blinded_path::message::{BlindedMessagePath, MessageForwardNode};
-use crate::blinded_path::payment::{BlindedPaymentPath, Bolt12OfferContext, Bolt12RefundContext, PaymentConstraints, PaymentContext, ReceiveTlvs};
+use crate::blinded_path::payment::{AsyncBolt12OfferContext, BlindedPaymentPath, Bolt12OfferContext, Bolt12RefundContext, PaymentConstraints, PaymentContext, ReceiveTlvs};
 use crate::chain;
 use crate::chain::{Confirm, ChannelMonitorUpdateStatus, Watch, BestBlock};
 use crate::chain::chaininterface::{BroadcasterInterface, ConfirmationTarget, FeeEstimator, LowerBoundedFeeEstimator};
@@ -86,7 +86,6 @@ use crate::util::ser::{BigSize, FixedLengthReader, Readable, ReadableArgs, Maybe
 use crate::util::logger::{Level, Logger, WithContext};
 use crate::util::errors::APIError;
 #[cfg(async_payments)] use {
-	crate::blinded_path::payment::AsyncBolt12OfferContext,
 	crate::offers::offer::Amount,
 	crate::offers::static_invoice::{DEFAULT_RELATIVE_EXPIRY as STATIC_INVOICE_DEFAULT_RELATIVE_EXPIRY, StaticInvoice, StaticInvoiceBuilder},
 };
@@ -5875,7 +5874,7 @@ where
 								let blinded_failure = routing.blinded_failure();
 								let (
 									cltv_expiry, onion_payload, payment_data, payment_context, phantom_shared_secret,
-									mut onion_fields, has_recipient_created_payment_secret
+									mut onion_fields, has_recipient_created_payment_secret, invoice_request_opt
 								) = match routing {
 									PendingHTLCRouting::Receive {
 										payment_data, payment_metadata, payment_context,
@@ -5887,11 +5886,11 @@ where
 												payment_metadata, custom_tlvs };
 										(incoming_cltv_expiry, OnionPayload::Invoice { _legacy_hop_data },
 											Some(payment_data), payment_context, phantom_shared_secret, onion_fields,
-											true)
+											true, None)
 									},
 									PendingHTLCRouting::ReceiveKeysend {
 										payment_data, payment_preimage, payment_metadata, incoming_cltv_expiry,
-										custom_tlvs, invoice_request: _, payment_context: _, requires_blinded_error: _,
+										custom_tlvs, invoice_request, payment_context, requires_blinded_error: _,
 										has_recipient_created_payment_secret,
 									} => {
 										let onion_fields = RecipientOnionFields {
@@ -5900,7 +5899,8 @@ where
 											custom_tlvs,
 										};
 										(incoming_cltv_expiry, OnionPayload::Spontaneous(payment_preimage),
-											payment_data, None, None, onion_fields, has_recipient_created_payment_secret)
+											payment_data, payment_context, None, onion_fields,
+											has_recipient_created_payment_secret, invoice_request)
 									},
 									_ => {
 										panic!("short_channel_id == 0 should imply any pending_forward entries are of type Receive");
@@ -6102,7 +6102,58 @@ where
 										check_total_value!(purpose);
 									},
 									OnionPayload::Spontaneous(preimage) => {
-										let purpose = events::PaymentPurpose::SpontaneousPayment(preimage);
+										let purpose = if let Some(PaymentContext::AsyncBolt12Offer(
+											AsyncBolt12OfferContext { offer_nonce, offer_id: _ }
+										)) = payment_context {
+											let payment_data = match payment_data {
+												Some(data) => data,
+												None => {
+													fail_htlc!(claimable_htlc, payment_hash);
+												}
+											};
+											let (payment_preimage_opt, min_final_cltv_expiry_delta) =
+												match inbound_payment::verify(
+													payment_hash, &payment_data,
+													self.highest_seen_timestamp.load(Ordering::Acquire) as u64,
+													&self.inbound_payment_key, &self.logger
+												) {
+													Ok(result) => result,
+													Err(()) => {
+														log_trace!(self.logger, "Failing new async payment HTLC with payment_hash {} as payment verification failed", &payment_hash);
+														fail_htlc!(claimable_htlc, payment_hash);
+													}
+												};
+											debug_assert!(payment_preimage_opt.is_none());
+											if let Some(min_final_cltv_expiry_delta) = min_final_cltv_expiry_delta {
+												let expected_min_expiry_height = (self.current_best_block().height + min_final_cltv_expiry_delta as u32) as u64;
+												if (cltv_expiry as u64) < expected_min_expiry_height {
+													log_trace!(self.logger, "Failing new async payment HTLC with payment_hash {} as its CLTV expiry was too soon (had {}, earliest expected {})", &payment_hash, cltv_expiry, expected_min_expiry_height);
+													fail_htlc!(claimable_htlc, payment_hash);
+												}
+											}
+											let invreq_fields = match invoice_request_opt
+												.and_then(|invreq| invreq.verify_using_recipient_data(
+													offer_nonce, &self.inbound_payment_key, &self.secp_ctx
+												).ok())
+											{
+												Some(verified_invreq) => verified_invreq.fields(),
+												None => {
+													fail_htlc!(claimable_htlc, payment_hash);
+												}
+											};
+											match events::PaymentPurpose::from_parts(
+												Some(preimage), payment_data.payment_secret, payment_context,
+												Some(invreq_fields),
+											) {
+												Ok(purpose) => purpose,
+												Err(()) => {
+													fail_htlc!(claimable_htlc, payment_hash);
+												}
+											}
+										} else {
+											// TODO: handle when the context is set but unexpected
+											events::PaymentPurpose::SpontaneousPayment(preimage)
+										};
 										check_total_value!(purpose);
 									}
 								}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -9748,7 +9748,7 @@ where
 			Ok((payment_hash, payment_secret)) => {
 				let payment_context = PaymentContext::Bolt12Refund(Bolt12RefundContext {});
 				let payment_paths = self.create_blinded_payment_paths(
-					Some(amount_msats), payment_secret, payment_context
+					Some(amount_msats), payment_secret, payment_context, relative_expiry,
 				)
 					.map_err(|_| Bolt12SemanticError::MissingPaths)?;
 
@@ -10055,14 +10055,20 @@ where
 	/// Creates multi-hop blinded payment paths for the given `amount_msats` by delegating to
 	/// [`Router::create_blinded_payment_paths`].
 	fn create_blinded_payment_paths(
-		&self, amount_msats: Option<u64>, payment_secret: PaymentSecret, payment_context: PaymentContext
+		&self, amount_msats: Option<u64>, payment_secret: PaymentSecret, payment_context: PaymentContext,
+		relative_expiry_seconds: u32
 	) -> Result<Vec<BlindedPaymentPath>, ()> {
 		let secp_ctx = &self.secp_ctx;
 
 		let first_hops = self.list_usable_channels();
 		let payee_node_id = self.get_our_node_id();
-		let max_cltv_expiry = self.best_block.read().unwrap().height + CLTV_FAR_FAR_AWAY
-			+ LATENCY_GRACE_PERIOD_BLOCKS;
+
+		const SECONDS_PER_BLOCK: u32 = 10 * 60;
+		let relative_expiry_blocks = relative_expiry_seconds / SECONDS_PER_BLOCK;
+		let max_cltv_expiry = core::cmp::max(relative_expiry_blocks, CLTV_FAR_FAR_AWAY)
+			.saturating_add(LATENCY_GRACE_PERIOD_BLOCKS)
+			.saturating_add(self.best_block.read().unwrap().height);
+
 		let payee_tlvs = ReceiveTlvs {
 			payment_secret,
 			payment_constraints: PaymentConstraints {
@@ -11585,7 +11591,7 @@ where
 					invoice_request: invoice_request.fields(),
 				});
 				let payment_paths = match self.create_blinded_payment_paths(
-					Some(amount_msats), payment_secret, payment_context
+					Some(amount_msats), payment_secret, payment_context, relative_expiry
 				) {
 					Ok(payment_paths) => payment_paths,
 					Err(()) => {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -6078,11 +6078,16 @@ where
 								match claimable_htlc.onion_payload {
 									OnionPayload::Invoice { .. } => {
 										let payment_data = payment_data.unwrap();
-										let purpose = events::PaymentPurpose::from_parts(
+										let purpose = match events::PaymentPurpose::from_parts(
 											payment_preimage,
 											payment_data.payment_secret,
 											payment_context,
-										);
+										) {
+											Ok(purpose) => purpose,
+											Err(()) => {
+												fail_htlc!(claimable_htlc, payment_hash);
+											},
+										};
 										check_total_value!(purpose);
 									},
 									OnionPayload::Spontaneous(preimage) => {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -72,8 +72,6 @@ use crate::offers::offer::{Offer, OfferBuilder};
 use crate::offers::parse::Bolt12SemanticError;
 use crate::offers::refund::{Refund, RefundBuilder};
 use crate::offers::signer;
-#[cfg(async_payments)]
-use crate::offers::static_invoice::StaticInvoice;
 use crate::onion_message::async_payments::{AsyncPaymentsMessage, HeldHtlcAvailable, ReleaseHeldHtlc, AsyncPaymentsMessageHandler};
 use crate::onion_message::dns_resolution::HumanReadableName;
 use crate::onion_message::messenger::{Destination, MessageRouter, Responder, ResponseInstruction, MessageSendInstructions};
@@ -87,6 +85,11 @@ use crate::util::string::UntrustedString;
 use crate::util::ser::{BigSize, FixedLengthReader, Readable, ReadableArgs, MaybeReadable, Writeable, Writer, VecWriter};
 use crate::util::logger::{Level, Logger, WithContext};
 use crate::util::errors::APIError;
+#[cfg(async_payments)] use {
+	crate::blinded_path::payment::AsyncBolt12OfferContext,
+	crate::offers::offer::Amount,
+	crate::offers::static_invoice::{DEFAULT_RELATIVE_EXPIRY as STATIC_INVOICE_DEFAULT_RELATIVE_EXPIRY, StaticInvoice, StaticInvoiceBuilder},
+};
 
 #[cfg(feature = "dnssec")]
 use crate::blinded_path::message::DNSResolverContext;
@@ -9553,6 +9556,86 @@ where
 	create_offer_builder!(self, OfferWithDerivedMetadataBuilder);
 	#[cfg(c_bindings)]
 	create_refund_builder!(self, RefundMaybeWithDerivedMetadataBuilder);
+
+	/// Create an offer for receiving async payments as an often-offline recipient.
+	///
+	/// Because we may be offline when the payer attempts to request an invoice, you MUST:
+	/// 1. Provide at least 1 [`BlindedPath`] for onion messages terminating at an always-online node
+	///    that will serve the [`StaticInvoice`] created from this offer on our behalf.
+	/// 2. Use [`Self::create_static_invoice_builder_for_async_receive_offer`] to create a
+	///    [`StaticInvoice`] from this [`Offer`] plus the returned [`Nonce`], and provide the static
+	///    invoice to the aforementioned always-online node.
+	#[cfg(async_payments)]
+	pub fn create_async_receive_offer_builder(
+		&self, message_paths_to_always_online_node: Vec<BlindedMessagePath>
+	) -> Result<(OfferBuilder<DerivedMetadata, secp256k1::All>, Nonce), Bolt12SemanticError> {
+		if message_paths_to_always_online_node.is_empty() {
+			return Err(Bolt12SemanticError::MissingPaths)
+		}
+
+		let node_id = self.get_our_node_id();
+		let expanded_key = &self.inbound_payment_key;
+		let entropy = &*self.entropy_source;
+		let secp_ctx = &self.secp_ctx;
+
+		let nonce = Nonce::from_entropy_source(entropy);
+		let mut builder = OfferBuilder::deriving_signing_pubkey(
+			node_id, expanded_key, nonce, secp_ctx
+		).chain_hash(self.chain_hash);
+
+		for path in message_paths_to_always_online_node {
+			builder = builder.path(path);
+		}
+
+		Ok((builder.into(), nonce))
+	}
+
+	/// Creates a [`StaticInvoiceBuilder`] from the corresponding [`Offer`] and [`Nonce`] that were
+	/// created via [`Self::create_async_receive_offer_builder`]. If `relative_expiry` is unset, the
+	/// invoice's expiry will default to [`STATIC_INVOICE_DEFAULT_RELATIVE_EXPIRY`].
+	#[cfg(async_payments)]
+	pub fn create_static_invoice_builder_for_async_receive_offer<'a>(
+		&self, offer: &'a Offer, offer_nonce: Nonce, relative_expiry: Option<Duration>
+	) -> Result<StaticInvoiceBuilder<'a>, Bolt12SemanticError> {
+		let expanded_key = &self.inbound_payment_key;
+		let entropy = &*self.entropy_source;
+		let secp_ctx = &self.secp_ctx;
+
+		let payment_context = PaymentContext::AsyncBolt12Offer(
+			AsyncBolt12OfferContext { offer_id: offer.id(), offer_nonce }
+		);
+		let amount_msat = offer.amount().and_then(|amount| {
+			match amount {
+				Amount::Bitcoin { amount_msats } => Some(amount_msats),
+				Amount::Currency { .. } => None
+			}
+		});
+
+		let relative_expiry = relative_expiry.unwrap_or(STATIC_INVOICE_DEFAULT_RELATIVE_EXPIRY);
+		let relative_expiry_secs: u32 = relative_expiry.as_secs().try_into().unwrap_or(u32::MAX);
+
+		let created_at = self.duration_since_epoch();
+		let payment_secret = inbound_payment::create_for_spontaneous_payment(
+			&self.inbound_payment_key, amount_msat, relative_expiry_secs, created_at.as_secs(), None
+		).map_err(|()| Bolt12SemanticError::InvalidAmount)?;
+
+		let payment_paths = self.create_blinded_payment_paths(
+			amount_msat, payment_secret, payment_context, relative_expiry_secs
+		).map_err(|()| Bolt12SemanticError::MissingPaths)?;
+
+		let nonce = Nonce::from_entropy_source(entropy);
+		let hmac = offer.id().hmac_for_static_invoice(nonce, expanded_key);
+		let context = MessageContext::AsyncPayments(
+			AsyncPaymentsContext::InboundPayment { offer_id: offer.id(), nonce, hmac }
+		);
+		let async_receive_message_paths = self.create_blinded_paths(context)
+			.map_err(|()| Bolt12SemanticError::MissingPaths)?;
+
+		StaticInvoiceBuilder::for_offer_using_derived_keys(
+			offer, payment_paths, async_receive_message_paths, created_at, expanded_key,
+			offer_nonce, secp_ctx
+		)
+	}
 
 	/// Pays for an [`Offer`] using the given parameters by creating an [`InvoiceRequest`] and
 	/// enqueuing it to be sent via an onion message. [`ChannelManager`] will pay the actual

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -9748,7 +9748,7 @@ where
 			Ok((payment_hash, payment_secret)) => {
 				let payment_context = PaymentContext::Bolt12Refund(Bolt12RefundContext {});
 				let payment_paths = self.create_blinded_payment_paths(
-					amount_msats, payment_secret, payment_context
+					Some(amount_msats), payment_secret, payment_context
 				)
 					.map_err(|_| Bolt12SemanticError::MissingPaths)?;
 
@@ -10055,7 +10055,7 @@ where
 	/// Creates multi-hop blinded payment paths for the given `amount_msats` by delegating to
 	/// [`Router::create_blinded_payment_paths`].
 	fn create_blinded_payment_paths(
-		&self, amount_msats: u64, payment_secret: PaymentSecret, payment_context: PaymentContext
+		&self, amount_msats: Option<u64>, payment_secret: PaymentSecret, payment_context: PaymentContext
 	) -> Result<Vec<BlindedPaymentPath>, ()> {
 		let secp_ctx = &self.secp_ctx;
 
@@ -11585,7 +11585,7 @@ where
 					invoice_request: invoice_request.fields(),
 				});
 				let payment_paths = match self.create_blinded_payment_paths(
-					amount_msats, payment_secret, payment_context
+					Some(amount_msats), payment_secret, payment_context
 				) {
 					Ok(payment_paths) => payment_paths,
 					Err(()) => {

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1468,7 +1468,7 @@ pub fn create_announced_chan_between_nodes_with_value<'a, 'b, 'c: 'd, 'd>(nodes:
 }
 
 pub fn create_unannounced_chan_between_nodes_with_value<'a, 'b, 'c, 'd>(nodes: &'a Vec<Node<'b, 'c, 'd>>, a: usize, b: usize, channel_value: u64, push_msat: u64) -> (msgs::ChannelReady, Transaction) {
-	let mut no_announce_cfg = test_default_channel_config();
+	let mut no_announce_cfg = nodes[a].node.get_current_default_configuration().clone();
 	no_announce_cfg.channel_handshake_config.announce_for_forwarding = false;
 	nodes[a].node.create_channel(nodes[b].node.get_our_node_id(), channel_value, push_msat, 42, None, Some(no_announce_cfg)).unwrap();
 	let open_channel = get_event_msg!(nodes[a], MessageSendEvent::SendOpenChannel, nodes[b].node.get_our_node_id());
@@ -2700,6 +2700,9 @@ pub fn do_pass_along_path<'a, 'b, 'c>(args: PassAlongPathArgs) -> Option<Event> 
 							PaymentPurpose::Bolt12OfferPayment { payment_preimage, payment_secret, .. } => {
 								assert_eq!(expected_preimage, *payment_preimage);
 								assert_eq!(our_payment_secret.unwrap(), *payment_secret);
+								if let Some(secret) = our_payment_secret {
+									assert_eq!(secret, *payment_secret);
+								}
 								assert_eq!(Some(*payment_secret), onion_fields.as_ref().unwrap().payment_secret);
 							},
 							PaymentPurpose::Bolt12RefundPayment { payment_preimage, payment_secret, .. } => {

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -36,6 +36,7 @@ use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentPreimage, PaymentHash, PaymentSecret};
 use crate::types::features::{ChannelFeatures, ChannelTypeFeatures, InitFeatures, NodeFeatures};
 use crate::ln::onion_utils;
+use crate::offers::invoice_request::InvoiceRequest;
 use crate::onion_message;
 use crate::sign::{NodeSigner, Recipient};
 
@@ -1790,6 +1791,7 @@ mod fuzzy_internal_msgs {
 			payment_context: PaymentContext,
 			intro_node_blinding_point: Option<PublicKey>,
 			keysend_preimage: Option<PaymentPreimage>,
+			invoice_request: Option<InvoiceRequest>,
 			custom_tlvs: Vec<(u64, Vec<u8>)>,
 		}
 	}
@@ -2851,6 +2853,7 @@ impl<NS: Deref> ReadableArgs<(Option<PublicKey>, NS)> for InboundOnionPayload wh
 		let mut payment_metadata: Option<WithoutLength<Vec<u8>>> = None;
 		let mut total_msat = None;
 		let mut keysend_preimage: Option<PaymentPreimage> = None;
+		let mut invoice_request: Option<InvoiceRequest> = None;
 		let mut custom_tlvs = Vec::new();
 
 		let tlv_len = BigSize::read(r)?;
@@ -2864,6 +2867,7 @@ impl<NS: Deref> ReadableArgs<(Option<PublicKey>, NS)> for InboundOnionPayload wh
 			(12, intro_node_blinding_point, option),
 			(16, payment_metadata, option),
 			(18, total_msat, (option, encoding: (u64, HighZeroBytesDroppedBigSize))),
+			(77_777, invoice_request, option),
 			// See https://github.com/lightning/blips/blob/master/blip-0003.md
 			(5482373484, keysend_preimage, option)
 		}, |msg_type: u64, msg_reader: &mut FixedLengthReader<_>| -> Result<bool, DecodeError> {
@@ -2894,7 +2898,7 @@ impl<NS: Deref> ReadableArgs<(Option<PublicKey>, NS)> for InboundOnionPayload wh
 					short_channel_id, payment_relay, payment_constraints, features, next_blinding_override
 				})} => {
 					if amt.is_some() || cltv_value.is_some() || total_msat.is_some() ||
-						keysend_preimage.is_some()
+						keysend_preimage.is_some() || invoice_request.is_some()
 					{
 						return Err(DecodeError::InvalidValue)
 					}
@@ -2920,13 +2924,14 @@ impl<NS: Deref> ReadableArgs<(Option<PublicKey>, NS)> for InboundOnionPayload wh
 						payment_context,
 						intro_node_blinding_point,
 						keysend_preimage,
+						invoice_request,
 						custom_tlvs,
 					})
 				},
 			}
 		} else if let Some(short_channel_id) = short_id {
 			if payment_data.is_some() || payment_metadata.is_some() || encrypted_tlvs_opt.is_some() ||
-				total_msat.is_some()
+				total_msat.is_some() || invoice_request.is_some()
 			{ return Err(DecodeError::InvalidValue) }
 			Ok(Self::Forward {
 				short_channel_id,
@@ -2934,7 +2939,7 @@ impl<NS: Deref> ReadableArgs<(Option<PublicKey>, NS)> for InboundOnionPayload wh
 				outgoing_cltv_value: cltv_value.ok_or(DecodeError::InvalidValue)?,
 			})
 		} else {
-			if encrypted_tlvs_opt.is_some() || total_msat.is_some() {
+			if encrypted_tlvs_opt.is_some() || total_msat.is_some() || invoice_request.is_some() {
 				return Err(DecodeError::InvalidValue)
 			}
 			if let Some(data) = &payment_data {

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -146,7 +146,7 @@ pub(super) fn create_recv_pending_htlc_info(
 		msgs::InboundOnionPayload::BlindedReceive {
 			sender_intended_htlc_amt_msat, total_msat, cltv_expiry_height, payment_secret,
 			intro_node_blinding_point, payment_constraints, payment_context, keysend_preimage,
-			custom_tlvs
+			custom_tlvs, invoice_request: _
 		} => {
 			check_blinded_payment_constraints(
 				sender_intended_htlc_amt_msat, cltv_expiry, &payment_constraints

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -135,18 +135,19 @@ pub(super) fn create_recv_pending_htlc_info(
 ) -> Result<PendingHTLCInfo, InboundHTLCErr> {
 	let (
 		payment_data, keysend_preimage, custom_tlvs, onion_amt_msat, onion_cltv_expiry,
-		payment_metadata, payment_context, requires_blinded_error, has_recipient_created_payment_secret
+		payment_metadata, payment_context, requires_blinded_error, has_recipient_created_payment_secret,
+		invoice_request
 	) = match hop_data {
 		msgs::InboundOnionPayload::Receive {
 			payment_data, keysend_preimage, custom_tlvs, sender_intended_htlc_amt_msat,
 			cltv_expiry_height, payment_metadata, ..
 		} =>
 			(payment_data, keysend_preimage, custom_tlvs, sender_intended_htlc_amt_msat,
-			 cltv_expiry_height, payment_metadata, None, false, keysend_preimage.is_none()),
+			 cltv_expiry_height, payment_metadata, None, false, keysend_preimage.is_none(), None),
 		msgs::InboundOnionPayload::BlindedReceive {
 			sender_intended_htlc_amt_msat, total_msat, cltv_expiry_height, payment_secret,
 			intro_node_blinding_point, payment_constraints, payment_context, keysend_preimage,
-			custom_tlvs, invoice_request: _
+			custom_tlvs, invoice_request
 		} => {
 			check_blinded_payment_constraints(
 				sender_intended_htlc_amt_msat, cltv_expiry, &payment_constraints
@@ -161,7 +162,7 @@ pub(super) fn create_recv_pending_htlc_info(
 			let payment_data = msgs::FinalOnionHopData { payment_secret, total_msat };
 			(Some(payment_data), keysend_preimage, custom_tlvs,
 			 sender_intended_htlc_amt_msat, cltv_expiry_height, None, Some(payment_context),
-			 intro_node_blinding_point.is_none(), true)
+			 intro_node_blinding_point.is_none(), true, invoice_request)
 		}
 		msgs::InboundOnionPayload::Forward { .. } => {
 			return Err(InboundHTLCErr {
@@ -242,6 +243,8 @@ pub(super) fn create_recv_pending_htlc_info(
 			custom_tlvs,
 			requires_blinded_error,
 			has_recipient_created_payment_secret,
+			invoice_request,
+			payment_context,
 		}
 	} else if let Some(data) = payment_data {
 		PendingHTLCRouting::Receive {

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -134,13 +134,16 @@ pub(crate) enum PendingOutboundPayment {
 	},
 }
 
+#[derive(Clone)]
 pub(crate) struct RetryableInvoiceRequest {
 	pub(crate) invoice_request: InvoiceRequest,
 	pub(crate) nonce: Nonce,
+	pub(super) needs_retry: bool,
 }
 
 impl_writeable_tlv_based!(RetryableInvoiceRequest, {
 	(0, invoice_request, required),
+	(1, needs_retry, (default_value, true)),
 	(2, nonce, required),
 });
 
@@ -746,7 +749,12 @@ pub(super) struct OutboundPayments {
 impl OutboundPayments {
 	pub(super) fn new(pending_outbound_payments: HashMap<PaymentId, PendingOutboundPayment>) -> Self {
 		let has_invoice_requests = pending_outbound_payments.values().any(|payment| {
-			matches!(payment, PendingOutboundPayment::AwaitingInvoice { retryable_invoice_request: Some(_), .. })
+			matches!(
+				payment,
+				PendingOutboundPayment::AwaitingInvoice {
+					retryable_invoice_request: Some(invreq), ..
+				} if invreq.needs_retry
+			)
 		});
 
 		Self {
@@ -2217,11 +2225,12 @@ impl OutboundPayments {
 			.iter_mut()
 			.filter_map(|(payment_id, payment)| {
 				if let PendingOutboundPayment::AwaitingInvoice {
-					retryable_invoice_request, ..
+					retryable_invoice_request: Some(invreq), ..
 				} = payment {
-					retryable_invoice_request.take().map(|retryable_invoice_request| {
-						(*payment_id, retryable_invoice_request)
-					})
+					if invreq.needs_retry {
+						invreq.needs_retry = false;
+						Some((*payment_id, invreq.clone()))
+					} else { None }
 				} else {
 					None
 				}

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -1028,7 +1028,10 @@ impl OutboundPayments {
 	) -> Result<(), Bolt12PaymentError> where ES::Target: EntropySource {
 		macro_rules! abandon_with_entry {
 			($payment: expr, $reason: expr) => {
-				debug_assert!(matches!($payment.get(), PendingOutboundPayment::AwaitingInvoice { .. }));
+				assert!(
+					matches!($payment.get(), PendingOutboundPayment::AwaitingInvoice { .. }),
+					"Generating PaymentFailed for unexpected outbound payment type can result in funds loss"
+				);
 				pending_events.lock().unwrap().push_back((events::Event::PaymentFailed {
 					payment_id,
 					payment_hash: None,

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -1028,17 +1028,13 @@ impl OutboundPayments {
 	) -> Result<(), Bolt12PaymentError> where ES::Target: EntropySource {
 		macro_rules! abandon_with_entry {
 			($payment: expr, $reason: expr) => {
-				$payment.get_mut().mark_abandoned($reason);
-				if let PendingOutboundPayment::Abandoned { reason, .. } = $payment.get() {
-					if $payment.get().remaining_parts() == 0 {
-						pending_events.lock().unwrap().push_back((events::Event::PaymentFailed {
-							payment_id,
-							payment_hash: None,
-							reason: *reason,
-						}, None));
-						$payment.remove();
-					}
-				}
+				debug_assert!(matches!($payment.get(), PendingOutboundPayment::AwaitingInvoice { .. }));
+				pending_events.lock().unwrap().push_back((events::Event::PaymentFailed {
+					payment_id,
+					payment_hash: None,
+					reason: Some($reason),
+				}, None));
+				$payment.remove();
 			}
 		}
 

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -149,7 +149,8 @@ impl OffersMessageHandler for IgnoringMessageHandler {
 }
 impl AsyncPaymentsMessageHandler for IgnoringMessageHandler {
 	fn handle_held_htlc_available(
-		&self, _message: HeldHtlcAvailable, _responder: Option<Responder>,
+		&self, _message: HeldHtlcAvailable, _context: AsyncPaymentsContext,
+		_responder: Option<Responder>,
 	) -> Option<(ReleaseHeldHtlc, ResponseInstruction)> {
 		None
 	}

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -150,6 +150,15 @@ impl OfferId {
 	) -> Hmac<Sha256> {
 		signer::hmac_for_static_invoice_offer_id(*self, nonce, expanded_key)
 	}
+
+	/// Authenticates the offer id using an HMAC and a [`Nonce`] taken from an
+	/// [`AsyncPaymentsContext::InboundPayment`].
+	#[cfg(async_payments)]
+	pub fn verify_for_static_invoice_payment(
+		&self, hmac: Hmac<Sha256>, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
+	) -> Result<(), ()> {
+		signer::verify_static_invoice_offer_id(*self, hmac, nonce, expanded_key)
+	}
 }
 
 impl Borrow<[u8]> for OfferId {

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -98,6 +98,13 @@ use crate::offers::signer::{Metadata, MetadataMaterial, self};
 use crate::util::ser::{CursorReadable, HighZeroBytesDroppedBigSize, Readable, WithoutLength, Writeable, Writer};
 use crate::util::string::PrintableString;
 
+#[cfg(async_payments)]
+use {
+	bitcoin::hashes::hmac::Hmac,
+	bitcoin::hashes::sha256::Hash as Sha256,
+	crate::ln::inbound_payment,
+};
+
 #[cfg(not(c_bindings))]
 use {
 	crate::offers::invoice_request::InvoiceRequestBuilder,
@@ -133,6 +140,15 @@ impl OfferId {
 		let tlv_stream = Offer::tlv_stream_iter(bytes);
 		let tagged_hash = TaggedHash::from_tlv_stream(Self::ID_TAG, tlv_stream);
 		Self(tagged_hash.to_bytes())
+	}
+
+	/// Constructs an HMAC to include in [`AsyncPaymentsContext::InboundPayment`] for the offer id
+	/// along with the given [`Nonce`].
+	#[cfg(async_payments)]
+	pub fn hmac_for_static_invoice(
+		&self, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
+	) -> Hmac<Sha256> {
+		signer::hmac_for_static_invoice_offer_id(*self, nonce, expanded_key)
 	}
 }
 

--- a/lightning/src/offers/signer.rs
+++ b/lightning/src/offers/signer.rs
@@ -20,6 +20,8 @@ use crate::ln::channelmanager::PaymentId;
 use crate::ln::inbound_payment::{ExpandedKey, IV_LEN};
 use crate::offers::merkle::TlvRecord;
 use crate::offers::nonce::Nonce;
+#[cfg(async_payments)]
+use crate::offers::offer::OfferId;
 use crate::util::ser::Writeable;
 
 use crate::prelude::*;
@@ -45,6 +47,10 @@ const ASYNC_PAYMENT_ID_HMAC_INPUT: &[u8; 16] = &[6; 16];
 
 // HMAC input for a `PaymentHash`. The HMAC is used in `OffersContext::InboundPayment`.
 const PAYMENT_HASH_HMAC_INPUT: &[u8; 16] = &[7; 16];
+
+// HMAC input for an `OfferId`. The HMAC is used in `AsyncPaymentsContext::InboundPayment`.
+#[cfg(async_payments)]
+const ASYNC_PAYMENT_OFFER_ID_HMAC_INPUT: &[u8; 16] = &[8; 16];
 
 /// Message metadata which possibly is derived from [`MetadataMaterial`] such that it can be
 /// verified.
@@ -456,6 +462,20 @@ fn hmac_for_payment_id(
 	hmac.input(&nonce.0);
 	hmac.input(hmac_input);
 	hmac.input(&payment_id.0);
+
+	Hmac::from_engine(hmac)
+}
+
+#[cfg(async_payments)]
+pub(crate) fn hmac_for_static_invoice_offer_id(
+	offer_id: OfferId, nonce: Nonce, expanded_key: &ExpandedKey,
+) -> Hmac<Sha256> {
+	const IV_BYTES: &[u8; IV_LEN] = b"LDK Offer ID ~~~";
+	let mut hmac = expanded_key.hmac_for_offer();
+	hmac.input(IV_BYTES);
+	hmac.input(&nonce.0);
+	hmac.input(ASYNC_PAYMENT_OFFER_ID_HMAC_INPUT);
+	hmac.input(&offer_id.0);
 
 	Hmac::from_engine(hmac)
 }

--- a/lightning/src/offers/signer.rs
+++ b/lightning/src/offers/signer.rs
@@ -479,3 +479,10 @@ pub(crate) fn hmac_for_static_invoice_offer_id(
 
 	Hmac::from_engine(hmac)
 }
+
+#[cfg(async_payments)]
+pub(crate) fn verify_static_invoice_offer_id(
+	offer_id: OfferId, hmac: Hmac<Sha256>, nonce: Nonce, expanded_key: &ExpandedKey,
+) -> Result<(), ()> {
+	if hmac_for_static_invoice_offer_id(offer_id, nonce, expanded_key) == hmac { Ok(()) } else { Err(()) }
+}

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -49,7 +49,7 @@ use crate::offers::invoice::is_expired;
 use crate::prelude::*;
 
 /// Static invoices default to expiring after 2 weeks.
-const DEFAULT_RELATIVE_EXPIRY: Duration = Duration::from_secs(3600 * 24 * 14);
+pub const DEFAULT_RELATIVE_EXPIRY: Duration = Duration::from_secs(3600 * 24 * 14);
 
 /// Tag for the hash function used when signing a [`StaticInvoice`]'s merkle root.
 pub const SIGNATURE_TAG: &'static str = concat!("lightning", "static_invoice", "signature");
@@ -102,8 +102,8 @@ pub struct StaticInvoiceBuilder<'a> {
 impl<'a> StaticInvoiceBuilder<'a> {
 	/// Initialize a [`StaticInvoiceBuilder`] from the given [`Offer`].
 	///
-	/// Unless [`StaticInvoiceBuilder::relative_expiry`] is set, the invoice will expire 24 hours
-	/// after `created_at`.
+	/// The invoice's expiration will default to [`DEFAULT_RELATIVE_EXPIRY`] after `created_at` unless
+	/// overridden by [`StaticInvoiceBuilder::relative_expiry`].
 	pub fn for_offer_using_derived_keys<T: secp256k1::Signing>(
 		offer: &'a Offer, payment_paths: Vec<BlindedPaymentPath>,
 		message_paths: Vec<BlindedMessagePath>, created_at: Duration, expanded_key: &ExpandedKey,

--- a/lightning/src/onion_message/async_payments.rs
+++ b/lightning/src/onion_message/async_payments.rs
@@ -28,7 +28,7 @@ pub trait AsyncPaymentsMessageHandler {
 	/// Handle a [`HeldHtlcAvailable`] message. A [`ReleaseHeldHtlc`] should be returned to release
 	/// the held funds.
 	fn handle_held_htlc_available(
-		&self, message: HeldHtlcAvailable, responder: Option<Responder>,
+		&self, message: HeldHtlcAvailable, context: AsyncPaymentsContext, responder: Option<Responder>,
 	) -> Option<(ReleaseHeldHtlc, ResponseInstruction)>;
 
 	/// Handle a [`ReleaseHeldHtlc`] message. If authentication of the message succeeds, an HTLC

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -85,7 +85,8 @@ struct TestAsyncPaymentsMessageHandler {}
 
 impl AsyncPaymentsMessageHandler for TestAsyncPaymentsMessageHandler {
 	fn handle_held_htlc_available(
-		&self, _message: HeldHtlcAvailable, _responder: Option<Responder>,
+		&self, _message: HeldHtlcAvailable, _context: AsyncPaymentsContext,
+		_responder: Option<Responder>,
 	) -> Option<(ReleaseHeldHtlc, ResponseInstruction)> {
 		None
 	}

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -1625,8 +1625,16 @@ where
 					},
 					#[cfg(async_payments)]
 					ParsedOnionMessageContents::AsyncPayments(AsyncPaymentsMessage::HeldHtlcAvailable(msg)) => {
+						let context = match context {
+							Some(MessageContext::AsyncPayments(context)) => context,
+							Some(_) => {
+								debug_assert!(false, "Checked in peel_onion_message");
+								return
+							},
+							None => return,
+						};
 						let response_instructions = self.async_payments_handler.handle_held_htlc_available(
-							msg, responder
+							msg, context, responder
 						);
 						if let Some((msg, instructions)) = response_instructions {
 							let _ = self.handle_onion_message_response(msg, instructions);

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -104,9 +104,6 @@ impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref, S: Deref, SP: Size
 		// recipient's node_id.
 		const MIN_PEER_CHANNELS: usize = 3;
 
-		const DEFAULT_AMT_MSAT: u64 = 100_000_000;
-		let amount_msats = amount_msats.unwrap_or(DEFAULT_AMT_MSAT);
-
 		let has_one_peer = first_hops
 			.first()
 			.map(|details| details.counterparty.node_id)
@@ -123,9 +120,9 @@ impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref, S: Deref, SP: Size
 
 		let paths = first_hops.into_iter()
 			.filter(|details| details.counterparty.features.supports_route_blinding())
-			.filter(|details| amount_msats <= details.inbound_capacity_msat)
-			.filter(|details| amount_msats >= details.inbound_htlc_minimum_msat.unwrap_or(0))
-			.filter(|details| amount_msats <= details.inbound_htlc_maximum_msat.unwrap_or(u64::MAX))
+			.filter(|details| amount_msats.unwrap_or(0) <= details.inbound_capacity_msat)
+			.filter(|details| amount_msats.unwrap_or(u64::MAX) >= details.inbound_htlc_minimum_msat.unwrap_or(0))
+			.filter(|details| amount_msats.unwrap_or(0) <= details.inbound_htlc_maximum_msat.unwrap_or(u64::MAX))
 			// Limit to peers with announced channels unless the recipient is unannounced.
 			.filter(|details| network_graph
 					.node(&NodeId::from_pubkey(&details.counterparty.node_id))

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -95,7 +95,7 @@ impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref, S: Deref, SP: Size
 		T: secp256k1::Signing + secp256k1::Verification
 	> (
 		&self, recipient: PublicKey, first_hops: Vec<ChannelDetails>, tlvs: ReceiveTlvs,
-		amount_msats: u64, secp_ctx: &Secp256k1<T>
+		amount_msats: Option<u64>, secp_ctx: &Secp256k1<T>
 	) -> Result<Vec<BlindedPaymentPath>, ()> {
 		// Limit the number of blinded paths that are computed.
 		const MAX_PAYMENT_PATHS: usize = 3;
@@ -103,6 +103,9 @@ impl<G: Deref<Target = NetworkGraph<L>>, L: Deref, ES: Deref, S: Deref, SP: Size
 		// Ensure peers have at least three channels so that it is more difficult to infer the
 		// recipient's node_id.
 		const MIN_PEER_CHANNELS: usize = 3;
+
+		const DEFAULT_AMT_MSAT: u64 = 100_000_000;
+		let amount_msats = amount_msats.unwrap_or(DEFAULT_AMT_MSAT);
 
 		let has_one_peer = first_hops
 			.first()
@@ -218,7 +221,7 @@ pub trait Router {
 		T: secp256k1::Signing + secp256k1::Verification
 	> (
 		&self, recipient: PublicKey, first_hops: Vec<ChannelDetails>, tlvs: ReceiveTlvs,
-		amount_msats: u64, secp_ctx: &Secp256k1<T>
+		amount_msats: Option<u64>, secp_ctx: &Secp256k1<T>
 	) -> Result<Vec<BlindedPaymentPath>, ()>;
 }
 

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -251,7 +251,7 @@ impl<'a> Router for TestRouter<'a> {
 		T: secp256k1::Signing + secp256k1::Verification
 	>(
 		&self, recipient: PublicKey, first_hops: Vec<ChannelDetails>, tlvs: ReceiveTlvs,
-		amount_msats: u64, secp_ctx: &Secp256k1<T>,
+		amount_msats: Option<u64>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedPaymentPath>, ()> {
 		let mut expected_paths = self.next_blinded_payment_paths.lock().unwrap();
 		if expected_paths.is_empty() {


### PR DESCRIPTION
Finishes support for receiving async payments. 

The last piece after this for the async-receive side is support for being the async receiver's LSP and serving invoices on their behalf. 

Partially addresses #2298 

Based on #3408 