### PR TITLE
Log before and after `Event` processing calls

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -573,7 +573,7 @@ where C::Target: chain::Filter,
 		for funding_txo in mons_to_process {
 			let mut ev;
 			match super::channelmonitor::process_events_body!(
-				self.monitors.read().unwrap().get(&funding_txo).map(|m| &m.monitor), ev, handler(ev).await) {
+				self.monitors.read().unwrap().get(&funding_txo).map(|m| &m.monitor), self.logger, ev, handler(ev).await) {
 				Ok(()) => {},
 				Err(ReplayEvent ()) => {
 					self.event_notifier.notify();
@@ -909,7 +909,7 @@ impl<ChannelSigner: EcdsaChannelSigner, C: Deref, T: Deref, F: Deref, L: Deref, 
 	/// [`BumpTransaction`]: events::Event::BumpTransaction
 	fn process_pending_events<H: Deref>(&self, handler: H) where H::Target: EventHandler {
 		for monitor_state in self.monitors.read().unwrap().values() {
-			match monitor_state.monitor.process_pending_events(&handler) {
+			match monitor_state.monitor.process_pending_events(&handler, &self.logger) {
 				Ok(()) => {},
 				Err(ReplayEvent ()) => {
 					self.event_notifier.notify();

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3321,8 +3321,11 @@ macro_rules! process_events_body {
 
 			let mut num_handled_events = 0;
 			for (event, action_opt) in pending_events {
+				log_trace!($self.logger, "Handling event {:?}...", event);
 				$event_to_handle = event;
-				match $handle_event {
+				let event_handling_result = $handle_event;
+				log_trace!($self.logger, "Done handling event, result: {:?}", event_handling_result);
+				match event_handling_result {
 					Ok(()) => {
 						if let Some(action) = action_opt {
 							post_event_actions.push(action);


### PR DESCRIPTION
At various points we've had issues where `Event` processing for a user possibly is taking a long time, causing other things to stall. However, due to lack of logging during `Event` processing itself this can be rather difficult to debug. In
85eb8145fba1dbf3b9348d9142cc105ee13db33b we attempted to add logging for this, but in doing so ended up with more verbose logging than we were comfortable with.

Instead, here, we log only when we actually process an `Event`, directly in the callsite passing the `Event` to the user.

Fixes #3331