### PR TITLE
Fix premature claims broadcast

### DIFF
--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -756,7 +756,7 @@ impl<ChannelSigner: EcdsaChannelSigner> OnchainTxHandler<ChannelSigner> {
 				}
 
 				let package_locktime = req.package_locktime(cur_height);
-				if package_locktime > cur_height + 1 {
+				if package_locktime > cur_height {
 					log_info!(logger, "Delaying claim of package until its timelock at {} (current height {}), the following outpoints are spent:", package_locktime, cur_height);
 					for outpoint in req.outpoints() {
 						log_info!(logger, "  Outpoint {}", outpoint);


### PR DESCRIPTION
A claim transaction with locktime T can only be mined at block heights of T+1 or above.  Due to an off-by-one bug, we were broadcasting some claim transactions one block before they could actually be mined.

AFAICT, nothing bad resulted from this bug -- later rebroadcasts of the transaction would eventually succeed once the correct height was reached.