### PR TITLE
Let `ChannelSigner` set `to_remote`, `to_local`, htlc tx scriptpubkeys

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -96,7 +96,7 @@ use bitcoin::secp256k1::PublicKey;
 /// provided for bulding transactions for a watchtower:
 /// [`ChannelMonitor::initial_counterparty_commitment_tx`],
 /// [`ChannelMonitor::counterparty_commitment_txs_from_update`],
-/// [`ChannelMonitor::sign_to_local_justice_tx`], [`TrustedCommitmentTransaction::revokeable_output_index`],
+/// [`ChannelMonitor::punish_revokeable_output`], [`TrustedCommitmentTransaction::revokeable_output_index`],
 /// [`TrustedCommitmentTransaction::build_to_local_justice_tx`].
 ///
 /// [`TrustedCommitmentTransaction::revokeable_output_index`]: crate::ln::chan_utils::TrustedCommitmentTransaction::revokeable_output_index

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -29,7 +29,6 @@ use bitcoin::hashes::Hash;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hash_types::{Txid, BlockHash};
 
-use bitcoin::ecdsa::Signature as BitcoinSignature;
 use bitcoin::secp256k1::{self, SecretKey, PublicKey, Secp256k1, ecdsa::Signature};
 
 use crate::ln::channel::INITIAL_COMMITMENT_NUMBER;
@@ -1675,8 +1674,8 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 	/// This is provided so that watchtower clients in the persistence pipeline are able to build
 	/// justice transactions for each counterparty commitment upon each update. It's intended to be
 	/// used within an implementation of [`Persist::update_persisted_channel`], which is provided
-	/// with a monitor and an update. Once revoked, signing a justice transaction can be done using
-	/// [`Self::sign_to_local_justice_tx`].
+	/// with a monitor and an update. Once revoked, punishing a revokeable output can be done using
+	/// [`Self::punish_revokeable_output`].
 	///
 	/// It is expected that a watchtower client may use this method to retrieve the latest counterparty
 	/// commitment transaction(s), and then hold the necessary data until a later update in which
@@ -1692,12 +1691,12 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 		self.inner.lock().unwrap().counterparty_commitment_txs_from_update(update)
 	}
 
-	/// Wrapper around [`EcdsaChannelSigner::sign_justice_revoked_output`] to make
-	/// signing the justice transaction easier for implementors of
+	/// Wrapper around [`ChannelSigner::punish_revokeable_output`] to make
+	/// punishing a revokeable output easier for implementors of
 	/// [`chain::chainmonitor::Persist`]. On success this method returns the provided transaction
-	/// signing the input at `input_idx`. This method will only produce a valid signature for
+	/// finalizing the input at `input_idx`. This method will only produce a valid transaction for
 	/// a transaction spending the `to_local` output of a commitment transaction, i.e. this cannot
-	/// be used for revoked HTLC outputs.
+	/// be used for revoked HTLC outputs of a commitment transaction.
 	///
 	/// `Value` is the value of the output being spent by the input at `input_idx`, committed
 	/// in the BIP 143 signature.
@@ -1707,10 +1706,10 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 	/// to the commitment transaction being revoked, this will return a signed transaction, but
 	/// the signature will not be valid.
 	///
-	/// [`EcdsaChannelSigner::sign_justice_revoked_output`]: crate::sign::ecdsa::EcdsaChannelSigner::sign_justice_revoked_output
+	/// [`ChannelSigner::punish_revokeable_output`]: crate::sign::ChannelSigner::punish_revokeable_output
 	/// [`Persist`]: crate::chain::chainmonitor::Persist
-	pub fn sign_to_local_justice_tx(&self, justice_tx: Transaction, input_idx: usize, value: u64, commitment_number: u64) -> Result<Transaction, ()> {
-		self.inner.lock().unwrap().sign_to_local_justice_tx(justice_tx, input_idx, value, commitment_number)
+	pub fn punish_revokeable_output(&self, justice_tx: &Transaction, input_idx: usize, value: u64, commitment_number: u64) -> Result<Transaction, ()> {
+		self.inner.lock().unwrap().punish_revokeable_output(justice_tx, input_idx, value, commitment_number)
 	}
 
 	pub(crate) fn get_min_seen_secret(&self) -> u64 {
@@ -3458,27 +3457,14 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 		}).collect()
 	}
 
-	fn sign_to_local_justice_tx(
-		&self, mut justice_tx: Transaction, input_idx: usize, value: u64, commitment_number: u64
+	fn punish_revokeable_output(
+		&self, justice_tx: &Transaction, input_idx: usize, value: u64, commitment_number: u64
 	) -> Result<Transaction, ()> {
 		let secret = self.get_secret(commitment_number).ok_or(())?;
 		let per_commitment_key = SecretKey::from_slice(&secret).map_err(|_| ())?;
 		let their_per_commitment_point = PublicKey::from_secret_key(
 			&self.onchain_tx_handler.secp_ctx, &per_commitment_key);
-
-		let revocation_pubkey = RevocationKey::from_basepoint(&self.onchain_tx_handler.secp_ctx,
-			&self.holder_revocation_basepoint, &their_per_commitment_point);
-		let delayed_key = DelayedPaymentKey::from_basepoint(&self.onchain_tx_handler.secp_ctx,
-			&self.counterparty_commitment_params.counterparty_delayed_payment_base_key, &their_per_commitment_point);
-		let revokeable_redeemscript = chan_utils::get_revokeable_redeemscript(&revocation_pubkey,
-			self.counterparty_commitment_params.on_counterparty_tx_csv, &delayed_key);
-
-		let sig = self.onchain_tx_handler.signer.sign_justice_revoked_output(
-			&justice_tx, input_idx, value, &per_commitment_key, &self.onchain_tx_handler.secp_ctx)?;
-		justice_tx.input[input_idx].witness.push_ecdsa_signature(&BitcoinSignature::sighash_all(sig));
-		justice_tx.input[input_idx].witness.push(&[1u8]);
-		justice_tx.input[input_idx].witness.push(revokeable_redeemscript.as_bytes());
-		Ok(justice_tx)
+		self.onchain_tx_handler.signer.punish_revokeable_output(justice_tx, input_idx, value, &per_commitment_key, &self.onchain_tx_handler.secp_ctx, &their_per_commitment_point)
 	}
 
 	/// Can only fail if idx is < get_min_seen_secret

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -604,15 +604,9 @@ impl PackageSolvingData {
 	fn finalize_input<Signer: EcdsaChannelSigner>(&self, bumped_tx: &mut Transaction, i: usize, onchain_handler: &mut OnchainTxHandler<Signer>) -> bool {
 		match self {
 			PackageSolvingData::RevokedOutput(ref outp) => {
-				let chan_keys = TxCreationKeys::derive_new(&onchain_handler.secp_ctx, &outp.per_commitment_point, &outp.counterparty_delayed_payment_base_key, &outp.counterparty_htlc_base_key, &onchain_handler.signer.pubkeys().revocation_basepoint, &onchain_handler.signer.pubkeys().htlc_basepoint);
-				let witness_script = chan_utils::get_revokeable_redeemscript(&chan_keys.revocation_key, outp.on_counterparty_tx_csv, &chan_keys.broadcaster_delayed_payment_key);
 				//TODO: should we panic on signer failure ?
-				if let Ok(sig) = onchain_handler.signer.sign_justice_revoked_output(&bumped_tx, i, outp.amount.to_sat(), &outp.per_commitment_key, &onchain_handler.secp_ctx) {
-					let mut ser_sig = sig.serialize_der().to_vec();
-					ser_sig.push(EcdsaSighashType::All as u8);
-					bumped_tx.input[i].witness.push(ser_sig);
-					bumped_tx.input[i].witness.push(vec!(1));
-					bumped_tx.input[i].witness.push(witness_script.clone().into_bytes());
+				if let Ok(tx) = onchain_handler.signer.punish_revokeable_output(bumped_tx, i, outp.amount.to_sat(), &outp.per_commitment_key, &onchain_handler.secp_ctx, &outp.per_commitment_point) {
+					*bumped_tx = tx;
 				} else { return false; }
 			},
 			PackageSolvingData::RevokedHTLCOutput(ref outp) => {

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -704,13 +704,12 @@ pub(crate) fn make_funding_redeemscript_from_slices(broadcaster_funding_key: &[u
 ///
 /// Panics if htlc.transaction_output_index.is_none() (as such HTLCs do not appear in the
 /// commitment transaction).
-pub fn build_htlc_transaction(commitment_txid: &Txid, feerate_per_kw: u32, contest_delay: u16, htlc: &HTLCOutputInCommitment, channel_type_features: &ChannelTypeFeatures, broadcaster_delayed_payment_key: &DelayedPaymentKey, revocation_key: &RevocationKey) -> Transaction {
-	let txins= vec![build_htlc_input(commitment_txid, htlc, channel_type_features)];
+pub fn build_htlc_transaction(commitment_txid: &Txid, feerate_per_kw: u32, htlc: &HTLCOutputInCommitment, channel_type_features: &ChannelTypeFeatures, revokeable_spk: ScriptBuf) -> Transaction {
+	let txins = vec![build_htlc_input(commitment_txid, htlc, channel_type_features)];
 
 	let mut txouts: Vec<TxOut> = Vec::new();
 	txouts.push(build_htlc_output(
-		feerate_per_kw, contest_delay, htlc, channel_type_features,
-		broadcaster_delayed_payment_key, revocation_key
+		feerate_per_kw, htlc, channel_type_features, revokeable_spk,
 	));
 
 	Transaction {
@@ -734,7 +733,7 @@ pub(crate) fn build_htlc_input(commitment_txid: &Txid, htlc: &HTLCOutputInCommit
 }
 
 pub(crate) fn build_htlc_output(
-	feerate_per_kw: u32, contest_delay: u16, htlc: &HTLCOutputInCommitment, channel_type_features: &ChannelTypeFeatures, broadcaster_delayed_payment_key: &DelayedPaymentKey, revocation_key: &RevocationKey
+	feerate_per_kw: u32, htlc: &HTLCOutputInCommitment, channel_type_features: &ChannelTypeFeatures, revokeable_spk: ScriptBuf
 ) -> TxOut {
 	let weight = if htlc.offered {
 		htlc_timeout_tx_weight(channel_type_features)
@@ -749,7 +748,7 @@ pub(crate) fn build_htlc_output(
 	};
 
 	TxOut {
-		script_pubkey: get_revokeable_redeemscript(revocation_key, contest_delay, broadcaster_delayed_payment_key).to_p2wsh(),
+		script_pubkey: revokeable_spk,
 		value: output_value,
 	}
 }
@@ -1740,8 +1739,7 @@ impl<'a> TrustedCommitmentTransaction<'a> {
 	///
 	/// This function is only valid in the holder commitment context, it always uses EcdsaSighashType::All.
 	pub fn get_htlc_sigs<T: secp256k1::Signing, ES: Deref>(
-		&self, htlc_base_key: &SecretKey, channel_parameters: &DirectedChannelTransactionParameters,
-		entropy_source: &ES, secp_ctx: &Secp256k1<T>,
+		&self, htlc_base_key: &SecretKey, entropy_source: &ES, secp_ctx: &Secp256k1<T>, revokeable_spk: ScriptBuf,
 	) -> Result<Vec<Signature>, ()> where ES::Target: EntropySource {
 		let inner = self.inner;
 		let keys = &inner.keys;
@@ -1751,7 +1749,7 @@ impl<'a> TrustedCommitmentTransaction<'a> {
 
 		for this_htlc in inner.htlcs.iter() {
 			assert!(this_htlc.transaction_output_index.is_some());
-			let htlc_tx = build_htlc_transaction(&txid, inner.feerate_per_kw, channel_parameters.contest_delay(), &this_htlc, &self.channel_type_features, &keys.broadcaster_delayed_payment_key, &keys.revocation_key);
+			let htlc_tx = build_htlc_transaction(&txid, inner.feerate_per_kw, &this_htlc, &self.channel_type_features, revokeable_spk.clone());
 
 			let htlc_redeemscript = get_htlc_redeemscript_with_explicit_keys(&this_htlc, &self.channel_type_features, &keys.broadcaster_htlc_key, &keys.countersignatory_htlc_key, &keys.revocation_key);
 
@@ -1762,11 +1760,7 @@ impl<'a> TrustedCommitmentTransaction<'a> {
 	}
 
 	/// Builds the second-level holder HTLC transaction for the HTLC with index `htlc_index`.
-	pub(crate) fn build_unsigned_htlc_tx(
-		&self, channel_parameters: &DirectedChannelTransactionParameters, htlc_index: usize,
-		preimage: &Option<PaymentPreimage>,
-	) -> Transaction {
-		let keys = &self.inner.keys;
+	pub(crate) fn build_unsigned_htlc_tx(&self, htlc_index: usize, preimage: &Option<PaymentPreimage>, revokeable_spk: ScriptBuf) -> Transaction {
 		let this_htlc = &self.inner.htlcs[htlc_index];
 		assert!(this_htlc.transaction_output_index.is_some());
 		// if we don't have preimage for an HTLC-Success, we can't generate an HTLC transaction.
@@ -1775,8 +1769,8 @@ impl<'a> TrustedCommitmentTransaction<'a> {
 		if  this_htlc.offered && preimage.is_some() { unreachable!(); }
 
 		build_htlc_transaction(
-			&self.inner.built.txid, self.inner.feerate_per_kw, channel_parameters.contest_delay(), &this_htlc,
-			&self.channel_type_features, &keys.broadcaster_delayed_payment_key, &keys.revocation_key
+			&self.inner.built.txid, self.inner.feerate_per_kw, &this_htlc,
+			&self.channel_type_features, revokeable_spk,
 		)
 	}
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -5130,11 +5130,11 @@ impl<SP: Deref> Channel<SP> where
 
 		let mut nondust_htlc_sources = Vec::with_capacity(htlcs_cloned.len());
 		let mut htlcs_and_sigs = Vec::with_capacity(htlcs_cloned.len());
+		let revokeable_spk = self.context.holder_signer.as_ref().get_revokeable_spk(true, commitment_stats.tx.commitment_number(), &commitment_stats.tx.per_commitment_point(), &self.context.secp_ctx);
 		for (idx, (htlc, mut source_opt)) in htlcs_cloned.drain(..).enumerate() {
 			if let Some(_) = htlc.transaction_output_index {
 				let htlc_tx = chan_utils::build_htlc_transaction(&commitment_txid, commitment_stats.feerate_per_kw,
-					self.context.get_counterparty_selected_contest_delay().unwrap(), &htlc, &self.context.channel_type,
-					&keys.broadcaster_delayed_payment_key, &keys.revocation_key);
+					&htlc, &self.context.channel_type, revokeable_spk.clone());
 
 				let htlc_redeemscript = chan_utils::get_htlc_redeemscript(&htlc, &self.context.channel_type, &keys);
 				let htlc_sighashtype = if self.context.channel_type.supports_anchors_zero_fee_htlc_tx() { EcdsaSighashType::SinglePlusAnyoneCanPay } else { EcdsaSighashType::All };
@@ -8103,6 +8103,7 @@ impl<SP: Deref> Channel<SP> where
 						).map_err(|_| ChannelError::Ignore("Failed to get signatures for new commitment_signed".to_owned()))?;
 					signature = res.0;
 					htlc_signatures = res.1;
+					let revokeable_spk = ecdsa.get_revokeable_spk(false, commitment_stats.tx.commitment_number(), &commitment_stats.tx.per_commitment_point(), &self.context.secp_ctx);
 
 					log_trace!(logger, "Signed remote commitment tx {} (txid {}) with redeemscript {} -> {} in channel {}",
 						encode::serialize_hex(&commitment_stats.tx.trust().built_transaction().transaction),
@@ -8111,7 +8112,7 @@ impl<SP: Deref> Channel<SP> where
 
 					for (ref htlc_sig, ref htlc) in htlc_signatures.iter().zip(htlcs) {
 						log_trace!(logger, "Signed remote HTLC tx {} with redeemscript {} with pubkey {} -> {} in channel {}",
-							encode::serialize_hex(&chan_utils::build_htlc_transaction(&counterparty_commitment_txid, commitment_stats.feerate_per_kw, self.context.get_holder_selected_contest_delay(), htlc, &self.context.channel_type, &counterparty_keys.broadcaster_delayed_payment_key, &counterparty_keys.revocation_key)),
+							encode::serialize_hex(&chan_utils::build_htlc_transaction(&counterparty_commitment_txid, commitment_stats.feerate_per_kw, htlc, &self.context.channel_type, revokeable_spk.clone())),
 							encode::serialize_hex(&chan_utils::get_htlc_redeemscript(&htlc, &self.context.channel_type, &counterparty_keys)),
 							log_bytes!(counterparty_keys.broadcaster_htlc_key.to_public_key().serialize()),
 							log_bytes!(htlc_sig.serialize_compact()[..]), &self.context.channel_id());
@@ -11017,9 +11018,8 @@ mod tests {
 					let remote_signature = Signature::from_der(&<Vec<u8>>::from_hex($counterparty_htlc_sig_hex).unwrap()[..]).unwrap();
 
 					let ref htlc = htlcs[$htlc_idx];
-					let mut htlc_tx = chan_utils::build_htlc_transaction(&unsigned_tx.txid, chan.context.feerate_per_kw,
-						chan.context.get_counterparty_selected_contest_delay().unwrap(),
-						&htlc, $opt_anchors, &keys.broadcaster_delayed_payment_key, &keys.revocation_key);
+					let revokeable_spk = signer.get_revokeable_spk(true, holder_commitment_tx.commitment_number(), &holder_commitment_tx.per_commitment_point(), &secp_ctx);
+					let mut htlc_tx = chan_utils::build_htlc_transaction(&unsigned_tx.txid, chan.context.feerate_per_kw, &htlc, $opt_anchors, revokeable_spk);
 					let htlc_redeemscript = chan_utils::get_htlc_redeemscript(&htlc, $opt_anchors, &keys);
 					let htlc_sighashtype = if $opt_anchors.supports_anchors_zero_fee_htlc_tx() { EcdsaSighashType::SinglePlusAnyoneCanPay } else { EcdsaSighashType::All };
 					let htlc_sighash = Message::from_digest(sighash::SighashCache::new(&htlc_tx).p2wsh_signature_hash(0, &htlc_redeemscript, htlc.to_bitcoin_amount(), htlc_sighashtype).unwrap().as_raw_hash().to_byte_array());

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -3164,13 +3164,18 @@ impl<SP: Deref> ChannelContext<SP> where SP::Target: SignerProvider {
 		let channel_parameters =
 			if local { self.channel_transaction_parameters.as_holder_broadcastable() }
 			else { self.channel_transaction_parameters.as_counterparty_broadcastable() };
+		let broadcaster_payment_script = self.holder_signer.as_ref().get_revokeable_spk(local, commitment_number, &keys.per_commitment_point, &self.secp_ctx);
+		let broadcaster_txout = TxOut {
+			script_pubkey: broadcaster_payment_script,
+			value: Amount::from_sat(value_to_a as u64),
+		};
 		let counterparty_payment_script = self.holder_signer.as_ref().get_counterparty_payment_script(!local);
 		let counterparty_txout = TxOut {
 			script_pubkey: counterparty_payment_script,
 			value: Amount::from_sat(value_to_b as u64),
 		};
 		let tx = CommitmentTransaction::new_with_auxiliary_htlc_data(commitment_number,
-		                                                             value_to_a as u64,
+		                                                             broadcaster_txout,
 		                                                             counterparty_txout,
 		                                                             funding_pubkey_a,
 		                                                             funding_pubkey_b,

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -766,6 +766,11 @@ fn test_update_fee_that_funder_cannot_afford() {
 			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
 		).flatten().unwrap();
 		let local_chan_signer = local_chan.get_signer();
+		let broadcaster_payment_script = local_chan_signer.as_ref().get_revokeable_spk(false, INITIAL_COMMITMENT_NUMBER - 1, &commit_tx_keys.per_commitment_point, &secp_ctx);
+		let broadcaster_txout = TxOut {
+			script_pubkey: broadcaster_payment_script,
+			value: Amount::from_sat(push_sats),
+		};
 		let counterparty_payment_script = local_chan_signer.as_ref().get_counterparty_payment_script(true);
 		let counterparty_txout = TxOut {
 			script_pubkey: counterparty_payment_script,
@@ -774,7 +779,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 		let mut htlcs: Vec<(HTLCOutputInCommitment, ())> = vec![];
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
 			INITIAL_COMMITMENT_NUMBER - 1,
-			push_sats,
+			broadcaster_txout,
 			counterparty_txout,
 			local_funding, remote_funding,
 			commit_tx_keys.clone(),
@@ -1526,6 +1531,11 @@ fn test_fee_spike_violation_fails_htlc() {
 			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
 		).flatten().unwrap();
 		let local_chan_signer = local_chan.get_signer();
+		let broadcaster_payment_script = local_chan_signer.as_ref().get_revokeable_spk(false, commitment_number, &commit_tx_keys.per_commitment_point, &secp_ctx);
+		let broadcaster_txout = TxOut {
+			script_pubkey: broadcaster_payment_script,
+			value: Amount::from_sat(95000),
+		};
 		let counterparty_payment_script = local_chan_signer.as_ref().get_counterparty_payment_script(true);
 		let counterparty_txout = TxOut {
 			script_pubkey: counterparty_payment_script,
@@ -1533,7 +1543,7 @@ fn test_fee_spike_violation_fails_htlc() {
 		};
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
 			commitment_number,
-			95000,
+			broadcaster_txout,
 			counterparty_txout,
 			local_funding, remote_funding,
 			commit_tx_keys.clone(),

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -766,11 +766,16 @@ fn test_update_fee_that_funder_cannot_afford() {
 			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
 		).flatten().unwrap();
 		let local_chan_signer = local_chan.get_signer();
+		let counterparty_payment_script = local_chan_signer.as_ref().get_counterparty_payment_script(true);
+		let counterparty_txout = TxOut {
+			script_pubkey: counterparty_payment_script,
+			value: Amount::from_sat(channel_value - push_sats - commit_tx_fee_msat(non_buffer_feerate + 4, 0, &channel_type_features) / 1000),
+		};
 		let mut htlcs: Vec<(HTLCOutputInCommitment, ())> = vec![];
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
 			INITIAL_COMMITMENT_NUMBER - 1,
 			push_sats,
-			channel_value - push_sats - commit_tx_fee_msat(non_buffer_feerate + 4, 0, &channel_type_features) / 1000,
+			counterparty_txout,
 			local_funding, remote_funding,
 			commit_tx_keys.clone(),
 			non_buffer_feerate + 4,
@@ -1521,10 +1526,15 @@ fn test_fee_spike_violation_fails_htlc() {
 			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
 		).flatten().unwrap();
 		let local_chan_signer = local_chan.get_signer();
+		let counterparty_payment_script = local_chan_signer.as_ref().get_counterparty_payment_script(true);
+		let counterparty_txout = TxOut {
+			script_pubkey: counterparty_payment_script,
+			value: Amount::from_sat(local_chan_balance),
+		};
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
 			commitment_number,
 			95000,
-			local_chan_balance,
+			counterparty_txout,
 			local_funding, remote_funding,
 			commit_tx_keys.clone(),
 			feerate_per_kw,

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -1328,6 +1328,14 @@ impl InMemorySigner {
 			witness_script.as_bytes(),
 		]))
 	}
+
+	#[cfg(test)]
+	pub(crate) fn overwrite_channel_parameters(
+		&mut self, channel_parameters: &ChannelTransactionParameters,
+	) {
+		assert!(channel_parameters.is_populated(), "Channel parameters must be fully populated");
+		self.channel_parameters = Some(channel_parameters.clone());
+	}
 }
 
 impl EntropySource for InMemorySigner {

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -65,6 +65,7 @@ use crate::crypto::chacha20::ChaCha20;
 use crate::io::{self, Error};
 use crate::ln::msgs::DecodeError;
 use crate::prelude::*;
+use crate::sign::chan_utils::TxCreationKeys;
 use crate::sign::ecdsa::EcdsaChannelSigner;
 #[cfg(taproot)]
 use crate::sign::taproot::TaprootChannelSigner;
@@ -790,13 +791,28 @@ pub trait ChannelSigner {
 	/// channel_parameters.is_populated() MUST be true.
 	fn provide_channel_parameters(&mut self, channel_parameters: &ChannelTransactionParameters);
 
-	/// Returns the scriptpubkey that should be placed in the `to_remote` output of commitment
-	/// transactions. Assumes the signer has already been given the channel parameters via
+	/// Returns the script pubkey that should be placed in the `to_remote` output of commitment
+	/// transactions.
+	///
+	/// Assumes the signer has already been given the channel parameters via
 	/// `provide_channel_parameters`.
 	///
-	/// If `to_self` is set, return the `to_remote` script pubkey for the counterparty's commitment
+	/// If `to_self` is set, return the `to_remote` script pubkey for the remote party's commitment
 	/// transaction, otherwise, for the local party's.
 	fn get_counterparty_payment_script(&self, to_self: bool) -> ScriptBuf;
+
+	/// Returns the script pubkey that should be placed in the `to_local` output of commitment
+	/// transactions, and in the output of second level HTLC transactions.
+	///
+	/// Assumes the signer has already been given the channel parameters via
+	/// `provide_channel_parameters`.
+	///
+	/// If `to_self` is set, return the revokeable script pubkey for local party's
+	/// commitment / htlc transaction, otherwise, for the remote party's.
+	fn get_revokeable_spk(
+		&self, to_self: bool, commitment_number: u64, per_commitment_point: &PublicKey,
+		secp_ctx: &Secp256k1<secp256k1::All>,
+	) -> ScriptBuf;
 }
 
 /// Specifies the recipient of an invoice.
@@ -1398,6 +1414,30 @@ impl ChannelSigner for InMemorySigner {
 		};
 		let payment_point = &params.countersignatory_pubkeys().payment_point;
 		get_counterparty_payment_script(params.channel_type_features(), payment_point)
+	}
+
+	fn get_revokeable_spk(
+		&self, to_self: bool, _commitment_number: u64, per_commitment_point: &PublicKey,
+		secp_ctx: &Secp256k1<secp256k1::All>,
+	) -> ScriptBuf {
+		let params = if to_self {
+			self.channel_parameters.as_ref().unwrap().as_holder_broadcastable()
+		} else {
+			self.channel_parameters.as_ref().unwrap().as_counterparty_broadcastable()
+		};
+		let contest_delay = params.contest_delay();
+		let keys = TxCreationKeys::from_channel_static_keys(
+			per_commitment_point,
+			params.broadcaster_pubkeys(),
+			params.countersignatory_pubkeys(),
+			secp_ctx,
+		);
+		get_revokeable_redeemscript(
+			&keys.revocation_key,
+			contest_delay,
+			&keys.broadcaster_delayed_payment_key,
+		)
+		.to_p2wsh()
 	}
 }
 

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -308,7 +308,8 @@ impl EcdsaChannelSigner for TestChannelSigner {
 			}
 		}
 		assert_eq!(htlc_tx.input[input], htlc_descriptor.unsigned_tx_input());
-		assert_eq!(htlc_tx.output[input], htlc_descriptor.tx_output(secp_ctx));
+		let revokeable_spk = self.get_revokeable_spk(true, htlc_descriptor.per_commitment_number, &htlc_descriptor.per_commitment_point, secp_ctx);
+		assert_eq!(htlc_tx.output[input], htlc_descriptor.tx_output(revokeable_spk));
 		{
 			let witness_script = htlc_descriptor.witness_script(secp_ctx);
 			let sighash_type = if self.channel_type_features().supports_anchors_zero_fee_htlc_tx() {

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -162,6 +162,11 @@ impl TestChannelSigner {
 	fn is_signer_available(&self, signer_op: SignerOp) -> bool {
 		!self.get_enforcement_state().disabled_signer_ops.contains(&signer_op)
 	}
+
+	#[cfg(test)]
+	pub(crate) fn overwrite_channel_parameters(&mut self, channel_parameters: &ChannelTransactionParameters) {
+		self.inner.overwrite_channel_parameters(channel_parameters)
+	}
 }
 
 impl ChannelSigner for TestChannelSigner {

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -226,6 +226,13 @@ impl ChannelSigner for TestChannelSigner {
 	fn get_revokeable_spk(&self, to_self: bool, commitment_number: u64, per_commitment_point: &PublicKey, secp_ctx: &Secp256k1<secp256k1::All>) -> ScriptBuf {
 		self.inner.get_revokeable_spk(to_self, commitment_number, per_commitment_point, secp_ctx)
 	}
+
+	fn punish_revokeable_output(
+		&self, justice_tx: &Transaction, input: usize, amount: u64, per_commitment_key: &SecretKey,
+		secp_ctx: &Secp256k1<secp256k1::All>, per_commitment_point: &PublicKey,
+	) -> Result<Transaction, ()> {
+		self.inner.punish_revokeable_output(justice_tx, input, amount, per_commitment_key, secp_ctx, per_commitment_point)
+	}
 }
 
 impl EcdsaChannelSigner for TestChannelSigner {

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -517,7 +517,7 @@ impl<Signer: sign::ecdsa::EcdsaChannelSigner> chainmonitor::Persist<Signer> for 
 			while let Some(JusticeTxData { justice_tx, value, commitment_number }) = channel_state.front() {
 				let input_idx = 0;
 				let commitment_txid = justice_tx.input[input_idx].previous_output.txid;
-				match data.sign_to_local_justice_tx(justice_tx.clone(), input_idx, value.to_sat(), *commitment_number) {
+				match data.punish_revokeable_output(justice_tx, input_idx, value.to_sat(), *commitment_number) {
 					Ok(signed_justice_tx) => {
 						let dup = self.watchtower_state.lock().unwrap()
 							.get_mut(&funding_txo).unwrap()


### PR DESCRIPTION
See commit message for a description of this specific commit.

This begins work on allowing the customization of different outputs of the commitment transaction, in preparation for taproot channels and also to allow people to set the outputs to arbitrary scripts if they don't require compatibility with the formal LN spec.

This PR begins with the `to_remote` output, with the goal of illustrating the approach taken with a simple example.

If this approach is ok, I will next work on `StaticPaymentOutputDescriptor`, as it would need to be updated to handle the taproot / arbitrary scripts used in this output. I can do this work in this PR, or in a follow-up depending on your preference.

My approach is to ask the channel signers to do more work (but not more than that of most hardware wallets):
- Set the appropriate SPK's for the different outputs of the commitment transaction.
- Return the full witness to spend such an output (not just the signature); this is not shown here, but is the current plan for the `to_local` outputs in a justice scenario.

By putting scriptpubkey and witness construction behind the signer trait, we can have some parts of LDK be implemented in terms of scriptpubkeys and witnesses, and these parts can then remain the same across segwit, taproot, and arbitrary scripts.

Let me know what you think, thank you for your input.

cc @arik-so @TheBlueMatt

~~EDIT 2024-12-13~~

~~In cbac0e768098636e730e73573f5ca7ebb686dc0d I apply the same approach to the `to_local` output of the commit tx, and in 72ca0a9daac4e58d16fe8cb4e5182011d3b1f8fb same approach to the htlc tx output.~~

EDIT 2024-12-15

~~In the last two commits, I apply the same approach to the `to_local` output of the commit tx, and to the htlc tx output.~~

I also apply the same approach to the `to_local` output of the commit tx, and to the htlc tx output later in the same patchset.

Instead of returning only the witness when punishing a revokeable output, I instead choose to ask the `ChannelSigner` to return a full transaction with the specified input finalized to punish the corresponding previous output. This is primarily to leave the possibility of a signer to customize how the sequence field of the input is set.