### PR TITLE
Include counterparty node ids in PaymentForwarded 

### DIFF
--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -1184,6 +1184,17 @@ pub enum Event {
 		/// caveat described for the `total_fee_earned_msat` field. Moreover it will be `None` for
 		/// events generated or serialized by versions prior to 0.0.122.
 		next_user_channel_id: Option<u128>,
+
+		/// The node id of the previous node.
+		/// 
+		/// This is only `None` for events generated or serialized by versions prior to 0.1
+		prev_node_id: Option<PublicKey>,
+
+		/// The node id of the next node.
+		/// 
+		/// This is only `None` for events generated or serialized by versions prior to 0.1
+		next_node_id: Option<PublicKey>,
+
 		/// The total fee, in milli-satoshis, which was earned as a result of the payment.
 		///
 		/// Note that if we force-closed the channel over which we forwarded an HTLC while the HTLC
@@ -1601,8 +1612,8 @@ impl Writeable for Event {
 			}
 			&Event::PaymentForwarded {
 				prev_channel_id, next_channel_id, prev_user_channel_id, next_user_channel_id,
-				total_fee_earned_msat, skimmed_fee_msat, claim_from_onchain_tx,
-				outbound_amount_forwarded_msat,
+				prev_node_id, next_node_id, total_fee_earned_msat, skimmed_fee_msat,
+				claim_from_onchain_tx, outbound_amount_forwarded_msat,
 			} => {
 				7u8.write(writer)?;
 				write_tlv_fields!(writer, {
@@ -1614,6 +1625,8 @@ impl Writeable for Event {
 					(7, skimmed_fee_msat, option),
 					(9, prev_user_channel_id, option),
 					(11, next_user_channel_id, option),
+					(13, prev_node_id, option),
+					(15, next_node_id, option)
 				});
 			},
 			&Event::ChannelClosed { ref channel_id, ref user_channel_id, ref reason,
@@ -1981,6 +1994,8 @@ impl MaybeReadable for Event {
 					let mut next_channel_id = None;
 					let mut prev_user_channel_id = None;
 					let mut next_user_channel_id = None;
+					let mut prev_node_id = None;
+					let mut next_node_id = None;
 					let mut total_fee_earned_msat = None;
 					let mut skimmed_fee_msat = None;
 					let mut claim_from_onchain_tx = false;
@@ -1994,11 +2009,14 @@ impl MaybeReadable for Event {
 						(7, skimmed_fee_msat, option),
 						(9, prev_user_channel_id, option),
 						(11, next_user_channel_id, option),
+						(13, prev_node_id, option),
+						(15, next_node_id, option)
 					});
 					Ok(Some(Event::PaymentForwarded {
 						prev_channel_id, next_channel_id, prev_user_channel_id,
-						next_user_channel_id, total_fee_earned_msat, skimmed_fee_msat,
-						claim_from_onchain_tx, outbound_amount_forwarded_msat,
+						next_user_channel_id, prev_node_id, next_node_id,
+						total_fee_earned_msat, skimmed_fee_msat, claim_from_onchain_tx,
+						outbound_amount_forwarded_msat,
 					}))
 				};
 				f()

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -3502,7 +3502,7 @@ fn do_test_reload_mon_update_completion_actions(close_during_reload: bool) {
 	let bc_update_id = nodes[1].chain_monitor.latest_monitor_update_id.lock().unwrap().get(&chan_id_bc).unwrap().2;
 	let mut events = nodes[1].node.get_and_clear_pending_events();
 	assert_eq!(events.len(), if close_during_reload { 2 } else { 1 });
-	expect_payment_forwarded(events.pop().unwrap(), &nodes[1], &nodes[0], &nodes[2], Some(1000),
+	expect_payment_forwarded(events.pop().unwrap(), &nodes[1], Some(1000),
 		None, close_during_reload, false, false);
 	if close_during_reload {
 		match events[0] {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7309,6 +7309,7 @@ where
 			HTLCSource::PreviousHopData(hop_data) => {
 				let prev_channel_id = hop_data.channel_id;
 				let prev_user_channel_id = hop_data.user_channel_id;
+				let prev_node_id = hop_data.counterparty_node_id;
 				let completed_blocker = RAAMonitorUpdateBlockingAction::from_prev_hop_data(&hop_data);
 				self.claim_funds_from_hop(hop_data, payment_preimage, None,
 					|htlc_claim_value_msat, definitely_duplicate| {
@@ -7358,6 +7359,8 @@ where
 									next_channel_id: Some(next_channel_id),
 									prev_user_channel_id,
 									next_user_channel_id,
+									prev_node_id,
+									next_node_id: next_channel_counterparty_node_id,
 									total_fee_earned_msat,
 									skimmed_fee_msat,
 									claim_from_onchain_tx: from_onchain,


### PR DESCRIPTION
resolves #3455

This commit adds counterparty node IDs to `PaymentForwarded` to address the potential ambiguity of using `ChannelIds` alone, especially in cases like v1 0conf opens where `ChannelIds` may not be unique. Including the counterparty node IDs provides better clarity and makes the information more useful.
