### PR TITLE
[0.1] Bump versions to LDK 0.1.0, invoice 0.33.0, types 0.2.0, beta1

### DIFF
--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-background-processor"
-version = "0.0.124"
+version = "0.1.0-beta1"
 authors = ["Valentine Wallace <vwallace@protonmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
@@ -23,14 +23,14 @@ default = ["std"]
 bitcoin = { version = "0.32.2", default-features = false }
 bitcoin_hashes = { version = "0.14.0", default-features = false }
 bitcoin-io = { version = "0.1.2", default-features = false }
-lightning = { version = "0.0.124", path = "../lightning", default-features = false }
-lightning-rapid-gossip-sync = { version = "0.0.124", path = "../lightning-rapid-gossip-sync", default-features = false }
+lightning = { version = "0.1.0-beta1", path = "../lightning", default-features = false }
+lightning-rapid-gossip-sync = { version = "0.1.0-beta1", path = "../lightning-rapid-gossip-sync", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.35", features = [ "macros", "rt", "rt-multi-thread", "sync", "time" ] }
-lightning = { version = "0.0.124", path = "../lightning", features = ["_test_utils"] }
-lightning-invoice = { version = "0.32.0", path = "../lightning-invoice" }
-lightning-persister = { version = "0.0.124", path = "../lightning-persister" }
+lightning = { version = "0.1.0-beta1", path = "../lightning", features = ["_test_utils"] }
+lightning-invoice = { version = "0.33.0-beta1", path = "../lightning-invoice" }
+lightning-persister = { version = "0.1.0-beta1", path = "../lightning-persister" }
 
 [lints]
 workspace = true

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-block-sync"
-version = "0.0.124"
+version = "0.1.0-beta1"
 authors = ["Jeffrey Czyz", "Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
@@ -19,13 +19,13 @@ rpc-client = [ "serde_json", "chunked_transfer" ]
 
 [dependencies]
 bitcoin = "0.32.2"
-lightning = { version = "0.0.124", path = "../lightning" }
+lightning = { version = "0.1.0-beta1", path = "../lightning" }
 tokio = { version = "1.35", features = [ "io-util", "net", "time", "rt" ], optional = true }
 serde_json = { version = "1.0", optional = true }
 chunked_transfer = { version = "1.4", optional = true }
 
 [dev-dependencies]
-lightning = { version = "0.0.124", path = "../lightning", features = ["_test_utils"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", features = ["_test_utils"] }
 tokio = { version = "1.35", features = [ "macros", "rt" ] }
 
 [lints]

--- a/lightning-custom-message/Cargo.toml
+++ b/lightning-custom-message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-custom-message"
-version = "0.0.124"
+version = "0.1.0-beta1"
 authors = ["Jeffrey Czyz"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
@@ -15,7 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bitcoin = "0.32.2"
-lightning = { version = "0.0.124", path = "../lightning" }
+lightning = { version = "0.1.0-beta1", path = "../lightning" }
 
 [lints]
 workspace = true

--- a/lightning-dns-resolver/Cargo.toml
+++ b/lightning-dns-resolver/Cargo.toml
@@ -8,12 +8,12 @@ description = "A crate which implements DNSSEC resolution for lightning clients 
 edition = "2021"
 
 [dependencies]
-lightning = { version = "0.0.124", path = "../lightning", default-features = false }
-lightning-types = { version = "0.1", path = "../lightning-types", default-features = false }
+lightning = { version = "0.1.0-beta1", path = "../lightning", default-features = false }
+lightning-types = { version = "0.2.0-beta1", path = "../lightning-types", default-features = false }
 dnssec-prover = { version = "0.6", default-features = false, features = [ "std", "tokio" ] }
 tokio = { version = "1.0", default-features = false, features = ["rt"] }
 
 [dev-dependencies]
 bitcoin = { version = "0.32" }
 tokio = { version = "1.0", default-features = false, features = ["macros", "time"] }
-lightning = { version = "0.0.124", path = "../lightning", features = ["dnssec", "_test_utils"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", features = ["dnssec", "_test_utils"] }

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lightning-invoice"
 description = "Data structures to parse and serialize BOLT11 lightning invoices"
-version = "0.32.0"
+version = "0.33.0-beta1"
 authors = ["Sebastian Geisler <sgeisler@wh2.tu-dresden.de>"]
 documentation = "https://docs.rs/lightning-invoice/"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ std = []
 
 [dependencies]
 bech32 = { version = "0.11.0", default-features = false }
-lightning-types = { version = "0.1.0", path = "../lightning-types", default-features = false }
+lightning-types = { version = "0.2.0-beta1", path = "../lightning-types", default-features = false }
 serde = { version = "1.0.118", optional = true }
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 

--- a/lightning-liquidity/Cargo.toml
+++ b/lightning-liquidity/Cargo.toml
@@ -19,9 +19,9 @@ std = ["lightning/std"]
 backtrace = ["dep:backtrace"]
 
 [dependencies]
-lightning = { version = "0.0.124", path = "../lightning", default-features = false }
-lightning-types = { version = "0.1", path = "../lightning-types", default-features = false }
-lightning-invoice = { version = "0.32.0", path = "../lightning-invoice", default-features = false, features = ["serde"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", default-features = false }
+lightning-types = { version = "0.2.0-beta1", path = "../lightning-types", default-features = false }
+lightning-invoice = { version = "0.33.0-beta1", path = "../lightning-invoice", default-features = false, features = ["serde"] }
 
 bitcoin = { version = "0.32.2", default-features = false, features = ["serde"] }
 
@@ -31,10 +31,10 @@ serde_json = "1.0"
 backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]
-lightning = { version = "0.0.124", path = "../lightning", default-features = false, features = ["_test_utils"] }
-lightning-invoice = { version = "0.32.0", path = "../lightning-invoice", default-features = false, features = ["serde", "std"] }
-lightning-persister = { version = "0.0.124", path = "../lightning-persister", default-features = false }
-lightning-background-processor = { version = "0.0.124", path = "../lightning-background-processor", default-features = false, features = ["std"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", default-features = false, features = ["_test_utils"] }
+lightning-invoice = { version = "0.33.0-beta1", path = "../lightning-invoice", default-features = false, features = ["serde", "std"] }
+lightning-persister = { version = "0.1.0-beta1", path = "../lightning-persister", default-features = false }
+lightning-background-processor = { version = "0.1.0-beta1", path = "../lightning-background-processor", default-features = false, features = ["std"] }
 
 proptest = "1.0.0"
 tokio = { version = "1.35", default-features = false, features = [ "rt-multi-thread", "time", "sync", "macros" ] }

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-net-tokio"
-version = "0.0.124"
+version = "0.1.0-beta1"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning/"
@@ -16,12 +16,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bitcoin = "0.32.2"
-lightning = { version = "0.0.124", path = "../lightning" }
+lightning = { version = "0.1.0-beta1", path = "../lightning" }
 tokio = { version = "1.35", features = [ "rt", "sync", "net", "time" ] }
 
 [dev-dependencies]
 tokio = { version = "1.35", features = [ "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
-lightning = { version = "0.0.124", path = "../lightning", features = ["_test_utils"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", features = ["_test_utils"] }
 
 [lints]
 workspace = true

--- a/lightning-persister/Cargo.toml
+++ b/lightning-persister/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-persister"
-version = "0.0.124"
+version = "0.1.0-beta1"
 authors = ["Valentine Wallace", "Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
@@ -15,7 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bitcoin = "0.32.2"
-lightning = { version = "0.0.124", path = "../lightning" }
+lightning = { version = "0.1.0-beta1", path = "../lightning" }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48.0", default-features = false, features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
@@ -24,7 +24,7 @@ windows-sys = { version = "0.48.0", default-features = false, features = ["Win32
 criterion = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-lightning = { version = "0.0.124", path = "../lightning", features = ["_test_utils"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", features = ["_test_utils"] }
 bitcoin = { version = "0.32.2", default-features = false }
 
 [lints]

--- a/lightning-rapid-gossip-sync/Cargo.toml
+++ b/lightning-rapid-gossip-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-rapid-gossip-sync"
-version = "0.0.124"
+version = "0.1.0-beta1"
 authors = ["Arik Sosman <git@arik.io>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
@@ -14,7 +14,7 @@ default = ["std"]
 std = ["bitcoin-io/std", "bitcoin_hashes/std"]
 
 [dependencies]
-lightning = { version = "0.0.124", path = "../lightning", default-features = false }
+lightning = { version = "0.1.0-beta1", path = "../lightning", default-features = false }
 bitcoin = { version = "0.32.2", default-features = false }
 bitcoin_hashes = { version = "0.14.0", default-features = false }
 bitcoin-io = { version = "0.1.2", default-features = false }
@@ -23,7 +23,7 @@ bitcoin-io = { version = "0.1.2", default-features = false }
 criterion = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-lightning = { version = "0.0.124", path = "../lightning", features = ["_test_utils"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", features = ["_test_utils"] }
 
 [lints]
 workspace = true

--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-transaction-sync"
-version = "0.0.124"
+version = "0.1.0-beta1"
 authors = ["Elias Rohrer"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
@@ -23,7 +23,7 @@ electrum = ["electrum-client"]
 async-interface = []
 
 [dependencies]
-lightning = { version = "0.0.124", path = "../lightning", default-features = false, features = ["std"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", default-features = false, features = ["std"] }
 lightning-macros = { version = "0.1", path = "../lightning-macros", default-features = false }
 bitcoin = { version = "0.32.2", default-features = false }
 futures = { version = "0.3", optional = true }
@@ -31,7 +31,7 @@ esplora-client = { version = "0.11", default-features = false, optional = true }
 electrum-client = { version = "0.21.0", optional = true }
 
 [dev-dependencies]
-lightning = { version = "0.0.124", path = "../lightning", default-features = false, features = ["std", "_test_utils"] }
+lightning = { version = "0.1.0-beta1", path = "../lightning", default-features = false, features = ["std", "_test_utils"] }
 tokio = { version = "1.35.0", features = ["macros"] }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]

--- a/lightning-types/Cargo.toml
+++ b/lightning-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-types"
-version = "0.1.0"
+version = "0.2.0-beta1"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning/"

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning"
-version = "0.0.124"
+version = "0.1.0-beta1"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning/"
@@ -33,8 +33,8 @@ grind_signatures = []
 default = ["std", "grind_signatures"]
 
 [dependencies]
-lightning-types = { version = "0.1.0", path = "../lightning-types", default-features = false }
-lightning-invoice = { version = "0.32.0", path = "../lightning-invoice", default-features = false }
+lightning-types = { version = "0.2.0-beta1", path = "../lightning-types", default-features = false }
+lightning-invoice = { version = "0.33.0-beta1", path = "../lightning-invoice", default-features = false }
 
 bech32 = { version = "0.11.0", default-features = false }
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
@@ -50,7 +50,7 @@ libm = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 regex = "1.5.6"
-lightning-types = { version = "0.1.0", path = "../lightning-types", features = ["_test_utils"] }
+lightning-types = { version = "0.2.0-beta1", path = "../lightning-types", features = ["_test_utils"] }
 
 [dev-dependencies.bitcoin]
 version = "0.32.2"


### PR DESCRIPTION
Sadly, both `lightning-invoice` and `lightning-types` need a minor version bump as they both upgraded `bech32` which changed the public API.