### PR TITLE
Introduce check for dangling RAA blockers in test_utils

### DIFF
--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -652,6 +652,11 @@ impl<'a, 'b, 'c> Drop for Node<'a, 'b, 'c> {
 				panic!("Had {} excess added monitors on node {}", added_monitors.len(), self.logger.id);
 			}
 
+			let raa_blockers = self.node.get_and_clear_pending_raa_blockers();
+			if !raa_blockers.is_empty() {
+				panic!( "Had excess RAA blockers on node {}: {:?}", self.logger.id, raa_blockers);
+			}
+
 			// Check that if we serialize the network graph, we can deserialize it again.
 			let network_graph = {
 				let mut w = test_utils::TestVecWriter(Vec::new());


### PR DESCRIPTION
Partially addresses #3381

## Summary
This PR addresses the issue of unhandled dangling RAA blockers during testing by introducing a check in Node::Drop().

## Changes:

1. Added a validation in `Node::Drop()` to ensure no dangling RAA blockers remain unhandled.
2. Updated the test to handle RAA blockers, fixing the failure caused by the new validation.