### PR TITLE
Refactor `ChannelPhase` variants from `ChannelManager`

### DIFF
--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -20,7 +20,7 @@ use crate::chain::transaction::OutPoint;
 use crate::chain::{ChannelMonitorUpdateStatus, Listen, Watch};
 use crate::events::{Event, MessageSendEvent, MessageSendEventsProvider, PaymentPurpose, ClosureReason, HTLCDestination};
 use crate::ln::channelmanager::{RAACommitmentOrder, PaymentSendFailure, PaymentId, RecipientOnionFields};
-use crate::ln::channel::{AnnouncementSigsState, ChannelPhase};
+use crate::ln::channel::AnnouncementSigsState;
 use crate::ln::msgs;
 use crate::ln::types::ChannelId;
 use crate::ln::msgs::{ChannelMessageHandler, RoutingMessageHandler};
@@ -98,7 +98,7 @@ fn test_monitor_and_persister_update_fail() {
 	{
 		let mut node_0_per_peer_lock;
 		let mut node_0_peer_state_lock;
-		if let ChannelPhase::Funded(ref mut channel) = get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, chan.2) {
+		if let Some(channel) = get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, chan.2).as_funded_mut() {
 			if let Ok(Some(update)) = channel.commitment_signed(&updates.commitment_signed, &node_cfgs[0].logger) {
 				// Check that the persister returns InProgress (and will never actually complete)
 				// as the monitor update errors.

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1134,11 +1134,11 @@ pub(super) enum Channel<SP: Deref> where SP::Target: SignerProvider {
 	Funded(FundedChannel<SP>),
 }
 
-impl<'a, SP: Deref> Channel<SP> where
+impl<SP: Deref> Channel<SP> where
 	SP::Target: SignerProvider,
 	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
 {
-	pub fn context(&'a self) -> &'a ChannelContext<SP> {
+	pub fn context(&self) -> &ChannelContext<SP> {
 		match self {
 			Channel::Funded(chan) => &chan.context,
 			Channel::UnfundedOutboundV1(chan) => &chan.context,
@@ -1147,7 +1147,7 @@ impl<'a, SP: Deref> Channel<SP> where
 		}
 	}
 
-	pub fn context_mut(&'a mut self) -> &'a mut ChannelContext<SP> {
+	pub fn context_mut(&mut self) -> &mut ChannelContext<SP> {
 		match self {
 			Channel::Funded(ref mut chan) => &mut chan.context,
 			Channel::UnfundedOutboundV1(ref mut chan) => &mut chan.context,

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1185,6 +1185,34 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 		}
 	}
 
+	pub fn as_unfunded_outbound_v1_mut(&mut self) -> Option<&mut OutboundV1Channel<SP>> {
+		if let ChannelPhase::UnfundedOutboundV1(channel) = self {
+			Some(channel)
+		} else {
+			None
+		}
+	}
+
+	pub fn is_unfunded_outbound_v1(&self) -> bool {
+		matches!(self, ChannelPhase::UnfundedOutboundV1(_))
+	}
+
+	pub fn into_unfunded_outbound_v1(self) -> Result<OutboundV1Channel<SP>, Self> {
+		if let ChannelPhase::UnfundedOutboundV1(channel) = self {
+			Ok(channel)
+		} else {
+			Err(self)
+		}
+	}
+
+	pub fn into_unfunded_inbound_v1(self) -> Result<InboundV1Channel<SP>, Self> {
+		if let ChannelPhase::UnfundedInboundV1(channel) = self {
+			Ok(channel)
+		} else {
+			Err(self)
+		}
+	}
+
 	pub fn as_unfunded_v2(&self) -> Option<&PendingV2Channel<SP>> {
 		if let ChannelPhase::UnfundedV2(channel) = self {
 			Some(channel)

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1152,6 +1152,22 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 			ChannelPhase::UnfundedV2(ref mut chan) => &mut chan.context,
 		}
 	}
+
+	pub fn as_funded(&self) -> Option<&Channel<SP>> {
+		if let ChannelPhase::Funded(channel) = self {
+			Some(channel)
+		} else {
+			None
+		}
+	}
+
+	pub fn as_funded_mut(&mut self) -> Option<&mut Channel<SP>> {
+		if let ChannelPhase::Funded(channel) = self {
+			Some(channel)
+		} else {
+			None
+		}
+	}
 }
 
 /// Contains all state common to unfunded inbound/outbound channels.

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1358,6 +1358,16 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 }
 
+impl<SP: Deref> From<Channel<SP>> for ChannelPhase<SP>
+where
+	SP::Target: SignerProvider,
+	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
+{
+	fn from(channel: Channel<SP>) -> Self {
+		ChannelPhase::Funded(channel)
+	}
+}
+
 /// Contains all state common to unfunded inbound/outbound channels.
 pub(super) struct UnfundedChannelContext {
 	/// A counter tracking how many ticks have elapsed since this unfunded channel was

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1180,6 +1180,14 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 			None
 		}
 	}
+
+	pub fn as_unfunded_v2_mut(&mut self) -> Option<&mut PendingV2Channel<SP>> {
+		if let ChannelPhase::UnfundedV2(channel) = self {
+			Some(channel)
+		} else {
+			None
+		}
+	}
 }
 
 /// Contains all state common to unfunded inbound/outbound channels.

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1378,6 +1378,16 @@ where
 	}
 }
 
+impl<SP: Deref> From<PendingV2Channel<SP>> for ChannelPhase<SP>
+where
+	SP::Target: SignerProvider,
+	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
+{
+	fn from(channel: PendingV2Channel<SP>) -> Self {
+		ChannelPhase::UnfundedV2(channel)
+	}
+}
+
 impl<SP: Deref> From<Channel<SP>> for ChannelPhase<SP>
 where
 	SP::Target: SignerProvider,

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1201,6 +1201,14 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 		}
 	}
 
+	pub fn into_unfunded_v2(self) -> Option<PendingV2Channel<SP>> {
+		if let ChannelPhase::UnfundedV2(channel) = self {
+			Some(channel)
+		} else {
+			None
+		}
+	}
+
 	pub fn signer_maybe_unblocked<L: Deref>(
 		&mut self, chain_hash: ChainHash, logger: &L,
 	) -> Option<SignerResumeUpdates> where L::Target: Logger {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1156,6 +1156,15 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 		}
 	}
 
+	pub fn unfunded_context_mut(&mut self) -> Option<&mut UnfundedChannelContext> {
+		match self {
+			ChannelPhase::Funded(_) => { debug_assert!(false); None },
+			ChannelPhase::UnfundedOutboundV1(chan) => Some(&mut chan.unfunded_context),
+			ChannelPhase::UnfundedInboundV1(chan) => Some(&mut chan.unfunded_context),
+			ChannelPhase::UnfundedV2(chan) => Some(&mut chan.unfunded_context),
+		}
+	}
+
 	pub fn is_funded(&self) -> bool {
 		matches!(self, ChannelPhase::Funded(_))
 	}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1124,9 +1124,9 @@ impl_writeable_tlv_based!(PendingChannelMonitorUpdate, {
 	(0, update, required),
 });
 
-/// The `ChannelPhase` enum describes the current phase in life of a lightning channel with each of
+/// The `Channel` enum describes the current phase in life of a lightning channel with each of
 /// its variants containing an appropriate channel struct.
-pub(super) enum ChannelPhase<SP: Deref> where SP::Target: SignerProvider {
+pub(super) enum Channel<SP: Deref> where SP::Target: SignerProvider {
 	UnfundedOutboundV1(OutboundV1Channel<SP>),
 	UnfundedInboundV1(InboundV1Channel<SP>),
 	#[allow(dead_code)] // TODO(dual_funding): Remove once creating V2 channels is enabled.
@@ -1134,43 +1134,43 @@ pub(super) enum ChannelPhase<SP: Deref> where SP::Target: SignerProvider {
 	Funded(FundedChannel<SP>),
 }
 
-impl<'a, SP: Deref> ChannelPhase<SP> where
+impl<'a, SP: Deref> Channel<SP> where
 	SP::Target: SignerProvider,
 	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
 {
 	pub fn context(&'a self) -> &'a ChannelContext<SP> {
 		match self {
-			ChannelPhase::Funded(chan) => &chan.context,
-			ChannelPhase::UnfundedOutboundV1(chan) => &chan.context,
-			ChannelPhase::UnfundedInboundV1(chan) => &chan.context,
-			ChannelPhase::UnfundedV2(chan) => &chan.context,
+			Channel::Funded(chan) => &chan.context,
+			Channel::UnfundedOutboundV1(chan) => &chan.context,
+			Channel::UnfundedInboundV1(chan) => &chan.context,
+			Channel::UnfundedV2(chan) => &chan.context,
 		}
 	}
 
 	pub fn context_mut(&'a mut self) -> &'a mut ChannelContext<SP> {
 		match self {
-			ChannelPhase::Funded(ref mut chan) => &mut chan.context,
-			ChannelPhase::UnfundedOutboundV1(ref mut chan) => &mut chan.context,
-			ChannelPhase::UnfundedInboundV1(ref mut chan) => &mut chan.context,
-			ChannelPhase::UnfundedV2(ref mut chan) => &mut chan.context,
+			Channel::Funded(ref mut chan) => &mut chan.context,
+			Channel::UnfundedOutboundV1(ref mut chan) => &mut chan.context,
+			Channel::UnfundedInboundV1(ref mut chan) => &mut chan.context,
+			Channel::UnfundedV2(ref mut chan) => &mut chan.context,
 		}
 	}
 
 	pub fn unfunded_context_mut(&mut self) -> Option<&mut UnfundedChannelContext> {
 		match self {
-			ChannelPhase::Funded(_) => { debug_assert!(false); None },
-			ChannelPhase::UnfundedOutboundV1(chan) => Some(&mut chan.unfunded_context),
-			ChannelPhase::UnfundedInboundV1(chan) => Some(&mut chan.unfunded_context),
-			ChannelPhase::UnfundedV2(chan) => Some(&mut chan.unfunded_context),
+			Channel::Funded(_) => { debug_assert!(false); None },
+			Channel::UnfundedOutboundV1(chan) => Some(&mut chan.unfunded_context),
+			Channel::UnfundedInboundV1(chan) => Some(&mut chan.unfunded_context),
+			Channel::UnfundedV2(chan) => Some(&mut chan.unfunded_context),
 		}
 	}
 
 	pub fn is_funded(&self) -> bool {
-		matches!(self, ChannelPhase::Funded(_))
+		matches!(self, Channel::Funded(_))
 	}
 
 	pub fn as_funded(&self) -> Option<&FundedChannel<SP>> {
-		if let ChannelPhase::Funded(channel) = self {
+		if let Channel::Funded(channel) = self {
 			Some(channel)
 		} else {
 			None
@@ -1178,7 +1178,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 
 	pub fn as_funded_mut(&mut self) -> Option<&mut FundedChannel<SP>> {
-		if let ChannelPhase::Funded(channel) = self {
+		if let Channel::Funded(channel) = self {
 			Some(channel)
 		} else {
 			None
@@ -1186,7 +1186,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 
 	pub fn as_unfunded_outbound_v1_mut(&mut self) -> Option<&mut OutboundV1Channel<SP>> {
-		if let ChannelPhase::UnfundedOutboundV1(channel) = self {
+		if let Channel::UnfundedOutboundV1(channel) = self {
 			Some(channel)
 		} else {
 			None
@@ -1194,11 +1194,11 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 
 	pub fn is_unfunded_outbound_v1(&self) -> bool {
-		matches!(self, ChannelPhase::UnfundedOutboundV1(_))
+		matches!(self, Channel::UnfundedOutboundV1(_))
 	}
 
 	pub fn into_unfunded_outbound_v1(self) -> Result<OutboundV1Channel<SP>, Self> {
-		if let ChannelPhase::UnfundedOutboundV1(channel) = self {
+		if let Channel::UnfundedOutboundV1(channel) = self {
 			Ok(channel)
 		} else {
 			Err(self)
@@ -1206,7 +1206,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 
 	pub fn into_unfunded_inbound_v1(self) -> Result<InboundV1Channel<SP>, Self> {
-		if let ChannelPhase::UnfundedInboundV1(channel) = self {
+		if let Channel::UnfundedInboundV1(channel) = self {
 			Ok(channel)
 		} else {
 			Err(self)
@@ -1214,7 +1214,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 
 	pub fn as_unfunded_v2(&self) -> Option<&PendingV2Channel<SP>> {
-		if let ChannelPhase::UnfundedV2(channel) = self {
+		if let Channel::UnfundedV2(channel) = self {
 			Some(channel)
 		} else {
 			None
@@ -1222,7 +1222,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 
 	pub fn as_unfunded_v2_mut(&mut self) -> Option<&mut PendingV2Channel<SP>> {
-		if let ChannelPhase::UnfundedV2(channel) = self {
+		if let Channel::UnfundedV2(channel) = self {
 			Some(channel)
 		} else {
 			None
@@ -1230,7 +1230,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 
 	pub fn into_unfunded_v2(self) -> Option<PendingV2Channel<SP>> {
-		if let ChannelPhase::UnfundedV2(channel) = self {
+		if let Channel::UnfundedV2(channel) = self {
 			Some(channel)
 		} else {
 			None
@@ -1241,8 +1241,8 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 		&mut self, chain_hash: ChainHash, logger: &L,
 	) -> Option<SignerResumeUpdates> where L::Target: Logger {
 		match self {
-			ChannelPhase::Funded(chan) => Some(chan.signer_maybe_unblocked(logger)),
-			ChannelPhase::UnfundedOutboundV1(chan) => {
+			Channel::Funded(chan) => Some(chan.signer_maybe_unblocked(logger)),
+			Channel::UnfundedOutboundV1(chan) => {
 				let (open_channel, funding_created) = chan.signer_maybe_unblocked(chain_hash, logger);
 				Some(SignerResumeUpdates {
 					commitment_update: None,
@@ -1258,7 +1258,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 					shutdown_result: None,
 				})
 			},
-			ChannelPhase::UnfundedInboundV1(chan) => {
+			Channel::UnfundedInboundV1(chan) => {
 				let logger = WithChannelContext::from(logger, &chan.context, None);
 				let accept_channel = chan.signer_maybe_unblocked(&&logger);
 				Some(SignerResumeUpdates {
@@ -1275,16 +1275,16 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 					shutdown_result: None,
 				})
 			},
-			ChannelPhase::UnfundedV2(_) => None,
+			Channel::UnfundedV2(_) => None,
 		}
 	}
 
 	pub fn is_resumable(&self) -> bool {
 		match self {
-			ChannelPhase::Funded(_) => false,
-			ChannelPhase::UnfundedOutboundV1(chan) => chan.is_resumable(),
-			ChannelPhase::UnfundedInboundV1(_) => false,
-			ChannelPhase::UnfundedV2(_) => false,
+			Channel::Funded(_) => false,
+			Channel::UnfundedOutboundV1(chan) => chan.is_resumable(),
+			Channel::UnfundedInboundV1(_) => false,
+			Channel::UnfundedV2(_) => false,
 		}
 	}
 
@@ -1292,13 +1292,13 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 		&mut self, chain_hash: ChainHash, logger: &L,
 	) -> Option<OpenChannelMessage> where L::Target: Logger {
 		match self {
-			ChannelPhase::Funded(_) => None,
-			ChannelPhase::UnfundedOutboundV1(chan) => {
+			Channel::Funded(_) => None,
+			Channel::UnfundedOutboundV1(chan) => {
 				let logger = WithChannelContext::from(logger, &chan.context, None);
 				chan.get_open_channel(chain_hash, &&logger)
 					.map(|msg| OpenChannelMessage::V1(msg))
 			},
-			ChannelPhase::UnfundedInboundV1(_) => {
+			Channel::UnfundedInboundV1(_) => {
 				// Since unfunded inbound channel maps are cleared upon disconnecting a peer,
 				// they are not persisted and won't be recovered after a crash.
 				// Therefore, they shouldn't exist at this point.
@@ -1306,7 +1306,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 				None
 			},
 			#[cfg(dual_funding)]
-			ChannelPhase::UnfundedV2(chan) => {
+			Channel::UnfundedV2(chan) => {
 				if chan.context.is_outbound() {
 					Some(OpenChannelMessage::V2(chan.get_open_channel_v2(chain_hash)))
 				} else {
@@ -1318,7 +1318,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 				}
 			},
 			#[cfg(not(dual_funding))]
-			ChannelPhase::UnfundedV2(_) => {
+			Channel::UnfundedV2(_) => {
 				debug_assert!(false);
 				None
 			},
@@ -1333,15 +1333,15 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 		L::Target: Logger,
 	{
 		match self {
-			ChannelPhase::Funded(_) => Ok(None),
-			ChannelPhase::UnfundedOutboundV1(chan) => {
+			Channel::Funded(_) => Ok(None),
+			Channel::UnfundedOutboundV1(chan) => {
 				let logger = WithChannelContext::from(logger, &chan.context, None);
 				chan.maybe_handle_error_without_close(chain_hash, fee_estimator, &&logger)
 					.map(|msg| Some(OpenChannelMessage::V1(msg)))
 			},
-			ChannelPhase::UnfundedInboundV1(_) => Ok(None),
+			Channel::UnfundedInboundV1(_) => Ok(None),
 			#[cfg(dual_funding)]
-			ChannelPhase::UnfundedV2(chan) => {
+			Channel::UnfundedV2(chan) => {
 				if chan.context.is_outbound() {
 					chan.maybe_handle_error_without_close(chain_hash, fee_estimator)
 						.map(|msg| Some(OpenChannelMessage::V2(msg)))
@@ -1350,7 +1350,7 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 				}
 			},
 			#[cfg(not(dual_funding))]
-			ChannelPhase::UnfundedV2(_) => {
+			Channel::UnfundedV2(_) => {
 				debug_assert!(false);
 				Ok(None)
 			},
@@ -1358,43 +1358,43 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 }
 
-impl<SP: Deref> From<OutboundV1Channel<SP>> for ChannelPhase<SP>
+impl<SP: Deref> From<OutboundV1Channel<SP>> for Channel<SP>
 where
 	SP::Target: SignerProvider,
 	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
 {
 	fn from(channel: OutboundV1Channel<SP>) -> Self {
-		ChannelPhase::UnfundedOutboundV1(channel)
+		Channel::UnfundedOutboundV1(channel)
 	}
 }
 
-impl<SP: Deref> From<InboundV1Channel<SP>> for ChannelPhase<SP>
+impl<SP: Deref> From<InboundV1Channel<SP>> for Channel<SP>
 where
 	SP::Target: SignerProvider,
 	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
 {
 	fn from(channel: InboundV1Channel<SP>) -> Self {
-		ChannelPhase::UnfundedInboundV1(channel)
+		Channel::UnfundedInboundV1(channel)
 	}
 }
 
-impl<SP: Deref> From<PendingV2Channel<SP>> for ChannelPhase<SP>
+impl<SP: Deref> From<PendingV2Channel<SP>> for Channel<SP>
 where
 	SP::Target: SignerProvider,
 	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
 {
 	fn from(channel: PendingV2Channel<SP>) -> Self {
-		ChannelPhase::UnfundedV2(channel)
+		Channel::UnfundedV2(channel)
 	}
 }
 
-impl<SP: Deref> From<FundedChannel<SP>> for ChannelPhase<SP>
+impl<SP: Deref> From<FundedChannel<SP>> for Channel<SP>
 where
 	SP::Target: SignerProvider,
 	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
 {
 	fn from(channel: FundedChannel<SP>) -> Self {
-		ChannelPhase::Funded(channel)
+		Channel::Funded(channel)
 	}
 }
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1358,6 +1358,16 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 	}
 }
 
+impl<SP: Deref> From<OutboundV1Channel<SP>> for ChannelPhase<SP>
+where
+	SP::Target: SignerProvider,
+	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
+{
+	fn from(channel: OutboundV1Channel<SP>) -> Self {
+		ChannelPhase::UnfundedOutboundV1(channel)
+	}
+}
+
 impl<SP: Deref> From<Channel<SP>> for ChannelPhase<SP>
 where
 	SP::Target: SignerProvider,

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1153,6 +1153,10 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 		}
 	}
 
+	pub fn is_funded(&self) -> bool {
+		matches!(self, ChannelPhase::Funded(_))
+	}
+
 	pub fn as_funded(&self) -> Option<&Channel<SP>> {
 		if let ChannelPhase::Funded(channel) = self {
 			Some(channel)

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1172,6 +1172,14 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 			None
 		}
 	}
+
+	pub fn as_unfunded_v2(&self) -> Option<&PendingV2Channel<SP>> {
+		if let ChannelPhase::UnfundedV2(channel) = self {
+			Some(channel)
+		} else {
+			None
+		}
+	}
 }
 
 /// Contains all state common to unfunded inbound/outbound channels.

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1233,6 +1233,15 @@ impl<'a, SP: Deref> ChannelPhase<SP> where
 			ChannelPhase::UnfundedV2(_) => None,
 		}
 	}
+
+	pub fn is_resumable(&self) -> bool {
+		match self {
+			ChannelPhase::Funded(_) => false,
+			ChannelPhase::UnfundedOutboundV1(chan) => chan.is_resumable(),
+			ChannelPhase::UnfundedInboundV1(_) => false,
+			ChannelPhase::UnfundedV2(_) => false,
+		}
+	}
 }
 
 /// Contains all state common to unfunded inbound/outbound channels.

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1368,6 +1368,16 @@ where
 	}
 }
 
+impl<SP: Deref> From<InboundV1Channel<SP>> for ChannelPhase<SP>
+where
+	SP::Target: SignerProvider,
+	<SP::Target as SignerProvider>::EcdsaSigner: ChannelSigner,
+{
+	fn from(channel: InboundV1Channel<SP>) -> Self {
+		ChannelPhase::UnfundedInboundV1(channel)
+	}
+}
+
 impl<SP: Deref> From<Channel<SP>> for ChannelPhase<SP>
 where
 	SP::Target: SignerProvider,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7689,7 +7689,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 									msg,
 								}
 							});
-							(*temporary_channel_id, ChannelPhase::UnfundedInboundV1(channel), message_send_event)
+							(*temporary_channel_id, ChannelPhase::from(channel), message_send_event)
 						})
 					},
 					#[cfg(dual_funding)]
@@ -7977,7 +7977,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 						msg,
 					}
 				});
-				(ChannelPhase::UnfundedInboundV1(channel), message_send_event)
+				(ChannelPhase::from(channel), message_send_event)
 			},
 			#[cfg(dual_funding)]
 			OpenChannelMessageRef::V2(msg) => {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7713,7 +7713,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 								node_id: channel.context.get_counterparty_node_id(),
 								msg: channel.accept_inbound_dual_funded_channel()
 							};
-							(channel.context.channel_id(), ChannelPhase::UnfundedV2(channel), Some(message_send_event))
+							(channel.context.channel_id(), ChannelPhase::from(channel), Some(message_send_event))
 						})
 					},
 				}
@@ -7991,7 +7991,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					node_id: *counterparty_node_id,
 					msg: channel.accept_inbound_dual_funded_channel(),
 				};
-				(ChannelPhase::UnfundedV2(channel), Some(message_send_event))
+				(ChannelPhase::from(channel), Some(message_send_event))
 			},
 		};
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1366,13 +1366,7 @@ impl <SP: Deref> PeerState<SP> where SP::Target: SignerProvider {
 				return false;
 			}
 		}
-		!self.channel_by_id.iter().any(|(_, phase)|
-			match phase {
-				ChannelPhase::Funded(_) | ChannelPhase::UnfundedOutboundV1(_) => true,
-				ChannelPhase::UnfundedInboundV1(_) => false,
-				ChannelPhase::UnfundedV2(chan) => chan.context.is_outbound(),
-			}
-		)
+		!self.channel_by_id.iter().any(|(_, channel)| channel.is_funded() || channel.context().is_outbound())
 			&& self.monitor_update_blocked_actions.is_empty()
 			&& self.closed_channel_monitor_update_ids.is_empty()
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8124,7 +8124,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 								});
 							}
 
-							if let Some(chan) = e.insert(ChannelPhase::Funded(chan)).as_funded_mut() {
+							if let Some(chan) = e.insert(ChannelPhase::from(chan)).as_funded_mut() {
 								handle_new_monitor_update!(self, persist_state, peer_state_lock, peer_state,
 									per_peer_state, chan, INITIAL_MONITOR);
 							} else {
@@ -8171,7 +8171,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 								// We really should be able to insert here without doing a second
 								// lookup, but sadly rust stdlib doesn't currently allow keeping
 								// the original Entry around with the value removed.
-								let chan = peer_state.channel_by_id.entry(msg.channel_id).or_insert(ChannelPhase::Funded(chan));
+								let chan = peer_state.channel_by_id.entry(msg.channel_id).or_insert(ChannelPhase::from(chan));
 								if let Some(chan) = chan.as_funded_mut() {
 									handle_new_monitor_update!(self, persist_status, peer_state_lock, peer_state, per_peer_state, chan, INITIAL_MONITOR);
 								} else { unreachable!(); }
@@ -8326,7 +8326,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 									.into()))
 						},
 					}.map_err(|err| MsgHandleErrInternal::send_err_msg_no_close(format!("{}", err), msg.channel_id))?;
-					peer_state.channel_by_id.insert(channel_id, ChannelPhase::Funded(channel));
+					peer_state.channel_by_id.insert(channel_id, ChannelPhase::from(channel));
 					if let Some(funding_ready_for_sig_event) = funding_ready_for_sig_event_opt {
 						let mut pending_events = self.pending_events.lock().unwrap();
 						pending_events.push_back((funding_ready_for_sig_event, None));
@@ -13253,7 +13253,7 @@ where
 					per_peer_state.entry(channel.context.get_counterparty_node_id())
 						.or_insert_with(|| Mutex::new(empty_peer_state()))
 						.get_mut().unwrap()
-						.channel_by_id.insert(channel.context.channel_id(), ChannelPhase::Funded(channel));
+						.channel_by_id.insert(channel.context.channel_id(), ChannelPhase::from(channel));
 				}
 			} else if channel.is_awaiting_initial_mon_persist() {
 				// If we were persisted and shut down while the initial ChannelMonitor persistence

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3668,7 +3668,7 @@ where
 					panic!("RNG is bad???");
 				}
 			},
-			hash_map::Entry::Vacant(entry) => { entry.insert(ChannelPhase::UnfundedOutboundV1(channel)); }
+			hash_map::Entry::Vacant(entry) => { entry.insert(ChannelPhase::from(channel)); }
 		}
 
 		if let Some(msg) = res {
@@ -5116,7 +5116,7 @@ where
 						return Err(APIError::ChannelUnavailable { err });
 					}
 				}
-				e.insert(ChannelPhase::UnfundedOutboundV1(chan));
+				e.insert(ChannelPhase::from(chan));
 			}
 		}
 		Ok(())

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -3605,9 +3605,7 @@ macro_rules! get_channel_value_stat {
 	($node: expr, $counterparty_node: expr, $channel_id: expr) => {{
 		let peer_state_lock = $node.node.per_peer_state.read().unwrap();
 		let chan_lock = peer_state_lock.get(&$counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
-		let chan = chan_lock.channel_by_id.get(&$channel_id).map(
-			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
-		).flatten().unwrap();
+		let chan = chan_lock.channel_by_id.get(&$channel_id).and_then(ChannelPhase::as_funded).unwrap();
 		chan.get_value_stat()
 	}}
 }

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -3605,7 +3605,7 @@ macro_rules! get_channel_value_stat {
 	($node: expr, $counterparty_node: expr, $channel_id: expr) => {{
 		let peer_state_lock = $node.node.per_peer_state.read().unwrap();
 		let chan_lock = peer_state_lock.get(&$counterparty_node.node.get_our_node_id()).unwrap().lock().unwrap();
-		let chan = chan_lock.channel_by_id.get(&$channel_id).and_then(ChannelPhase::as_funded).unwrap();
+		let chan = chan_lock.channel_by_id.get(&$channel_id).and_then(Channel::as_funded).unwrap();
 		chan.get_value_stat()
 	}}
 }

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -21,7 +21,7 @@ use crate::sign::{ecdsa::EcdsaChannelSigner, EntropySource, OutputSpender, Signe
 use crate::events::{Event, FundingInfo, MessageSendEvent, MessageSendEventsProvider, PathFailure, PaymentPurpose, ClosureReason, HTLCDestination, PaymentFailureReason};
 use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentPreimage, PaymentSecret, PaymentHash};
-use crate::ln::channel::{CONCURRENT_INBOUND_HTLC_FEE_BUFFER, FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE, MIN_AFFORDABLE_HTLC_COUNT, get_holder_selected_channel_reserve_satoshis, OutboundV1Channel, InboundV1Channel, COINBASE_MATURITY, ChannelPhase};
+use crate::ln::channel::{CONCURRENT_INBOUND_HTLC_FEE_BUFFER, FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE, MIN_AFFORDABLE_HTLC_COUNT, get_holder_selected_channel_reserve_satoshis, OutboundV1Channel, InboundV1Channel, COINBASE_MATURITY, Channel};
 use crate::ln::channelmanager::{self, PaymentId, RAACommitmentOrder, PaymentSendFailure, RecipientOnionFields, BREAKDOWN_TIMEOUT, ENABLE_GOSSIP_TICKS, DISABLE_GOSSIP_TICKS, MIN_CLTV_EXPIRY_DELTA};
 use crate::ln::channel::{DISCONNECT_PEER_AWAITING_RESPONSE_TICKS, ChannelError};
 use crate::ln::{chan_utils, onion_utils};
@@ -216,7 +216,7 @@ fn do_test_counterparty_no_reserve(send_from_initiator: bool) {
 
 		let channel_phase = get_channel_ref!(sender_node, counterparty_node, sender_node_per_peer_lock, sender_node_peer_state_lock, temp_channel_id);
 		match channel_phase {
-			ChannelPhase::UnfundedInboundV1(_) | ChannelPhase::UnfundedOutboundV1(_) => {
+			Channel::UnfundedInboundV1(_) | Channel::UnfundedOutboundV1(_) => {
 				let chan_context = channel_phase.context_mut();
 				chan_context.holder_selected_channel_reserve_satoshis = 0;
 				chan_context.holder_max_htlc_value_in_flight_msat = 100_000_000;
@@ -734,7 +734,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 	let (local_revocation_basepoint, local_htlc_basepoint, local_funding) = {
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let local_chan = chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
+		let local_chan = chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let chan_signer = local_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
@@ -743,7 +743,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
 		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
-		let remote_chan = chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
+		let remote_chan = chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
@@ -758,7 +758,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 	let res = {
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let local_chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
+		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let local_chan_signer = local_chan.get_signer();
 		let mut htlcs: Vec<(HTLCOutputInCommitment, ())> = vec![];
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
@@ -1464,7 +1464,7 @@ fn test_fee_spike_violation_fails_htlc() {
 	let (local_revocation_basepoint, local_htlc_basepoint, local_secret, next_local_point, local_funding) = {
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let local_chan = chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
+		let local_chan = chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let chan_signer = local_chan.get_signer();
 		// Make the signer believe we validated another commitment, so we can release the secret
 		chan_signer.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
@@ -1478,7 +1478,7 @@ fn test_fee_spike_violation_fails_htlc() {
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
 		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
-		let remote_chan = chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
+		let remote_chan = chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
@@ -1507,7 +1507,7 @@ fn test_fee_spike_violation_fails_htlc() {
 	let res = {
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let local_chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
+		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let local_chan_signer = local_chan.get_signer();
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
 			commitment_number,
@@ -7774,7 +7774,7 @@ fn test_counterparty_raa_skip_no_crash() {
 	{
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let mut guard = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let keys = guard.channel_by_id.get(&channel_id).and_then(ChannelPhase::as_funded).unwrap()
+		let keys = guard.channel_by_id.get(&channel_id).and_then(Channel::as_funded).unwrap()
 			.get_signer();
 
 		const INITIAL_COMMITMENT_NUMBER: u64 = (1 << 48) - 1;
@@ -9221,11 +9221,11 @@ fn test_duplicate_chan_id() {
 		// try to create another channel. Instead, we drop the channel entirely here (leaving the
 		// channelmanager in a possibly nonsense state instead).
 		match a_peer_state.channel_by_id.remove(&open_chan_2_msg.common_fields.temporary_channel_id).unwrap() {
-			ChannelPhase::UnfundedOutboundV1(mut chan) => {
+			Channel::UnfundedOutboundV1(mut chan) => {
 				let logger = test_utils::TestLogger::new();
 				chan.get_funding_created(tx.clone(), funding_outpoint, false, &&logger).map_err(|_| ()).unwrap()
 			},
-			_ => panic!("Unexpected ChannelPhase variant"),
+			_ => panic!("Unexpected Channel variant"),
 		}.unwrap()
 	};
 	check_added_monitors!(nodes[0], 0);
@@ -9927,10 +9927,10 @@ fn do_test_max_dust_htlc_exposure(dust_outbound_balance: bool, exposure_breach_e
 		let mut node_0_per_peer_lock;
 		let mut node_0_peer_state_lock;
 		match get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, temporary_channel_id) {
-			ChannelPhase::UnfundedOutboundV1(chan) => {
+			Channel::UnfundedOutboundV1(chan) => {
 				chan.context.holder_dust_limit_satoshis = 546;
 			},
-			_ => panic!("Unexpected ChannelPhase variant"),
+			_ => panic!("Unexpected Channel variant"),
 		}
 	}
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -734,9 +734,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 	let (local_revocation_basepoint, local_htlc_basepoint, local_funding) = {
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let local_chan = chan_lock.channel_by_id.get(&chan.2).map(
-			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
-		).flatten().unwrap();
+		let local_chan = chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
 		let chan_signer = local_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
@@ -745,9 +743,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
 		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
-		let remote_chan = chan_lock.channel_by_id.get(&chan.2).map(
-			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
-		).flatten().unwrap();
+		let remote_chan = chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
@@ -762,9 +758,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 	let res = {
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let local_chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).map(
-			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
-		).flatten().unwrap();
+		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
 		let local_chan_signer = local_chan.get_signer();
 		let mut htlcs: Vec<(HTLCOutputInCommitment, ())> = vec![];
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
@@ -1470,9 +1464,7 @@ fn test_fee_spike_violation_fails_htlc() {
 	let (local_revocation_basepoint, local_htlc_basepoint, local_secret, next_local_point, local_funding) = {
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let local_chan = chan_lock.channel_by_id.get(&chan.2).map(
-			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
-		).flatten().unwrap();
+		let local_chan = chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
 		let chan_signer = local_chan.get_signer();
 		// Make the signer believe we validated another commitment, so we can release the secret
 		chan_signer.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
@@ -1486,9 +1478,7 @@ fn test_fee_spike_violation_fails_htlc() {
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
 		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
-		let remote_chan = chan_lock.channel_by_id.get(&chan.2).map(
-			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
-		).flatten().unwrap();
+		let remote_chan = chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
 		let chan_signer = remote_chan.get_signer();
 		let pubkeys = chan_signer.as_ref().pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
@@ -1517,9 +1507,7 @@ fn test_fee_spike_violation_fails_htlc() {
 	let res = {
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let local_chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).map(
-			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
-		).flatten().unwrap();
+		let local_chan = local_chan_lock.channel_by_id.get(&chan.2).and_then(ChannelPhase::as_funded).unwrap();
 		let local_chan_signer = local_chan.get_signer();
 		let commitment_tx = CommitmentTransaction::new_with_auxiliary_htlc_data(
 			commitment_number,
@@ -7786,9 +7774,8 @@ fn test_counterparty_raa_skip_no_crash() {
 	{
 		let per_peer_state = nodes[0].node.per_peer_state.read().unwrap();
 		let mut guard = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
-		let keys = guard.channel_by_id.get_mut(&channel_id).map(
-			|phase| if let ChannelPhase::Funded(chan) = phase { Some(chan) } else { None }
-		).flatten().unwrap().get_signer();
+		let keys = guard.channel_by_id.get(&channel_id).and_then(ChannelPhase::as_funded).unwrap()
+			.get_signer();
 
 		const INITIAL_COMMITMENT_NUMBER: u64 = (1 << 48) - 1;
 
@@ -8523,7 +8510,7 @@ fn test_update_err_monitor_lockdown() {
 	{
 		let mut node_0_per_peer_lock;
 		let mut node_0_peer_state_lock;
-		if let ChannelPhase::Funded(ref mut channel) = get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, chan_1.2) {
+		if let Some(channel) = get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, chan_1.2).as_funded_mut() {
 			if let Ok(Some(update)) = channel.commitment_signed(&updates.commitment_signed, &node_cfgs[0].logger) {
 				assert_eq!(watchtower.chain_monitor.update_channel(outpoint, &update), ChannelMonitorUpdateStatus::InProgress);
 				assert_eq!(nodes[0].chain_monitor.update_channel(outpoint, &update), ChannelMonitorUpdateStatus::Completed);
@@ -8625,7 +8612,7 @@ fn test_concurrent_monitor_claim() {
 	{
 		let mut node_0_per_peer_lock;
 		let mut node_0_peer_state_lock;
-		if let ChannelPhase::Funded(ref mut channel) = get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, chan_1.2) {
+		if let Some(channel) = get_channel_ref!(nodes[0], nodes[1], node_0_per_peer_lock, node_0_peer_state_lock, chan_1.2).as_funded_mut() {
 			if let Ok(Some(update)) = channel.commitment_signed(&updates.commitment_signed, &node_cfgs[0].logger) {
 				// Watchtower Alice should already have seen the block and reject the update
 				assert_eq!(watchtower_alice.chain_monitor.update_channel(outpoint, &update), ChannelMonitorUpdateStatus::InProgress);


### PR DESCRIPTION
Exposing `ChannelPhase` in `ChannelManager` has led to verbose `match` statements, which need to be modified each time a `ChannelPhase` is added. Making `ChannelPhase` an implementation detail of `Channel` would help avoid
this.

This PR is a step in that direction by removing direct use of `ChannelPhase` variants from `ChannelManager`. Instead, various methods are added to `ChannelPhase` in order to obtain the underlying structs held by each variant. `Channel` is also renamed to `FundedChannel` such that `ChannelPhase` can be renamed to `Channel`. A follow-up PR will hide `ChannelPhase` inside `Channel`, if desired.

Based on #3498.