### PR TITLE
Expand #3313 test

### DIFF
--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -2319,11 +2319,10 @@ fn no_double_pay_with_stale_channelmanager() {
 		.without_clearing_recipient_events();
 	do_pass_along_path(args);
 
-	expect_recent_payment!(nodes[0], RecentPaymentDetails::Pending, payment_id);
-	match get_event!(nodes[1], Event::PaymentClaimable) {
-		Event::PaymentClaimable { .. } => {},
+	let payment_preimage = match get_event!(nodes[1], Event::PaymentClaimable) {
+		Event::PaymentClaimable { purpose, .. } => purpose.preimage(),
 		_ => panic!("No Event::PaymentClaimable"),
-	}
+	};
 
 	// Reload with the stale manager and check that receiving the invoice again won't result in a
 	// duplicate payment attempt.

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -2281,7 +2281,8 @@ fn no_double_pay_with_stale_channelmanager() {
 	let alice_id = nodes[0].node.get_our_node_id();
 	let bob_id = nodes[1].node.get_our_node_id();
 
-	let amt_msat = nodes[0].node.list_usable_channels()[0].next_outbound_htlc_limit_msat + 1; // Force MPP
+	// ??: The amount need to be modified to match the total amount received to bob, why?
+	let amt_msat = nodes[0].node.list_usable_channels()[0].next_outbound_htlc_limit_msat + 1000; // Force MPP
 	let offer = nodes[1].node
 		.create_offer_builder(None).unwrap()
 		.clear_paths()
@@ -2320,7 +2321,7 @@ fn no_double_pay_with_stale_channelmanager() {
 	do_pass_along_path(args);
 
 	let payment_preimage = match get_event!(nodes[1], Event::PaymentClaimable) {
-		Event::PaymentClaimable { purpose, .. } => purpose.preimage(),
+		Event::PaymentClaimable { purpose, .. } => purpose.preimage().unwrap(),
 		_ => panic!("No Event::PaymentClaimable"),
 	};
 
@@ -2351,4 +2352,8 @@ fn no_double_pay_with_stale_channelmanager() {
 	check_closed_broadcast!(nodes[1], true);
 	check_added_monitors!(nodes[1], 2);
 	check_closed_event!(nodes[1], 2, ClosureReason::HolderForceClosed { broadcasted_latest_txn: Some(true) }, [alice_id, alice_id], 10_000_000);
+
+	nodes[1].node.claim_funds(payment_preimage);
+	expect_payment_claimed!(nodes[1], payment_hash, amt_msat);
+	check_added_monitors!(nodes[1], 2);
 }

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -2341,5 +2341,15 @@ fn no_double_pay_with_stale_channelmanager() {
 	// Alice and Bob is closed. Since no 2nd attempt should be made, check that no events are
 	// generated in response to the duplicate invoice.
 	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
-}
 
+	// Claim payment on chain
+
+	// First close the channel between bob and alice, from bob's side
+	let error_message = "Channel force-closed";
+	nodes[1].node.force_close_broadcasting_latest_txn(&chan_id_0, &alice_id, error_message.to_string()).unwrap();
+	check_closed_broadcast!(nodes[1], true);
+	nodes[1].node.force_close_broadcasting_latest_txn(&chan_id_1, &alice_id, error_message.to_string()).unwrap();
+	check_closed_broadcast!(nodes[1], true);
+	check_added_monitors!(nodes[1], 2);
+	check_closed_event!(nodes[1], 2, ClosureReason::HolderForceClosed { broadcasted_latest_txn: Some(true) }, [alice_id, alice_id], 10_000_000);
+}


### PR DESCRIPTION
Resolves #3320

This PR expands the test introduced in #3313 to include claiming the payment on-chain after Alice's node reloads. It ensures that, once we verify Alice's node does not reattempt paying a duplicate invoice, the payment process is also completed successfully.