### PR TITLE
ci: silence unnecessary_map_or lint as solution requires MSRV >= 1.70

### DIFF
--- a/ci/check-lint.sh
+++ b/ci/check-lint.sh
@@ -93,4 +93,5 @@ RUSTFLAGS='-D warnings' cargo clippy -- \
 	-A clippy::unnecessary_to_owned \
 	-A clippy::unnecessary_unwrap \
 	-A clippy::unused_unit \
-	-A clippy::useless_conversion
+	-A clippy::useless_conversion \
+	-A clippy::unnecessary_map_or `# to be removed once we hit MSRV 1.70`


### PR DESCRIPTION
Rust 1.84.0 was recently released along with some new clippy lints, one of which is `unnecessary_map_or`. Unfortunately this lint suggests using `Option::is_some_and` as a fix, but this is only available in Rust
 version >= 1.70, while we still have an MSRV of 1.63. So we silence that
lint for now.

We'd still like our lint CI to use stable Rust so that we can benefit from new lint checks which may be helpful and don't require an MSRV bump, but sometimes new lints (like in this case) do.

See:
  https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
  https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some_and