### PR TITLE
Add a backport GitHub Actions workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,37 @@
+# Adapted from https://github.com/NixOS/nixpkgs/blob/24a8c64/.github/workflows/backport.yml
+# Under the MIT license with original copyright:
+# Copyright (c) 2003-2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
+
+name: Backport
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+# WARNING:
+# When extending this action, be aware that $GITHUB_TOKEN allows write access to
+# the GitHub repository. This means that it should not evaluate user input in a
+# way that allows code injection.
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  backport:
+    name: Backport Pull Request
+    if: github.repository_owner == 'lightningdevkit' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Create backport PRs
+        uses: korthout/backport-action@be567af183754f6a5d831ae90f648954763f17f5 # v3.1.0
+        with:
+          # If you want any labels copied over from the original PR, use copy_labels_pattern.
+          # See: https://github.com/korthout/backport-action#backport-action
+          # copy_labels_pattern: 'severity:\ssecurity'
+          pull_description: |-
+            Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
+
+            * [ ] Please ensure that this backport is acceptable for release.


### PR DESCRIPTION
Now that we have release branches such as 0.1, we would like some convenient way to backport certain PRs that target `main`.

This workflow was adapted from the one in the NixOS/nixpkgs repo and works as follows:

To attempt to automatically create a PR that backports a PR merged to main, add the `backport X.Y` label to the merged PR where `X.Y` is an existing release branch (e.g `backport 0.1`). If the action is able to cherry-pick all the commits of the merged PR into a new PR targeting the `X.Y` branch, then the backport PR will be created. Otherwise, the GitHub Actions bot will reply to the merged PR indicating that there were merge conflicts and that you will manually need to backport by cherry-picking and resolving those conflicts.

NOTE: For this action to work we must allow GitHub Actions to create pull requests. This checkbox can be found in settings at Actions > General > Workflow permissions.