### PR TITLE
Support `Bolt12Invoice::payment_paths` in bindings

### DIFF
--- a/lightning/src/offers/invoice_macros.rs
+++ b/lightning/src/offers/invoice_macros.rs
@@ -109,9 +109,6 @@ macro_rules! invoice_accessors_common { ($self: ident, $contents: expr, $invoice
 	/// Blinded paths provide recipient privacy by obfuscating its node id. Note, however, that this
 	/// privacy is lost if a public node id is used for
 	#[doc = concat!("[`", stringify!($invoice_type), "::signing_pubkey`].")]
-	///
-	/// This is not exported to bindings users as slices with non-reference types cannot be ABI
-	/// matched in another language.
 	pub fn payment_paths(&$self) -> &[BlindedPaymentPath] {
 		$contents.payment_paths()
 	}


### PR DESCRIPTION
Lack of bindings support was because the method used to return a slice of tuples, it seems. Now that it returns `&[BlindedPaymentPath]`, bindings should be possible given that they can be generated for `Bolt12Invoice::message_paths`.