### PR TITLE
Drop spurious debug assertion in sweeping logic

### DIFF
--- a/lightning/src/util/sweep.rs
+++ b/lightning/src/util/sweep.rs
@@ -173,7 +173,6 @@ impl OutputSpendStatus {
 				latest_broadcast_height,
 				..
 			} => {
-				debug_assert!(confirmation_height >= *latest_broadcast_height);
 				*self = Self::PendingThresholdConfirmations {
 					first_broadcast_hash: *first_broadcast_hash,
 					latest_broadcast_height: *latest_broadcast_height,


### PR DESCRIPTION
With the `Confirm` interface, transaction confirmations can come in at any time, so asserting that a confirmation is more recent than the last time we broadcasted a transaction can lead to spurious assertion failures.