### PR TITLE
Move `lightning-transaction-sync` tests to dedicated script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
-        toolchain: [ stable, beta, 1.63.0 ] # 1.63.0 is the MSRV for all crates.
+        toolchain: [ stable, beta, 1.63.0 ] # 1.63.0 is the MSRV for all crates but `lightning-transaction-sync`.
         exclude:
           - platform: windows-latest
             toolchain: 1.63.0
@@ -44,6 +44,27 @@ jobs:
       - name: Set RUSTFLAGS to deny warnings
         if: "matrix.toolchain == '1.63.0'"
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"
+      - name: Run CI script
+        shell: bash # Default on Winblows is powershell
+        run: CI_ENV=1 CI_MINIMIZE_DISK_USAGE=1 ./ci/ci-tests.sh
+
+  build-tx-sync:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ ubuntu-latest, macos-latest ]
+        toolchain: [ stable, beta, 1.75.0 ] # 1.75.0 is the MSRV for `lightning-transaction-sync`.
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Install Rust ${{ matrix.toolchain }} toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ matrix.toolchain }}
+          rustup override set ${{ matrix.toolchain }}
+      - name: Set RUSTFLAGS to deny warnings
+        if: "matrix.toolchain == '1.75.0'"
+        run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"
       - name: Enable caching for bitcoind
         id: cache-bitcoind
         uses: actions/cache@v4
@@ -57,7 +78,7 @@ jobs:
           path: bin/electrs-${{ runner.os }}-${{ runner.arch }}
           key: electrs-${{ runner.os }}-${{ runner.arch }}
       - name: Download bitcoind/electrs
-        if: "matrix.platform != 'windows-latest' && (steps.cache-bitcoind.outputs.cache-hit != 'true' || steps.cache-electrs.outputs.cache-hit != 'true')"
+        if: "steps.cache-bitcoind.outputs.cache-hit != 'true' || steps.cache-electrs.outputs.cache-hit != 'true'"
         run: |
             source ./contrib/download_bitcoind_electrs.sh
             mkdir bin
@@ -69,7 +90,7 @@ jobs:
             echo "ELECTRS_EXE=$( pwd )/bin/electrs-${{ runner.os }}-${{ runner.arch }}" >> "$GITHUB_ENV"
       - name: Run CI script
         shell: bash # Default on Winblows is powershell
-        run: CI_ENV=1 CI_MINIMIZE_DISK_USAGE=1 ./ci/ci-tests.sh
+        run: CI_ENV=1 CI_MINIMIZE_DISK_USAGE=1 ./ci/ci-tx-sync-tests.sh
 
   coverage:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ members = [
     "lightning-background-processor",
     "lightning-rapid-gossip-sync",
     "lightning-custom-message",
-    "lightning-transaction-sync",
     "lightning-macros",
     "lightning-dns-resolver",
     "lightning-liquidity",
@@ -21,6 +20,7 @@ members = [
 ]
 
 exclude = [
+    "lightning-transaction-sync",
     "no-std-check",
     "msrv-no-dev-deps-check",
     "bench",

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -2,7 +2,6 @@
 set -eox pipefail
 
 RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
-HOST_PLATFORM="$(rustc --version --verbose | grep "host:" | awk '{ print $2 }')"
 
 # Some crates require pinning to meet our MSRV even for our downstream users,
 # which we do here.
@@ -10,19 +9,6 @@ HOST_PLATFORM="$(rustc --version --verbose | grep "host:" | awk '{ print $2 }')"
 function PIN_RELEASE_DEPS {
 	# Starting with version 1.39.0, the `tokio` crate has an MSRV of rustc 1.70.0
 	[ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p tokio --precise "1.38.1" --verbose
-
-	# Starting with version 0.7.12, the `tokio-util` crate has an MSRV of rustc 1.70.0
-	[ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p tokio-util --precise "0.7.11" --verbose
-
-	# url 2.5.3 switched to idna 1.0.3 and ICU4X, which requires rustc 1.67 or newer.
-	# Here we opt to keep using unicode-rs by pinning idna_adapter as described here: https://docs.rs/crate/idna_adapter/1.2.0
-	[ "$RUSTC_MINOR_VERSION" -lt 67 ] && cargo update -p idna_adapter --precise "1.1.0" --verbose
-
-	# indexmap 2.6.0 upgraded to hashbrown 0.15, which unfortunately bumped their MSRV to rustc 1.65 with the 0.15.1 release (and 2.7.0 was released since).
-	[ "$RUSTC_MINOR_VERSION" -lt 65 ] && cargo update -p indexmap@2.7.0 --precise "2.5.0" --verbose
-
-	# Starting with version 0.23.20, the `rustls` crate has an MSRV of rustc 1.71.0
-	[ "$RUSTC_MINOR_VERSION" -lt 71 ] && cargo update -p rustls@0.23.20 --precise "0.23.19" --verbose
 
 	return 0 # Don't fail the script if our rustc is higher than the last check
 }
@@ -35,15 +21,12 @@ PIN_RELEASE_DEPS # pin the release dependencies in our main workspace
 # The addr2line v0.21 crate (a dependency of `backtrace` starting with 0.3.69) relies on rustc 1.65
 [ "$RUSTC_MINOR_VERSION" -lt 65 ] && cargo update -p backtrace --precise "0.3.68" --verbose
 
-# Starting with version 0.5.9 (there is no .6-.8), the `home` crate has an MSRV of rustc 1.70.0.
-[ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p home --precise "0.5.5" --verbose
-
 # proptest 1.3.0 requires rustc 1.64.0
 [ "$RUSTC_MINOR_VERSION" -lt 64 ] && cargo update -p proptest --precise "1.2.0" --verbose
 
 export RUST_BACKTRACE=1
 
-echo -e "\n\nChecking the full workspace."
+echo -e "\n\nChecking the workspace, except lightning-transaction-sync."
 cargo check --verbose --color always
 
 # When the workspace members change, make sure to update the list here as well
@@ -58,7 +41,6 @@ WORKSPACE_MEMBERS=(
 	lightning-background-processor
 	lightning-rapid-gossip-sync
 	lightning-custom-message
-	lightning-transaction-sync
 	lightning-macros
 	lightning-dns-resolver
 	lightning-liquidity
@@ -82,25 +64,6 @@ cargo test -p lightning-block-sync --verbose --color always --features rpc-clien
 cargo check -p lightning-block-sync --verbose --color always --features rpc-client,rest-client
 cargo test -p lightning-block-sync --verbose --color always --features rpc-client,rest-client,tokio
 cargo check -p lightning-block-sync --verbose --color always --features rpc-client,rest-client,tokio
-
-if [[ "$HOST_PLATFORM" != *windows* ]]; then
-	echo -e "\n\nChecking Transaction Sync Clients with features."
-	cargo check -p lightning-transaction-sync --verbose --color always --features esplora-blocking
-	cargo check -p lightning-transaction-sync --verbose --color always --features esplora-async
-	cargo check -p lightning-transaction-sync --verbose --color always --features esplora-async-https
-	cargo check -p lightning-transaction-sync --verbose --color always --features electrum
-
-	if [ -z "$CI_ENV" ] && [[ -z "$BITCOIND_EXE" || -z "$ELECTRS_EXE" ]]; then
-		echo -e "\n\nSkipping testing Transaction Sync Clients due to BITCOIND_EXE or ELECTRS_EXE being unset."
-		cargo check -p lightning-transaction-sync --tests
-	else
-		echo -e "\n\nTesting Transaction Sync Clients with features."
-		cargo test -p lightning-transaction-sync --verbose --color always --features esplora-blocking
-		cargo test -p lightning-transaction-sync --verbose --color always --features esplora-async
-		cargo test -p lightning-transaction-sync --verbose --color always --features esplora-async-https
-		cargo test -p lightning-transaction-sync --verbose --color always --features electrum
-	fi
-fi
 
 echo -e "\n\nTest futures builds"
 cargo test -p lightning-background-processor --verbose --color always --features futures
@@ -145,7 +108,7 @@ cargo test -p lightning-invoice --verbose --color always --no-default-features -
 echo -e "\n\nTesting no_std build on a downstream no-std crate"
 # check no-std compatibility across dependencies
 pushd no-std-check
-cargo check --verbose --color always --features lightning-transaction-sync
+cargo check --verbose --color always
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 popd
 

--- a/ci/ci-tx-sync-tests.sh
+++ b/ci/ci-tx-sync-tests.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eox pipefail
+
+RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
+
+pushd lightning-transaction-sync
+
+# Some crates require pinning to meet our MSRV even for our downstream users,
+# which we do here.
+# Further crates which appear only as dev-dependencies are pinned further down.
+function PIN_RELEASE_DEPS {
+	return 0 # Don't fail the script if our rustc is higher than the last check
+}
+
+PIN_RELEASE_DEPS # pin the release dependencies
+
+# Starting with version 0.5.11, the `home` crate has an MSRV of rustc 1.81.0.
+[ "$RUSTC_MINOR_VERSION" -lt 81 ] && cargo update -p home --precise "0.5.9" --verbose
+
+export RUST_BACKTRACE=1
+
+echo -e "\n\nChecking Transaction Sync Clients with features."
+cargo check --verbose --color always --features esplora-blocking
+cargo check --verbose --color always --features esplora-async
+cargo check --verbose --color always --features esplora-async-https
+cargo check --verbose --color always --features electrum
+
+if [ -z "$CI_ENV" ] && [[ -z "$BITCOIND_EXE" || -z "$ELECTRS_EXE" ]]; then
+	echo -e "\n\nSkipping testing Transaction Sync Clients due to BITCOIND_EXE or ELECTRS_EXE being unset."
+	cargo check --tests
+else
+	echo -e "\n\nTesting Transaction Sync Clients with features."
+	cargo test --verbose --color always --features esplora-blocking
+	cargo test --verbose --color always --features esplora-async
+	cargo test --verbose --color always --features esplora-async-https
+	cargo test --verbose --color always --features electrum
+fi
+
+popd

--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -37,5 +37,11 @@ tokio = { version = "1.35.0", features = ["macros"] }
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 electrsd = { version = "0.28.0", default-features = false, features = ["legacy"] }
 
-[lints]
-workspace = true
+[lints.rust.unexpected_cfgs]
+level = "forbid"
+# When adding a new cfg attribute, ensure that it is added to this list.
+#
+# Note that Cargo automatically declares corresponding cfgs for every feature
+# defined in the member-level [features] tables as "expected".
+check-cfg = [
+]

--- a/msrv-no-dev-deps-check/Cargo.toml
+++ b/msrv-no-dev-deps-check/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 lightning = { path = "../lightning" }
 lightning-block-sync = { path = "../lightning-block-sync", features = [ "rest-client", "rpc-client" ] }
-lightning-transaction-sync = { path = "../lightning-transaction-sync", features = [ "esplora-async-https", "electrum" ] }
 lightning-invoice = { path = "../lightning-invoice" }
 lightning-net-tokio = { path = "../lightning-net-tokio" }
 lightning-persister = { path = "../lightning-persister" }

--- a/no-std-check/Cargo.toml
+++ b/no-std-check/Cargo.toml
@@ -11,7 +11,3 @@ lightning = { path = "../lightning", default-features = false }
 lightning-invoice = { path = "../lightning-invoice", default-features = false }
 lightning-rapid-gossip-sync = { path = "../lightning-rapid-gossip-sync", default-features = false }
 lightning-background-processor = { path = "../lightning-background-processor", features = ["futures"], default-features = false }
-
-# Obviously lightning-transaction-sync doesn't support no-std, but it should build
-# even if lightning is built with no-std.
-lightning-transaction-sync = { path = "../lightning-transaction-sync", optional = true }


### PR DESCRIPTION
.. and bump its MSRV to 1.75.

Recently, `rustls` bumped their MSRV to v1.71. As we depend on them and don't want to continuously pin this security-critical dependency back, we have no choice left but to bump the MSRV for `lightning-transaction-sync` to a version >= v1.71, too.

Here, we hence move the `lightning-transaction-sync` tests to a dedicated script and propose to introduce a secondary MSRV of 1.75.

We chose this particular version, because:

a) it's > 1 year old
b) it provides a buffer on top of v1.71, i.e., if some crate bumped to a version > 1.71, there is a chance we don't immediately have to react again
c) it stabilized `async fn`s in traits (see https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html), which might become handy for related (BDK) crates, which hopefully will adopt the same target.