### PR TITLE
Fix package splitting logic

### DIFF
--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -964,7 +964,6 @@ impl<ChannelSigner: EcdsaChannelSigner> OnchainTxHandler<ChannelSigner> {
 								self.pending_claim_events.retain(|entry| entry.0 != *claim_id);
 							}
 						}
-						break; //No need to iterate further, either tx is our or their
 					} else {
 						panic!("Inconsistencies between pending_claim_requests map and claimable_outpoints map");
 					}


### PR DESCRIPTION
When scanning confirmed transactions for spends that conflict with our existing packages, we should continue scanning after detecting the first conflicting package since a transaction can conflict with multiple packages.

This ensures that we remove *all* inputs from our packages that have already been spent by the counterparty so that valid claim transactions are generated.

Fixes https://github.com/lightningdevkit/rust-lightning/issues/3537.