### PR TITLE
Further decouple ChannelManager from Channel state somewhat

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -933,6 +933,13 @@ pub(super) struct ReestablishResponses {
 	pub shutdown_msg: Option<msgs::Shutdown>,
 }
 
+/// The first message we send to our peer after connection
+pub(super) enum ReconnectionMsg {
+	Reestablish(msgs::ChannelReestablish),
+	Open(OpenChannelMessage),
+	None,
+}
+
 /// The result of a shutdown that should be handled.
 #[must_use]
 pub(crate) struct ShutdownResult {
@@ -1286,7 +1293,8 @@ impl<SP: Deref> Channel<SP> where
 	}
 
 	/// Should be called when the peer is disconnected. Returns true if the channel can be resumed
-	/// when the peer reconnects. If not, the channel must be immediately closed.
+	/// when the peer reconnects (via [`Self::peer_connected_get_handshake`]). If not, the channel
+	/// must be immediately closed.
 	pub fn peer_disconnected_is_resumable<L: Deref>(&mut self, logger: &L) -> bool where L::Target: Logger {
 		match &mut self.phase {
 			ChannelPhase::Undefined => unreachable!(),
@@ -1303,41 +1311,43 @@ impl<SP: Deref> Channel<SP> where
 		}
 	}
 
-	pub fn maybe_get_open_channel<L: Deref>(
+	/// Should be called when the peer re-connects, returning an initial message which we should
+	/// send our peer to begin the channel reconnection process.
+	pub fn peer_connected_get_handshake<L: Deref>(
 		&mut self, chain_hash: ChainHash, logger: &L,
-	) -> Option<OpenChannelMessage> where L::Target: Logger {
+	) -> ReconnectionMsg where L::Target: Logger {
 		match &mut self.phase {
 			ChannelPhase::Undefined => unreachable!(),
-			ChannelPhase::Funded(_) => None,
+			ChannelPhase::Funded(chan) =>
+				ReconnectionMsg::Reestablish(chan.get_channel_reestablish(logger)),
 			ChannelPhase::UnfundedOutboundV1(chan) => {
-				let logger = WithChannelContext::from(logger, &chan.context, None);
-				chan.get_open_channel(chain_hash, &&logger)
-					.map(|msg| OpenChannelMessage::V1(msg))
+				chan.get_open_channel(chain_hash, logger)
+					.map(|msg| ReconnectionMsg::Open(OpenChannelMessage::V1(msg)))
+					.unwrap_or(ReconnectionMsg::None)
 			},
 			ChannelPhase::UnfundedInboundV1(_) => {
 				// Since unfunded inbound channel maps are cleared upon disconnecting a peer,
 				// they are not persisted and won't be recovered after a crash.
 				// Therefore, they shouldn't exist at this point.
 				debug_assert!(false);
-				None
+				ReconnectionMsg::None
 			},
 			#[cfg(dual_funding)]
 			ChannelPhase::UnfundedV2(chan) => {
 				if chan.context.is_outbound() {
-					Some(OpenChannelMessage::V2(chan.get_open_channel_v2(chain_hash)))
+					ReconnectionMsg::Open(OpenChannelMessage::V2(
+						chan.get_open_channel_v2(chain_hash)
+					))
 				} else {
 					// Since unfunded inbound channel maps are cleared upon disconnecting a peer,
 					// they are not persisted and won't be recovered after a crash.
 					// Therefore, they shouldn't exist at this point.
 					debug_assert!(false);
-					None
+					ReconnectionMsg::None
 				}
 			},
 			#[cfg(not(dual_funding))]
-			ChannelPhase::UnfundedV2(_) => {
-				debug_assert!(false);
-				None
-			},
+			ChannelPhase::UnfundedV2(_) => ReconnectionMsg::None,
 		}
 	}
 
@@ -8100,7 +8110,7 @@ impl<SP: Deref> FundedChannel<SP> where
 
 	/// May panic if called on a channel that wasn't immediately-previously
 	/// self.remove_uncommitted_htlcs_and_mark_paused()'d
-	pub fn get_channel_reestablish<L: Deref>(&mut self, logger: &L) -> msgs::ChannelReestablish where L::Target: Logger {
+	fn get_channel_reestablish<L: Deref>(&mut self, logger: &L) -> msgs::ChannelReestablish where L::Target: Logger {
 		assert!(self.context.channel_state.is_peer_disconnected());
 		assert_ne!(self.context.cur_counterparty_commitment_transaction_number, INITIAL_COMMITMENT_NUMBER);
 		// This is generally the first function which gets called on any given channel once we're


### PR DESCRIPTION
Just a few tiny followups to #3513 to keep moving towards ChannelManager caring less about the specific state the channel is in.