### PR TITLE
Add `check-cfg` lint to `fuzz` to quiet warnings

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -49,3 +49,13 @@ opt-level = 1
 name = "lightning_fuzz"
 path = "src/lib.rs"
 crate-type = ["rlib", "dylib", "staticlib"]
+
+[lints.rust.unexpected_cfgs]
+level = "forbid"
+# When adding a new cfg attribute, ensure that it is added to this list.
+check-cfg = [
+    "cfg(fuzzing)",
+    "cfg(secp256k1_fuzz)",
+    "cfg(hashes_fuzz)",
+    "cfg(taproot)",
+]


### PR DESCRIPTION
Previously, the fuzzer would complain about unknown `cfg` flags. Here, we add them to the list of allowed flags to quiet the many warnings.