### PR TITLE
Add SemVer compatibility checks to CI

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,57 @@
+name: SemVer checks
+on:
+  push:
+    branches-ignore:
+      - master
+  pull_request:
+    branches-ignore:
+      - master
+
+jobs:
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Install Rust stable toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain stable
+          rustup override set stable
+      - name: Check SemVer with default features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            feature-group: default-features
+      - name: Check SemVer *without* default features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            feature-group: only-explicit-features
+      - name: Check lightning-background-processor SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            package: lightning-background-processor
+            feature-group: only-explicit-features
+            features: futures
+      - name: Check lightning-block-sync SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            package: lightning-block-sync
+            feature-group: only-explicit-features
+            features: rpc-client,rest-client
+      - name: Check lightning-transaction-sync electrum SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            manifest-path: lightning-transaction-sync/Cargo.toml
+            feature-group: only-explicit-features
+            features: electrum
+      - name: Check lightning-transaction-sync esplora-blocking SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            manifest-path: lightning-transaction-sync/Cargo.toml
+            feature-group: only-explicit-features
+            features: esplora-blocking
+      - name: Check lightning-transaction-sync esplora-async SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            manifest-path: lightning-transaction-sync/Cargo.toml
+            feature-group: only-explicit-features
+            features: esplora-async


### PR DESCRIPTION
We recently introduced release branches that need to remain backwards compatible. However, even small changes to item visibility during backporting fixes might introduce SemVer violations (see https://doc.rust-lang.org/cargo/reference/semver.html#change-categories for a list of changs that would be considered major/minor).

To make sure we don't accidentally introduce such changes in the backports, we here add a new `semver-checks` CI job that utilizes `cargo-semver-checks`
(https://github.com/obi1kenobi/cargo-semver-checks), and have it run on any push or pull requests towards anything else but `main`/`master` (i.e., all feature branches to come).

Example output from a local run:
```
lightning-invoice> cargo semver-checks --default-features
    Building lightning-invoice v0.32.0 (current)
       Built [   0.329s] (current)
     Parsing lightning-invoice v0.32.0 (current)
      Parsed [   0.005s] (current)
     Parsing lightning-invoice v0.32.0 (baseline, cached)
      Parsed [   0.006s] (baseline)
    Checking lightning-invoice v0.32.0 -> v0.32.0 (no change)
     Checked [   0.010s] 107 checks: 105 pass, 2 fail, 0 warn, 0 skip

--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 1 of variant Bolt11ParseError::InvalidSliceLength in /Users/erohrer/workspace/rust-lightning/lightning-invoice/src/lib.rs:106
  field 2 of variant Bolt11ParseError::InvalidSliceLength in /Users/erohrer/workspace/rust-lightning/lightning-invoice/src/lib.rs:106

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Enum Bolt11InvoiceDescription (1 -> 0 lifetime params) in /Users/erohrer/workspace/rust-lightning/lightning-invoice/src/lib.rs:243

     Summary semver requires new major version: 2 major and 0 minor checks failed
    Finished [   0.895s] lightning-invoice
exit 1
```