### PR TITLE
Fix router-backtrack cases in last-hop hints

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -53,7 +53,7 @@ use lightning::ln::channelmanager::{
 use lightning::ln::functional_test_utils::*;
 use lightning::ln::inbound_payment::ExpandedKey;
 use lightning::ln::msgs::{
-	self, ChannelMessageHandler, CommitmentUpdate, DecodeError, Init, UpdateAddHTLC,
+	ChannelMessageHandler, CommitmentUpdate, DecodeError, Init, UpdateAddHTLC,
 };
 use lightning::ln::script::ShutdownScript;
 use lightning::ln::types::ChannelId;
@@ -118,7 +118,7 @@ impl Router for FuzzRouter {
 	fn find_route(
 		&self, _payer: &PublicKey, _params: &RouteParameters,
 		_first_hops: Option<&[&ChannelDetails]>, _inflight_htlcs: InFlightHtlcs,
-	) -> Result<Route, msgs::LightningError> {
+	) -> Result<Route, &'static str> {
 		unreachable!()
 	}
 

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -44,7 +44,7 @@ use lightning::ln::channelmanager::{
 };
 use lightning::ln::functional_test_utils::*;
 use lightning::ln::inbound_payment::ExpandedKey;
-use lightning::ln::msgs::{self, DecodeError};
+use lightning::ln::msgs::DecodeError;
 use lightning::ln::peer_handler::{
 	IgnoringMessageHandler, MessageHandler, PeerManager, SocketDescriptor,
 };
@@ -151,11 +151,8 @@ impl Router for FuzzRouter {
 	fn find_route(
 		&self, _payer: &PublicKey, _params: &RouteParameters,
 		_first_hops: Option<&[&ChannelDetails]>, _inflight_htlcs: InFlightHtlcs,
-	) -> Result<Route, msgs::LightningError> {
-		Err(msgs::LightningError {
-			err: String::from("Not implemented"),
-			action: msgs::ErrorAction::IgnoreError,
-		})
+	) -> Result<Route, &'static str> {
+		Err("Not implemented")
 	}
 
 	fn create_blinded_payment_paths<T: secp256k1::Signing + secp256k1::Verification>(

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -2169,7 +2169,7 @@ macro_rules! get_payment_preimage_hash {
 }
 
 /// Gets a route from the given sender to the node described in `payment_params`.
-pub fn get_route(send_node: &Node, route_params: &RouteParameters) -> Result<Route, msgs::LightningError> {
+pub fn get_route(send_node: &Node, route_params: &RouteParameters) -> Result<Route, &'static str> {
 	let scorer = TestScorer::new();
 	let keys_manager = TestKeysInterface::new(&[0u8; 32], Network::Testnet);
 	let random_seed_bytes = keys_manager.get_secure_random_bytes();
@@ -2181,7 +2181,7 @@ pub fn get_route(send_node: &Node, route_params: &RouteParameters) -> Result<Rou
 }
 
 /// Like `get_route` above, but adds a random CLTV offset to the final hop.
-pub fn find_route(send_node: &Node, route_params: &RouteParameters) -> Result<Route, msgs::LightningError> {
+pub fn find_route(send_node: &Node, route_params: &RouteParameters) -> Result<Route, &'static str> {
 	let scorer = TestScorer::new();
 	let keys_manager = TestKeysInterface::new(&[0u8; 32], Network::Testnet);
 	let random_seed_bytes = keys_manager.get_secure_random_bytes();

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -2430,7 +2430,6 @@ mod tests {
 	use crate::ln::channelmanager::{PaymentId, RecipientOnionFields};
 	use crate::ln::inbound_payment::ExpandedKey;
 	use crate::types::features::{Bolt12InvoiceFeatures, ChannelFeatures, NodeFeatures};
-	use crate::ln::msgs::{ErrorAction, LightningError};
 	use crate::ln::outbound_payment::{Bolt12PaymentError, OutboundPayments, PendingOutboundPayment, Retry, RetryableSendFailure, StaleExpiration};
 	#[cfg(feature = "std")]
 	use crate::offers::invoice::DEFAULT_RELATIVE_EXPIRY;
@@ -2532,8 +2531,7 @@ mod tests {
 		let payment_params = PaymentParameters::from_node_id(
 			PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap()), 0);
 		let route_params = RouteParameters::from_payment_params_and_value(payment_params, 0);
-		router.expect_find_route(route_params.clone(),
-			Err(LightningError { err: String::new(), action: ErrorAction::IgnoreError }));
+		router.expect_find_route(route_params.clone(), Err(""));
 
 		let pending_events = Mutex::new(VecDeque::new());
 		if on_retry {
@@ -2863,13 +2861,11 @@ mod tests {
 		);
 		assert!(outbound_payments.has_pending_payments());
 
-		router.expect_find_route(
-			RouteParameters::from_payment_params_and_value(
-				PaymentParameters::from_bolt12_invoice(&invoice),
-				invoice.amount_msats(),
-			),
-			Err(LightningError { err: String::new(), action: ErrorAction::IgnoreError }),
+		let route_params = RouteParameters::from_payment_params_and_value(
+			PaymentParameters::from_bolt12_invoice(&invoice),
+			invoice.amount_msats(),
 		);
+		router.expect_find_route(route_params, Err(""));
 
 		assert_eq!(
 			outbound_payments.send_payment_for_bolt12_invoice(

--- a/lightning/src/ln/reload_tests.rs
+++ b/lightning/src/ln/reload_tests.rs
@@ -964,6 +964,7 @@ fn do_test_partial_claim_before_restart(persist_both_monitors: bool) {
 
 		// Ensure that the remaining channel is fully operation and not blocked (and that after a
 		// cycle of commitment updates the payment preimage is ultimately pruned).
+		nodes[0].node.peer_disconnected(nodes[1].node.get_our_node_id());
 		send_payment(&nodes[0], &[&nodes[2], &nodes[3]], 100_000);
 		assert!(!get_monitor!(nodes[3], chan_id_not_persisted).get_stored_preimages().contains_key(&payment_hash));
 	}

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -2514,8 +2514,15 @@ where L::Target: Logger {
 						let curr_min = cmp::max(
 							$next_hops_path_htlc_minimum_msat, htlc_minimum_msat
 						);
-						let candidate_fees = $candidate.fees();
 						let src_node_counter = $candidate.src_node_counter();
+						let mut candidate_fees = $candidate.fees();
+						if src_node_counter == payer_node_counter {
+							// We do not charge ourselves a fee to use our own channels.
+							candidate_fees = RoutingFees {
+								proportional_millionths: 0,
+								base_msat: 0,
+							};
+						}
 						let path_htlc_minimum_msat = compute_fees_saturating(curr_min, candidate_fees)
 							.saturating_add(curr_min);
 

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -2332,7 +2332,9 @@ where L::Target: Logger {
 					})?;
 
 			if let Some((first_channels, _)) = first_hop_targets.get(target) {
-				if first_channels.iter().any(|d| d.outbound_scid_alias == Some(hop.short_channel_id)) {
+				let matches_an_scid = |d: &&ChannelDetails|
+					d.outbound_scid_alias == Some(hop.short_channel_id) || d.short_channel_id == Some(hop.short_channel_id);
+				if first_channels.iter().any(matches_an_scid) {
 					log_trace!(logger, "Ignoring route hint with SCID {} (and any previous) due to it being a direct channel of ours.",
 						hop.short_channel_id);
 					break;

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -2320,10 +2320,16 @@ where L::Target: Logger {
 		for (hop, prev_hop_id) in hop_iter.zip(prev_hop_iter) {
 			let (target, private_target_node_counter) =
 				node_counters.private_node_counter_from_pubkey(&prev_hop_id)
-					.expect("node_counter_from_pubkey is called on all unblinded_route_hints keys above, so is always Some here");
+					.ok_or_else(|| {
+						debug_assert!(false);
+						LightningError { err: "We should always have private target node counters available".to_owned(), action: ErrorAction::IgnoreError }
+					})?;
 			let (_src_id, private_source_node_counter) =
 				node_counters.private_node_counter_from_pubkey(&hop.src_node_id)
-					.expect("node_counter_from_pubkey is called on all unblinded_route_hints keys above, so is always Some here");
+					.ok_or_else(|| {
+						debug_assert!(false);
+						LightningError { err: "We should always have private source node counters available".to_owned(), action: ErrorAction::IgnoreError }
+					})?;
 
 			if let Some((first_channels, _)) = first_hop_targets.get(target) {
 				if first_channels.iter().any(|d| d.outbound_scid_alias == Some(hop.short_channel_id)) {


### PR DESCRIPTION
This fixes the router fuzzer-identified issue in #3553 which ultimately were because the router was backtracking and overwriting the preferred path to a node after we'd already processed hops away from that node. We fix it both for blinded and non-blinded paths, though in two very different ways (removing a lot of code for the non-blinded case!).