### PR TITLE
(2/3) Add Enum for HTLCHandlingFailed Reasons

### DIFF
--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -20,7 +20,7 @@ use crate::ln::msgs::{
 	BaseMessageHandler, ChannelMessageHandler, MessageSendEvent, OnionMessageHandler,
 };
 use crate::ln::offers_tests;
-use crate::ln::onion_utils::INVALID_ONION_BLINDING;
+use crate::ln::onion_utils::LocalHTLCFailureReason;
 use crate::ln::outbound_payment::PendingOutboundPayment;
 use crate::ln::outbound_payment::Retry;
 use crate::offers::invoice_request::InvoiceRequest;
@@ -179,7 +179,10 @@ fn invalid_keysend_payment_secret() {
 	assert_eq!(updates_2_1.update_fail_malformed_htlcs.len(), 1);
 	let update_malformed = &updates_2_1.update_fail_malformed_htlcs[0];
 	assert_eq!(update_malformed.sha256_of_onion, [0; 32]);
-	assert_eq!(update_malformed.failure_code, INVALID_ONION_BLINDING);
+	assert_eq!(
+		update_malformed.failure_code,
+		LocalHTLCFailureReason::InvalidOnionBlinding.failure_code()
+	);
 	nodes[1]
 		.node
 		.handle_update_fail_malformed_htlc(nodes[2].node.get_our_node_id(), update_malformed);
@@ -196,7 +199,8 @@ fn invalid_keysend_payment_secret() {
 		&nodes[0],
 		payment_hash,
 		false,
-		PaymentFailedConditions::new().expected_htlc_error_data(INVALID_ONION_BLINDING, &[0; 32]),
+		PaymentFailedConditions::new()
+			.expected_htlc_error_data(LocalHTLCFailureReason::InvalidOnionBlinding, &[0; 32]),
 	);
 }
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -50,7 +50,7 @@ use crate::ln::chan_utils::{
 #[cfg(splicing)]
 use crate::ln::chan_utils::FUNDING_TRANSACTION_WITNESS_WEIGHT;
 use crate::ln::chan_utils;
-use crate::ln::onion_utils::{HTLCFailReason, AttributionData};
+use crate::ln::onion_utils::{HTLCFailReason, LocalHTLCFailureReason, AttributionData};
 use crate::chain::BestBlock;
 use crate::chain::chaininterface::{FeeEstimator, ConfirmationTarget, LowerBoundedFeeEstimator, fee_for_weight};
 use crate::chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdate, ChannelMonitorUpdateStep, LATENCY_GRACE_PERIOD_BLOCKS};
@@ -7846,21 +7846,17 @@ impl<SP: Deref> FundedChannel<SP> where
 
 	fn internal_htlc_satisfies_config(
 		&self, htlc: &msgs::UpdateAddHTLC, amt_to_forward: u64, outgoing_cltv_value: u32, config: &ChannelConfig,
-	) -> Result<(), (&'static str, u16)> {
+	) -> Result<(), (&'static str, LocalHTLCFailureReason)> {
 		let fee = amt_to_forward.checked_mul(config.forwarding_fee_proportional_millionths as u64)
 			.and_then(|prop_fee| (prop_fee / 1000000).checked_add(config.forwarding_fee_base_msat as u64));
 		if fee.is_none() || htlc.amount_msat < fee.unwrap() ||
 			(htlc.amount_msat - fee.unwrap()) < amt_to_forward {
-			return Err((
-				"Prior hop has deviated from specified fees parameters or origin node has obsolete ones",
-				0x1000 | 12, // fee_insufficient
-			));
+			return Err(("Prior hop has deviated from specified fees parameters or origin node has obsolete ones",
+				LocalHTLCFailureReason::FeeInsufficient));
 		}
 		if (htlc.cltv_expiry as u64) < outgoing_cltv_value as u64 + config.cltv_expiry_delta as u64 {
-			return Err((
-				"Forwarding node has tampered with the intended HTLC values or origin node has an obsolete cltv_expiry_delta",
-				0x1000 | 13, // incorrect_cltv_expiry
-			));
+			return Err(("Forwarding node has tampered with the intended HTLC values or origin node has an obsolete cltv_expiry_delta",
+				LocalHTLCFailureReason::IncorrectCLTVExpiry));
 		}
 		Ok(())
 	}
@@ -7870,7 +7866,7 @@ impl<SP: Deref> FundedChannel<SP> where
 	/// unsuccessful, falls back to the previous one if one exists.
 	pub fn htlc_satisfies_config(
 		&self, htlc: &msgs::UpdateAddHTLC, amt_to_forward: u64, outgoing_cltv_value: u32,
-	) -> Result<(), (&'static str, u16)> {
+	) -> Result<(), (&'static str, LocalHTLCFailureReason)> {
 		self.internal_htlc_satisfies_config(&htlc, amt_to_forward, outgoing_cltv_value, &self.context.config())
 			.or_else(|err| {
 				if let Some(prev_config) = self.context.prev_config() {
@@ -7885,13 +7881,13 @@ impl<SP: Deref> FundedChannel<SP> where
 	/// this function determines whether to fail the HTLC, or forward / claim it.
 	pub fn can_accept_incoming_htlc<F: Deref, L: Deref>(
 		&self, msg: &msgs::UpdateAddHTLC, fee_estimator: &LowerBoundedFeeEstimator<F>, logger: L
-	) -> Result<(), (&'static str, u16)>
+	) -> Result<(), (&'static str, LocalHTLCFailureReason)>
 	where
 		F::Target: FeeEstimator,
 		L::Target: Logger
 	{
 		if self.context.channel_state.is_local_shutdown_sent() {
-			return Err(("Shutdown was already sent", 0x4000|8))
+			return Err(("Shutdown was already sent", LocalHTLCFailureReason::PermanentChannelFailure))
 		}
 
 		let dust_exposure_limiting_feerate = self.context.get_dust_exposure_limiting_feerate(&fee_estimator);
@@ -7902,7 +7898,8 @@ impl<SP: Deref> FundedChannel<SP> where
 			// Note that the total dust exposure includes both the dust HTLCs and the excess mining fees of the counterparty commitment transaction
 			log_info!(logger, "Cannot accept value that would put our total dust exposure at {} over the limit {} on counterparty commitment tx",
 				on_counterparty_tx_dust_htlc_exposure_msat, max_dust_htlc_exposure_msat);
-			return Err(("Exceeded our total dust exposure limit on counterparty commitment tx", 0x1000|7))
+			return Err(("Exceeded our total dust exposure limit on counterparty commitment tx",
+				LocalHTLCFailureReason::TemporaryChannelFailure))
 		}
 		let htlc_success_dust_limit = if self.funding.get_channel_type().supports_anchors_zero_fee_htlc_tx() {
 			0
@@ -7916,7 +7913,8 @@ impl<SP: Deref> FundedChannel<SP> where
 			if on_holder_tx_dust_htlc_exposure_msat > max_dust_htlc_exposure_msat {
 				log_info!(logger, "Cannot accept value that would put our exposure to dust HTLCs at {} over the limit {} on holder commitment tx",
 					on_holder_tx_dust_htlc_exposure_msat, max_dust_htlc_exposure_msat);
-				return Err(("Exceeded our dust exposure limit on holder commitment tx", 0x1000|7))
+				return Err(("Exceeded our dust exposure limit on holder commitment tx",
+					LocalHTLCFailureReason::TemporaryChannelFailure))
 			}
 		}
 
@@ -7954,7 +7952,7 @@ impl<SP: Deref> FundedChannel<SP> where
 			}
 			if pending_remote_value_msat.saturating_sub(self.funding.holder_selected_channel_reserve_satoshis * 1000).saturating_sub(anchor_outputs_value_msat) < remote_fee_cost_incl_stuck_buffer_msat {
 				log_info!(logger, "Attempting to fail HTLC due to fee spike buffer violation in channel {}. Rebalancing is required.", &self.context.channel_id());
-				return Err(("Fee spike buffer violation", 0x1000|7));
+				return Err(("Fee spike buffer violation", LocalHTLCFailureReason::TemporaryChannelFailure));
 			}
 		}
 
@@ -11581,7 +11579,7 @@ mod tests {
 	use bitcoin::network::Network;
 	#[cfg(splicing)]
 	use bitcoin::Weight;
-	use crate::ln::onion_utils::{AttributionData, INVALID_ONION_BLINDING};
+	use crate::ln::onion_utils::{AttributionData, LocalHTLCFailureReason};
 	use crate::types::payment::{PaymentHash, PaymentPreimage};
 	use crate::ln::channel_keys::{RevocationKey, RevocationBasepoint};
 	use crate::ln::channelmanager::{self, HTLCSource, PaymentId};
@@ -12223,7 +12221,8 @@ mod tests {
 			htlc_id, err_packet: msgs::OnionErrorPacket { data: vec![42], attribution_data: Some(AttributionData::new()) }
 		};
 		let dummy_holding_cell_malformed_htlc = |htlc_id| HTLCUpdateAwaitingACK::FailMalformedHTLC {
-			htlc_id, failure_code: INVALID_ONION_BLINDING, sha256_of_onion: [0; 32],
+			htlc_id, failure_code: LocalHTLCFailureReason::InvalidOnionBlinding.failure_code(),
+			sha256_of_onion: [0; 32],
 		};
 		let mut holding_cell_htlc_updates = Vec::with_capacity(12);
 		for i in 0..12 {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -7887,7 +7887,7 @@ impl<SP: Deref> FundedChannel<SP> where
 		L::Target: Logger
 	{
 		if self.context.channel_state.is_local_shutdown_sent() {
-			return Err(("Shutdown was already sent", LocalHTLCFailureReason::PermanentChannelFailure))
+			return Err(("Shutdown was already sent", LocalHTLCFailureReason::ChannelClosed))
 		}
 
 		let dust_exposure_limiting_feerate = self.context.get_dust_exposure_limiting_feerate(&fee_estimator);
@@ -7899,7 +7899,7 @@ impl<SP: Deref> FundedChannel<SP> where
 			log_info!(logger, "Cannot accept value that would put our total dust exposure at {} over the limit {} on counterparty commitment tx",
 				on_counterparty_tx_dust_htlc_exposure_msat, max_dust_htlc_exposure_msat);
 			return Err(("Exceeded our total dust exposure limit on counterparty commitment tx",
-				LocalHTLCFailureReason::TemporaryChannelFailure))
+				LocalHTLCFailureReason::DustLimitCounterparty))
 		}
 		let htlc_success_dust_limit = if self.funding.get_channel_type().supports_anchors_zero_fee_htlc_tx() {
 			0
@@ -7914,7 +7914,7 @@ impl<SP: Deref> FundedChannel<SP> where
 				log_info!(logger, "Cannot accept value that would put our exposure to dust HTLCs at {} over the limit {} on holder commitment tx",
 					on_holder_tx_dust_htlc_exposure_msat, max_dust_htlc_exposure_msat);
 				return Err(("Exceeded our dust exposure limit on holder commitment tx",
-					LocalHTLCFailureReason::TemporaryChannelFailure))
+					LocalHTLCFailureReason::DustLimitHolder))
 			}
 		}
 
@@ -7952,7 +7952,7 @@ impl<SP: Deref> FundedChannel<SP> where
 			}
 			if pending_remote_value_msat.saturating_sub(self.funding.holder_selected_channel_reserve_satoshis * 1000).saturating_sub(anchor_outputs_value_msat) < remote_fee_cost_incl_stuck_buffer_msat {
 				log_info!(logger, "Attempting to fail HTLC due to fee spike buffer violation in channel {}. Rebalancing is required.", &self.context.channel_id());
-				return Err(("Fee spike buffer violation", LocalHTLCFailureReason::TemporaryChannelFailure));
+				return Err(("Fee spike buffer violation", LocalHTLCFailureReason::FeeSpikeBuffer));
 			}
 		}
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5974,17 +5974,17 @@ where
 													onion_packet.hmac, payment_hash, None, &*self.node_signer
 												) {
 													Ok(res) => res,
-													Err(onion_utils::OnionDecodeErr::Malformed { err_msg, err_code }) => {
+													Err(onion_utils::OnionDecodeErr::Malformed { err_msg, reason }) => {
 														let sha256_of_onion = Sha256::hash(&onion_packet.hop_data).to_byte_array();
 														// In this scenario, the phantom would have sent us an
 														// `update_fail_malformed_htlc`, meaning here we encrypt the error as
 														// if it came from us (the second-to-last hop) but contains the sha256
 														// of the onion.
-														failed_payment!(err_msg, err_code, sha256_of_onion.to_vec(), None);
+														failed_payment!(err_msg, reason, sha256_of_onion.to_vec(), None);
 													},
-													Err(onion_utils::OnionDecodeErr::Relay { err_msg, err_code, shared_secret, .. }) => {
+													Err(onion_utils::OnionDecodeErr::Relay { err_msg, reason, shared_secret, .. }) => {
 														let phantom_shared_secret = shared_secret.secret_bytes();
-														failed_payment!(err_msg, err_code, Vec::new(), Some(phantom_shared_secret));
+														failed_payment!(err_msg, reason, Vec::new(), Some(phantom_shared_secret));
 													},
 												};
 												let phantom_shared_secret = next_hop.shared_secret().secret_bytes();

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -6102,22 +6102,17 @@ where
 								};
 								log_trace!(logger, "Forwarding HTLC from SCID {} with payment_hash {} and next hop SCID {} over {} channel {} with corresponding peer {}",
 									prev_short_channel_id, &payment_hash, short_chan_id, channel_description, optimal_channel.context.channel_id(), &counterparty_node_id);
-								if let Err(e) = optimal_channel.queue_add_htlc(outgoing_amt_msat,
+								if let Err((reason, msg)) = optimal_channel.queue_add_htlc(outgoing_amt_msat,
 										payment_hash, outgoing_cltv_value, htlc_source.clone(),
 										onion_packet.clone(), skimmed_fee_msat, next_blinding_point, &self.fee_estimator,
 										&&logger)
 								{
-									if let ChannelError::Ignore(msg) = e {
-										log_trace!(logger, "Failed to forward HTLC with payment_hash {} to peer {}: {}", &payment_hash, &counterparty_node_id, msg);
-									} else {
-										panic!("Stated return value requirements in send_htlc() were not met");
-									}
+									log_trace!(logger, "Failed to forward HTLC with payment_hash {} to peer {}: {}", &payment_hash, &counterparty_node_id, msg);
 
 									if let Some(chan) = peer_state.channel_by_id
 										.get_mut(&forward_chan_id)
 										.and_then(Channel::as_funded_mut)
 									{
-										let reason = LocalHTLCFailureReason::TemporaryChannelFailure;
 										let data = self.get_htlc_inbound_temp_fail_data(reason);
 										failed_forwards.push((htlc_source, payment_hash,
 											HTLCFailReason::reason(reason, data),

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -46,7 +46,7 @@ pub mod wire;
 #[allow(dead_code)] // TODO(dual_funding): Remove once contribution to V2 channels is enabled.
 pub(crate) mod interactivetxs;
 
-pub use onion_utils::create_payment_onion;
+pub use onion_utils::{create_payment_onion, LocalHTLCFailureReason};
 // Older rustc (which we support) refuses to let us call the get_payment_preimage_hash!() macro
 // without the node parameter being mut. This is incorrect, and thus newer rustcs will complain
 // about an unnecessary mut. Thus, we silence the unused_mut warning in two test modules below.

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -549,11 +549,11 @@ where
 		msg.payment_hash, msg.blinding_point, node_signer
 	) {
 		Ok(res) => res,
-		Err(onion_utils::OnionDecodeErr::Malformed { err_msg, err_code }) => {
-			return encode_malformed_error(err_msg, err_code);
+		Err(onion_utils::OnionDecodeErr::Malformed { err_msg, reason }) => {
+			return encode_malformed_error(err_msg, reason);
 		},
-		Err(onion_utils::OnionDecodeErr::Relay { err_msg, err_code, shared_secret, trampoline_shared_secret }) => {
-			return encode_relay_error(err_msg, err_code, shared_secret.secret_bytes(), trampoline_shared_secret.map(|tss| tss.secret_bytes()), &[0; 0]);
+		Err(onion_utils::OnionDecodeErr::Relay { err_msg, reason, shared_secret, trampoline_shared_secret }) => {
+			return encode_relay_error(err_msg, reason, shared_secret.secret_bytes(), trampoline_shared_secret.map(|tss| tss.secret_bytes()), &[0; 0]);
 		},
 	};
 

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -367,8 +367,8 @@ pub(super) fn create_recv_pending_htlc_info(
 		let hashed_preimage = PaymentHash(Sha256::hash(&payment_preimage.0).to_byte_array());
 		if hashed_preimage != payment_hash {
 			return Err(InboundHTLCErr {
-				err_code: 0x4000|22,
-				err_data: Vec::new(),
+				err_code: 0x4000 | 15,
+				err_data: invalid_payment_err_data(amt_msat, current_height),
 				msg: "Payment preimage didn't match payment hash",
 			});
 		}

--- a/lightning/src/ln/priv_short_conf_tests.rs
+++ b/lightning/src/ln/priv_short_conf_tests.rs
@@ -14,6 +14,7 @@
 use crate::chain::ChannelMonitorUpdateStatus;
 use crate::events::{ClosureReason, Event, HTLCDestination};
 use crate::ln::channelmanager::{MIN_CLTV_EXPIRY_DELTA, PaymentId, RecipientOnionFields};
+use crate::ln::onion_utils::LocalHTLCFailureReason;
 use crate::routing::gossip::RoutingFees;
 use crate::routing::router::{PaymentParameters, RouteHint, RouteHintHop};
 use crate::types::features::ChannelTypeFeatures;
@@ -456,7 +457,7 @@ fn test_inbound_scid_privacy() {
 
 	expect_payment_failed_conditions(&nodes[0], payment_hash_2, false,
 		PaymentFailedConditions::new().blamed_scid(last_hop[0].short_channel_id.unwrap())
-			.blamed_chan_closed(true).expected_htlc_error_data(0x4000|10, &[0; 0]));
+			.blamed_chan_closed(true).expected_htlc_error_data(LocalHTLCFailureReason::UnknownNextPeer, &[0; 0]));
 }
 
 #[test]
@@ -513,7 +514,7 @@ fn test_scid_alias_returned() {
 	let err_data = 0u16.to_be_bytes();
 	expect_payment_failed_conditions(&nodes[0], payment_hash, false,
 		PaymentFailedConditions::new().blamed_scid(last_hop[0].inbound_scid_alias.unwrap())
-			.blamed_chan_closed(false).expected_htlc_error_data(0x1000|7, &err_data));
+			.blamed_chan_closed(false).expected_htlc_error_data(LocalHTLCFailureReason::TemporaryChannelFailure, &err_data));
 
 	route.paths[0].hops[1].fee_msat = 10_000; // Reset to the correct payment amount
 	route.paths[0].hops[0].fee_msat = 0; // But set fee paid to the middle hop to 0
@@ -542,7 +543,7 @@ fn test_scid_alias_returned() {
 	err_data.extend_from_slice(&0u16.to_be_bytes());
 	expect_payment_failed_conditions(&nodes[0], payment_hash, false,
 		PaymentFailedConditions::new().blamed_scid(last_hop[0].inbound_scid_alias.unwrap())
-			.blamed_chan_closed(false).expected_htlc_error_data(0x1000|12, &err_data));
+			.blamed_chan_closed(false).expected_htlc_error_data(LocalHTLCFailureReason::FeeInsufficient, &err_data));
 }
 
 #[test]

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -20,7 +20,7 @@ use crate::routing::router::{PaymentParameters, get_route, RouteParameters};
 use crate::ln::msgs;
 use crate::ln::types::ChannelId;
 use crate::ln::msgs::{BaseMessageHandler, ChannelMessageHandler, ErrorAction, MessageSendEvent};
-use crate::ln::onion_utils::INVALID_ONION_BLINDING;
+use crate::ln::onion_utils::LocalHTLCFailureReason;
 use crate::ln::script::ShutdownScript;
 use crate::util::test_utils;
 use crate::util::test_utils::OnGetShutdownScriptpubkey;
@@ -484,7 +484,7 @@ fn do_htlc_fail_async_shutdown(blinded_recipient: bool) {
 
 	if blinded_recipient {
 		expect_payment_failed_conditions(&nodes[0], our_payment_hash, false,
-			PaymentFailedConditions::new().expected_htlc_error_data(INVALID_ONION_BLINDING, &[0; 32]));
+			PaymentFailedConditions::new().expected_htlc_error_data(LocalHTLCFailureReason::InvalidOnionBlinding, &[0; 32]));
 	} else {
 		expect_payment_failed_with_update!(nodes[0], our_payment_hash, false, chan_2.0.contents.short_channel_id, true);
 	}


### PR DESCRIPTION
This PR adds an enum to represent all possible BOLT 04 error codes, along with some variants that surface additional information that will be useful to the end user.

Depends on #3699
API changes in #3700