### PR TITLE
remove the cfg test that it is not needed

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8310,7 +8310,6 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 			), ChannelId([0; 32])));
 		}
 
-		#[cfg(not(test))]
 		if msg.data.len() > MAX_PEER_STORAGE_SIZE {
 			log_debug!(logger, "Sending warning to peer and ignoring peer storage request from {} as its over 1KiB", log_pubkey!(counterparty_node_id));
 


### PR DESCRIPTION
Trying to determine why the CI is failing (appears specific to Rust 1.63), likely due to changes in Clippy’s warning emission.

However, this commit is changing the code and not just fixing the warning because I am not able to understand why we should skip this code during `tests`?

I am probably missing some context here but for now I will open the PR anyway

--- 

```
     Running `rustc --crate-name lightning --edition=2021 lightning/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C opt-level=1 -C lto=off -C embed-bitcode=no -C debuginfo=2 -C debug-assertions=on --test --cfg 'feature="default"' --cfg 'feature="grind_signatures"' --cfg 'feature="std"' -C metadata=7f2d308b97eed1fd -C extra-filename=-7f2d308b97eed1fd --out-dir /home/runner/work/rust-lightning/rust-lightning/target/debug/deps -C incremental=/home/runner/work/rust-lightning/rust-lightning/target/debug/incremental -L dependency=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps --extern bech32=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/libbech32-16d69ba236ca57d8.rlib --extern bitcoin=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/libbitcoin-eca0fe041fbfc4dc.rlib --extern dnssec_prover=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/libdnssec_prover-1dd31ceabfa87dd5.rlib --extern hashbrown=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/libhashbrown-d9958110f8162c77.rlib --extern libm=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/liblibm-274dde3847e6cc8d.rlib --extern lightning_invoice=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/liblightning_invoice-56ed15b130ee9288.rlib --extern lightning_macros=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/liblightning_macros-528cdf9e072c4caf.so --extern lightning_types=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/liblightning_types-2a1be369ae37a72c.rlib --extern possiblyrandom=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/libpossiblyrandom-5fb85e240a23737f.rlib --extern regex=/home/runner/work/rust-lightning/rust-lightning/target/debug/deps/libregex-187d4eaedfe307ba.rlib -D warnings -L native=/home/runner/work/rust-lightning/rust-lightning/target/debug/build/bitcoinconsensus-9dfaf2ad2edfe5f6/out -L native=/home/runner/work/rust-lightning/rust-lightning/target/debug/build/bitcoinconsensus-9dfaf2ad2edfe5f6/out -L native=/home/runner/work/rust-lightning/rust-lightning/target/debug/build/secp256k1-sys-44754c91469ec6ec/out`
error: constant `MAX_PEER_STORAGE_SIZE` is never used
    --> lightning/src/ln/channelmanager.rs:2882:1
     |
2882 | const MAX_PEER_STORAGE_SIZE: usize = 1024;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `-D dead-code` implied by `-D warnings`

error: could not compile `lightning` due to previous error
```