### PR TITLE
Support scalar tweak to rotate holder funding key during splicing

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1359,8 +1359,9 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 	) -> ChannelMonitor<Signer> {
 
 		assert!(commitment_transaction_number_obscure_factor <= (1 << 48));
+		let holder_pubkeys = &channel_parameters.holder_pubkeys;
 		let counterparty_payment_script = chan_utils::get_counterparty_payment_script(
-			&channel_parameters.channel_type_features, &keys.pubkeys().payment_point
+			&channel_parameters.channel_type_features, &holder_pubkeys.payment_point
 		);
 
 		let counterparty_channel_parameters = channel_parameters.counterparty_parameters.as_ref().unwrap();
@@ -1369,7 +1370,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 		let counterparty_commitment_params = CounterpartyCommitmentParameters { counterparty_delayed_payment_base_key, counterparty_htlc_base_key, on_counterparty_tx_csv };
 
 		let channel_keys_id = keys.channel_keys_id();
-		let holder_revocation_basepoint = keys.pubkeys().revocation_basepoint;
+		let holder_revocation_basepoint = holder_pubkeys.revocation_basepoint;
 
 		// block for Rust 1.34 compat
 		let (holder_commitment_tx, current_holder_commitment_number) = {
@@ -5417,6 +5418,7 @@ mod tests {
 				selected_contest_delay: 67,
 			}),
 			funding_outpoint: Some(funding_outpoint),
+			splice_parent_funding_txid: None,
 			channel_type_features: ChannelTypeFeatures::only_static_remote_key(),
 			channel_value_satoshis: 0,
 		};
@@ -5669,6 +5671,7 @@ mod tests {
 				selected_contest_delay: 67,
 			}),
 			funding_outpoint: Some(funding_outpoint),
+			splice_parent_funding_txid: None,
 			channel_type_features: ChannelTypeFeatures::only_static_remote_key(),
 			channel_value_satoshis: 0,
 		};

--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -1352,6 +1352,7 @@ mod tests {
 				selected_contest_delay: 67,
 			}),
 			funding_outpoint: Some(funding_outpoint),
+			splice_parent_funding_txid: None,
 			channel_type_features: ChannelTypeFeatures::only_static_remote_key(),
 			channel_value_satoshis: 0,
 		};

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -605,7 +605,20 @@ impl PackageSolvingData {
 		let channel_parameters = &onchain_handler.channel_transaction_parameters;
 		match self {
 			PackageSolvingData::RevokedOutput(ref outp) => {
-				let chan_keys = TxCreationKeys::derive_new(&onchain_handler.secp_ctx, &outp.per_commitment_point, &outp.counterparty_delayed_payment_base_key, &outp.counterparty_htlc_base_key, &onchain_handler.signer.pubkeys().revocation_basepoint, &onchain_handler.signer.pubkeys().htlc_basepoint);
+				let directed_parameters =
+					&onchain_handler.channel_transaction_parameters.as_counterparty_broadcastable();
+				debug_assert_eq!(
+					directed_parameters.broadcaster_pubkeys().delayed_payment_basepoint,
+					outp.counterparty_delayed_payment_base_key,
+				);
+				debug_assert_eq!(
+					directed_parameters.broadcaster_pubkeys().htlc_basepoint,
+					outp.counterparty_htlc_base_key,
+				);
+				let chan_keys = TxCreationKeys::from_channel_static_keys(
+					&outp.per_commitment_point, directed_parameters.broadcaster_pubkeys(),
+					directed_parameters.countersignatory_pubkeys(), &onchain_handler.secp_ctx,
+				);
 				let witness_script = chan_utils::get_revokeable_redeemscript(&chan_keys.revocation_key, outp.on_counterparty_tx_csv, &chan_keys.broadcaster_delayed_payment_key);
 				//TODO: should we panic on signer failure ?
 				if let Ok(sig) = onchain_handler.signer.sign_justice_revoked_output(channel_parameters, &bumped_tx, i, outp.amount.to_sat(), &outp.per_commitment_key, &onchain_handler.secp_ctx) {
@@ -617,7 +630,20 @@ impl PackageSolvingData {
 				} else { return false; }
 			},
 			PackageSolvingData::RevokedHTLCOutput(ref outp) => {
-				let chan_keys = TxCreationKeys::derive_new(&onchain_handler.secp_ctx, &outp.per_commitment_point, &outp.counterparty_delayed_payment_base_key, &outp.counterparty_htlc_base_key, &onchain_handler.signer.pubkeys().revocation_basepoint, &onchain_handler.signer.pubkeys().htlc_basepoint);
+				let directed_parameters =
+					&onchain_handler.channel_transaction_parameters.as_counterparty_broadcastable();
+				debug_assert_eq!(
+					directed_parameters.broadcaster_pubkeys().delayed_payment_basepoint,
+					outp.counterparty_delayed_payment_base_key,
+				);
+				debug_assert_eq!(
+					directed_parameters.broadcaster_pubkeys().htlc_basepoint,
+					outp.counterparty_htlc_base_key,
+				);
+				let chan_keys = TxCreationKeys::from_channel_static_keys(
+					&outp.per_commitment_point, directed_parameters.broadcaster_pubkeys(),
+					directed_parameters.countersignatory_pubkeys(), &onchain_handler.secp_ctx,
+				);
 				let witness_script = chan_utils::get_htlc_redeemscript_with_explicit_keys(&outp.htlc, &onchain_handler.channel_type_features(), &chan_keys.broadcaster_htlc_key, &chan_keys.countersignatory_htlc_key, &chan_keys.revocation_key);
 				//TODO: should we panic on signer failure ?
 				if let Ok(sig) = onchain_handler.signer.sign_justice_revoked_htlc(channel_parameters, &bumped_tx, i, outp.amount, &outp.per_commitment_key, &outp.htlc, &onchain_handler.secp_ctx) {
@@ -629,7 +655,20 @@ impl PackageSolvingData {
 				} else { return false; }
 			},
 			PackageSolvingData::CounterpartyOfferedHTLCOutput(ref outp) => {
-				let chan_keys = TxCreationKeys::derive_new(&onchain_handler.secp_ctx, &outp.per_commitment_point, &outp.counterparty_delayed_payment_base_key, &outp.counterparty_htlc_base_key, &onchain_handler.signer.pubkeys().revocation_basepoint, &onchain_handler.signer.pubkeys().htlc_basepoint);
+				let directed_parameters =
+					&onchain_handler.channel_transaction_parameters.as_counterparty_broadcastable();
+				debug_assert_eq!(
+					directed_parameters.broadcaster_pubkeys().delayed_payment_basepoint,
+					outp.counterparty_delayed_payment_base_key,
+				);
+				debug_assert_eq!(
+					directed_parameters.broadcaster_pubkeys().htlc_basepoint,
+					outp.counterparty_htlc_base_key,
+				);
+				let chan_keys = TxCreationKeys::from_channel_static_keys(
+					&outp.per_commitment_point, directed_parameters.broadcaster_pubkeys(),
+					directed_parameters.countersignatory_pubkeys(), &onchain_handler.secp_ctx,
+				);
 				let witness_script = chan_utils::get_htlc_redeemscript_with_explicit_keys(&outp.htlc, &onchain_handler.channel_type_features(), &chan_keys.broadcaster_htlc_key, &chan_keys.countersignatory_htlc_key, &chan_keys.revocation_key);
 
 				if let Ok(sig) = onchain_handler.signer.sign_counterparty_htlc_transaction(channel_parameters, &bumped_tx, i, &outp.htlc.amount_msat / 1000, &outp.per_commitment_point, &outp.htlc, &onchain_handler.secp_ctx) {
@@ -641,7 +680,20 @@ impl PackageSolvingData {
 				}
 			},
 			PackageSolvingData::CounterpartyReceivedHTLCOutput(ref outp) => {
-				let chan_keys = TxCreationKeys::derive_new(&onchain_handler.secp_ctx, &outp.per_commitment_point, &outp.counterparty_delayed_payment_base_key, &outp.counterparty_htlc_base_key, &onchain_handler.signer.pubkeys().revocation_basepoint, &onchain_handler.signer.pubkeys().htlc_basepoint);
+				let directed_parameters =
+					&onchain_handler.channel_transaction_parameters.as_counterparty_broadcastable();
+				debug_assert_eq!(
+					directed_parameters.broadcaster_pubkeys().delayed_payment_basepoint,
+					outp.counterparty_delayed_payment_base_key,
+				);
+				debug_assert_eq!(
+					directed_parameters.broadcaster_pubkeys().htlc_basepoint,
+					outp.counterparty_htlc_base_key,
+				);
+				let chan_keys = TxCreationKeys::from_channel_static_keys(
+					&outp.per_commitment_point, directed_parameters.broadcaster_pubkeys(),
+					directed_parameters.countersignatory_pubkeys(), &onchain_handler.secp_ctx,
+				);
 				let witness_script = chan_utils::get_htlc_redeemscript_with_explicit_keys(&outp.htlc, &onchain_handler.channel_type_features(), &chan_keys.broadcaster_htlc_key, &chan_keys.countersignatory_htlc_key, &chan_keys.revocation_key);
 
 				if let Ok(sig) = onchain_handler.signer.sign_counterparty_htlc_transaction(channel_parameters, &bumped_tx, i, &outp.htlc.amount_msat / 1000, &outp.per_commitment_point, &outp.htlc, &onchain_handler.secp_ctx) {

--- a/lightning/src/ln/dual_funding_tests.rs
+++ b/lightning/src/ln/dual_funding_tests.rs
@@ -169,6 +169,7 @@ fn do_test_v2_channel_establishment(session: V2ChannelEstablishmentTestSession) 
 		holder_selected_contest_delay: open_channel_v2_msg.common_fields.to_self_delay,
 		is_outbound_from_holder: true,
 		funding_outpoint,
+		splice_parent_funding_txid: None,
 		channel_type_features,
 		channel_value_satoshis: funding_satoshis,
 	};

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -737,7 +737,7 @@ pub fn test_update_fee_that_funder_cannot_afford() {
 		let chan_lock = per_peer_state.get(&nodes[1].node.get_our_node_id()).unwrap().lock().unwrap();
 		let local_chan = chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let chan_signer = local_chan.get_signer();
-		let pubkeys = chan_signer.as_ref().pubkeys();
+		let pubkeys = chan_signer.as_ref().pubkeys(None, &secp_ctx);
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
 		 pubkeys.funding_pubkey)
 	};
@@ -746,7 +746,7 @@ pub fn test_update_fee_that_funder_cannot_afford() {
 		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
 		let remote_chan = chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let chan_signer = remote_chan.get_signer();
-		let pubkeys = chan_signer.as_ref().pubkeys();
+		let pubkeys = chan_signer.as_ref().pubkeys(None, &secp_ctx);
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
 		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx).unwrap(),
 		 pubkeys.funding_pubkey)
@@ -1468,21 +1468,21 @@ pub fn test_fee_spike_violation_fails_htlc() {
 		// Make the signer believe we validated another commitment, so we can release the secret
 		chan_signer.as_ecdsa().unwrap().get_enforcement_state().last_holder_commitment -= 1;
 
-		let pubkeys = chan_signer.as_ref().pubkeys();
+		let pubkeys = chan_signer.as_ref().pubkeys(None, &secp_ctx);
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint,
 		 chan_signer.as_ref().release_commitment_secret(INITIAL_COMMITMENT_NUMBER).unwrap(),
 		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 2, &secp_ctx).unwrap(),
-		 chan_signer.as_ref().pubkeys().funding_pubkey)
+		 chan_signer.as_ref().pubkeys(None, &secp_ctx).funding_pubkey)
 	};
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_point, remote_funding) = {
 		let per_peer_state = nodes[1].node.per_peer_state.read().unwrap();
 		let chan_lock = per_peer_state.get(&nodes[0].node.get_our_node_id()).unwrap().lock().unwrap();
 		let remote_chan = chan_lock.channel_by_id.get(&chan.2).and_then(Channel::as_funded).unwrap();
 		let chan_signer = remote_chan.get_signer();
-		let pubkeys = chan_signer.as_ref().pubkeys();
+		let pubkeys = chan_signer.as_ref().pubkeys(None, &secp_ctx);
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint,
 		 chan_signer.as_ref().get_per_commitment_point(INITIAL_COMMITMENT_NUMBER - 1, &secp_ctx).unwrap(),
-		 chan_signer.as_ref().pubkeys().funding_pubkey)
+		 chan_signer.as_ref().pubkeys(None, &secp_ctx).funding_pubkey)
 	};
 
 	// Assemble the set of keys we can use for signatures for our commitment_signed message.

--- a/lightning/src/sign/ecdsa.rs
+++ b/lightning/src/sign/ecdsa.rs
@@ -238,7 +238,8 @@ pub trait EcdsaChannelSigner: ChannelSigner {
 	///
 	/// [`NodeSigner::sign_gossip_message`]: crate::sign::NodeSigner::sign_gossip_message
 	fn sign_channel_announcement_with_funding_key(
-		&self, msg: &UnsignedChannelAnnouncement, secp_ctx: &Secp256k1<secp256k1::All>,
+		&self, channel_parameters: &ChannelTransactionParameters,
+		msg: &UnsignedChannelAnnouncement, secp_ctx: &Secp256k1<secp256k1::All>,
 	) -> Result<Signature, ()>;
 
 	/// Signs the input of a splicing funding transaction with our funding key.

--- a/lightning/src/util/dyn_signer.rs
+++ b/lightning/src/util/dyn_signer.rs
@@ -21,7 +21,7 @@ use crate::sign::{NodeSigner, Recipient, SignerProvider, SpendableOutputDescript
 use bitcoin;
 use bitcoin::absolute::LockTime;
 use bitcoin::secp256k1::All;
-use bitcoin::{secp256k1, ScriptBuf, Transaction, TxOut};
+use bitcoin::{secp256k1, ScriptBuf, Transaction, TxOut, Txid};
 use lightning_invoice::RawBolt11Invoice;
 #[cfg(taproot)]
 use musig2::types::{PartialSignature, PublicNonce};
@@ -154,8 +154,10 @@ delegate!(DynSigner, EcdsaChannelSigner, inner,
 		htlc: &HTLCOutputInCommitment, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()>,
 	fn sign_closing_transaction(, channel_parameters: &ChannelTransactionParameters,
 		closing_tx: &ClosingTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()>,
-	fn sign_channel_announcement_with_funding_key(, msg: &UnsignedChannelAnnouncement,
-		secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()>,
+	fn sign_channel_announcement_with_funding_key(,
+		channel_parameters: &ChannelTransactionParameters, msg: &UnsignedChannelAnnouncement,
+		secp_ctx: &Secp256k1<secp256k1::All>
+	) -> Result<Signature, ()>,
 	fn sign_holder_anchor_input(, channel_parameters: &ChannelTransactionParameters,
 		anchor_tx: &Transaction, input: usize,
 		secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()>,
@@ -177,7 +179,9 @@ delegate!(DynSigner, ChannelSigner,
 		holder_tx: &HolderCommitmentTransaction,
 		preimages: Vec<PaymentPreimage>
 	) -> Result<(), ()>,
-	fn pubkeys(,) -> &ChannelPublicKeys,
+	fn pubkeys(,
+		splice_parent_funding_txid: Option<Txid>, secp_ctx: &Secp256k1<secp256k1::All>
+	) -> ChannelPublicKeys,
 	fn channel_keys_id(,) -> [u8; 32],
 	fn validate_counterparty_revocation(, idx: u64, secret: &SecretKey) -> Result<(), ()>
 );

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -30,6 +30,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::sighash;
 use bitcoin::sighash::EcdsaSighashType;
 use bitcoin::transaction::Transaction;
+use bitcoin::Txid;
 
 #[cfg(taproot)]
 use crate::ln::msgs::PartialSignatureWithNonce;
@@ -210,8 +211,10 @@ impl ChannelSigner for TestChannelSigner {
 		Ok(())
 	}
 
-	fn pubkeys(&self) -> &ChannelPublicKeys {
-		self.inner.pubkeys()
+	fn pubkeys(
+		&self, splice_parent_funding_txid: Option<Txid>, secp_ctx: &Secp256k1<secp256k1::All>,
+	) -> ChannelPublicKeys {
+		self.inner.pubkeys(splice_parent_funding_txid, secp_ctx)
 	}
 
 	fn channel_keys_id(&self) -> [u8; 32] {
@@ -467,9 +470,10 @@ impl EcdsaChannelSigner for TestChannelSigner {
 	}
 
 	fn sign_channel_announcement_with_funding_key(
-		&self, msg: &msgs::UnsignedChannelAnnouncement, secp_ctx: &Secp256k1<secp256k1::All>,
+		&self, channel_parameters: &ChannelTransactionParameters,
+		msg: &msgs::UnsignedChannelAnnouncement, secp_ctx: &Secp256k1<secp256k1::All>,
 	) -> Result<Signature, ()> {
-		self.inner.sign_channel_announcement_with_funding_key(msg, secp_ctx)
+		self.inner.sign_channel_announcement_with_funding_key(channel_parameters, msg, secp_ctx)
 	}
 
 	fn sign_splicing_funding_input(


### PR DESCRIPTION
We introduce a scalar tweak that can be applied to the base funding key to obtain the channel's funding key used in the 2-of-2 multisig. This is used to derive additional keys from the same secret backing the base `funding_pubkey`, as we have to rotate keys for each successful splice attempt.

The tweak is computed similar to existing tweaks used in [BOLT-3](https://github.com/lightning/bolts/blob/master/03-transactions.md#key-derivation), but rather than using the `per_commitment_point`, we use the txid of the funding transaction the splice transaction is spending to guarantee uniqueness, and the `revocation_basepoint` to guarantee only the channel participants can re-derive the new funding key.

```
tweak = SHA256(splice_parent_funding_txid || revocation_basepoint || base_funding_pubkey)
tweaked_funding_key = base_funding_key + tweak
```

Depends on #3604.
Fixes #3542.