### PR TITLE
Pin idna_adapter for older Rust versions in CI

### DIFF
--- a/ci/ci-tx-sync-tests.sh
+++ b/ci/ci-tx-sync-tests.sh
@@ -17,6 +17,9 @@ PIN_RELEASE_DEPS # pin the release dependencies
 # Starting with version 0.5.11, the `home` crate has an MSRV of rustc 1.81.0.
 [ "$RUSTC_MINOR_VERSION" -lt 81 ] && cargo update -p home --precise "0.5.9" --verbose
 
+# Starting with version 1.2.0, the `idna_adapter` crate has an MSRV of rustc 1.81.0.
+[ "$RUSTC_MINOR_VERSION" -lt 81 ] && cargo update -p idna_adapter --precise "1.1.0" --verbose
+
 export RUST_BACKTRACE=1
 
 echo -e "\n\nChecking Transaction Sync Clients with features."


### PR DESCRIPTION
Litemap and zerofrom had recent releases increasing their MSRVs to 1.81.0, which broke tx-sync tests in CI for Rust version 1.75.0.