### PR TITLE
Fix Channel being left in indeterminite state from 9f9a7a92e1c15cad

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1534,6 +1534,7 @@ impl<SP: Deref> Channel<SP> where
 				res
 			},
 			_ => {
+				self.phase = phase;
 				debug_assert!(!matches!(self.phase, ChannelPhase::Undefined));
 				Err(ChannelError::close("Got a commitment_signed message for an unfunded V1 channel!".into()))
 			}


### PR DESCRIPTION
9f9a7a92e1c15cad13111f7b0b072640edf2b28b introduced some changes to channel state transitions but left one case where we'd leave a channel in an undefined phase (upon receiving a `commitment_signed` in the wrong state), which we fix here.