### PR TITLE
Static invoice server

### DIFF
--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -405,6 +405,24 @@ pub enum OffersContext {
 /// [`AsyncPaymentsMessage`]: crate::onion_message::async_payments::AsyncPaymentsMessage
 #[derive(Clone, Debug)]
 pub enum AsyncPaymentsContext {
+	/// Context used by a [`BlindedMessagePath`] provided out-of-band to an async recipient, where the
+	/// context is provided back to the static invoice server in corresponding [`OfferPathsRequest`]s.
+	///
+	/// [`OfferPathsRequest`]: crate::onion_message::async_payments::OfferPathsRequest
+	OfferPathsRequest {
+		/// An identifier for the async recipient that is requesting blinded paths to include in their
+		/// [`Offer::paths`]. This ID will be surfaced when the async recipient eventually sends a
+		/// corresponding [`ServeStaticInvoice`] message, and can be used to rate limit the recipient.
+		///
+		/// [`Offer::paths`]: crate::offers::offer::Offer::paths
+		/// [`ServeStaticInvoice`]: crate::onion_message::async_payments::ServeStaticInvoice
+		recipient_id: Vec<u8>,
+		/// An optional field indicating the time as duration since the Unix epoch at which this path
+		/// expires and messages sent over it should be ignored.
+		///
+		/// Useful to timeout async recipients that are no longer supported as clients.
+		path_absolute_expiry: Option<core::time::Duration>,
+	},
 	/// Context used by a reply path to an [`OfferPathsRequest`], provided back to us as an async
 	/// recipient in corresponding [`OfferPaths`] messages from the static invoice server.
 	///
@@ -527,6 +545,10 @@ impl_writeable_tlv_based_enum!(AsyncPaymentsContext,
 	(3, StaticInvoicePersisted) => {
 		(0, offer_id, required),
 		(2, path_absolute_expiry, required),
+	},
+	(4, OfferPathsRequest) => {
+		(0, recipient_id, required),
+		(2, path_absolute_expiry, option),
 	},
 );
 

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -35,6 +35,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 
 use core::mem;
 use core::ops::Deref;
+use core::time::Duration;
 
 /// A blinded path to be used for sending or receiving a message, hiding the identity of the
 /// recipient.
@@ -342,6 +343,43 @@ pub enum OffersContext {
 		/// [`Offer`]: crate::offers::offer::Offer
 		nonce: Nonce,
 	},
+	/// Context used by a [`BlindedMessagePath`] within the [`Offer`] of an async recipient.
+	///
+	/// This variant is received by the static invoice server when handling an [`InvoiceRequest`] on
+	/// behalf of said async recipient.
+	///
+	/// [`Offer`]: crate::offers::offer::Offer
+	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+	StaticInvoiceRequested {
+		/// An identifier for the async recipient for whom we as a static invoice server are serving
+		/// [`StaticInvoice`]s. Used paired with the
+		/// [`OffersContext::StaticInvoiceRequested::invoice_id`] when looking up a corresponding
+		/// [`StaticInvoice`] to return to the payer if the recipient is offline. This id was previously
+		/// provided via [`AsyncPaymentsContext::ServeStaticInvoice::recipient_id`].
+		///
+		/// Also useful for rate limiting the number of [`InvoiceRequest`]s we will respond to on
+		/// recipient's behalf.
+		///
+		/// [`StaticInvoice`]: crate::offers::static_invoice::StaticInvoice
+		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+		recipient_id: Vec<u8>,
+
+		/// A random unique identifier for a specific [`StaticInvoice`] that the recipient previously
+		/// requested be served on their behalf. Useful when paired with the
+		/// [`OffersContext::StaticInvoiceRequested::recipient_id`] to pull that specific invoice from
+		/// the database when payers send an [`InvoiceRequest`]. This id was previously
+		/// provided via [`AsyncPaymentsContext::ServeStaticInvoice::invoice_id`].
+		///
+		/// [`StaticInvoice`]: crate::offers::static_invoice::StaticInvoice
+		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+		invoice_id: u128,
+
+		/// The time as duration since the Unix epoch at which this path expires and messages sent over
+		/// it should be ignored.
+		///
+		/// Useful to timeout async recipients that are no longer supported as clients.
+		path_absolute_expiry: Duration,
+	},
 	/// Context used by a [`BlindedMessagePath`] within a [`Refund`] or as a reply path for an
 	/// [`InvoiceRequest`].
 	///
@@ -438,6 +476,41 @@ pub enum AsyncPaymentsContext {
 		/// [`OfferPaths`]: crate::onion_message::async_payments::OfferPaths
 		path_absolute_expiry: core::time::Duration,
 	},
+	/// Context used by a reply path to an [`OfferPaths`] message, provided back to us as the static
+	/// invoice server in corresponding [`ServeStaticInvoice`] messages.
+	///
+	/// [`OfferPaths`]: crate::onion_message::async_payments::OfferPaths
+	/// [`ServeStaticInvoice`]: crate::onion_message::async_payments::ServeStaticInvoice
+	ServeStaticInvoice {
+		/// An identifier for the async recipient that is requesting that a [`StaticInvoice`] be served
+		/// on their behalf.
+		///
+		/// Useful when surfaced alongside the below `invoice_id` when payers send an
+		/// [`InvoiceRequest`], to pull the specific static invoice from the database.
+		///
+		/// Also useful to rate limit the invoices being persisted on behalf of a particular recipient.
+		///
+		/// This id will be provided back to us as the static invoice server via
+		/// [`OffersContext::StaticInvoiceRequested::recipient_id`].
+		///
+		/// [`StaticInvoice`]: crate::offers::static_invoice::StaticInvoice
+		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+		recipient_id: Vec<u8>,
+		/// A random identifier for the specific [`StaticInvoice`] that the recipient is requesting be
+		/// served on their behalf. Useful when surfaced alongside the above `recipient_id` when payers
+		/// send an [`InvoiceRequest`], to pull the specific static invoice from the database. This id
+		/// will be provided back to us as the static invoice server via
+		/// [`OffersContext::StaticInvoiceRequested::invoice_id`].
+		///
+		/// [`StaticInvoice`]: crate::offers::static_invoice::StaticInvoice
+		/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
+		invoice_id: u128,
+		/// The time as duration since the Unix epoch at which this path expires and messages sent over
+		/// it should be ignored.
+		///
+		/// Useful to timeout async recipients that are no longer supported as clients.
+		path_absolute_expiry: core::time::Duration,
+	},
 	/// Context used by a reply path to a [`ServeStaticInvoice`] message, provided back to us in
 	/// corresponding [`StaticInvoicePersisted`] messages.
 	///
@@ -526,6 +599,11 @@ impl_writeable_tlv_based_enum!(OffersContext,
 		(1, nonce, required),
 		(2, hmac, required)
 	},
+	(3, StaticInvoiceRequested) => {
+		(0, recipient_id, required),
+		(2, invoice_id, required),
+		(4, path_absolute_expiry, required),
+	},
 );
 
 impl_writeable_tlv_based_enum!(AsyncPaymentsContext,
@@ -549,6 +627,11 @@ impl_writeable_tlv_based_enum!(AsyncPaymentsContext,
 	(4, OfferPathsRequest) => {
 		(0, recipient_id, required),
 		(2, path_absolute_expiry, option),
+	},
+	(5, ServeStaticInvoice) => {
+		(0, recipient_id, required),
+		(2, invoice_id, required),
+		(4, path_absolute_expiry, required),
 	},
 );
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5272,6 +5272,11 @@ where
 		}
 	}
 
+	#[cfg(all(test, async_payments))]
+	pub(crate) fn test_check_refresh_async_receive_offers(&self) {
+		self.check_refresh_async_receive_offer_cache(false);
+	}
+
 	/// Should be called after handling an [`Event::PersistStaticInvoice`], where the `Responder`
 	/// comes from [`Event::PersistStaticInvoice::invoice_persisted_path`].
 	#[cfg(async_payments)]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11499,6 +11499,34 @@ where
 		inbound_payment::get_payment_preimage(payment_hash, payment_secret, expanded_key)
 	}
 
+	/// [`BlindedMessagePath`]s for an async recipient to communicate with this node and interactively
+	/// build [`Offer`]s and [`StaticInvoice`]s for receiving async payments.
+	///
+	/// ## Usage
+	/// 1. Static invoice server calls [`Self::blinded_paths_for_async_recipient`]
+	/// 2. Static invoice server communicates the resulting paths out-of-band to the async recipient,
+	///    who calls [`Self::set_paths_to_static_invoice_server`] to configure themselves with these
+	///    paths
+	/// 3. Async recipient automatically sends [`OfferPathsRequest`]s over the configured paths, and
+	///    uses the resulting paths from the server's [`OfferPaths`] response to build their async
+	///    receive offer
+	///
+	/// If `relative_expiry` is unset, the [`BlindedMessagePath`]s will never expire.
+	///
+	/// Returns the paths that the recipient should be configured with via
+	/// [`Self::set_paths_to_static_invoice_server`].
+	///
+	/// The provided `recipient_id` must uniquely identify the recipient, and will be surfaced later
+	/// when the recipient provides us with a static invoice to persist and serve to payers on their
+	/// behalf.
+	#[cfg(async_payments)]
+	pub fn blinded_paths_for_async_recipient(
+		&self, recipient_id: Vec<u8>, relative_expiry: Option<Duration>,
+	) -> Result<Vec<BlindedMessagePath>, ()> {
+		let peers = self.get_peers_for_blinded_path();
+		self.flow.blinded_paths_for_async_recipient(recipient_id, relative_expiry, peers)
+	}
+
 	#[cfg(any(test, async_payments))]
 	pub(super) fn duration_since_epoch(&self) -> Duration {
 		#[cfg(not(feature = "std"))]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -13482,6 +13482,19 @@ where
 		&self, _message: OfferPathsRequest, _context: AsyncPaymentsContext,
 		_responder: Option<Responder>,
 	) -> Option<(OfferPaths, ResponseInstruction)> {
+		#[cfg(async_payments)]
+		{
+			let peers = self.get_peers_for_blinded_path();
+			let entropy = &*self.entropy_source;
+			let (message, reply_path_context) =
+				match self.flow.handle_offer_paths_request(_context, peers, entropy) {
+					Some(msg) => msg,
+					None => return None,
+				};
+			_responder.map(|resp| (message, resp.respond_with_reply_path(reply_path_context)))
+		}
+
+		#[cfg(not(async_payments))]
 		None
 	}
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1331,6 +1331,7 @@ macro_rules! reload_node {
 			_reload_node(&$node, $new_config, &chanman_encoded, $monitors_encoded);
 		$node.node = &$new_channelmanager;
 		$node.onion_messenger.set_offers_handler(&$new_channelmanager);
+		$node.onion_messenger.set_async_payments_handler(&$new_channelmanager);
 	};
 	($node: expr, $chanman_encoded: expr, $monitors_encoded: expr, $persister: ident, $new_chain_monitor: ident, $new_channelmanager: ident) => {
 		reload_node!(

--- a/lightning/src/offers/async_receive_offer_cache.rs
+++ b/lightning/src/offers/async_receive_offer_cache.rs
@@ -194,6 +194,16 @@ const OFFER_REFRESH_THRESHOLD: Duration = Duration::from_secs(2 * 60 * 60);
 #[cfg(async_payments)]
 const MIN_OFFER_PATHS_RELATIVE_EXPIRY_SECS: u64 = 3 * 30 * 24 * 60 * 60;
 
+#[cfg(all(test, async_payments))]
+pub(crate) const TEST_MAX_CACHED_OFFERS_TARGET: usize = MAX_CACHED_OFFERS_TARGET;
+#[cfg(all(test, async_payments))]
+pub(crate) const TEST_MAX_UPDATE_ATTEMPTS: u8 = MAX_UPDATE_ATTEMPTS;
+#[cfg(all(test, async_payments))]
+pub(crate) const TEST_OFFER_REFRESH_THRESHOLD: Duration = OFFER_REFRESH_THRESHOLD;
+#[cfg(all(test, async_payments))]
+pub(crate) const TEST_MIN_OFFER_PATHS_RELATIVE_EXPIRY_SECS: u64 =
+	MIN_OFFER_PATHS_RELATIVE_EXPIRY_SECS;
+
 #[cfg(async_payments)]
 impl AsyncReceiveOfferCache {
 	/// Retrieve a cached [`Offer`] for receiving async payments as an often-offline recipient, as

--- a/lightning/src/offers/async_receive_offer_cache.rs
+++ b/lightning/src/offers/async_receive_offer_cache.rs
@@ -461,6 +461,21 @@ impl AsyncReceiveOfferCache {
 
 		false
 	}
+
+	#[cfg(test)]
+	pub(super) fn test_get_payable_offers(&self) -> Vec<Offer> {
+		self.offers_with_idx()
+			.filter_map(|(_, offer)| {
+				if matches!(offer.status, OfferStatus::Ready { .. })
+					|| matches!(offer.status, OfferStatus::Used)
+				{
+					Some(offer.offer.clone())
+				} else {
+					None
+				}
+			})
+			.collect()
+	}
 }
 
 impl Writeable for AsyncReceiveOfferCache {

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -253,11 +253,18 @@ pub(crate) const TEST_OFFERS_MESSAGE_REQUEST_LIMIT: usize = OFFERS_MESSAGE_REQUE
 /// The default relative expiry for reply paths where a quick response is expected and the reply
 /// path is single-use.
 #[cfg(async_payments)]
-const TEMP_REPLY_PATH_RELATIVE_EXPIRY: Duration = Duration::from_secs(7200);
+const TEMP_REPLY_PATH_RELATIVE_EXPIRY: Duration = Duration::from_secs(2 * 60 * 60);
+
+#[cfg(all(async_payments, test))]
+pub(crate) const TEST_TEMP_REPLY_PATH_RELATIVE_EXPIRY: Duration = TEMP_REPLY_PATH_RELATIVE_EXPIRY;
 
 // Default to async receive offers and the paths used to update them lasting one year.
 #[cfg(async_payments)]
 const DEFAULT_ASYNC_RECEIVE_OFFER_EXPIRY: Duration = Duration::from_secs(365 * 24 * 60 * 60);
+
+#[cfg(all(async_payments, test))]
+pub(crate) const TEST_DEFAULT_ASYNC_RECEIVE_OFFER_EXPIRY: Duration =
+	DEFAULT_ASYNC_RECEIVE_OFFER_EXPIRY;
 
 impl<MR: Deref> OffersMessageFlow<MR>
 where

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -247,6 +247,9 @@ pub const MAX_STATIC_INVOICE_SIZE_BYTES: usize = 5 * 1024;
 /// even if multiple invoices are received.
 const OFFERS_MESSAGE_REQUEST_LIMIT: usize = 10;
 
+#[cfg(all(async_payments, test))]
+pub(crate) const TEST_OFFERS_MESSAGE_REQUEST_LIMIT: usize = OFFERS_MESSAGE_REQUEST_LIMIT;
+
 /// The default relative expiry for reply paths where a quick response is expected and the reply
 /// path is single-use.
 #[cfg(async_payments)]
@@ -1234,6 +1237,11 @@ where
 	pub(crate) fn get_async_receive_offer(&self) -> Result<(Offer, bool), ()> {
 		let mut cache = self.async_receive_offer_cache.lock().unwrap();
 		cache.get_async_receive_offer(self.duration_since_epoch())
+	}
+
+	#[cfg(all(test, async_payments))]
+	pub(crate) fn test_get_async_receive_offers(&self) -> Vec<Offer> {
+		self.async_receive_offer_cache.lock().unwrap().test_get_payable_offers()
 	}
 
 	/// Sends out [`OfferPathsRequest`] and [`ServeStaticInvoice`] onion messages if we are an

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1223,6 +1223,10 @@ impl InvoiceContents {
 		is_expired(self.created_at(), self.relative_expiry())
 	}
 
+	fn is_expired_no_std(&self, duration_since_epoch: Duration) -> bool {
+		self.created_at().saturating_add(self.relative_expiry()) < duration_since_epoch
+	}
+
 	fn payment_hash(&self) -> PaymentHash {
 		self.fields().payment_hash
 	}

--- a/lightning/src/offers/invoice_macros.rs
+++ b/lightning/src/offers/invoice_macros.rs
@@ -131,6 +131,11 @@ macro_rules! invoice_accessors_common { ($self: ident, $contents: expr, $invoice
 		$contents.is_expired()
 	}
 
+	/// Whether the invoice has expired given the current time as duration since the Unix epoch.
+	pub fn is_expired_no_std(&$self, duration_since_epoch: Duration) -> bool {
+		$contents.is_expired_no_std(duration_since_epoch)
+	}
+
 	/// Fallback addresses for paying the invoice on-chain, in order of most-preferred to
 	/// least-preferred.
 	pub fn fallbacks(&$self) -> Vec<Address> {

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -395,6 +395,18 @@ impl StaticInvoice {
 		self.signature
 	}
 
+	/// Whether the [`Offer`] that this invoice is based on is expired.
+	#[cfg(feature = "std")]
+	pub fn is_offer_expired(&self) -> bool {
+		self.contents.is_expired()
+	}
+
+	/// Whether the [`Offer`] that this invoice is based on is expired, given the current time as
+	/// duration since the Unix epoch.
+	pub fn is_offer_expired_no_std(&self, duration_since_epoch: Duration) -> bool {
+		self.contents.is_offer_expired_no_std(duration_since_epoch)
+	}
+
 	#[allow(unused)] // TODO: remove this once we remove the `async_payments` cfg flag
 	pub(crate) fn is_from_same_offer(&self, invreq: &InvoiceRequest) -> bool {
 		let invoice_offer_tlv_stream =
@@ -411,7 +423,6 @@ impl InvoiceContents {
 		self.offer.is_expired()
 	}
 
-	#[cfg(not(feature = "std"))]
 	fn is_offer_expired_no_std(&self, duration_since_epoch: Duration) -> bool {
 		self.offer.is_expired_no_std(duration_since_epoch)
 	}
@@ -526,6 +537,10 @@ impl InvoiceContents {
 	#[cfg(feature = "std")]
 	fn is_expired(&self) -> bool {
 		is_expired(self.created_at(), self.relative_expiry())
+	}
+
+	fn is_expired_no_std(&self, duration_since_epoch: Duration) -> bool {
+		self.created_at().saturating_add(self.relative_expiry()) < duration_since_epoch
 	}
 
 	fn fallbacks(&self) -> Vec<Address> {

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -1324,6 +1324,11 @@ where
 		self.offers_handler = offers_handler;
 	}
 
+	#[cfg(any(test, feature = "_test_utils"))]
+	pub fn set_async_payments_handler(&mut self, async_payments_handler: APH) {
+		self.async_payments_handler = async_payments_handler;
+	}
+
 	/// Sends an [`OnionMessage`] based on its [`MessageSendInstructions`].
 	pub fn send_onion_message<T: OnionMessageContents>(
 		&self, contents: T, instructions: MessageSendInstructions,


### PR DESCRIPTION
As part of supporting [async payments](https://github.com/lightning/bolts/pull/1149), we want to support serving static invoices on behalf of an often-offline payee, in response to invoice requests from payers. 

See [this doc](https://docs.google.com/document/d/14txLmLZeEHr8dRvMlfZU-IUI_KrkGHxgjq_0mF27sgo/edit?usp=sharing) for more details on the protocol. Here we implement the server-side of the linked protocol. 

Based on #3618