### PR TITLE
Reject channels serialized with version <= 2

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -10642,8 +10642,6 @@ impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, u32, &'c Ch
 		// ChannelTransactionParameters may have had an empty features set upon deserialization.
 		// To account for that, we're proactively setting/overriding the field here.
 		channel_parameters.channel_type_features = chan_features.clone();
-		// ChannelTransactionParameters::channel_value_satoshis defaults to 0 prior to version 0.2.
-		channel_parameters.channel_value_satoshis = channel_value_satoshis;
 
 		let mut secp_ctx = Secp256k1::new();
 		secp_ctx.seeded_randomize(&entropy_source.get_secure_random_bytes());


### PR DESCRIPTION
Follow-ups to #3604 

- e23d32dadd839ed4b095798c192691104a5aad99 removed support for these versions, so serializations with them should be explicitly rejected.
- 21ed4778413af700c590b8aaa5e3a14855f38d08 changed `ChannelTransactionParameters` deserialization to pass in `channel_value_satoshis`, so it does not actually need to be overwritten as was done in an earlier draft of the commit.
