### PR TITLE
[0.1-bindings] Rename `SpendableOutputDescriptor::outpoint()`

### DIFF
--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -540,7 +540,7 @@ impl SpendableOutputDescriptor {
 	}
 
 	/// Returns the outpoint of the spendable output.
-	pub fn outpoint(&self) -> OutPoint {
+	pub fn spendable_outpoint(&self) -> OutPoint {
 		match self {
 			Self::StaticOutput { outpoint, .. } => *outpoint,
 			Self::StaticPaymentOutput(descriptor) => descriptor.outpoint,

--- a/lightning/src/util/sweep.rs
+++ b/lightning/src/util/sweep.rs
@@ -74,7 +74,7 @@ impl TrackedSpendableOutput {
 
 	/// Returns whether the output is spent in the given transaction.
 	pub fn is_spent_in(&self, tx: &Transaction) -> bool {
-		let prev_outpoint = self.descriptor.outpoint().into_bitcoin_outpoint();
+		let prev_outpoint = self.descriptor.spendable_outpoint().into_bitcoin_outpoint();
 		tx.input.iter().any(|input| input.previous_output == prev_outpoint)
 	}
 }


### PR DESCRIPTION
We support some languages (okay, just JavaScript) where functions and fields exist in the same namespace. Sadly, because we map enums as base classes with child classes that add additional fields, this requires that fields in enum variants do not have the same name as functions implemented on that enum.

We violated this in 0.1.1 with
`SpendableOutputDescriptor::outpoint` which aliases the `outpoint` fields on two `SpendableOutputDescriptor` variants.

Here we rename the new `outpoint` method, which we'll have to carry on the 0.1-bindings branch in addition to going in 0.2.