### PR TITLE
Add idempotency check to prevent duplicate `InvoiceReceived` events

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -12477,6 +12477,23 @@ where
 				);
 
 				if self.default_configuration.manually_handle_bolt12_invoices {
+					// Prevent duplicate `InvoiceReceived` events by checking if this invoice was already processed.
+					let already_present = self.pending_events.lock().unwrap().iter().any(|(e, _)| {
+						matches!(e, Event::InvoiceReceived { payment_id: existing_id, .. } if existing_id == &payment_id)
+					});
+
+					if already_present {
+						return None;
+					}
+
+					match self.pending_outbound_payments.pending_outbound_payments.lock().unwrap().entry(payment_id) {
+						hash_map::Entry::Occupied(entry) => match entry.get() {
+							PendingOutboundPayment::AwaitingInvoice { .. } => (),
+							_ => return None
+						},
+						hash_map::Entry::Vacant(_) => return None,
+					}
+
 					let event = Event::InvoiceReceived {
 						payment_id, invoice, context, responder,
 					};

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -1186,7 +1186,14 @@ fn pays_bolt12_invoice_asynchronously() {
 	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
 	bob.onion_messenger.handle_onion_message(alice_id, &onion_message);
 
-	let (invoice, context) = match get_event!(bob, Event::InvoiceReceived) {
+	// Re-process the same onion message to ensure idempotency — 
+	// we should not generate a duplicate `InvoiceReceived` event.
+	bob.onion_messenger.handle_onion_message(alice_id, &onion_message);
+
+	let mut events = bob.node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+
+	let (invoice, context) = match events.pop().unwrap() {
 		Event::InvoiceReceived { payment_id: actual_payment_id, invoice, context, .. } => {
 			assert_eq!(actual_payment_id, payment_id);
 			(invoice, context)


### PR DESCRIPTION
Solves #3653

When `manually_handle_bolt12_invoice` is enabled, we shouldn’t emit multiple `InvoiceReceived` events for the same invoice — it can be confusing and misleading for consumers of the event stream.

This PR adds a simple idempotency check to make sure we only emit the event once per invoice.

Also added a test to make sure this behavior stays in place going forward.