### PR TITLE
Use proper libm power method for `f64`s

### DIFF
--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -1817,7 +1817,7 @@ fn powf64(n: f64, exp: f64) -> f64 {
 }
 #[cfg(not(feature = "std"))]
 fn powf64(n: f64, exp: f64) -> f64 {
-	libm::powf(n as f32, exp as f32) as f64
+	libm::pow(n, exp)
 }
 
 mod bucketed_history {


### PR DESCRIPTION
For some reason when attempting to raise floats to powers in scoring we'd converted our `f64`s to `f32`s, called `libm::powf` (on no-std targets), then converted the result back to an `f64`. `libm::pow`, however, exists and raises `f64`s to a power natively.

Here we correct this, using the proper `f64`-native `pow`.

While I doubt its related, I went to look if we have any conversion in LDK itself in response to
https://github.com/lightningdevkit/ldk-node/issues/483 (where Android binaries failed to load due to a missing `__extenddftf2`.