### PR TITLE
Introduce FundingScope abstraction to ChannelMonitor

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2125,9 +2125,6 @@ trait InitialRemoteCommitmentReceiver<SP: Deref> where SP::Target: SignerProvide
 
 		let context = self.context();
 		let funding = self.funding();
-		let funding_redeemscript = funding.get_funding_redeemscript();
-		let funding_txo = funding.get_funding_txo().unwrap();
-		let funding_txo_script = funding_redeemscript.to_p2wsh();
 		let obscure_factor = get_commitment_transaction_number_obscure_factor(&funding.get_holder_pubkeys().payment_point, &funding.get_counterparty_pubkeys().payment_point, funding.is_outbound());
 		let shutdown_script = context.shutdown_scriptpubkey.clone().map(|script| script.into_inner());
 		let monitor_signer = signer_provider.derive_channel_signer(context.channel_keys_id);
@@ -2135,9 +2132,8 @@ trait InitialRemoteCommitmentReceiver<SP: Deref> where SP::Target: SignerProvide
 		// ChannelMonitorImp::first_confirmed_funding_txo during channel establishment, not splicing
 		let channel_monitor = ChannelMonitor::new(
 			context.secp_ctx.clone(), monitor_signer, shutdown_script,
-			funding.get_holder_selected_contest_delay(), &context.destination_script, funding_txo,
-			funding_txo_script, &funding.channel_transaction_parameters, funding.is_outbound(),
-			funding_redeemscript, funding.get_value_satoshis(), obscure_factor,
+			funding.get_holder_selected_contest_delay(), &context.destination_script,
+			&funding.channel_transaction_parameters, funding.is_outbound(), obscure_factor,
 			holder_commitment_tx, best_block, context.counterparty_node_id, context.channel_id(),
 		);
 		channel_monitor.provide_initial_counterparty_commitment_tx(


### PR DESCRIPTION
When establishing a channel, the funding transaction may be replaced either:

- after the funding transaction has confirmed using splicing,
- before the funding transaction has confirmed for v2 channel establishment using `tx_init_rbf`, or
- before the splice's funding transaction has confirmed using `tx_init_rbf`.

In each of these cases, fields in the `ChannelMonitor` will need to be updated once the new funding transaction confirms. This commit introduces a `FundingScope` to hold the aforementioned fields, allowing to swap in another `FundingScope` when necessary.

This is the same abstraction as in `channel.rs` representing a different set of data.