### PR TITLE
Re-export `lightning-invoice` as `bolt11-invoice` from `lightning`

### DIFF
--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -54,6 +54,9 @@ extern crate alloc;
 pub extern crate lightning_types as types;
 
 pub extern crate bitcoin;
+
+pub extern crate lightning_invoice as bolt11_invoice;
+
 #[cfg(any(test, feature = "std"))]
 extern crate core;
 


### PR DESCRIPTION
Now that `lightning` depends on `lightning-invoice`, we should re-export it like we do `bitcoin` and `types`.