### PR TITLE
make blinded path public

### DIFF
--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -38,7 +38,7 @@ use core::ops::Deref;
 /// A blinded path to be used for sending or receiving a message, hiding the identity of the
 /// recipient.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct BlindedMessagePath(pub(super) BlindedPath);
+pub struct BlindedMessagePath(pub BlindedPath);
 
 impl Writeable for BlindedMessagePath {
 	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {

--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -26,7 +26,7 @@ use crate::prelude::*;
 /// Onion messages and payments can be sent and received to blinded paths, which serve to hide the
 /// identity of the recipient.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub(crate) struct BlindedPath {
+pub struct BlindedPath {
 	/// To send to a blinded path, the sender first finds a route to the unblinded
 	/// `introduction_node`, which can unblind its [`encrypted_payload`] to find out the onion
 	/// message or payment's next hop and forward it along.


### PR DESCRIPTION
What do I want: Create custom responses to onion messages in a core lightning plugin. The core [hook](https://docs.corelightning.org/docs/hooks#onion_message_recv-and-onion_message_recv_secret) provides all the fields necessary to fill the blinded path. All I need is the `BlindedPath` struct to be publicly accessible.