### PR TITLE
Only run aggressive `test_node_counter_consistency` in tests

### DIFF
--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -1786,7 +1786,7 @@ where
 	}
 
 	fn test_node_counter_consistency(&self) {
-		#[cfg(debug_assertions)]
+		#[cfg(test)]
 		{
 			let channels = self.channels.read().unwrap();
 			let nodes = self.nodes.read().unwrap();


### PR DESCRIPTION
`test_node_counter_consistency` can make gossip operations *really* slow. This makes it a pretty bad idea in a general node just running in debug mode. It also makes our
`lightning-rapid-gossip-sync` real-world test painfully slow.

Thus, here, we make `test_node_counter_consistency` only actually run in the `lightning`-crate tests, rather than always with `debug_assertions`.