### PR TITLE
Fix router fuzz failure due to `LengthLimitedReader`

### DIFF
--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -150,7 +150,8 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 			let mut reader = &data[..];
 			match <$MsgType>::read_from_fixed_length_buffer(&mut reader) {
 				Ok(msg) => {
-					assert_eq!(reader.len(), $len);
+					// Check that we read the slice to the end
+					assert!(reader.is_empty());
 					msg
 				},
 				Err(e) => match e {


### PR DESCRIPTION
We recently switched the decode_msg macro in the router fuzz target from reading from a Cursor to reading from a slice. This caused a failure because the slice advances its pointer as it is being read from, so asserting that the length of the slice is equal to the length of the message that was read no longer works. Instead assert that the original fuzz data length is equal to the length of the message that was read.

Closes #3692