### PR TITLE
Minor error code fixes

### DIFF
--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -2160,7 +2160,7 @@ fn do_test_trampoline_single_hop_receive(success: bool) {
 		}
 		{
 			let payment_failed_conditions = PaymentFailedConditions::new()
-				.expected_htlc_error_data(INVALID_ONION_BLINDING, &[0; 0]);
+				.expected_htlc_error_data(0x4000 | 22, &[0; 0]);
 			expect_payment_failed_conditions(&nodes[0], payment_hash, true, payment_failed_conditions);
 		}
 	}

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1431,8 +1431,7 @@ impl HTLCFailReason {
 		const NODE: u16 = 0x2000;
 		const UPDATE: u16 = 0x1000;
 
-		     if failure_code == 1  | PERM { debug_assert!(data.is_empty()) }
-		else if failure_code == 2  | NODE { debug_assert!(data.is_empty()) }
+		if failure_code == 2  | NODE { debug_assert!(data.is_empty()) }
 		else if failure_code == 2  | PERM | NODE { debug_assert!(data.is_empty()) }
 		else if failure_code == 3  | PERM | NODE { debug_assert!(data.is_empty()) }
 		else if failure_code == 4  | BADONION | PERM { debug_assert_eq!(data.len(), 32) }

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1458,6 +1458,7 @@ impl HTLCFailReason {
 		else if failure_code == 21 { debug_assert!(data.is_empty()) }
 		else if failure_code == 22 | PERM { debug_assert!(data.len() <= 11) }
 		else if failure_code == 23 { debug_assert!(data.is_empty()) }
+		else if failure_code == INVALID_ONION_BLINDING { debug_assert_eq!(data.len(), 32) }
 		else if failure_code & BADONION != 0 {
 			// We set some bogus BADONION failure codes in test, so ignore unknown ones.
 		}

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1837,7 +1837,7 @@ where
 						if hop_data.intro_node_blinding_point.is_some() {
 							return Err(OnionDecodeErr::Relay {
 								err_msg: "Non-final intro node Trampoline onion data provided to us as last hop",
-								err_code: INVALID_ONION_BLINDING,
+								err_code: 0x4000 | 22,
 								shared_secret,
 								trampoline_shared_secret: Some(SharedSecret::from_bytes(
 									trampoline_shared_secret,

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -2037,8 +2037,8 @@ fn decode_next_hop<T, R: ReadableArgs<T>, N: NextPacketBytes>(
 	match R::read(&mut chacha_stream, read_args) {
 		Err(err) => {
 			let error_code = match err {
-				// Unknown realm byte
-				msgs::DecodeError::UnknownVersion => 0x4000 | 1,
+				// Unknown version
+				msgs::DecodeError::UnknownVersion => 0x8000 | 0x4000 | 1,
 				// invalid_onion_payload
 				msgs::DecodeError::UnknownRequiredFeature
 				| msgs::DecodeError::InvalidValue


### PR DESCRIPTION
This PR pulls a few trivial commits out of #3601 which deal with error code handling unrelated to the larger refactor.

Opening this up in a separate PR because it makes a change to one of the trampoline error codes that is a little spec-ambiguous, originally pointed out [here](https://github.com/lightningdevkit/rust-lightning/pull/3670#discussion_r2021454302).