### PR TITLE
[Draft] Combine FundedChannel and PendingV2Channel through traits

### DIFF
--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -19,7 +19,7 @@ use crate::chain::channelmonitor::{ANTI_REORG_DELAY, ChannelMonitor};
 use crate::chain::{ChannelMonitorUpdateStatus, Listen, Watch};
 use crate::events::{Event, PaymentPurpose, ClosureReason, HTLCDestination};
 use crate::ln::channelmanager::{PaymentId, RAACommitmentOrder, RecipientOnionFields};
-use crate::ln::channel::AnnouncementSigsState;
+use crate::ln::channel::{AnnouncementSigsState, FundedChannelTrait};
 use crate::ln::msgs;
 use crate::ln::types::ChannelId;
 use crate::ln::msgs::{BaseMessageHandler, ChannelMessageHandler, RoutingMessageHandler, MessageSendEvent};

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2030,9 +2030,8 @@ pub(super) struct ChannelContext<SP: Deref> where SP::Target: SignerProvider {
 	is_holder_quiescence_initiator: Option<bool>,
 }
 
-/// A channel struct implementing this trait can receive an initial counterparty commitment
-/// transaction signature.
-trait InitialRemoteCommitmentReceiver<SP: Deref> where SP::Target: SignerProvider {
+/// A channel struct that has a ChannelContext and a FundingScope
+trait WithContextAndFunding<SP: Deref> where SP::Target: SignerProvider {
 	fn context(&self) -> &ChannelContext<SP>;
 
 	fn context_mut(&mut self) -> &mut ChannelContext<SP>;
@@ -2040,7 +2039,11 @@ trait InitialRemoteCommitmentReceiver<SP: Deref> where SP::Target: SignerProvide
 	fn funding(&self) -> &FundingScope;
 
 	fn funding_mut(&mut self) -> &mut FundingScope;
+}
 
+/// A channel struct implementing this trait can receive an initial counterparty commitment
+/// transaction signature.
+trait InitialRemoteCommitmentReceiver<SP: Deref>: WithContextAndFunding<SP> where SP::Target: SignerProvider {
 	fn received_msg(&self) -> &'static str;
 
 	fn check_counterparty_commitment_signature<L: Deref>(
@@ -2153,67 +2156,85 @@ trait InitialRemoteCommitmentReceiver<SP: Deref> where SP::Target: SignerProvide
 	}
 }
 
-impl<SP: Deref> InitialRemoteCommitmentReceiver<SP> for OutboundV1Channel<SP> where SP::Target: SignerProvider {
+impl<SP: Deref> WithContextAndFunding<SP> for OutboundV1Channel<SP> where SP::Target: SignerProvider {
+	#[inline]
 	fn context(&self) -> &ChannelContext<SP> {
 		&self.context
 	}
 
+	#[inline]
 	fn context_mut(&mut self) -> &mut ChannelContext<SP> {
 		&mut self.context
 	}
 
+	#[inline]
 	fn funding(&self) -> &FundingScope {
 		&self.funding
 	}
 
+	#[inline]
 	fn funding_mut(&mut self) -> &mut FundingScope {
 		&mut self.funding
 	}
+}
 
+impl<SP: Deref> WithContextAndFunding<SP> for InboundV1Channel<SP> where SP::Target: SignerProvider {
+	#[inline]
+	fn context(&self) -> &ChannelContext<SP> {
+		&self.context
+	}
+
+	#[inline]
+	fn context_mut(&mut self) -> &mut ChannelContext<SP> {
+		&mut self.context
+	}
+
+	#[inline]
+	fn funding(&self) -> &FundingScope {
+		&self.funding
+	}
+
+	#[inline]
+	fn funding_mut(&mut self) -> &mut FundingScope {
+		&mut self.funding
+	}
+}
+
+impl<SP: Deref> WithContextAndFunding<SP> for FundedChannel<SP> where SP::Target: SignerProvider {
+	#[inline]
+	fn context(&self) -> &ChannelContext<SP> {
+		&self.context
+	}
+
+	#[inline]
+	fn context_mut(&mut self) -> &mut ChannelContext<SP> {
+		&mut self.context
+	}
+
+	#[inline]
+	fn funding(&self) -> &FundingScope {
+		&self.funding
+	}
+
+	#[inline]
+	fn funding_mut(&mut self) -> &mut FundingScope {
+		&mut self.funding
+	}
+}
+
+impl<SP: Deref> InitialRemoteCommitmentReceiver<SP> for OutboundV1Channel<SP> where SP::Target: SignerProvider {
 	fn received_msg(&self) -> &'static str {
 		"funding_signed"
 	}
 }
 
 impl<SP: Deref> InitialRemoteCommitmentReceiver<SP> for InboundV1Channel<SP> where SP::Target: SignerProvider {
-	fn context(&self) -> &ChannelContext<SP> {
-		&self.context
-	}
-
-	fn context_mut(&mut self) -> &mut ChannelContext<SP> {
-		&mut self.context
-	}
-
-	fn funding(&self) -> &FundingScope {
-		&self.funding
-	}
-
-	fn funding_mut(&mut self) -> &mut FundingScope {
-		&mut self.funding
-	}
-
 	fn received_msg(&self) -> &'static str {
 		"funding_created"
 	}
 }
 
 impl<SP: Deref> InitialRemoteCommitmentReceiver<SP> for FundedChannel<SP> where SP::Target: SignerProvider {
-	fn context(&self) -> &ChannelContext<SP> {
-		&self.context
-	}
-
-	fn context_mut(&mut self) -> &mut ChannelContext<SP> {
-		&mut self.context
-	}
-
-	fn funding(&self) -> &FundingScope {
-		&self.funding
-	}
-
-	fn funding_mut(&mut self) -> &mut FundingScope {
-		&mut self.funding
-	}
-
 	fn received_msg(&self) -> &'static str {
 		"commitment_signed"
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -50,7 +50,7 @@ use crate::events::{self, Event, EventHandler, EventsProvider, InboundChannelFun
 use crate::ln::inbound_payment;
 use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
-use crate::ln::channel::{self, Channel, ChannelError, ChannelUpdateStatus, FundedChannel, ShutdownResult, UpdateFulfillCommitFetch, OutboundV1Channel, ReconnectionMsg, InboundV1Channel, WithChannelContext};
+use crate::ln::channel::{self, Channel, ChannelError, ChannelUpdateStatus, FundedChannel, FundedChannelTrait, ShutdownResult, UpdateFulfillCommitFetch, OutboundV1Channel, ReconnectionMsg, InboundV1Channel, WithChannelContext};
 use crate::ln::channel::PendingV2Channel;
 use crate::ln::channel_state::ChannelDetails;
 use crate::types::features::{Bolt12InvoiceFeatures, ChannelFeatures, ChannelTypeFeatures, InitFeatures, NodeFeatures};

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -51,7 +51,7 @@ use crate::ln::inbound_payment;
 use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 use crate::ln::channel::{self, Channel, ChannelError, ChannelUpdateStatus, FundedChannel, FundedChannelTrait, ShutdownResult, UpdateFulfillCommitFetch, OutboundV1Channel, ReconnectionMsg, InboundV1Channel, WithChannelContext};
-use crate::ln::channel::PendingV2Channel;
+use crate::ln::channel::{PendingV2Channel, PendingV2ChannelTrait};
 use crate::ln::channel_state::ChannelDetails;
 use crate::types::features::{Bolt12InvoiceFeatures, ChannelFeatures, ChannelTypeFeatures, InitFeatures, NodeFeatures};
 #[cfg(any(feature = "_test_utils", test))]

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -22,7 +22,7 @@ use crate::events::bump_transaction::WalletSource;
 use crate::events::{Event, FundingInfo, PathFailure, PaymentPurpose, ClosureReason, HTLCDestination, PaymentFailureReason};
 use crate::ln::types::ChannelId;
 use crate::types::payment::{PaymentPreimage, PaymentSecret, PaymentHash};
-use crate::ln::channel::{get_holder_selected_channel_reserve_satoshis, Channel, InboundV1Channel, OutboundV1Channel, COINBASE_MATURITY, CONCURRENT_INBOUND_HTLC_FEE_BUFFER, FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE, MIN_AFFORDABLE_HTLC_COUNT};
+use crate::ln::channel::{get_holder_selected_channel_reserve_satoshis, Channel, FundedChannelTrait, InboundV1Channel, OutboundV1Channel, COINBASE_MATURITY, CONCURRENT_INBOUND_HTLC_FEE_BUFFER, FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE, MIN_AFFORDABLE_HTLC_COUNT};
 use crate::ln::channelmanager::{self, PaymentId, RAACommitmentOrder, RecipientOnionFields, BREAKDOWN_TIMEOUT, ENABLE_GOSSIP_TICKS, DISABLE_GOSSIP_TICKS, MIN_CLTV_EXPIRY_DELTA};
 use crate::ln::channel::{DISCONNECT_PEER_AWAITING_RESPONSE_TICKS, ChannelError, MIN_CHAN_DUST_LIMIT_SATOSHIS};
 use crate::ln::{chan_utils, onion_utils};


### PR DESCRIPTION
The `RefundingChannel` -- used by splicing and possibly dual funding -- can acts as both Funded and Pending (depending on the context). To achieve that, in this PR both `FundedChannel` and `PendingV2Channel` are placed behind traits, so they can be combined easily.

This PR is more of a proof-of-concept.

Notes:
- The changes to `FundedChannel` methods are substantial but mostly trivial, changing fields into accessors
- There were a few cases when 2 mutable accessors would conflict (of type `self.context_mut().somemethod(&self.funded())`), those cases were solved by extra local ref variables or obtaining both context and funding at the same time
- One issue: the visibility differences of the methods disappeared (pub vs. non), as all trait methods are public by default. This prompted several related types to be promoted to public, which is not very nice
- The first commit carves out `WithContextAndFunding` from `InitialRemoteCommitmentReceiver`, with the original intention that `PendingV2ChannelTrait` would also include it. But this is not the case, as `PendingV2ChannelTrait` needs its own funding! So this carve-out is not really needed.

My conclusion is that this could be solved in other way:
- In `RefundingChannel` include a full `FundedChannel`, as it is accessed mostly through `as_funded()` methods
- Include extra fields for pending, and implement `PendingV2ChannelTrait`
- leave `FundedChannel` as it is, no need for trait there
- this would mean much less change
- see this in #3720