### PR TITLE
Update libFuzzer fuzz instructions

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -61,6 +61,7 @@ To run fuzzing using `cargo-fuzz / libFuzzer`, run
 
 ```shell
 rustup install nightly # Note: libFuzzer requires a nightly version of rust.
+export RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz"
 cargo +nightly fuzz run --features "libfuzzer_fuzz" msg_ping_target
 ```
 Note: If you encounter a `SIGKILL` during run/build check for OOM in kernel logs and consider


### PR DESCRIPTION
Without this flag , following the usual routine generates this error 
<details>
<summary>Output</summary>

```
error: Fuzz targets need cfg=hashes_fuzz
  --> src/bin/msg_ping_target.rs:20:1
   |
20 | compile_error!("Fuzz targets need cfg=hashes_fuzz");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: Fuzz targets need cfg=secp256k1_fuzz
  --> src/bin/msg_ping_target.rs:23:1
   |
23 | compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `lightning-fuzz` (bin "msg_ping_target") due to 2 previous errors
Error: failed to build fuzz script: ASAN_OPTIONS="detect_odr_violation=0" RUSTFLAGS="-Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-pc-table -Cllvm-args=-sanitizer-coverage-trace-compares --cfg fuzzing -Clink-dead-code -Zsanitizer=address -Cdebug-assertions -C codegen-units=1" "cargo" "build" "--manifest-path" "/Users/prabhatverma/projects/rust-lightning/fuzz/Cargo.toml" "--target" "aarch64-apple-darwin" "--release" "--config" "profile.release.debug=true" "--features" "libfuzzer_fuzz" "--bin" "msg_ping_target"
```
</details>

After introducing this , normal fuzz operation is observed

```
INFO: Seed: 4260578952
INFO: Loaded 1 modules   (614 inline 8-bit counters): 614 [0x1027ee270, 0x1027ee4d6), 
INFO: Loaded 1 PC tables (614 PCs): 614 [0x1027ee4d8,0x1027f0b38), 
INFO:        0 files found in /Users/prabhatverma/projects/rust-lightning/fuzz/corpus/msg_ping_target
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2      INITED cov: 6 ft: 6 corp: 1/1b exec/s: 0 rss: 51Mb
#4194304        pulse  cov: 6 ft: 6 corp: 1/1b lim: 4096 exec/s: 1398101 rss: 461Mb
#8388608        pulse  cov: 6 ft: 6 corp: 1/1b lim: 4096 exec/s: 1398101 rss: 465Mb
#16777216       pulse  cov: 6 ft: 6 corp: 1/1b lim: 4096 exec/s: 1398101 rss: 468Mb
^C
==57544== libFuzzer: run interrupted; exiting
```