### PR TITLE
ln: reduce size_of Event from 1856 B -> 720 B, prep for inline storage in offer `*Contents`

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -3544,7 +3544,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 						package_target_feerate_sat_per_1000_weight,
 						commitment_tx,
 						commitment_tx_fee_satoshis,
-						anchor_descriptor: AnchorDescriptor {
+						anchor_descriptor: Box::new(AnchorDescriptor {
 							channel_derivation_parameters: ChannelDerivationParameters {
 								keys_id: self.channel_keys_id,
 								value_satoshis: channel_parameters.channel_value_satoshis,
@@ -3554,7 +3554,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 								txid: commitment_txid,
 								vout: anchor_output_idx,
 							},
-						},
+						}),
 						pending_htlcs: pending_nondust_htlcs,
 					}));
 				},

--- a/lightning/src/events/bump_transaction.rs
+++ b/lightning/src/events/bump_transaction.rs
@@ -172,7 +172,7 @@ pub enum BumpTransactionEvent {
 		commitment_tx_fee_satoshis: u64,
 		/// The descriptor to sign the anchor input of the anchor transaction constructed as a
 		/// result of consuming this event.
-		anchor_descriptor: AnchorDescriptor,
+		anchor_descriptor: Box<AnchorDescriptor>,
 		/// The set of pending HTLCs on the commitment transaction that need to be resolved once the
 		/// commitment transaction confirms.
 		pending_htlcs: Vec<HTLCOutputInCommitment>,
@@ -1076,14 +1076,14 @@ mod tests {
 			package_target_feerate_sat_per_1000_weight: 868,
 			commitment_tx_fee_satoshis: 930,
 			commitment_tx,
-			anchor_descriptor: AnchorDescriptor {
+			anchor_descriptor: Box::new(AnchorDescriptor {
 				channel_derivation_parameters: ChannelDerivationParameters {
 					value_satoshis: 42_000_000,
 					keys_id: [42; 32],
 					transaction_parameters,
 				},
 				outpoint: OutPoint { txid: Txid::from_byte_array([42; 32]), vout: 0 },
-			},
+			}),
 			pending_htlcs: Vec::new(),
 		});
 	}


### PR DESCRIPTION
It looks like the `Event` enum has gotten pretty large @ 1856 B, which forces even small variants like `Event::OnionMessagePeerConnected { peer_node_id: PublicKey }` to waste a bunch of memory. It also blows up the size of our handler Future(s), since we move `Event`s into them.

Fortunately we can clean up some of the low-hanging fruit pretty easily. Here's two diffs that reduce `size_of::<Event>()` from ~~1680 B -> 576 B~~ 1856 B -> 720 B.

1. Box `InvoiceContents` in `Bolt12Invoice` and `StaticInvoice`. This shrinks `Event` from 1856 B -> 1072 B
  + `InvoiceContents` is private, so this shouldn't be a breaking change
2. Box `AnchorDescriptor` in `BumpTransactionEvent`. This shrinks `Event` from 1072 B -> 720 B.
  + `AnchorDescriptor` is technically public and boxing it is a semver breaking change, but the struct's pretty deep in there... Guess I'll leave that to your discretion.

We could go even further to 320 B by boxing `PaymentPurpose`, but that feels like a much more invasive / semver breaking change.