### PR TITLE
Change method name `from_same_offer` to `is_from_same_offer`

### DIFF
--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -1114,7 +1114,7 @@ impl OutboundPayments {
 						.as_ref()
 						.ok_or(Bolt12PaymentError::UnexpectedInvoice)?
 						.invoice_request;
-					if !invoice.from_same_offer(invreq) {
+					if !invoice.is_from_same_offer(invreq) {
 						return Err(Bolt12PaymentError::UnexpectedInvoice)
 					}
 					if invoice.invoice_features().requires_unknown_bits_from(&features) {

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -390,7 +390,7 @@ impl StaticInvoice {
 	}
 
 	#[allow(unused)] // TODO: remove this once we remove the `async_payments` cfg flag
-	pub(crate) fn from_same_offer(&self, invreq: &InvoiceRequest) -> bool {
+	pub(crate) fn is_from_same_offer(&self, invreq: &InvoiceRequest) -> bool {
 		let invoice_offer_tlv_stream =
 			Offer::tlv_stream_iter(&self.bytes).map(|tlv_record| tlv_record.record_bytes);
 		let invreq_offer_tlv_stream =


### PR DESCRIPTION
This is a check that returns a bool and the current naming conflicts with standard conventions and causes a lint warning.

https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention