### PR TITLE
doc(CONTRIBUTING.md): fix link to project code of conduct on LDK website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ testing and risk-minimization. Any bug may cost users real money. That being
 said, we deeply welcome people contributing for the first time to an open source
 project or pick up Rust while contributing. Don't be shy, you'll learn.
 
-For the project Code of Conduct, see our [website](https://lightningdevkit.org/code_of_conduct).
+For the project Code of Conduct, see our [website](https://lightningdevkit.org/code-of-conduct/).
 
 Communication Channels
 -----------------------


### PR DESCRIPTION
On the contributing guide ([CONTRIBUTING.md](https://github.com/lightningdevkit/rust-lightning/blob/main/CONTRIBUTING.md#:~:text=For%20the%20project%20Code%20of%20Conduct%2C%20see%20our%20website.)), the link to the project Code of Conduct is broken, and returns 404 - Not Found.

This PR links it correctly, and closes #3739 