### PR TITLE
Limit `full_stack` fuzz runtime by limiting block connection ops

### DIFF
--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -299,6 +299,14 @@ impl<'a> MoneyLossDetector<'a> {
 	}
 
 	fn connect_block(&mut self, all_txn: &[Transaction]) {
+		if self.blocks_connected > 50_000 {
+			// Connecting blocks is relatively slow, and some commands can connect many blocks.
+			// This can inflate the total runtime substantially, leading to spurious timeouts.
+			// Instead, because block connection rate is expected to be limited by PoW, simply
+			// start ignoring blocks after the first 50k.
+			return;
+		}
+
 		let mut txdata = Vec::with_capacity(all_txn.len());
 		for (idx, tx) in all_txn.iter().enumerate() {
 			let txid = tx.compute_txid();


### PR DESCRIPTION
The `full_stack_target` fuzzer is generally pretty slow, but on some inputs the fuzzer is able to connect hundreds of thousands to millions of blocks, which is by far the slowest operation. In some cases, individual inputs can take tens of minutes to complete, which is not a realistic issue in LDK (we don't expect there to be million-block bursts in Bitcoin) so we simply disable it.