### PR TITLE
Revert separate non-dust HTLC sources for holder commitments

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -726,17 +726,6 @@ impl HTLCSource {
 		}
 	}
 
-	/// Checks whether this HTLCSource could possibly match the given HTLC output in a commitment
-	/// transaction. Useful to ensure different datastructures match up.
-	pub(crate) fn possibly_matches_output(&self, htlc: &super::chan_utils::HTLCOutputInCommitment) -> bool {
-		if let HTLCSource::OutboundRoute { first_hop_htlc_msat, .. } = self {
-			*first_hop_htlc_msat == htlc.amount_msat
-		} else {
-			// There's nothing we can check for forwarded HTLCs
-			true
-		}
-	}
-
 	/// Returns the CLTV expiry of the inbound HTLC (i.e. the source referred to by this object),
 	/// if the source was a forwarded HTLC and the HTLC was first forwarded on LDK 0.1.1 or later.
 	pub(crate) fn inbound_htlc_expiry(&self) -> Option<u32> {


### PR DESCRIPTION
We previously provided non-dust HTLC sources to avoid storing duplicate non-dust HTLC data in the `htlc_outputs` `Vec` where all HTLCs would be tracked in a holder commitment update. With splicing, we'll unfortunately be forced to store redundant copies of non-dust HTLC data within the commitment transaction for each relevant `FundingScope`. As a result, providing non-dust HTLC sources separately no longer provides any benefits. In the future, we also plan to rework how the HTLC data for holder and counterparty commitments are tracked to avoid storing duplicate `HTLCSource`s.

Along the way, this commit also omits setting the `Option<Signature>` for non-dust HTLCs, as they are already tracked within the `HolderCommitmentTransaction`.