### PR TITLE
LSPS2: Add TimeProvider trait for expiry checks in no-std and std builds

### DIFF
--- a/lightning-liquidity/Cargo.toml
+++ b/lightning-liquidity/Cargo.toml
@@ -14,8 +14,9 @@ categories = ["cryptography::cryptocurrencies"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
+default = ["std", "time"]
 std = ["lightning/std"]
+time = []
 backtrace = ["dep:backtrace"]
 
 [dependencies]

--- a/lightning-liquidity/src/lsps0/ser.rs
+++ b/lightning-liquidity/src/lsps0/ser.rs
@@ -30,8 +30,7 @@ use lightning::util::ser::{LengthLimitedRead, LengthReadable, WithoutLength};
 
 use bitcoin::secp256k1::PublicKey;
 
-#[cfg(feature = "std")]
-use std::time::{SystemTime, UNIX_EPOCH};
+use crate::sync::Arc;
 
 use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
@@ -205,12 +204,8 @@ impl LSPSDateTime {
 	}
 
 	/// Returns if the given time is in the past.
-	#[cfg(feature = "std")]
-	pub fn is_past(&self) -> bool {
-		let now_seconds_since_epoch = SystemTime::now()
-			.duration_since(UNIX_EPOCH)
-			.expect("system clock to be ahead of the unix epoch")
-			.as_secs();
+	pub fn is_past(&self, time_provider: Arc<dyn TimeProvider>) -> bool {
+		let now_seconds_since_epoch = time_provider.duration_since_epoch().as_secs();
 		let datetime_seconds_since_epoch =
 			self.0.timestamp().try_into().expect("expiration to be ahead of unix epoch");
 		now_seconds_since_epoch > datetime_seconds_since_epoch

--- a/lightning-liquidity/src/lsps0/ser.rs
+++ b/lightning-liquidity/src/lsps0/ser.rs
@@ -8,6 +8,7 @@ use alloc::string::String;
 
 use core::fmt::{self, Display};
 use core::str::FromStr;
+use core::time::Duration;
 
 use crate::lsps0::msgs::{
 	LSPS0ListProtocolsRequest, LSPS0Message, LSPS0Request, LSPS0Response,
@@ -782,5 +783,26 @@ pub(crate) mod u32_fee_rate {
 		let fee_rate_sat_kwu = u32::deserialize(deserializer)?;
 
 		Ok(FeeRate::from_sat_per_kwu(fee_rate_sat_kwu as u64))
+	}
+}
+
+/// Trait defining a time provider
+///
+/// This trait is used to provide the current time service operations and to convert between timestamps and durations.
+pub trait TimeProvider {
+	/// Get the current time as a duration since the Unix epoch.
+	fn duration_since_epoch(&self) -> Duration;
+}
+
+/// Default time provider using the system clock.
+#[derive(Clone, Debug)]
+#[cfg(feature = "time")]
+pub struct DefaultTimeProvider;
+
+#[cfg(feature = "time")]
+impl TimeProvider for DefaultTimeProvider {
+	fn duration_since_epoch(&self) -> Duration {
+		use std::time::{SystemTime, UNIX_EPOCH};
+		SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch")
 	}
 }

--- a/lightning-liquidity/tests/common/mod.rs
+++ b/lightning-liquidity/tests/common/mod.rs
@@ -460,6 +460,7 @@ pub(crate) fn create_liquidity_node(
 		Some(chain_params),
 		service_config,
 		client_config,
+		None,
 	));
 	let msg_handler = MessageHandler {
 		chan_handler: Arc::new(test_utils::TestChannelMessageHandler::new(


### PR DESCRIPTION
Closes https://github.com/lightningdevkit/rust-lightning/issues/3471

As discussed here https://github.com/lightningdevkit/rust-lightning/pull/3662#discussion_r2018697826

This PR introduces a TimeProvider trait to enable expiry checks for OpeningFeeParams on LSPS2 in both std and no-std environments. Previously, expiry validation was skipped in no-std builds due to the lack of a system clock. 

With this change:

- A TimeProvider trait is defined, allowing users to supply their own time source.
- A DefaultTimeProvider implementation is provided for std environments.
- All expiry checks (is_past, is_expired_opening_fee_params, etc.) now require a TimeProvider instance.
- The LSPS2 service, utility functions, and tests are updated to use the new trait.
- The API is extended to allow injecting a custom time provider, ensuring expiry checks are always performed, even in no-std builds.

This abstraction will be even more useful for LSPS5, which relies on time-based logic much more extensively than LSPS2.
