### PR TITLE
Make `generate_test_routes` deterministic based on its seed

### DIFF
--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -8843,16 +8843,20 @@ pub(crate) mod bench_utils {
 		let payer = payer_pubkey();
 		let random_seed_bytes = [42; 32];
 
-		let nodes = graph.read_only().nodes().clone();
+		let mut nodes = graph.read_only().nodes().clone();
 		let mut route_endpoints = Vec::new();
 		for _ in 0..route_count {
 			loop {
 				seed = seed.overflowing_mul(6364136223846793005).0.overflowing_add(1).0;
-				let src = PublicKey::from_slice(nodes.unordered_keys()
-					.skip((seed as usize) % nodes.len()).next().unwrap().as_slice()).unwrap();
+				let src_idx = (seed as usize) % nodes.len();
+				let src_key = nodes.range(..).skip(src_idx).next().unwrap().0;
+				let src = PublicKey::from_slice(src_key.as_slice()).unwrap();
+
 				seed = seed.overflowing_mul(6364136223846793005).0.overflowing_add(1).0;
-				let dst = PublicKey::from_slice(nodes.unordered_keys()
-					.skip((seed as usize) % nodes.len()).next().unwrap().as_slice()).unwrap();
+				let dst_idx = (seed as usize) % nodes.len();
+				let dst_key = nodes.range(..).skip(dst_idx).next().unwrap().0;
+				let dst = PublicKey::from_slice(dst_key.as_slice()).unwrap();
+
 				let params = PaymentParameters::from_node_id(dst, 42)
 					.with_bolt11_features(features.clone()).unwrap();
 				let first_hop = first_hop(src);


### PR DESCRIPTION
The intent of `generate_test_routes` is to be deterministic based on a seed which is printed at the start. That way if a test fails, the seed can be trivially hard-coded and the test can be replicated.

Sadly, it was not, as it used an iterator over an `IndexedMap` with key order randomization. Luckily, `IndexedMap` already supports sorted iteration, so we simply use it here.