### PR TITLE
Rename `Event::PaymentClaimable::inbound_channel_ids` to `via_...`

### DIFF
--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -251,18 +251,18 @@ fn mpp_to_one_hop_blinded_path() {
 		Some(payment_secret), ev.clone(), true, None);
 
 	match event.unwrap() {
-		Event::PaymentClaimable { mut inbound_channel_ids, .. } => {
-			let mut expected_inbound_channel_ids = nodes[3].node.list_channels()
+		Event::PaymentClaimable { mut via_channel_ids, .. } => {
+			let mut expected_via_channel_ids = nodes[3].node.list_channels()
 				.iter()
 				.map(|d| (d.channel_id, Some(d.user_channel_id)))
 				.collect::<Vec<(_, _)>>();
 
 			// `list_channels` returns channels in arbitrary order, so we sort both vectors
 			// to ensure the comparison is order-agnostic.
-			inbound_channel_ids.sort();
-			expected_inbound_channel_ids.sort();
+			via_channel_ids.sort();
+			expected_via_channel_ids.sort();
 
-			assert_eq!(inbound_channel_ids, expected_inbound_channel_ids);
+			assert_eq!(via_channel_ids, expected_via_channel_ids);
 		}
 		_ => panic!("Unexpected event"),
 	}

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -167,11 +167,11 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 	let events_3 = nodes[1].node.get_and_clear_pending_events();
 	assert_eq!(events_3.len(), 1);
 	match events_3[0] {
-		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref inbound_channel_ids, .. } => {
+		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref via_channel_ids, .. } => {
 			assert_eq!(payment_hash_1, *payment_hash);
 			assert_eq!(amount_msat, 1_000_000);
 			assert_eq!(receiver_node_id.unwrap(), nodes[1].node.get_our_node_id());
-			assert_eq!(*inbound_channel_ids, vec![(channel_id, Some(user_channel_id))]);
+			assert_eq!(*via_channel_ids, vec![(channel_id, Some(user_channel_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
 					assert!(payment_preimage.is_none());
@@ -550,11 +550,11 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 	let events_5 = nodes[1].node.get_and_clear_pending_events();
 	assert_eq!(events_5.len(), 1);
 	match events_5[0] {
-		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref inbound_channel_ids, .. } => {
+		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref via_channel_ids, .. } => {
 			assert_eq!(payment_hash_2, *payment_hash);
 			assert_eq!(amount_msat, 1_000_000);
 			assert_eq!(receiver_node_id.unwrap(), nodes[1].node.get_our_node_id());
-			assert_eq!(*inbound_channel_ids, vec![(channel_id, Some(user_channel_id))]);
+			assert_eq!(*via_channel_ids, vec![(channel_id, Some(user_channel_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
 					assert!(payment_preimage.is_none());
@@ -669,11 +669,11 @@ fn test_monitor_update_fail_cs() {
 	let events = nodes[1].node.get_and_clear_pending_events();
 	assert_eq!(events.len(), 1);
 	match events[0] {
-		Event::PaymentClaimable { payment_hash, ref purpose, amount_msat, receiver_node_id, ref inbound_channel_ids, .. } => {
+		Event::PaymentClaimable { payment_hash, ref purpose, amount_msat, receiver_node_id, ref via_channel_ids, .. } => {
 			assert_eq!(payment_hash, our_payment_hash);
 			assert_eq!(amount_msat, 1_000_000);
 			assert_eq!(receiver_node_id.unwrap(), nodes[1].node.get_our_node_id());
-			assert_eq!(*inbound_channel_ids, vec![(channel_id, Some(user_channel_id))]);
+			assert_eq!(*via_channel_ids, vec![(channel_id, Some(user_channel_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
 					assert!(payment_preimage.is_none());
@@ -1682,11 +1682,11 @@ fn test_monitor_update_fail_claim() {
 	let events = nodes[0].node.get_and_clear_pending_events();
 	assert_eq!(events.len(), 2);
 	match events[0] {
-		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref inbound_channel_ids, .. } => {
+		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref via_channel_ids, .. } => {
 			assert_eq!(payment_hash_2, *payment_hash);
 			assert_eq!(1_000_000, amount_msat);
 			assert_eq!(receiver_node_id.unwrap(), nodes[0].node.get_our_node_id());
-			assert_eq!(*inbound_channel_ids.last().unwrap(), (channel_id, Some(42)));
+			assert_eq!(*via_channel_ids.last().unwrap(), (channel_id, Some(42)));
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
 					assert!(payment_preimage.is_none());
@@ -1698,11 +1698,11 @@ fn test_monitor_update_fail_claim() {
 		_ => panic!("Unexpected event"),
 	}
 	match events[1] {
-		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref inbound_channel_ids, .. } => {
+		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref via_channel_ids, .. } => {
 			assert_eq!(payment_hash_3, *payment_hash);
 			assert_eq!(1_000_000, amount_msat);
 			assert_eq!(receiver_node_id.unwrap(), nodes[0].node.get_our_node_id());
-			assert_eq!(*inbound_channel_ids, vec![(channel_id, Some(42))]);
+			assert_eq!(*via_channel_ids, vec![(channel_id, Some(42))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
 					assert!(payment_preimage.is_none());

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -934,7 +934,7 @@ impl ClaimablePayment {
 	/// Returns the inbound `(channel_id, user_channel_id)` pairs for all HTLCs associated with the payment.
 	///
 	/// Note: The `user_channel_id` will be `None` for HTLCs created using LDK version 0.0.117 or prior.
-	fn inbound_channel_ids(&self) -> Vec<(ChannelId, Option<u128>)> {
+	fn via_channel_ids(&self) -> Vec<(ChannelId, Option<u128>)> {
 		self.htlcs.iter().map(|htlc| {
 			(htlc.prev_hop.channel_id, htlc.prev_hop.user_channel_id)
 		}).collect()
@@ -6362,7 +6362,7 @@ where
 												purpose: $purpose,
 												amount_msat,
 												counterparty_skimmed_fee_msat,
-												inbound_channel_ids: claimable_payment.inbound_channel_ids(),
+												via_channel_ids: claimable_payment.via_channel_ids(),
 												claim_deadline: Some(earliest_expiry - HTLC_FAIL_BACK_BUFFER),
 												onion_fields: claimable_payment.onion_fields.clone(),
 												payment_id: Some(payment_id),

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -2770,7 +2770,7 @@ pub fn do_pass_along_path<'a, 'b, 'c>(args: PassAlongPathArgs) -> Option<Event> 
 				assert_eq!(events_2.len(), 1);
 				match &events_2[0] {
 					Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat,
-						receiver_node_id, ref inbound_channel_ids,
+						receiver_node_id, ref via_channel_ids,
 						claim_deadline, onion_fields, ..
 					} => {
 						assert_eq!(our_payment_hash, *payment_hash);
@@ -2805,7 +2805,7 @@ pub fn do_pass_along_path<'a, 'b, 'c>(args: PassAlongPathArgs) -> Option<Event> 
 						}
 						assert_eq!(*amount_msat, recv_value);
 						let channels = node.node.list_channels();
-						for (chan_id, user_chan_id) in inbound_channel_ids {
+						for (chan_id, user_chan_id) in via_channel_ids {
 							let chan = channels.iter().find(|details| &details.channel_id == chan_id).unwrap();
 							assert_eq!(*user_chan_id, Some(chan.user_channel_id));
 						}

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -2127,11 +2127,11 @@ pub fn test_channel_reserve_holding_cell_htlcs() {
 	let events = nodes[2].node.get_and_clear_pending_events();
 	assert_eq!(events.len(), 2);
 	match events[0] {
-		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref inbound_channel_ids, .. } => {
+		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref via_channel_ids, .. } => {
 			assert_eq!(our_payment_hash_21, *payment_hash);
 			assert_eq!(recv_value_21, amount_msat);
 			assert_eq!(nodes[2].node.get_our_node_id(), receiver_node_id.unwrap());
-			assert_eq!(*inbound_channel_ids, vec![(chan_2.2, Some(chan_2_user_id))]);
+			assert_eq!(*via_channel_ids, vec![(chan_2.2, Some(chan_2_user_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
 					assert!(payment_preimage.is_none());
@@ -2143,11 +2143,11 @@ pub fn test_channel_reserve_holding_cell_htlcs() {
 		_ => panic!("Unexpected event"),
 	}
 	match events[1] {
-		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref inbound_channel_ids, .. } => {
+		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref via_channel_ids, .. } => {
 			assert_eq!(our_payment_hash_22, *payment_hash);
 			assert_eq!(recv_value_22, amount_msat);
 			assert_eq!(nodes[2].node.get_our_node_id(), receiver_node_id.unwrap());
-			assert_eq!(*inbound_channel_ids, vec![(chan_2.2, Some(chan_2_user_id))]);
+			assert_eq!(*via_channel_ids, vec![(chan_2.2, Some(chan_2_user_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
 					assert!(payment_preimage.is_none());
@@ -4374,11 +4374,11 @@ fn do_test_drop_messages_peer_disconnect(messages_delivered: u8, simulate_broken
 	let events_2 = nodes[1].node.get_and_clear_pending_events();
 	assert_eq!(events_2.len(), 1);
 	match events_2[0] {
-		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref inbound_channel_ids, .. } => {
+		Event::PaymentClaimable { ref payment_hash, ref purpose, amount_msat, receiver_node_id, ref via_channel_ids, .. } => {
 			assert_eq!(payment_hash_1, *payment_hash);
 			assert_eq!(amount_msat, 1_000_000);
 			assert_eq!(receiver_node_id.unwrap(), nodes[1].node.get_our_node_id());
-			assert_eq!(*inbound_channel_ids, vec![(channel_id, Some(user_channel_id))]);
+			assert_eq!(*via_channel_ids, vec![(channel_id, Some(user_channel_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment { payment_preimage, payment_secret, .. } => {
 					assert!(payment_preimage.is_none());


### PR DESCRIPTION
In c62aa23b7919d62f49bceb7ce1f87967fc5de077 we merged `via_channel_id` and `via_user_channel_id` and added support for MPP to the fields, but created a new `inbound_channel_ids` field to replace them. The existing fields were labeled `via_` to differentiate between inbound channels (i.e. channels which were to us) and channels over which we received the payment.

Here we restore the original naming by renaming the new `inbound_channel_ids` field to `via_channel_ids`.