### PR TITLE
Introduce structured, span-based observability through Logger interface

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -181,7 +181,7 @@ struct LatestMonitorState {
 }
 
 struct TestChainMonitor {
-	pub logger: Arc<dyn Logger>,
+	pub logger: Arc<dyn Logger<UserSpan = ()>>,
 	pub keys: Arc<KeyProvider>,
 	pub persister: Arc<TestPersister>,
 	pub chain_monitor: Arc<
@@ -190,7 +190,7 @@ struct TestChainMonitor {
 			Arc<dyn chain::Filter>,
 			Arc<TestBroadcaster>,
 			Arc<FuzzEstimator>,
-			Arc<dyn Logger>,
+			Arc<dyn Logger<UserSpan = ()>>,
 			Arc<TestPersister>,
 			Arc<KeyProvider>,
 		>,
@@ -199,8 +199,8 @@ struct TestChainMonitor {
 }
 impl TestChainMonitor {
 	pub fn new(
-		broadcaster: Arc<TestBroadcaster>, logger: Arc<dyn Logger>, feeest: Arc<FuzzEstimator>,
-		persister: Arc<TestPersister>, keys: Arc<KeyProvider>,
+		broadcaster: Arc<TestBroadcaster>, logger: Arc<dyn Logger<UserSpan = ()>>,
+		feeest: Arc<FuzzEstimator>, persister: Arc<TestPersister>, keys: Arc<KeyProvider>,
 	) -> Self {
 		Self {
 			chain_monitor: Arc::new(chainmonitor::ChainMonitor::new(
@@ -464,7 +464,7 @@ type ChanMan<'a> = ChannelManager<
 	Arc<FuzzEstimator>,
 	&'a FuzzRouter,
 	&'a FuzzRouter,
-	Arc<dyn Logger>,
+	Arc<dyn Logger<UserSpan = ()>>,
 >;
 
 #[inline]
@@ -640,7 +640,7 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 
 	macro_rules! make_node {
 		($node_id: expr, $fee_estimator: expr) => {{
-			let logger: Arc<dyn Logger> =
+			let logger: Arc<dyn Logger<UserSpan = ()>> =
 				Arc::new(test_logger::TestLogger::new($node_id.to_string(), out.clone()));
 			let node_secret = SecretKey::from_slice(&[
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -703,7 +703,7 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 	                   keys,
 	                   fee_estimator| {
 		let keys_manager = Arc::clone(keys);
-		let logger: Arc<dyn Logger> =
+		let logger: Arc<dyn Logger<UserSpan = ()>> =
 			Arc::new(test_logger::TestLogger::new(node_id.to_string(), out.clone()));
 		let chain_monitor = Arc::new(TestChainMonitor::new(
 			broadcast.clone(),

--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -315,7 +315,7 @@ impl SignerProvider for KeyProvider {
 #[cfg(test)]
 mod tests {
 	use bitcoin::hex::FromHex;
-	use lightning::util::logger::{Logger, Record};
+	use lightning::util::logger::{Logger, Record, Span};
 	use std::collections::HashMap;
 	use std::sync::Mutex;
 
@@ -324,6 +324,8 @@ mod tests {
 		pub lines: Mutex<HashMap<(String, String), usize>>,
 	}
 	impl Logger for TrackingLogger {
+		type UserSpan = ();
+
 		fn log(&self, record: Record) {
 			let mut lines_lock = self.lines.lock().unwrap();
 			let key = (record.module_path.to_string(), format!("{}", record.args));
@@ -337,6 +339,8 @@ mod tests {
 				record.args
 			);
 		}
+
+		fn start(&self, _span: Span, _parent: Option<&()>) -> () {}
 	}
 
 	#[test]

--- a/fuzz/src/process_onion_failure.rs
+++ b/fuzz/src/process_onion_failure.rs
@@ -63,7 +63,8 @@ fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 	}
 
 	let secp_ctx = Secp256k1::new();
-	let logger: Arc<dyn Logger> = Arc::new(test_logger::TestLogger::new("".to_owned(), out));
+	let logger: Arc<dyn Logger<UserSpan = ()>> =
+		Arc::new(test_logger::TestLogger::new("".to_owned(), out));
 
 	let session_priv = SecretKey::from_slice(&usize_to_32_bytes(213127)).unwrap();
 	let payment_id = PaymentId(usize_to_32_bytes(232299));

--- a/fuzz/src/utils/test_logger.rs
+++ b/fuzz/src/utils/test_logger.rs
@@ -7,7 +7,7 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-use lightning::util::logger::{Logger, Record};
+use lightning::util::logger::{Logger, Record, Span};
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 
@@ -58,6 +58,8 @@ impl<'a, Out: Output> Write for LockedWriteAdapter<'a, Out> {
 }
 
 impl<Out: Output> Logger for TestLogger<Out> {
+	type UserSpan = ();
+
 	fn log(&self, record: Record) {
 		write!(
 			LockedWriteAdapter(&self.out),
@@ -70,4 +72,6 @@ impl<Out: Output> Logger for TestLogger<Out> {
 		)
 		.unwrap();
 	}
+
+	fn start(&self, _span: Span, _parent: Option<&()>) -> () {}
 }

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -738,7 +738,9 @@ use futures_util::{dummy_waker, OptionalSelector, Selector, SelectorOutput};
 /// # use lightning_liquidity::lsps5::service::TimeProvider;
 /// # struct Logger {}
 /// # impl lightning::util::logger::Logger for Logger {
+/// #     type UserSpan = ();
 /// #     fn log(&self, _record: lightning::util::logger::Record) {}
+/// #     fn start(&self, _span: lightning::util::logger::Span, _parent: Option<&()>) -> () {}
 /// # }
 /// # struct StoreSync {}
 /// # impl lightning::util::persist::KVStoreSync for StoreSync {

--- a/lightning-dns-resolver/src/lib.rs
+++ b/lightning-dns-resolver/src/lib.rs
@@ -179,7 +179,7 @@ mod test {
 	use lightning::sign::{KeysManager, NodeSigner, ReceiveAuthKey, Recipient};
 	use lightning::types::features::InitFeatures;
 	use lightning::types::payment::PaymentHash;
-	use lightning::util::logger::Logger;
+	use lightning::util::logger::{Logger, Span};
 
 	use lightning::{commitment_signed_dance, expect_payment_claimed, get_htlc_update_msgs};
 	use lightning_types::string::UntrustedString;
@@ -192,9 +192,13 @@ mod test {
 		node: &'static str,
 	}
 	impl Logger for TestLogger {
+		type UserSpan = ();
+
 		fn log(&self, record: lightning::util::logger::Record) {
 			eprintln!("{}: {}", self.node, record.args);
 		}
+
+		fn start(&self, _span: Span, _parent: Option<&()>) -> () {}
 	}
 	impl Deref for TestLogger {
 		type Target = TestLogger;

--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -639,6 +639,8 @@ mod tests {
 
 	pub struct TestLogger();
 	impl lightning::util::logger::Logger for TestLogger {
+		type UserSpan = ();
+
 		fn log(&self, record: lightning::util::logger::Record) {
 			println!(
 				"{:<5} [{} : {}, {}] {}",
@@ -649,6 +651,8 @@ mod tests {
 				record.args
 			);
 		}
+
+		fn start(&self, _span: lightning::util::logger::Span, _parent: Option<&()>) -> () {}
 	}
 
 	struct MsgHandler {

--- a/lightning-rapid-gossip-sync/src/lib.rs
+++ b/lightning-rapid-gossip-sync/src/lib.rs
@@ -51,10 +51,12 @@
 //! use lightning::routing::gossip::NetworkGraph;
 //! use lightning_rapid_gossip_sync::RapidGossipSync;
 //!
-//! # use lightning::util::logger::{Logger, Record};
+//! # use lightning::util::logger::{Logger, Record, Span};
 //! # struct FakeLogger {}
 //! # impl Logger for FakeLogger {
+//! #     type UserSpan = ();
 //! #     fn log(&self, record: Record) { }
+//! #     fn start(&self, _span: Span, parent: Option<&()>) -> () {}
 //! # }
 //! # let logger = FakeLogger {};
 //!

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -66,7 +66,7 @@ use crate::sign::{
 use crate::types::features::ChannelTypeFeatures;
 use crate::types::payment::{PaymentHash, PaymentPreimage};
 use crate::util::byte_utils;
-use crate::util::logger::{Logger, Record};
+use crate::util::logger::{Logger, Record, Span};
 use crate::util::persist::MonitorName;
 use crate::util::ser::{
 	MaybeReadable, Readable, ReadableArgs, RequiredWrapper, UpgradableRequired, Writeable, Writer,
@@ -1634,11 +1634,17 @@ impl<'a, L: Deref> Logger for WithChannelMonitor<'a, L>
 where
 	L::Target: Logger,
 {
+	type UserSpan = <<L as Deref>::Target as Logger>::UserSpan;
+
 	fn log(&self, mut record: Record) {
 		record.peer_id = self.peer_id;
 		record.channel_id = self.channel_id;
 		record.payment_hash = self.payment_hash;
 		self.logger.log(record)
+	}
+
+	fn start(&self, span: Span, parent: Option<&Self::UserSpan>) -> Self::UserSpan {
+		self.logger.start(span, parent)
 	}
 }
 

--- a/lightning/src/ln/channel_state.rs
+++ b/lightning/src/ln/channel_state.rs
@@ -37,7 +37,7 @@ use core::ops::Deref;
 ///   through the exchange of commitment_signed and revoke_and_ack messages.
 ///
 /// This can be used to inspect what next message an HTLC is waiting for to advance its state.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum InboundHTLCStateDetails {
 	/// We have added this HTLC in our commitment transaction by receiving commitment_signed and
 	/// returning revoke_and_ack. We are awaiting the appropriate revoke_and_ack's from the remote
@@ -130,7 +130,7 @@ impl_writeable_tlv_based!(InboundHTLCDetails, {
 ///   through the exchange of commitment_signed and revoke_and_ack messages.
 ///
 /// This can be used to inspect what next message an HTLC is waiting for to advance its state.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum OutboundHTLCStateDetails {
 	/// We are awaiting the appropriate revoke_and_ack's from the remote before the HTLC is added
 	/// on the remote's commitment transaction after update_add_htlc.

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -11741,6 +11741,11 @@ pub fn test_payment_traces() {
 				Span::InboundHTLCState { state: None },
 				Some(Span::InboundHTLC { channel_id: channel_id_1, htlc_id: 0 }),
 			),
+			TestSpanBoundary::Start(
+				Span::WaitingOnPeer,
+				Some(Span::InboundHTLCState { state: None }),
+			),
+			TestSpanBoundary::End(Span::WaitingOnPeer),
 			TestSpanBoundary::End(Span::InboundHTLCState { state: None }),
 			TestSpanBoundary::Start(
 				Span::InboundHTLCState {
@@ -11757,6 +11762,20 @@ pub fn test_payment_traces() {
 				},
 				Some(Span::InboundHTLC { channel_id: channel_id_1, htlc_id: 0 }),
 			),
+			TestSpanBoundary::Start(
+				Span::WaitingOnMonitorPersist,
+				Some(Span::InboundHTLCState {
+					state: Some(InboundHTLCStateDetails::AwaitingRemoteRevokeToAdd)
+				}),
+			),
+			TestSpanBoundary::End(Span::WaitingOnMonitorPersist),
+			TestSpanBoundary::Start(
+				Span::WaitingOnPeer,
+				Some(Span::InboundHTLCState {
+					state: Some(InboundHTLCStateDetails::AwaitingRemoteRevokeToAdd)
+				}),
+			),
+			TestSpanBoundary::End(Span::WaitingOnPeer),
 			TestSpanBoundary::End(Span::InboundHTLCState {
 				state: Some(InboundHTLCStateDetails::AwaitingRemoteRevokeToAdd)
 			}),
@@ -11768,6 +11787,10 @@ pub fn test_payment_traces() {
 				Span::Forward,
 				Some(Span::InboundHTLC { channel_id: channel_id_1, htlc_id: 0 })
 			),
+			TestSpanBoundary::Start(Span::WaitingOnMonitorPersist, Some(Span::Forward),),
+			TestSpanBoundary::End(Span::WaitingOnMonitorPersist,),
+			TestSpanBoundary::Start(Span::WaitingOnForward, Some(Span::Forward),),
+			TestSpanBoundary::End(Span::WaitingOnForward,),
 			TestSpanBoundary::Start(
 				Span::OutboundHTLC { channel_id: channel_id_2, htlc_id: 0 },
 				Some(Span::Forward)
@@ -11801,6 +11824,19 @@ pub fn test_payment_traces() {
 				},
 				Some(Span::InboundHTLC { channel_id: channel_id_1, htlc_id: 0 }),
 			),
+			TestSpanBoundary::Start(
+				Span::WaitingOnMonitorPersist,
+				Some(Span::InboundHTLCState {
+					state: Some(InboundHTLCStateDetails::AwaitingRemoteRevokeToRemoveFulfill)
+				}),
+			),
+			TestSpanBoundary::End(Span::WaitingOnMonitorPersist),
+			TestSpanBoundary::Start(
+				Span::WaitingOnPeer,
+				Some(Span::InboundHTLCState {
+					state: Some(InboundHTLCStateDetails::AwaitingRemoteRevokeToRemoveFulfill)
+				}),
+			),
 			TestSpanBoundary::End(Span::OutboundHTLCState {
 				state: OutboundHTLCStateDetails::Committed
 			}),
@@ -11824,6 +11860,7 @@ pub fn test_payment_traces() {
 			}),
 			TestSpanBoundary::End(Span::OutboundHTLC { channel_id: channel_id_2, htlc_id: 0 }),
 			TestSpanBoundary::End(Span::Forward),
+			TestSpanBoundary::End(Span::WaitingOnPeer),
 			TestSpanBoundary::End(Span::InboundHTLCState {
 				state: Some(InboundHTLCStateDetails::AwaitingRemoteRevokeToRemoveFulfill)
 			}),

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -11801,6 +11801,20 @@ pub fn test_payment_traces() {
 				},
 				Some(Span::OutboundHTLC { channel_id: channel_id_2, htlc_id: 0 }),
 			),
+			TestSpanBoundary::Start(
+				Span::WaitingOnMonitorPersist,
+				Some(Span::OutboundHTLCState {
+					state: OutboundHTLCStateDetails::AwaitingRemoteRevokeToAdd
+				}),
+			),
+			TestSpanBoundary::End(Span::WaitingOnMonitorPersist,),
+			TestSpanBoundary::Start(
+				Span::WaitingOnPeer,
+				Some(Span::OutboundHTLCState {
+					state: OutboundHTLCStateDetails::AwaitingRemoteRevokeToAdd
+				}),
+			),
+			TestSpanBoundary::End(Span::WaitingOnPeer,),
 			TestSpanBoundary::End(Span::OutboundHTLCState {
 				state: OutboundHTLCStateDetails::AwaitingRemoteRevokeToAdd
 			}),
@@ -11808,12 +11822,31 @@ pub fn test_payment_traces() {
 				Span::OutboundHTLCState { state: OutboundHTLCStateDetails::Committed },
 				Some(Span::OutboundHTLC { channel_id: channel_id_2, htlc_id: 0 }),
 			),
+			TestSpanBoundary::Start(
+				Span::WaitingOnPeer,
+				Some(Span::OutboundHTLCState { state: OutboundHTLCStateDetails::Committed }),
+			),
+			TestSpanBoundary::End(Span::WaitingOnPeer),
+			TestSpanBoundary::Start(
+				Span::WaitingOnMonitorPersist,
+				Some(Span::OutboundHTLCState { state: OutboundHTLCStateDetails::Committed }),
+			),
+			TestSpanBoundary::End(Span::WaitingOnMonitorPersist),
+			TestSpanBoundary::Start(
+				Span::WaitingOnPeer,
+				Some(Span::OutboundHTLCState { state: OutboundHTLCStateDetails::Committed }),
+			),
+			TestSpanBoundary::End(Span::WaitingOnPeer),
 			TestSpanBoundary::End(Span::OutboundHTLCState {
 				state: OutboundHTLCStateDetails::Committed
 			}),
 			TestSpanBoundary::Start(
 				Span::OutboundHTLCState { state: OutboundHTLCStateDetails::Committed },
 				Some(Span::OutboundHTLC { channel_id: channel_id_2, htlc_id: 0 }),
+			),
+			TestSpanBoundary::Start(
+				Span::WaitingOnPeer,
+				Some(Span::OutboundHTLCState { state: OutboundHTLCStateDetails::Committed }),
 			),
 			TestSpanBoundary::End(Span::InboundHTLCState {
 				state: Some(InboundHTLCStateDetails::Committed)
@@ -11837,6 +11870,7 @@ pub fn test_payment_traces() {
 					state: Some(InboundHTLCStateDetails::AwaitingRemoteRevokeToRemoveFulfill)
 				}),
 			),
+			TestSpanBoundary::End(Span::WaitingOnPeer),
 			TestSpanBoundary::End(Span::OutboundHTLCState {
 				state: OutboundHTLCStateDetails::Committed
 			}),
@@ -11855,6 +11889,20 @@ pub fn test_payment_traces() {
 				},
 				Some(Span::OutboundHTLC { channel_id: channel_id_2, htlc_id: 0 }),
 			),
+			TestSpanBoundary::Start(
+				Span::WaitingOnMonitorPersist,
+				Some(Span::OutboundHTLCState {
+					state: OutboundHTLCStateDetails::AwaitingRemoteRevokeToRemoveSuccess
+				}),
+			),
+			TestSpanBoundary::End(Span::WaitingOnMonitorPersist),
+			TestSpanBoundary::Start(
+				Span::WaitingOnPeer,
+				Some(Span::OutboundHTLCState {
+					state: OutboundHTLCStateDetails::AwaitingRemoteRevokeToRemoveSuccess
+				}),
+			),
+			TestSpanBoundary::End(Span::WaitingOnPeer),
 			TestSpanBoundary::End(Span::OutboundHTLCState {
 				state: OutboundHTLCStateDetails::AwaitingRemoteRevokeToRemoveSuccess
 			}),

--- a/lightning/src/ln/invoice_utils.rs
+++ b/lightning/src/ln/invoice_utils.rs
@@ -16,7 +16,7 @@ use crate::routing::gossip::RoutingFees;
 use crate::routing::router::{RouteHint, RouteHintHop};
 use crate::sign::{EntropySource, NodeSigner, Recipient};
 use crate::types::payment::PaymentHash;
-use crate::util::logger::{Logger, Record};
+use crate::util::logger::{Logger, Record, Span};
 use alloc::collections::{btree_map, BTreeMap};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::PublicKey;
@@ -604,10 +604,16 @@ impl<'a, 'b, L: Deref> Logger for WithChannelDetails<'a, 'b, L>
 where
 	L::Target: Logger,
 {
+	type UserSpan = <<L as Deref>::Target as Logger>::UserSpan;
+
 	fn log(&self, mut record: Record) {
 		record.peer_id = Some(self.details.counterparty.node_id);
 		record.channel_id = Some(self.details.channel_id);
 		self.logger.log(record)
+	}
+
+	fn start(&self, span: Span, parent: Option<&Self::UserSpan>) -> Self::UserSpan {
+		self.logger.start(span, parent)
 	}
 }
 

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -196,13 +196,15 @@ where
 /// # use lightning::onion_message::messenger::{Destination, MessageRouter, MessageSendInstructions, OnionMessagePath, OnionMessenger};
 /// # use lightning::onion_message::packet::OnionMessageContents;
 /// # use lightning::sign::{NodeSigner, ReceiveAuthKey};
-/// # use lightning::util::logger::{Logger, Record};
+/// # use lightning::util::logger::{Logger, Record, Span};
 /// # use lightning::util::ser::{Writeable, Writer};
 /// # use lightning::io;
 /// # use std::sync::Arc;
 /// # struct FakeLogger;
 /// # impl Logger for FakeLogger {
+/// #     type UserSpan = ();
 /// #     fn log(&self, record: Record) { println!("{:?}" , record); }
+/// #     fn start(&self, _span: Span, parent: Option<&()>) -> () {}
 /// # }
 /// # struct FakeMessageRouter {}
 /// # impl MessageRouter for FakeMessageRouter {

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -9424,14 +9424,16 @@ pub mod benches {
 	use crate::routing::scoring::{ScoreLookUp, ScoreUpdate};
 	use crate::types::features::Bolt11InvoiceFeatures;
 	use crate::util::config::UserConfig;
-	use crate::util::logger::{Logger, Record};
+	use crate::util::logger::{Logger, Record, Span};
 	use crate::util::test_utils::TestLogger;
 
 	use criterion::Criterion;
 
 	struct DummyLogger {}
 	impl Logger for DummyLogger {
+		type UserSpan = ();
 		fn log(&self, _record: Record) {}
+		fn start(&self, _span: Span, _parent: Option<&()>) -> () {}
 	}
 
 	#[rustfmt::skip]

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -21,12 +21,14 @@
 //! # use lightning::routing::router::{RouteParameters, find_route};
 //! # use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters, ProbabilisticScoringDecayParameters};
 //! # use lightning::sign::KeysManager;
-//! # use lightning::util::logger::{Logger, Record};
+//! # use lightning::util::logger::{Logger, Record, Span};
 //! # use bitcoin::secp256k1::PublicKey;
 //! #
 //! # struct FakeLogger {};
 //! # impl Logger for FakeLogger {
+//! #     type UserSpan = ();
 //! #     fn log(&self, record: Record) { unimplemented!() }
+//! #     fn start(&self, _span: Span, parent: Option<&()>) -> () {}
 //! # }
 //! # fn find_scored_route(payer: PublicKey, route_params: RouteParameters, network_graph: NetworkGraph<&FakeLogger>) {
 //! # let logger = FakeLogger {};

--- a/lightning/src/util/logger.rs
+++ b/lightning/src/util/logger.rs
@@ -204,6 +204,14 @@ pub enum Span {
 		/// The state.
 		state: OutboundHTLCStateDetails,
 	},
+	/// Span representing the wait time until a peer responds.
+	WaitingOnPeer,
+	/// Span representing the wait time until a channel monitor persists.
+	WaitingOnMonitorPersist,
+	/// Span representing the wait time until async signing completes.
+	WaitingOnAsyncSigning,
+	/// Span representing the wait time until an HTLC gets forwarded.
+	WaitingOnForward,
 	/// Span representing sending an outbound Ping and receiving an inbound Pong.
 	PingPong {
 		/// The node id of the counterparty.

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -54,7 +54,7 @@ use crate::util::config::UserConfig;
 use crate::util::dyn_signer::{
 	DynKeysInterface, DynKeysInterfaceTrait, DynPhantomKeysInterface, DynSigner,
 };
-use crate::util::logger::{Logger, Record};
+use crate::util::logger::{Logger, Record, Span};
 #[cfg(feature = "std")]
 use crate::util::mut_global::MutGlobal;
 use crate::util::persist::{KVStoreSync, MonitorName};
@@ -1445,10 +1445,48 @@ impl BaseMessageHandler for TestRoutingMessageHandler {
 	}
 }
 
+pub struct TestUserSpan {
+	span: Span,
+	span_boundaries: Arc<Mutex<Vec<TestSpanBoundary>>>,
+}
+
+impl TestUserSpan {
+	fn new(
+		span: Span, parent_span: Option<&TestUserSpan>,
+		span_boundaries: Arc<Mutex<Vec<TestSpanBoundary>>>,
+	) -> Self {
+		{
+			let mut span_boundaries_guard = span_boundaries.lock().unwrap();
+			span_boundaries_guard
+				.push(TestSpanBoundary::Start(span.clone(), parent_span.map(|s| s.span.clone())));
+			core::mem::drop(span_boundaries_guard);
+		}
+		TestUserSpan { span, span_boundaries }
+	}
+}
+
+impl Drop for TestUserSpan {
+	fn drop(&mut self) {
+		if std::thread::panicking() {
+			return;
+		}
+		let mut span_boundaries = self.span_boundaries.lock().unwrap();
+		span_boundaries.push(TestSpanBoundary::End(self.span.clone()));
+		core::mem::drop(span_boundaries);
+	}
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum TestSpanBoundary {
+	Start(Span, Option<Span>),
+	End(Span),
+}
+
 pub struct TestLogger {
 	pub(crate) id: String,
 	pub lines: Mutex<HashMap<(&'static str, String), usize>>,
 	pub context: Mutex<HashMap<(&'static str, Option<PublicKey>, Option<ChannelId>), usize>>,
+	pub span_boundaries: Arc<Mutex<Vec<TestSpanBoundary>>>,
 }
 
 impl TestLogger {
@@ -1458,7 +1496,8 @@ impl TestLogger {
 	pub fn with_id(id: String) -> TestLogger {
 		let lines = Mutex::new(new_hash_map());
 		let context = Mutex::new(new_hash_map());
-		TestLogger { id, lines, context }
+		let span_boundaries = Arc::new(Mutex::new(Vec::new()));
+		TestLogger { id, lines, context, span_boundaries }
 	}
 	pub fn assert_log(&self, module: &str, line: String, count: usize) {
 		let log_entries = self.lines.lock().unwrap();
@@ -1505,6 +1544,8 @@ impl TestLogger {
 }
 
 impl Logger for TestLogger {
+	type UserSpan = TestUserSpan;
+
 	fn log(&self, record: Record) {
 		let context =
 			format!("{} {} [{}:{}]", self.id, record.level, record.module_path, record.line);
@@ -1536,6 +1577,10 @@ impl Logger for TestLogger {
 				.or_insert(0) += 1;
 			println!("{}", s);
 		}
+	}
+
+	fn start(&self, span: Span, parent: Option<&TestUserSpan>) -> TestUserSpan {
+		TestUserSpan::new(span, parent, Arc::clone(&self.span_boundaries))
 	}
 }
 


### PR DESCRIPTION
This change allows users to create hierarchical span objects through the `Logger` interface for specific computations, such as the handling of HTLCs. These span objects will be held in LDK across the corresponding lifetimes before being dropped, providing insight in durations and latencies.

This API is designed to be compatible with https://docs.rs/opentelemetry/latest/opentelemetry/trace/trait.Tracer.html, but can also be used more directly to derive time-based metrics or to log durations.

Hierarchical RAII spans are currently added for:
- HTLC lifetimes, HTLC state transitions, inbound to outbound HTLC forwarding (see `functional_tests.rs`).
- Ping/pong request-response pairs.