### PR TITLE
Make `ChangeDestinationSourceSyncWrapper` `pub`

### DIFF
--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -996,12 +996,7 @@ pub trait ChangeDestinationSourceSync {
 }
 
 /// A wrapper around [`ChangeDestinationSource`] to allow for async calls.
-#[cfg(any(test, feature = "_test_utils"))]
 pub struct ChangeDestinationSourceSyncWrapper<T: Deref>(T)
-where
-	T::Target: ChangeDestinationSourceSync;
-#[cfg(not(any(test, feature = "_test_utils")))]
-pub(crate) struct ChangeDestinationSourceSyncWrapper<T: Deref>(T)
 where
 	T::Target: ChangeDestinationSourceSync;
 


### PR DESCRIPTION
The idea of the wrapper is that you'd use it to wrap your `ChangeDestinationSourceSync` instance. To be able to do that outside of `lightning`, we'll need to make it `pub`.