### PR TITLE
Skip any erroring entry in `FilesystemStore::list`

### DIFF
--- a/lightning-persister/src/fs_store.rs
+++ b/lightning-persister/src/fs_store.rs
@@ -373,14 +373,7 @@ fn dir_entry_is_key(dir_entry: &fs::DirEntry) -> Result<bool, lightning::io::Err
 		}
 	}
 
-	let metadata = dir_entry.metadata().map_err(|e| {
-		let msg = format!(
-			"Failed to list keys at path {}: {}",
-			PrintableString(p.to_str().unwrap_or_default()),
-			e
-		);
-		lightning::io::Error::new(lightning::io::ErrorKind::Other, msg)
-	})?;
+	let metadata = dir_entry.metadata()?;
 
 	// We allow the presence of directories in the empty primary namespace and just skip them.
 	if metadata.is_dir() {


### PR DESCRIPTION
Closes #3795.

Previously, we would bubble up any error that we'd encouter during retrieving the metadata for all listed entries. Here we relax this somewhat to allow for minor inconsistencies between reading the directory entries and checking whether they are valid key entries.