### PR TITLE
Allow counterparty pending monitor update within quiescence handshake

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -9675,10 +9675,14 @@ impl<SP: Deref> FundedChannel<SP> where
 		self.mark_response_received();
 
 		if self.context.is_waiting_on_peer_pending_channel_update()
-			|| self.context.is_monitor_or_signer_pending_channel_update()
+			|| self.context.signer_pending_revoke_and_ack
+			|| self.context.signer_pending_commitment_update
 		{
 			// Since we've already sent `stfu`, it should not be possible for one of our updates to
-			// be pending, so anything pending currently must be from a counterparty update.
+			// be pending, so anything pending currently must be from a counterparty update. We may
+			// have a monitor update pending if we've processed a message from the counterparty, but
+			// we don't consider this when becoming quiescent since the states are not mutually
+			// exclusive.
 			return Err(ChannelError::WarnAndDisconnect(
 				"Received counterparty stfu while having pending counterparty updates".to_owned()
 			));


### PR DESCRIPTION
Previously, if we were negotiating quiescence, and we had already sent our `stfu`, we'd disconnect upon receiving the counterparty's `stfu` if we had a pending monitor update. This could result from processing a counterparty's final `revoke_and_ack` to an update, and immediately processing their `stfu` (which is valid from their point of view) without complete the monitor update. This was unintended, as we are able to track the quiescent and pending monitor update flags at the same time. Note that this commit still considers whether our signer owes any messages, as these are indicative of a channel update still pending.

Fixes #3805.