### PR TITLE
Implement std::error::Error for SocketParseError

### DIFF
--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -1066,6 +1066,8 @@ pub enum SocketAddressParseError {
 	InvalidOnionV3,
 }
 
+impl std::error::Error for SocketAddressParseError {}
+
 impl fmt::Display for SocketAddressParseError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {


### PR DESCRIPTION
SocketParseError does not implement std Error which means it can't be used in standard ways like combining ? and anyhow. This is problematic since it's a public interface and being able to use anyhow on public errors is nice.

This commit implements std::error::Error for SocketParseError