### PR TITLE
Bump to `electrum-client` v0.23, `esplora-client` v0.12, `electrsd` v0.34

### DIFF
--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -35,15 +35,15 @@ lightning = { version = "0.2.0", path = "../lightning", default-features = false
 lightning-macros = { version = "0.2", path = "../lightning-macros", default-features = false }
 bitcoin = { version = "0.32.2", default-features = false }
 futures = { version = "0.3", optional = true }
-esplora-client = { version = "0.11", default-features = false, optional = true }
-electrum-client = { version = "0.22.0", optional = true, default-features = false, features = ["proxy"] }
+esplora-client = { version = "0.12", default-features = false, optional = true }
+electrum-client = { version = "0.23.1", optional = true, default-features = false, features = ["proxy"] }
 
 [dev-dependencies]
 lightning = { version = "0.2.0", path = "../lightning", default-features = false, features = ["std", "_test_utils"] }
 tokio = { version = "1.35.0", features = ["macros"] }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
-electrsd = { version = "0.33.0", default-features = false, features = ["legacy"] }
+electrsd = { version = "0.34.0", default-features = false, features = ["legacy"] }
 corepc-node = { version = "0.7.0", default-features = false, features = ["28_0"] }
 
 [lints.rust.unexpected_cfgs]


### PR DESCRIPTION
We bump these crates to the latest versions to ensure compatibility with the upcoming BDK release.