### PR TITLE
Add currency conversion support for BOLT 12 offers

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -65,6 +65,7 @@ use lightning::ln::msgs::{
 use lightning::ln::outbound_payment::RecipientOnionFields;
 use lightning::ln::script::ShutdownScript;
 use lightning::ln::types::ChannelId;
+use lightning::offers::currency::NullCurrencyConversion;
 use lightning::offers::invoice::UnsignedBolt12Invoice;
 use lightning::onion_message::messenger::{Destination, MessageRouter, OnionMessagePath};
 use lightning::routing::router::{
@@ -928,6 +929,7 @@ type ChanMan<'a> = ChannelManager<
 	Arc<FuzzEstimator>,
 	&'a FuzzRouter,
 	&'a FuzzRouter,
+	Arc<NullCurrencyConversion>,
 	Arc<dyn Logger + MaybeSend + MaybeSync>,
 >;
 
@@ -975,6 +977,7 @@ struct HarnessNode<'a> {
 	monitor: Arc<TestChainMonitor>,
 	persister: Arc<HarnessPersister>,
 	keys_manager: Arc<KeyProvider>,
+	currency_conversion: Arc<NullCurrencyConversion>,
 	logger: Arc<dyn Logger + MaybeSend + MaybeSync>,
 	broadcaster: Arc<TestBroadcaster>,
 	fee_estimator: Arc<FuzzEstimator>,
@@ -1028,8 +1031,9 @@ impl<'a> HarnessNode<'a> {
 
 	fn new<Out: Output + MaybeSend + MaybeSync>(
 		node_id: u8, wallet: Arc<TestWalletSource>, fee_estimator: Arc<FuzzEstimator>,
-		broadcaster: Arc<TestBroadcaster>, persistence_style: ChannelMonitorUpdateStatus,
-		deferred: bool, out: &Out, router: &'a FuzzRouter, chan_type: ChanType,
+		broadcaster: Arc<TestBroadcaster>, currency_conversion: Arc<NullCurrencyConversion>,
+		persistence_style: ChannelMonitorUpdateStatus, deferred: bool, out: &Out,
+		router: &'a FuzzRouter, chan_type: ChanType,
 	) -> Self {
 		let logger = Self::build_logger(node_id, out);
 		let node_secret = SecretKey::from_slice(&[
@@ -1061,6 +1065,7 @@ impl<'a> HarnessNode<'a> {
 			Arc::clone(&broadcaster),
 			router,
 			router,
+			Arc::clone(&currency_conversion),
 			Arc::clone(&logger),
 			Arc::clone(&keys_manager),
 			Arc::clone(&keys_manager),
@@ -1075,6 +1080,7 @@ impl<'a> HarnessNode<'a> {
 			monitor,
 			persister,
 			keys_manager,
+			currency_conversion,
 			logger,
 			broadcaster,
 			fee_estimator,
@@ -1373,6 +1379,7 @@ impl<'a> HarnessNode<'a> {
 			chain_monitor: Arc::clone(&chain_monitor),
 			tx_broadcaster: Arc::clone(&self.broadcaster),
 			router,
+			currency_conversion: Arc::clone(&self.currency_conversion),
 			message_router: router,
 			logger: Arc::clone(&logger),
 			config: build_node_config(chan_type),
@@ -2487,6 +2494,7 @@ impl<'a, Out: Output + MaybeSend + MaybeSync> Harness<'a, Out> {
 		let broadcast_a = Arc::new(TestBroadcaster { txn_broadcasted: RefCell::new(Vec::new()) });
 		let broadcast_b = Arc::new(TestBroadcaster { txn_broadcasted: RefCell::new(Vec::new()) });
 		let broadcast_c = Arc::new(TestBroadcaster { txn_broadcasted: RefCell::new(Vec::new()) });
+		let currency_conversion = Arc::new(NullCurrencyConversion);
 
 		// 3 nodes is enough to hit all the possible cases, notably
 		// unknown-source-unknown-dest forwarding.
@@ -2496,6 +2504,7 @@ impl<'a, Out: Output + MaybeSend + MaybeSync> Harness<'a, Out> {
 				Arc::clone(&wallet_a),
 				Arc::clone(&fee_est_a),
 				Arc::clone(&broadcast_a),
+				Arc::clone(&currency_conversion),
 				persistence_styles[0],
 				deferred[0],
 				&out,
@@ -2507,6 +2516,7 @@ impl<'a, Out: Output + MaybeSend + MaybeSync> Harness<'a, Out> {
 				Arc::clone(&wallet_b),
 				Arc::clone(&fee_est_b),
 				Arc::clone(&broadcast_b),
+				Arc::clone(&currency_conversion),
 				persistence_styles[1],
 				deferred[1],
 				&out,
@@ -2518,6 +2528,7 @@ impl<'a, Out: Output + MaybeSend + MaybeSync> Harness<'a, Out> {
 				Arc::clone(&wallet_c),
 				Arc::clone(&fee_est_c),
 				Arc::clone(&broadcast_c),
+				Arc::clone(&currency_conversion),
 				persistence_styles[2],
 				deferred[2],
 				&out,

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -51,7 +51,9 @@ use lightning::ln::peer_handler::{
 };
 use lightning::ln::script::ShutdownScript;
 use lightning::ln::types::ChannelId;
+use lightning::offers::currency::{CurrencyConversion, ExchangeRateBound};
 use lightning::offers::invoice::UnsignedBolt12Invoice;
+use lightning::offers::offer::CurrencyCode;
 use lightning::onion_message::messenger::{Destination, MessageRouter, OnionMessagePath};
 use lightning::routing::gossip::{NetworkGraph, P2PGossipSync};
 use lightning::routing::router::{
@@ -184,6 +186,14 @@ impl MessageRouter for FuzzRouter {
 	}
 }
 
+struct FuzzCurrencyConversion {}
+
+impl CurrencyConversion for FuzzCurrencyConversion {
+	fn conversion_range(&self, _currency: CurrencyCode) -> Result<ExchangeRateBound, ()> {
+		Err(())
+	}
+}
+
 struct TestBroadcaster {
 	txn_broadcasted: Mutex<Vec<Transaction>>,
 }
@@ -239,6 +249,7 @@ type ChannelMan<'a> = ChannelManager<
 	Arc<FuzzEstimator>,
 	&'a FuzzRouter,
 	&'a FuzzRouter,
+	&'a FuzzCurrencyConversion,
 	Arc<dyn Logger + MaybeSend + MaybeSync>,
 >;
 type PeerMan<'a> = PeerManager<
@@ -548,6 +559,7 @@ pub fn do_test(mut data: &[u8], logger: &Arc<dyn Logger + MaybeSend + MaybeSync>
 	});
 	let fee_est = Arc::new(FuzzEstimator { input: input.clone() });
 	let router = FuzzRouter {};
+	let conversion = FuzzCurrencyConversion {};
 
 	macro_rules! get_slice {
 		($len: expr) => {
@@ -613,6 +625,7 @@ pub fn do_test(mut data: &[u8], logger: &Arc<dyn Logger + MaybeSend + MaybeSync>
 		broadcast.clone(),
 		&router,
 		&router,
+		&conversion,
 		Arc::clone(&logger),
 		keys_manager.clone(),
 		keys_manager.clone(),

--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -16,6 +16,7 @@ use lightning::blinded_path::payment::{
 };
 use lightning::ln::channelmanager::MIN_FINAL_CLTV_EXPIRY_DELTA;
 use lightning::ln::inbound_payment::ExpandedKey;
+use lightning::offers::currency::NullCurrencyConversion;
 use lightning::offers::invoice::UnsignedBolt12Invoice;
 use lightning::offers::invoice_request::{InvoiceRequest, InvoiceRequestFields};
 use lightning::offers::offer::OfferId;
@@ -145,7 +146,7 @@ fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
 	.unwrap();
 
 	let payment_hash = PaymentHash([42; 32]);
-	invoice_request.respond_with(vec![payment_path], payment_hash)?.build()
+	invoice_request.respond_with(&NullCurrencyConversion, vec![payment_path], payment_hash)?.build()
 }
 
 pub fn invoice_request_deser_test<Out: test_logger::Output>(data: &[u8], out: Out) {

--- a/fuzz/src/lsps_message.rs
+++ b/fuzz/src/lsps_message.rs
@@ -9,6 +9,7 @@ use lightning::chain::{chainmonitor, BlockLocator};
 use lightning::ln::channelmanager::{ChainParameters, ChannelManager};
 use lightning::ln::peer_handler::CustomMessageHandler;
 use lightning::ln::wire::CustomMessageReader;
+use lightning::offers::currency::NullCurrencyConversion;
 use lightning::onion_message::messenger::DefaultMessageRouter;
 use lightning::routing::gossip::NetworkGraph;
 use lightning::routing::router::DefaultRouter;
@@ -46,6 +47,7 @@ pub fn do_test(data: &[u8]) {
 		Arc::clone(&scorer),
 		Default::default(),
 	));
+	let converter = Arc::new(NullCurrencyConversion);
 	let msg_router =
 		Arc::new(DefaultMessageRouter::new(Arc::clone(&network_graph), Arc::clone(&keys_manager)));
 	let chain_source = Arc::new(TestChainSource::new(Network::Bitcoin));
@@ -68,6 +70,7 @@ pub fn do_test(data: &[u8]) {
 		Arc::clone(&tx_broadcaster),
 		Arc::clone(&router),
 		Arc::clone(&msg_router),
+		Arc::clone(&converter),
 		Arc::clone(&logger),
 		Arc::clone(&keys_manager),
 		Arc::clone(&keys_manager),

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -379,6 +379,9 @@ type DynMessageRouter = lightning::onion_message::messenger::DefaultMessageRoute
 >;
 
 #[cfg(not(c_bindings))]
+type DynCurrencyConversion = lightning::offers::currency::NullCurrencyConversion;
+
+#[cfg(not(c_bindings))]
 type DynSignerProvider = dyn lightning::sign::SignerProvider<EcdsaSigner = lightning::sign::InMemorySigner>
 	+ Send
 	+ Sync;
@@ -393,6 +396,7 @@ type DynChannelManager = lightning::ln::channelmanager::ChannelManager<
 	&'static (dyn FeeEstimator + Send + Sync),
 	&'static DynRouter,
 	&'static DynMessageRouter,
+	&'static DynCurrencyConversion,
 	&'static (dyn Logger + Send + Sync),
 >;
 
@@ -1949,6 +1953,7 @@ mod tests {
 		IgnoringMessageHandler, MessageHandler, PeerManager, SocketDescriptor,
 	};
 	use lightning::ln::types::ChannelId;
+	use lightning::offers::currency::NullCurrencyConversion;
 	use lightning::onion_message::messenger::{DefaultMessageRouter, OnionMessenger};
 	use lightning::routing::gossip::{NetworkGraph, P2PGossipSync};
 	use lightning::routing::router::{CandidateRouteHop, DefaultRouter, Path, RouteHop};
@@ -2044,6 +2049,7 @@ mod tests {
 				Arc<KeysManager>,
 			>,
 		>,
+		Arc<NullCurrencyConversion>,
 		Arc<test_utils::TestLogger>,
 	>;
 
@@ -2468,6 +2474,7 @@ mod tests {
 				Arc::clone(&network_graph),
 				Arc::clone(&keys_manager),
 			));
+			let conversion = Arc::new(NullCurrencyConversion);
 			let chain_source = Arc::new(test_utils::TestChainSource::new(Network::Bitcoin));
 			let kv_store =
 				Arc::new(Persister::new(format!("{}_persister_{}", &persist_dir, i).into()));
@@ -2494,6 +2501,7 @@ mod tests {
 				Arc::clone(&tx_broadcaster),
 				Arc::clone(&router),
 				Arc::clone(&msg_router),
+				Arc::clone(&conversion),
 				Arc::clone(&logger),
 				Arc::clone(&keys_manager),
 				Arc::clone(&keys_manager),

--- a/lightning-block-sync/src/init.rs
+++ b/lightning-block-sync/src/init.rs
@@ -53,6 +53,7 @@ where
 /// use lightning::chain::chaininterface::BroadcasterInterface;
 /// use lightning::chain::chaininterface::FeeEstimator;
 /// use lightning::ln::channelmanager::{ChannelManager, ChannelManagerReadArgs};
+/// use lightning::offers::currency::CurrencyConversion;
 /// use lightning::onion_message::messenger::MessageRouter;
 /// use lightning::routing::router::Router;
 /// use lightning::sign;
@@ -74,6 +75,7 @@ where
 /// 	F: FeeEstimator,
 /// 	R: Router,
 /// 	MR: MessageRouter,
+/// 	CC: CurrencyConversion,
 /// 	L: Logger,
 /// 	C: chain::Filter,
 /// 	P: chainmonitor::Persist<SP::EcdsaSigner>,
@@ -88,6 +90,7 @@ where
 /// 	fee_estimator: &F,
 /// 	router: &R,
 /// 	message_router: &MR,
+/// 	currency_conversion: &CC,
 /// 	logger: &L,
 /// 	persister: &P,
 /// ) {
@@ -108,11 +111,12 @@ where
 /// 			tx_broadcaster,
 /// 			router,
 /// 			message_router,
+/// 			currency_conversion,
 /// 			logger,
 /// 			config,
 /// 			vec![&mut monitor],
 /// 		);
-/// 		<(BlockLocator, ChannelManager<&ChainMonitor<SP::EcdsaSigner, &C, &T, &F, &L, &P, &ES>, &T, &ES, &NS, &SP, &F, &R, &MR, &L>)>::read(
+/// 		<(BlockLocator, ChannelManager<&ChainMonitor<SP::EcdsaSigner, &C, &T, &F, &L, &P, &ES>, &T, &ES, &NS, &SP, &F, &R, &MR, &CC, &L>)>::read(
 /// 			&mut Cursor::new(&serialized_manager), read_args).unwrap()
 /// 	};
 ///

--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -44,7 +44,7 @@ use crate::offers::flow::{
 };
 use crate::offers::invoice_request::InvoiceRequest;
 use crate::offers::nonce::Nonce;
-use crate::offers::offer::{Amount, Offer};
+use crate::offers::offer::{Amount, CurrencyCode, Offer};
 use crate::offers::static_invoice::{
 	StaticInvoice, StaticInvoiceBuilder,
 	DEFAULT_RELATIVE_EXPIRY as STATIC_INVOICE_DEFAULT_RELATIVE_EXPIRY,
@@ -63,6 +63,7 @@ use crate::types::features::Bolt12InvoiceFeatures;
 use crate::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 use crate::util::config::{HTLCInterceptionFlags, UserConfig};
 use crate::util::ser::Writeable;
+use crate::util::test_utils::TestCurrencyConversion;
 use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 use bitcoin::secp256k1;
@@ -1165,6 +1166,127 @@ fn async_receive_flow_success() {
 	let keysend_preimage = extract_payment_preimage(&claimable_ev);
 	let (res, _) =
 		claim_payment_along_route(ClaimAlongRouteArgs::new(&nodes[0], route, keysend_preimage));
+	assert_eq!(res, Some(PaidBolt12Invoice::StaticInvoice(static_invoice)));
+}
+
+#[test]
+fn async_receive_flow_uses_currency_conversion() {
+	// Test that an often-offline recipient's currency-denominated async offer is paid using the
+	// sender's configured currency conversion when the sender receives the static invoice.
+	let secp_ctx = Secp256k1::new();
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+
+	let mut allow_priv_chan_fwds_cfg = test_default_channel_config();
+	allow_priv_chan_fwds_cfg.accept_forwards_to_priv_channels = true;
+	let node_chanmgrs =
+		create_node_chanmgrs(3, &node_cfgs, &[None, Some(allow_priv_chan_fwds_cfg), None]);
+
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	create_unannounced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0);
+
+	let sender = &nodes[0];
+	let always_online_node = &nodes[1];
+	let async_recipient = &nodes[2];
+	let sender_id = sender.node.get_our_node_id();
+	let always_online_node_id = always_online_node.node.get_our_node_id();
+	let async_recipient_id = async_recipient.node.get_our_node_id();
+
+	let blinded_paths_to_always_online_node = always_online_node
+		.message_router
+		.create_blinded_paths(
+			always_online_node_id,
+			always_online_node.keys_manager.get_receive_auth_key(),
+			MessageContext::Offers(OffersContext::InvoiceRequest {
+				nonce: Nonce([42; 16]),
+				payment_metadata: None,
+			}),
+			Vec::new(),
+			&secp_ctx,
+		)
+		.unwrap();
+	let (offer_builder, nonce) = async_recipient
+		.node
+		.flow
+		.create_async_receive_offer_builder(
+			async_recipient.keys_manager,
+			&TestCurrencyConversion {},
+			blinded_paths_to_always_online_node,
+		)
+		.unwrap();
+	let offer = offer_builder
+		.amount(Amount::Currency { iso4217_code: CurrencyCode::new(*b"USD").unwrap(), amount: 10 })
+		.build()
+		.unwrap();
+	let static_invoice = create_static_invoice_builder(async_recipient, &offer, nonce, None)
+		.build_and_sign(&secp_ctx)
+		.unwrap();
+	assert!(static_invoice.invoice_features().supports_basic_mpp());
+
+	let converted_amt_msat = 10_000;
+	let expected_first_hop_amt_msat = converted_amt_msat + 1_000;
+	let payment_id = PaymentId([1; 32]);
+	sender.node.pay_for_offer(&offer, None, payment_id, Default::default()).unwrap();
+
+	let invreq_om =
+		sender.onion_messenger.next_onion_message_for_peer(always_online_node_id).unwrap();
+	let (invoice_request, invreq_reply_path) =
+		offers_tests::extract_invoice_request(always_online_node, &invreq_om);
+	assert_eq!(invoice_request.amount_msats(), None);
+
+	always_online_node
+		.onion_messenger
+		.send_onion_message(
+			ParsedOnionMessageContents::<Infallible>::Offers(OffersMessage::StaticInvoice(
+				static_invoice.clone(),
+			)),
+			MessageSendInstructions::WithoutReplyPath {
+				destination: Destination::BlindedPath(invreq_reply_path),
+			},
+		)
+		.unwrap();
+
+	let static_invoice_om =
+		always_online_node.onion_messenger.next_onion_message_for_peer(sender_id).unwrap();
+	sender.onion_messenger.handle_onion_message(always_online_node_id, &static_invoice_om);
+	sender.node.process_pending_htlc_forwards();
+	assert!(sender.node.get_and_clear_pending_msg_events().is_empty());
+
+	let held_htlc_available_om_0_1 =
+		sender.onion_messenger.next_onion_message_for_peer(always_online_node_id).unwrap();
+	always_online_node.onion_messenger.handle_onion_message(sender_id, &held_htlc_available_om_0_1);
+	let held_htlc_available_om_1_2 =
+		always_online_node.onion_messenger.next_onion_message_for_peer(async_recipient_id).unwrap();
+	async_recipient
+		.onion_messenger
+		.handle_onion_message(always_online_node_id, &held_htlc_available_om_1_2);
+
+	let release_held_htlc_om =
+		async_recipient.onion_messenger.next_onion_message_for_peer(sender_id).unwrap();
+	sender.onion_messenger.handle_onion_message(async_recipient_id, &release_held_htlc_om);
+
+	let mut events = sender.node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let ev = remove_first_msg_event_to_node(&always_online_node_id, &mut events);
+	let payment_hash = match ev {
+		MessageSendEvent::UpdateHTLCs { ref updates, .. } => {
+			// The first-hop HTLC includes the routing fee, while the final payment
+			// amount remains the currency-converted offer amount.
+			assert_eq!(updates.update_add_htlcs[0].amount_msat, expected_first_hop_amt_msat);
+			updates.update_add_htlcs[0].payment_hash
+		},
+		_ => panic!(),
+	};
+	check_added_monitors(sender, 1);
+
+	let route: &[&[&Node]] = &[&[always_online_node, async_recipient]];
+	let args = PassAlongPathArgs::new(sender, route[0], converted_amt_msat, payment_hash, ev)
+		.with_dummy_tlvs(&[DummyTlvs::default(); DEFAULT_PAYMENT_DUMMY_HOPS]);
+	let claimable_ev = do_pass_along_path(args).unwrap();
+	let keysend_preimage = extract_payment_preimage(&claimable_ev);
+	let (res, _) =
+		claim_payment_along_route(ClaimAlongRouteArgs::new(sender, route, keysend_preimage));
 	assert_eq!(res, Some(PaidBolt12Invoice::StaticInvoice(static_invoice)));
 }
 

--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -37,6 +37,7 @@ use crate::offers::async_receive_offer_cache::{
 	TEST_INVOICE_REFRESH_THRESHOLD, TEST_MAX_CACHED_OFFERS_TARGET, TEST_MAX_UPDATE_ATTEMPTS,
 	TEST_MIN_OFFER_PATHS_RELATIVE_EXPIRY_SECS, TEST_OFFER_REFRESH_THRESHOLD,
 };
+use crate::offers::currency::NullCurrencyConversion;
 use crate::offers::flow::{
 	TEST_DEFAULT_ASYNC_RECEIVE_OFFER_EXPIRY, TEST_OFFERS_MESSAGE_REQUEST_LIMIT,
 	TEST_TEMP_REPLY_PATH_RELATIVE_EXPIRY,
@@ -328,7 +329,11 @@ fn create_static_invoice<T: secp256k1::Signing + secp256k1::Verification>(
 	let (offer_builder, offer_nonce) = recipient
 		.node
 		.flow
-		.create_async_receive_offer_builder(entropy_source, blinded_paths_to_always_online_node)
+		.create_async_receive_offer_builder(
+			entropy_source,
+			&NullCurrencyConversion,
+			blinded_paths_to_always_online_node,
+		)
 		.unwrap();
 	let offer = offer_builder.build().unwrap();
 	let static_invoice =
@@ -702,7 +707,11 @@ fn static_invoice_unknown_required_features() {
 	let (offer_builder, nonce) = nodes[2]
 		.node
 		.flow
-		.create_async_receive_offer_builder(entropy_source, blinded_paths_to_always_online_node)
+		.create_async_receive_offer_builder(
+			entropy_source,
+			&NullCurrencyConversion,
+			blinded_paths_to_always_online_node,
+		)
 		.unwrap();
 	let offer = offer_builder.build().unwrap();
 	let static_invoice_unknown_req_features =
@@ -1772,7 +1781,11 @@ fn invalid_async_receive_with_retry<F1, F2>(
 	let (offer_builder, offer_nonce) = nodes[2]
 		.node
 		.flow
-		.create_async_receive_offer_builder(entropy_source, blinded_paths_to_always_online_node)
+		.create_async_receive_offer_builder(
+			entropy_source,
+			&NullCurrencyConversion,
+			blinded_paths_to_always_online_node,
+		)
 		.unwrap();
 	let offer = offer_builder.build().unwrap();
 	let amt_msat = 5000;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2550,7 +2550,7 @@ impl<
 ///     .create_offer_builder()?
 /// # ;
 /// # // Needed for compiling for c_bindings
-/// # let builder: lightning::offers::offer::OfferBuilder<_, _> = offer.into();
+/// # let builder: lightning::offers::offer::OfferBuilder<_, _, _> = offer.into();
 /// # let offer = builder
 ///     .description("coffee".to_string())
 ///     .amount_msats(10_000_000)
@@ -14701,7 +14701,7 @@ macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	pub fn create_offer_builder(&$self) -> Result<$builder, Bolt12SemanticError> {
 		let builder = $self.flow.create_offer_builder(
-			&$self.entropy_source, $self.get_peers_for_blinded_path()
+			&$self.entropy_source, &$self.currency_conversion, $self.get_peers_for_blinded_path()
 		)?;
 
 		Ok(builder.into())
@@ -14723,7 +14723,7 @@ macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 		router: ME,
 	) -> Result<$builder, Bolt12SemanticError> {
 		let builder = $self.flow.create_offer_builder_using_router(
-			router, &$self.entropy_source, $self.get_peers_for_blinded_path()
+			router, &$self.entropy_source, &$self.currency_conversion, $self.get_peers_for_blinded_path()
 		)?;
 
 		Ok(builder.into())
@@ -14764,7 +14764,7 @@ macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 		}
 
 		let builder = $self.flow.create_phantom_offer_builder(
-			&$self.entropy_source, peers, path_count_limit
+			&$self.entropy_source, &$self.currency_conversion, peers, path_count_limit
 		)?;
 
 		Ok(builder.into())
@@ -14891,12 +14891,12 @@ impl<
 	> ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	#[cfg(not(c_bindings))]
-	create_offer_builder!(self, OfferBuilder<'_, DerivedMetadata, secp256k1::All>);
+	create_offer_builder!(self, OfferBuilder<'_, DerivedMetadata, secp256k1::All, CC>);
 	#[cfg(not(c_bindings))]
 	create_refund_builder!(self, RefundBuilder<'_, secp256k1::All>);
 
 	#[cfg(c_bindings)]
-	create_offer_builder!(self, OfferWithDerivedMetadataBuilder);
+	create_offer_builder!(self, OfferWithDerivedMetadataBuilder<'_, CC>);
 	#[cfg(c_bindings)]
 	create_refund_builder!(self, RefundMaybeWithDerivedMetadataBuilder);
 
@@ -17552,6 +17552,7 @@ impl<
 			self.get_peers_for_blinded_path(),
 			self.list_usable_channels(),
 			&self.entropy_source,
+			&self.currency_conversion,
 			&self.router,
 		) {
 			Some((msg, ctx)) => (msg, ctx),

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5962,6 +5962,7 @@ impl<
 			let outbound_pmts_res = self.pending_outbound_payments.static_invoice_received(
 				invoice,
 				payment_id,
+				&self.currency_conversion,
 				features,
 				best_block_height,
 				self.duration_since_epoch(),
@@ -17401,6 +17402,7 @@ impl<
 						let result = self.flow.create_invoice_builder_from_invoice_request_with_keys(
 							&self.router,
 							&request,
+							&self.currency_conversion,
 							self.list_usable_channels(),
 							get_payment_info,
 							payment_metadata,
@@ -17426,6 +17428,7 @@ impl<
 						let result = self.flow.create_invoice_builder_from_invoice_request_without_keys(
 							&self.router,
 							&request,
+							&self.currency_conversion,
 							self.list_usable_channels(),
 							get_payment_info,
 							payment_metadata,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8731,7 +8731,7 @@ impl<
 									},
 								};
 
-								let verify_opt = invoice_request_opt.and_then(|invreq| {
+								let verified_invreq = match invoice_request_opt.and_then(|invreq| {
 									invreq
 										.verify_using_recipient_data(
 											offer_nonce,
@@ -8739,22 +8739,28 @@ impl<
 											&self.secp_ctx,
 										)
 										.ok()
-								});
-								let verified_invreq = match verify_opt {
-									Some(verified_invreq) => {
-										if let Some(invreq_amt_msat) =
-											verified_invreq.amount_msats()
-										{
-											if payment_data.total_msat < invreq_amt_msat {
-												fail_htlc!(payment_hash);
-											}
-										}
-										verified_invreq
-									},
+								}) {
+									Some(verified_invreq) => verified_invreq,
 									None => {
 										fail_htlc!(payment_hash);
 									},
 								};
+
+								match verified_invreq
+									.payable_amount_msats(&self.currency_conversion)
+								{
+									Ok(invreq_amt_msat) => {
+										if payment_data.total_msat < invreq_amt_msat {
+											fail_htlc!(payment_hash);
+										}
+									},
+									// If we cannot check the offer amount, reject the payment instead of risking
+									// accepting an underpayment.
+									Err(_) => {
+										fail_htlc!(payment_hash);
+									},
+								}
+
 								let payment_purpose_context =
 									PaymentContext::Bolt12Offer(Bolt12OfferContext {
 										offer_id: verified_invreq.offer_id(),

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -17347,6 +17347,9 @@ impl<
 					},
 					Err(Bolt12PaymentError::UnexpectedInvoice)
 						| Err(Bolt12PaymentError::DuplicateInvoice)
+						| Err(Bolt12PaymentError::UnverifiableAmount)
+						| Err(Bolt12PaymentError::InsufficientAmount)
+						| Err(Bolt12PaymentError::ExcessiveAmount)
 						| Ok(()) => return None,
 				};
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5861,6 +5861,13 @@ impl<
 	///   offer, or
 	/// - the refund corresponding to the invoice has already expired.
 	///
+	/// If the invoice corresponds to a currency-denominated offer and the invoice request did not
+	/// specify an explicit amount, the invoice amount is checked against the maximum amount payable
+	/// using the configured currency conversion. [`Bolt12PaymentError::UnverifiableAmount`] is
+	/// returned if the invoice amount could not be verified against the converted offer amount, and
+	/// [`Bolt12PaymentError::ExcessiveAmount`] is returned if the invoice quotes more than the
+	/// maximum amount we are willing to pay for the offer.
+	///
 	/// To retry the payment, request another invoice using a new `payment_id`.
 	///
 	/// Attempting to pay the same invoice twice while the first payment is still pending will
@@ -5873,9 +5880,16 @@ impl<
 	pub fn send_payment_for_bolt12_invoice(
 		&self, invoice: &Bolt12Invoice, context: Option<&OffersContext>,
 	) -> Result<(), Bolt12PaymentError> {
-		match self.flow.verify_bolt12_invoice(invoice, context) {
+		match self.flow.verify_bolt12_invoice(invoice, &self.currency_conversion, context) {
 			Ok(payment_id) => self.send_payment_for_verified_bolt12_invoice(invoice, payment_id),
-			Err(()) => Err(Bolt12PaymentError::UnexpectedInvoice),
+			Err(Bolt12SemanticError::UnexpectedAmount) => {
+				Err(Bolt12PaymentError::UnexpectedInvoice)
+			},
+			Err(Bolt12SemanticError::UnsupportedCurrency)
+			| Err(Bolt12SemanticError::MissingAmount)
+			| Err(Bolt12SemanticError::InvalidAmount) => Err(Bolt12PaymentError::UnverifiableAmount),
+			Err(Bolt12SemanticError::ExcessiveAmount) => Err(Bolt12PaymentError::ExcessiveAmount),
+			_ => Err(Bolt12PaymentError::UnexpectedInvoice),
 		}
 	}
 
@@ -17473,9 +17487,9 @@ impl<
 				})
 			},
 			OffersMessage::Invoice(invoice) => {
-				let payment_id = match self.flow.verify_bolt12_invoice(&invoice, context.as_ref()) {
+				let payment_id = match self.flow.verify_bolt12_invoice(&invoice, &self.currency_conversion, context.as_ref()) {
 					Ok(payment_id) => payment_id,
-					Err(()) => return None,
+					Err(_) => return None,
 				};
 
 				let logger = WithContext::for_payment(

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -94,6 +94,9 @@ use crate::ln::outbound_payment::{
 };
 use crate::ln::types::ChannelId;
 use crate::offers::async_receive_offer_cache::AsyncReceiveOfferCache;
+use crate::offers::currency::CurrencyConversion;
+#[cfg(not(c_bindings))]
+use crate::offers::currency::NullCurrencyConversion;
 use crate::offers::flow::{HeldHtlcReplyPath, InvreqResponseInstructions, OffersMessageFlow};
 use crate::offers::invoice::{Bolt12Invoice, UnsignedBolt12Invoice};
 use crate::offers::invoice_error::InvoiceError;
@@ -1979,6 +1982,7 @@ pub type SimpleArcChannelManager<M, T, F, L> = ChannelManager<
 		>,
 	>,
 	Arc<DefaultMessageRouter<Arc<NetworkGraph<Arc<L>>>, Arc<L>, Arc<KeysManager>>>,
+	Arc<NullCurrencyConversion>,
 	Arc<L>,
 >;
 
@@ -2010,6 +2014,7 @@ pub type SimpleRefChannelManager<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, M, T, F, L>
 		ProbabilisticScorer<&'f NetworkGraph<&'g L>, &'g L>,
 	>,
 	&'i DefaultMessageRouter<&'f NetworkGraph<&'g L>, &'g L, &'c KeysManager>,
+	&'i NullCurrencyConversion,
 	&'g L,
 >;
 
@@ -2036,6 +2041,8 @@ pub trait AChannelManager {
 	type Router: Router;
 	/// A type implementing [`MessageRouter`].
 	type MessageRouter: MessageRouter;
+	/// A type implementing [`CurrencyConversion`].
+	type CurrencyConversion: CurrencyConversion;
 	/// A type implementing [`Logger`].
 	type Logger: Logger;
 	/// Returns a reference to the actual [`ChannelManager`] object.
@@ -2050,6 +2057,7 @@ pub trait AChannelManager {
 		Self::FeeEstimator,
 		Self::Router,
 		Self::MessageRouter,
+		Self::CurrencyConversion,
 		Self::Logger,
 	>;
 }
@@ -2063,8 +2071,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> AChannelManager for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> AChannelManager for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	type Watch = M;
 	type Broadcaster = T;
@@ -2075,8 +2084,9 @@ impl<
 	type FeeEstimator = F;
 	type Router = R;
 	type MessageRouter = MR;
+	type CurrencyConversion = CC;
 	type Logger = L;
-	fn get_cm(&self) -> &ChannelManager<M, T, ES, NS, SP, F, R, MR, L> {
+	fn get_cm(&self) -> &ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L> {
 		self
 	}
 }
@@ -2156,6 +2166,7 @@ impl<
 /// #     tx_broadcaster: &dyn lightning::chain::chaininterface::BroadcasterInterface,
 /// #     router: &lightning::routing::router::DefaultRouter<&NetworkGraph<&'a L>, &'a L, &ES, &S, SP, SL>,
 /// #     message_router: &lightning::onion_message::messenger::DefaultMessageRouter<&NetworkGraph<&'a L>, &'a L, &ES>,
+/// #     currency_conversion: &lightning::offers::currency::NullCurrencyConversion,
 /// #     logger: &L,
 /// #     entropy_source: &ES,
 /// #     node_signer: &dyn lightning::sign::NodeSigner,
@@ -2171,18 +2182,18 @@ impl<
 /// };
 /// let config = UserConfig::default();
 /// let channel_manager = ChannelManager::new(
-///     fee_estimator, chain_monitor, tx_broadcaster, router, message_router, logger,
-///     entropy_source, node_signer, signer_provider, config.clone(), params, current_timestamp,
+///     fee_estimator, chain_monitor, tx_broadcaster, router, message_router, currency_conversion,
+///     logger, entropy_source, node_signer, signer_provider, config.clone(), params, current_timestamp,
 /// );
 ///
 /// // Restart from deserialized data
 /// let mut channel_monitors = read_channel_monitors();
 /// let args = ChannelManagerReadArgs::new(
 ///     entropy_source, node_signer, signer_provider, fee_estimator, chain_monitor, tx_broadcaster,
-///     router, message_router, logger, config, channel_monitors.iter().collect(),
+///     router, message_router, currency_conversion, logger, config, channel_monitors.iter().collect(),
 /// );
 /// let (best_block, channel_manager) =
-///     <(BlockLocator, ChannelManager<_, _, _, _, _, _, _, _, _>)>::read(&mut reader, args)?;
+///     <(BlockLocator, ChannelManager<_, _, _, _, _, _, _, _, _, _>)>::read(&mut reader, args)?;
 ///
 /// // Update the ChannelManager and ChannelMonitors with the latest chain data
 /// // ...
@@ -2829,6 +2840,7 @@ pub struct ChannelManager<
 	F: FeeEstimator,
 	R: Router,
 	MR: MessageRouter,
+	CC: CurrencyConversion,
 	L: Logger,
 > {
 	config: RwLock<UserConfig>,
@@ -2842,6 +2854,10 @@ pub struct ChannelManager<
 	pub(super) flow: OffersMessageFlow<MR, L>,
 	#[cfg(not(test))]
 	flow: OffersMessageFlow<MR, L>,
+	#[cfg(test)]
+	pub(super) currency_conversion: CC,
+	#[cfg(not(test))]
+	currency_conversion: CC,
 
 	#[cfg(any(test, feature = "_test_utils"))]
 	pub(super) best_block: RwLock<BlockLocator>,
@@ -3684,8 +3700,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	/// Constructs a new `ChannelManager` to hold several channels and route between them.
 	///
@@ -3706,9 +3723,9 @@ impl<
 	/// [`params.best_block.block_hash`]: chain::BlockLocator::block_hash
 	#[rustfmt::skip]
 	pub fn new(
-		fee_est: F, chain_monitor: M, tx_broadcaster: T, router: R, message_router: MR, logger: L,
-		entropy_source: ES, node_signer: NS, signer_provider: SP, config: UserConfig,
-		params: ChainParameters, current_timestamp: u32,
+		fee_est: F, chain_monitor: M, tx_broadcaster: T, router: R, message_router: MR,
+		currency_conversion: CC, logger: L, entropy_source: ES, node_signer: NS,
+		signer_provider: SP, config: UserConfig, params: ChainParameters, current_timestamp: u32,
 	) -> Self
 	where
 		L: Clone,
@@ -3722,7 +3739,8 @@ impl<
 		let flow = OffersMessageFlow::new(
 			ChainHash::using_genesis_block(params.network), params.best_block,
 			our_network_pubkey, current_timestamp, expanded_inbound_key,
-			node_signer.get_receive_auth_key(), secp_ctx.clone(), message_router, logger.clone(),
+			node_signer.get_receive_auth_key(), secp_ctx.clone(), message_router,
+			logger.clone(),
 		);
 
 		ChannelManager {
@@ -3733,6 +3751,7 @@ impl<
 			tx_broadcaster,
 			router,
 			flow,
+			currency_conversion,
 
 			best_block: RwLock::new(params.best_block),
 
@@ -14867,8 +14886,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	#[cfg(not(c_bindings))]
 	create_offer_builder!(self, OfferBuilder<'_, DerivedMetadata, secp256k1::All>);
@@ -15740,8 +15760,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> BaseMessageHandler for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> BaseMessageHandler for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	fn provided_node_features(&self) -> NodeFeatures {
 		provided_node_features(&self.config.read().unwrap())
@@ -16122,8 +16143,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> EventsProvider for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> EventsProvider for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	/// Processes events that must be periodically handled.
 	///
@@ -16147,8 +16169,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> chain::Listen for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> chain::Listen for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	fn filtered_block_connected(&self, header: &Header, txdata: &TransactionData, height: u32) {
 		{
@@ -16198,8 +16221,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> chain::Confirm for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> chain::Confirm for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	#[rustfmt::skip]
 	fn transactions_confirmed(&self, header: &Header, txdata: &TransactionData, height: u32) {
@@ -16361,8 +16385,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	/// Calls a function which handles an on-chain event (blocks dis/connected, transactions
 	/// un/confirmed, etc) on each channel, handling any resulting errors or messages generated by
@@ -16714,8 +16739,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> ChannelMessageHandler for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> ChannelMessageHandler for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	fn handle_open_channel(&self, counterparty_node_id: PublicKey, message: &msgs::OpenChannel) {
 		// Note that we never need to persist the updated ChannelManager for an inbound
@@ -17274,8 +17300,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> OffersMessageHandler for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> OffersMessageHandler for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	#[rustfmt::skip]
 	fn handle_message(
@@ -17494,8 +17521,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> AsyncPaymentsMessageHandler for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> AsyncPaymentsMessageHandler for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	fn handle_offer_paths_request(
 		&self, message: OfferPathsRequest, context: AsyncPaymentsContext,
@@ -17752,8 +17780,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> NodeIdLookUp for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> NodeIdLookUp for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	fn next_node_id(&self, short_channel_id: u64) -> Option<PublicKey> {
 		self.short_to_chan_info.read().unwrap().get(&short_channel_id).map(|(pubkey, _)| *pubkey)
@@ -18279,8 +18308,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger,
-	> Writeable for ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> Writeable for ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	#[rustfmt::skip]
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
@@ -19017,6 +19047,7 @@ pub struct ChannelManagerReadArgs<
 	F: FeeEstimator,
 	R: Router,
 	MR: MessageRouter,
+	CC: CurrencyConversion,
 	L: Logger + Clone,
 > {
 	/// A cryptographically secure source of entropy.
@@ -19055,6 +19086,11 @@ pub struct ChannelManagerReadArgs<
 	///
 	/// [`BlindedMessagePath`]: crate::blinded_path::message::BlindedMessagePath
 	pub message_router: MR,
+	/// The [`CurrencyConversion`] used for supporting and interpreting [`Offer`] amount
+	/// denoted in [`Amount::Currency`].
+	///
+	/// [`Amount::Currency`]: crate::offers::offer::Amount::Currency
+	pub currency_conversion: CC,
 	/// The Logger for use in the ChannelManager and which may be used to log information during
 	/// deserialization.
 	pub logger: L,
@@ -19095,16 +19131,18 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger + Clone,
-	> ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, L>
+	> ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	/// Simple utility function to create a ChannelManagerReadArgs which creates the monitor
 	/// HashMap for you. This is primarily useful for C bindings where it is not practical to
 	/// populate a HashMap directly from C.
 	pub fn new(
 		entropy_source: ES, node_signer: NS, signer_provider: SP, fee_estimator: F,
-		chain_monitor: M, tx_broadcaster: T, router: R, message_router: MR, logger: L,
-		config: UserConfig, mut channel_monitors: Vec<&'a ChannelMonitor<SP::EcdsaSigner>>,
+		chain_monitor: M, tx_broadcaster: T, router: R, message_router: MR,
+		currency_conversion: CC, logger: L, config: UserConfig,
+		mut channel_monitors: Vec<&'a ChannelMonitor<SP::EcdsaSigner>>,
 	) -> Self {
 		Self {
 			entropy_source,
@@ -19115,6 +19153,7 @@ impl<
 			tx_broadcaster,
 			router,
 			message_router,
+			currency_conversion,
 			logger,
 			config,
 			channel_monitors: hash_map_from_iter(
@@ -19172,15 +19211,18 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger + Clone,
-	> ReadableArgs<ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, L>>
-	for (BlockLocator, Arc<ChannelManager<M, T, ES, NS, SP, F, R, MR, L>>)
+	> ReadableArgs<ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, CC, L>>
+	for (BlockLocator, Arc<ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>>)
 {
 	fn read<Reader: io::Read>(
-		reader: &mut Reader, args: ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, L>,
+		reader: &mut Reader, args: ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, CC, L>,
 	) -> Result<Self, DecodeError> {
-		let (best_block, chan_manager) =
-			<(BlockLocator, ChannelManager<M, T, ES, NS, SP, F, R, MR, L>)>::read(reader, args)?;
+		let (best_block, chan_manager) = <(
+			BlockLocator,
+			ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>,
+		)>::read(reader, args)?;
 		Ok((best_block, Arc::new(chan_manager)))
 	}
 }
@@ -19195,12 +19237,13 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger + Clone,
-	> ReadableArgs<ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, L>>
-	for (BlockLocator, ChannelManager<M, T, ES, NS, SP, F, R, MR, L>)
+	> ReadableArgs<ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, CC, L>>
+	for (BlockLocator, ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>)
 {
 	fn read<Reader: io::Read>(
-		reader: &mut Reader, args: ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, L>,
+		reader: &mut Reader, args: ChannelManagerReadArgs<'a, M, T, ES, NS, SP, F, R, MR, CC, L>,
 	) -> Result<Self, DecodeError> {
 		// Stage 1: Pure deserialization into DTO
 		let data: ChannelManagerData<SP> = ChannelManagerData::read(
@@ -19227,8 +19270,9 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
+		CC: CurrencyConversion,
 		L: Logger + Clone,
-	> ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
+	> ChannelManager<M, T, ES, NS, SP, F, R, MR, CC, L>
 {
 	/// Constructs a `ChannelManager` from deserialized data and runtime dependencies.
 	///
@@ -19240,7 +19284,7 @@ impl<
 	/// [`ChannelMonitorUpdate`]s.
 	pub(super) fn from_channel_manager_data(
 		data: ChannelManagerData<SP>,
-		mut args: ChannelManagerReadArgs<'_, M, T, ES, NS, SP, F, R, MR, L>,
+		mut args: ChannelManagerReadArgs<'_, M, T, ES, NS, SP, F, R, MR, CC, L>,
 	) -> Result<(BlockLocator, Self), DecodeError> {
 		let ChannelManagerData {
 			chain_hash,
@@ -20477,6 +20521,7 @@ impl<
 			tx_broadcaster: args.tx_broadcaster,
 			router: args.router,
 			flow,
+			currency_conversion: args.currency_conversion,
 
 			best_block: RwLock::new(best_block),
 
@@ -22093,6 +22138,7 @@ pub mod bench {
 		&'a test_utils::TestFeeEstimator,
 		&'a test_utils::TestRouter<'a>,
 		&'a test_utils::TestMessageRouter<'a>,
+		&'a test_utils::TestCurrencyConversion,
 		&'a test_utils::TestLogger,
 	>;
 
@@ -22131,6 +22177,7 @@ pub mod bench {
 		let entropy = test_utils::TestKeysInterface::new(&[0u8; 32], network);
 		let router = test_utils::TestRouter::new(Arc::new(NetworkGraph::new(network, &logger_a)), &logger_a, &scorer);
 		let message_router = test_utils::TestMessageRouter::new_default(Arc::new(NetworkGraph::new(network, &logger_a)), &entropy);
+		let currency_conversion = test_utils::TestCurrencyConversion {};
 
 		let mut config: UserConfig = Default::default();
 		config.channel_config.max_dust_htlc_exposure = MaxDustHTLCExposure::FeeRateMultiplier(5_000_000 / 253);
@@ -22139,7 +22186,7 @@ pub mod bench {
 		let seed_a = [1u8; 32];
 		let keys_manager_a = KeysManager::new(&seed_a, 42, 42, true);
 		let chain_monitor_a = ChainMonitor::new(None, &tx_broadcaster, &logger_a, &fee_estimator, &persister_a, &keys_manager_a, keys_manager_a.get_peer_storage_key(), false);
-		let node_a = ChannelManager::new(&fee_estimator, &chain_monitor_a, &tx_broadcaster, &router, &message_router, &logger_a, &keys_manager_a, &keys_manager_a, &keys_manager_a, config.clone(), ChainParameters {
+		let node_a = ChannelManager::new(&fee_estimator, &chain_monitor_a, &tx_broadcaster, &router, &message_router, &currency_conversion, &logger_a, &keys_manager_a, &keys_manager_a, &keys_manager_a, config.clone(), ChainParameters {
 			network,
 			best_block: BlockLocator::from_network(network),
 		}, genesis_block.header.time);
@@ -22149,7 +22196,7 @@ pub mod bench {
 		let seed_b = [2u8; 32];
 		let keys_manager_b = KeysManager::new(&seed_b, 42, 42, true);
 		let chain_monitor_b = ChainMonitor::new(None, &tx_broadcaster, &logger_a, &fee_estimator, &persister_b, &keys_manager_b, keys_manager_b.get_peer_storage_key(), false);
-		let node_b = ChannelManager::new(&fee_estimator, &chain_monitor_b, &tx_broadcaster, &router, &message_router, &logger_b, &keys_manager_b, &keys_manager_b, &keys_manager_b, config.clone(), ChainParameters {
+		let node_b = ChannelManager::new(&fee_estimator, &chain_monitor_b, &tx_broadcaster, &router, &message_router, &currency_conversion, &logger_b, &keys_manager_b, &keys_manager_b, &keys_manager_b, config.clone(), ChainParameters {
 			network,
 			best_block: BlockLocator::from_network(network),
 		}, genesis_block.header.time);

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -14696,7 +14696,12 @@ macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 	///
 	/// Errors if the parameterized [`MessageRouter`] is unable to create a blinded path for the offer.
 	///
+	/// Currency-denominated amounts set on the returned builder are validated
+	/// with the [`ChannelManager`]'s configured [`CurrencyConversion`] when the
+	/// offer is built.
+	///
 	/// [`BlindedMessagePath`]: crate::blinded_path::message::BlindedMessagePath
+	/// [`CurrencyConversion`]: crate::offers::currency::CurrencyConversion
 	/// [`Offer`]: crate::offers::offer::Offer
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	pub fn create_offer_builder(&$self) -> Result<$builder, Bolt12SemanticError> {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -14946,6 +14946,12 @@ impl<
 	/// `amount_msats` allows you to overpay what is required to satisfy the offer, or may be
 	/// required if the offer does not require a specific amount.
 	///
+	/// If the offer specifies an amount in a fiat currency, `amount_msats` is not locally
+	/// checked against the offer amount when building the [`InvoiceRequest`]. Instead, the
+	/// payee verifies whether the requested amount is sufficient when deciding whether to
+	/// issue a [`Bolt12Invoice`]. If `amount_msats` is omitted, the payee may determine the
+	/// final invoice amount.
+	///
 	/// If the [`Offer`] was built from a human readable name resolved using BIP 353, you *must*
 	/// instead call [`Self::pay_for_offer_from_hrn`].
 	///

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -504,6 +504,7 @@ pub struct NodeCfg<'a> {
 	pub fee_estimator: &'a test_utils::TestFeeEstimator,
 	pub router: test_utils::TestRouter<'a>,
 	pub message_router: test_utils::TestMessageRouter<'a>,
+	pub currency_conversion: test_utils::TestCurrencyConversion,
 	pub chain_monitor: test_utils::TestChainMonitor<'a>,
 	pub keys_manager: &'a test_utils::TestKeysInterface,
 	pub logger: &'a test_utils::TestLogger,
@@ -521,6 +522,7 @@ pub type TestChannelManager<'node_cfg, 'chan_mon_cfg> = ChannelManager<
 	&'chan_mon_cfg test_utils::TestFeeEstimator,
 	&'node_cfg test_utils::TestRouter<'chan_mon_cfg>,
 	&'node_cfg test_utils::TestMessageRouter<'chan_mon_cfg>,
+	&'node_cfg test_utils::TestCurrencyConversion,
 	&'chan_mon_cfg test_utils::TestLogger,
 >;
 
@@ -555,6 +557,7 @@ pub struct Node<'chan_man, 'node_cfg: 'chan_man, 'chan_mon_cfg: 'node_cfg> {
 	pub fee_estimator: &'chan_mon_cfg test_utils::TestFeeEstimator,
 	pub router: &'node_cfg test_utils::TestRouter<'chan_mon_cfg>,
 	pub message_router: &'node_cfg test_utils::TestMessageRouter<'chan_mon_cfg>,
+	pub currency_conversion: &'node_cfg test_utils::TestCurrencyConversion,
 	pub chain_monitor: &'node_cfg test_utils::TestChainMonitor<'chan_mon_cfg>,
 	pub keys_manager: &'chan_mon_cfg test_utils::TestKeysInterface,
 	pub node: &'chan_man TestChannelManager<'node_cfg, 'chan_mon_cfg>,
@@ -740,6 +743,7 @@ pub trait NodeHolder {
 		<Self::CM as AChannelManager>::FeeEstimator,
 		<Self::CM as AChannelManager>::Router,
 		<Self::CM as AChannelManager>::MessageRouter,
+		<Self::CM as AChannelManager>::CurrencyConversion,
 		<Self::CM as AChannelManager>::Logger,
 	>;
 	fn chain_monitor(&self) -> Option<&test_utils::TestChainMonitor<'_>>;
@@ -757,6 +761,7 @@ impl<H: NodeHolder> NodeHolder for &H {
 		<Self::CM as AChannelManager>::FeeEstimator,
 		<Self::CM as AChannelManager>::Router,
 		<Self::CM as AChannelManager>::MessageRouter,
+		<Self::CM as AChannelManager>::CurrencyConversion,
 		<Self::CM as AChannelManager>::Logger,
 	> {
 		(*self).node()
@@ -887,6 +892,7 @@ impl<'a, 'b, 'c> Drop for Node<'a, 'b, 'c> {
 						&test_utils::TestFeeEstimator,
 						&test_utils::TestRouter,
 						&test_utils::TestMessageRouter,
+						&test_utils::TestCurrencyConversion,
 						&test_utils::TestLogger,
 					>,
 				)>::read(
@@ -906,6 +912,7 @@ impl<'a, 'b, 'c> Drop for Node<'a, 'b, 'c> {
 							network_graph,
 							self.keys_manager,
 						),
+						currency_conversion: &test_utils::TestCurrencyConversion {},
 						chain_monitor: self.chain_monitor,
 						tx_broadcaster: &broadcaster,
 						logger: &self.logger,
@@ -1337,6 +1344,7 @@ pub fn _reload_node<'a, 'b, 'c>(
 				fee_estimator: node.fee_estimator,
 				router: node.router,
 				message_router: node.message_router,
+				currency_conversion: node.currency_conversion,
 				chain_monitor: node.chain_monitor,
 				tx_broadcaster: node.tx_broadcaster,
 				logger: node.logger,
@@ -4611,6 +4619,7 @@ where
 				Arc::clone(&network_graph),
 				&cfg.keys_manager,
 			),
+			currency_conversion: test_utils::TestCurrencyConversion {},
 			chain_monitor,
 			keys_manager: &cfg.keys_manager,
 			node_seed: seed,
@@ -4712,6 +4721,7 @@ pub fn create_node_chanmgrs<'a, 'b>(
 		&'b test_utils::TestFeeEstimator,
 		&'a test_utils::TestRouter<'b>,
 		&'a test_utils::TestMessageRouter<'b>,
+		&'a test_utils::TestCurrencyConversion,
 		&'b test_utils::TestLogger,
 	>,
 > {
@@ -4726,6 +4736,7 @@ pub fn create_node_chanmgrs<'a, 'b>(
 			cfgs[i].tx_broadcaster,
 			&cfgs[i].router,
 			&cfgs[i].message_router,
+			&cfgs[i].currency_conversion,
 			cfgs[i].logger,
 			cfgs[i].keys_manager,
 			cfgs[i].keys_manager,
@@ -4756,6 +4767,7 @@ pub fn create_network<'a, 'b: 'a, 'c: 'b>(
 			&'c test_utils::TestFeeEstimator,
 			&'c test_utils::TestRouter,
 			&'c test_utils::TestMessageRouter,
+			&'c test_utils::TestCurrencyConversion,
 			&'c test_utils::TestLogger,
 		>,
 	>,
@@ -4812,6 +4824,7 @@ pub fn create_network<'a, 'b: 'a, 'c: 'b>(
 			fee_estimator: cfgs[i].fee_estimator,
 			router: &cfgs[i].router,
 			message_router: &cfgs[i].message_router,
+			currency_conversion: &cfgs[i].currency_conversion,
 			chain_monitor: &cfgs[i].chain_monitor,
 			keys_manager: &cfgs[i].keys_manager,
 			node: &chan_mgrs[i],

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -4874,6 +4874,7 @@ pub fn test_key_derivation_params() {
 		test_utils::TestRouter::new(Arc::clone(&network_graph), &chanmon_cfgs[0].logger, &scorer);
 	let message_router =
 		test_utils::TestMessageRouter::new_default(Arc::clone(&network_graph), &keys_manager);
+	let currency_conversion = test_utils::TestCurrencyConversion {};
 	let node = NodeCfg {
 		chain_source: &chanmon_cfgs[0].chain_source,
 		logger: &chanmon_cfgs[0].logger,
@@ -4881,6 +4882,7 @@ pub fn test_key_derivation_params() {
 		fee_estimator: &chanmon_cfgs[0].fee_estimator,
 		router,
 		message_router,
+		currency_conversion,
 		chain_monitor,
 		keys_manager: &keys_manager,
 		network_graph,

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -2398,7 +2398,7 @@ fn fails_paying_invoice_with_unknown_required_features() {
 
 	let invoice = match verified_invoice_request {
 		InvoiceRequestVerifiedFromOffer::DerivedKeys(request) => {
-			request.respond_using_derived_keys_no_std(payment_paths, payment_hash, created_at).unwrap()
+			request.respond_using_derived_keys_no_std(&NullCurrencyConversion, payment_paths, payment_hash, created_at).unwrap()
 				.features_unchecked(Bolt12InvoiceFeatures::unknown())
 				.build_and_sign(&secp_ctx).unwrap()
 		},

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -63,7 +63,7 @@ use crate::offers::invoice::Bolt12Invoice;
 use crate::offers::invoice_error::InvoiceError;
 use crate::offers::invoice_request::{InvoiceRequest, InvoiceRequestFields, InvoiceRequestVerifiedFromOffer};
 use crate::offers::nonce::Nonce;
-use crate::offers::offer::OfferBuilder;
+use crate::offers::offer::{Amount, CurrencyCode, OfferBuilder};
 use crate::offers::parse::Bolt12SemanticError;
 use crate::onion_message::messenger::{DefaultMessageRouter, Destination, MessageRouter, MessageSendInstructions, NodeIdMessageRouter, NullMessageRouter, PeeledOnion, DUMMY_HOPS_PATH_LENGTH, QR_CODED_DUMMY_HOPS_PATH_LENGTH};
 use crate::onion_message::offers::OffersMessage;
@@ -1399,6 +1399,64 @@ fn pays_bolt12_invoice_asynchronously() {
 		bob.node.send_payment_for_bolt12_invoice(&invoice, context.as_ref()),
 		Err(Bolt12PaymentError::UnexpectedInvoice),
 	);
+}
+
+#[test]
+fn creates_and_pays_bolt12_invoice_for_currency_denominated_offer() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 10_000_000, 1_000_000_000);
+
+	let alice = &nodes[0];
+	let alice_id = alice.node.get_our_node_id();
+	let bob = &nodes[1];
+	let bob_id = bob.node.get_our_node_id();
+
+	let offer = alice.node
+		.create_offer_builder()
+		.unwrap()
+		.amount(Amount::Currency {
+			iso4217_code: CurrencyCode::new(*b"USD").unwrap(),
+			amount: 10,
+		})
+		.build()
+		.unwrap();
+
+	let payment_id = PaymentId([1; 32]);
+	bob.node.pay_for_offer(&offer, None, payment_id, Default::default()).unwrap();
+	expect_recent_payment!(bob, RecentPaymentDetails::AwaitingInvoice, payment_id);
+
+	let onion_message = bob.onion_messenger.next_onion_message_for_peer(alice_id).unwrap();
+	let (invoice_request, _) = extract_invoice_request(alice, &onion_message);
+	assert_eq!(invoice_request.amount_msats(), None);
+
+	let payment_context = PaymentContext::Bolt12Offer(Bolt12OfferContext {
+		offer_id: offer.id(),
+		invoice_request: InvoiceRequestFields {
+			payer_signing_pubkey: invoice_request.payer_signing_pubkey(),
+			quantity: None,
+			payer_note_truncated: None,
+			human_readable_name: None,
+		},
+		payment_metadata: None,
+	});
+
+	alice.onion_messenger.handle_onion_message(bob_id, &onion_message);
+
+	let invoice_onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
+	let (invoice, _) = extract_invoice(bob, &invoice_onion_message);
+	assert_eq!(invoice.amount_msats(), 10_000);
+
+	bob.onion_messenger.handle_onion_message(alice_id, &invoice_onion_message);
+
+	route_bolt12_payment(bob, &[alice], &invoice);
+	expect_recent_payment!(bob, RecentPaymentDetails::Pending, payment_id);
+
+	claim_bolt12_payment(bob, &[alice], payment_context, &invoice);
+	expect_recent_payment!(bob, RecentPaymentDetails::Fulfilled, payment_id);
 }
 
 /// Checks that an offer can be created using an unannounced node as a blinded path's introduction

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -54,6 +54,7 @@ use crate::blinded_path::message::{MessageContext, OffersContext};
 use crate::events::{ClosureReason, Event, HTLCHandlingFailureType, PaidBolt12Invoice, PaymentFailureReason, PaymentPurpose};
 use crate::ln::channelmanager::{PaymentId, RecentPaymentDetails, self};
 use crate::ln::outbound_payment::{Bolt12PaymentError, RecipientOnionFields, Retry};
+use crate::offers::currency::NullCurrencyConversion;
 use crate::types::features::Bolt12InvoiceFeatures;
 use crate::ln::functional_test_utils::*;
 use crate::ln::msgs::{BaseMessageHandler, ChannelMessageHandler, Init, OnionMessage, OnionMessageHandler};
@@ -872,7 +873,7 @@ fn pays_for_offer_with_payment_metadata_in_invoice_request_context() {
 	assert!(!paths.is_empty());
 
 	let expanded_key = alice.keys_manager.get_expanded_key();
-	let mut builder = OfferBuilder::deriving_signing_pubkey(alice_id, &expanded_key, nonce, &secp_ctx)
+	let mut builder = OfferBuilder::deriving_signing_pubkey(alice_id, &expanded_key, nonce, &NullCurrencyConversion, &secp_ctx)
 		.chain(Network::Testnet)
 		.amount_msats(10_000_000);
 	for path in paths {

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -373,7 +373,7 @@ fn check_dummy_hop_pattern_in_offer() {
 	let onion_message = bob.onion_messenger.next_onion_message_for_peer(alice_id).unwrap();
 	let (invoice_request, reply_path) = extract_invoice_request(alice, &onion_message);
 
-	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
+	assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(10_000_000));
 	assert_ne!(invoice_request.payer_signing_pubkey(), bob_id);
 	assert!(check_dummy_hopped_path_length(&reply_path, alice, bob_id, DUMMY_HOPS_PATH_LENGTH));
 
@@ -395,7 +395,7 @@ fn check_dummy_hop_pattern_in_offer() {
 	let onion_message = bob.onion_messenger.next_onion_message_for_peer(alice_id).unwrap();
 	let (invoice_request, reply_path) = extract_invoice_request(alice, &onion_message);
 
-	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
+	assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(10_000_000));
 	assert_ne!(invoice_request.payer_signing_pubkey(), bob_id);
 	assert!(check_dummy_hopped_path_length(&reply_path, alice, bob_id, DUMMY_HOPS_PATH_LENGTH));
 }
@@ -581,7 +581,7 @@ fn creates_and_pays_for_offer_using_two_hop_blinded_path() {
 		},
 		payment_metadata: None,
 	});
-	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
+	assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(10_000_000));
 	assert_ne!(invoice_request.payer_signing_pubkey(), david_id);
 	assert!(check_dummy_hopped_path_length(&reply_path, bob, charlie_id, DUMMY_HOPS_PATH_LENGTH));
 
@@ -740,7 +740,7 @@ fn creates_and_pays_for_offer_using_one_hop_blinded_path() {
 		},
 		payment_metadata: None,
 	});
-	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
+	assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(10_000_000));
 	assert_ne!(invoice_request.payer_signing_pubkey(), bob_id);
 	assert!(check_dummy_hopped_path_length(&reply_path, alice, bob_id, DUMMY_HOPS_PATH_LENGTH));
 
@@ -1283,7 +1283,7 @@ fn creates_and_pays_for_offer_with_retry() {
 		},
 		payment_metadata: None,
 	});
-	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
+	assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(10_000_000));
 	assert_ne!(invoice_request.payer_signing_pubkey(), bob_id);
 	assert!(check_dummy_hopped_path_length(&reply_path, alice, bob_id, DUMMY_HOPS_PATH_LENGTH));
 	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
@@ -1599,7 +1599,7 @@ fn fails_authentication_when_handling_invoice_request() {
 	alice.onion_messenger.handle_onion_message(david_id, &onion_message);
 
 	let (invoice_request, reply_path) = extract_invoice_request(alice, &onion_message);
-	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
+	assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(10_000_000));
 	assert_ne!(invoice_request.payer_signing_pubkey(), david_id);
 	assert!(check_dummy_hopped_path_length(&reply_path, david, charlie_id, DUMMY_HOPS_PATH_LENGTH));
 
@@ -1628,7 +1628,7 @@ fn fails_authentication_when_handling_invoice_request() {
 	alice.onion_messenger.handle_onion_message(bob_id, &onion_message);
 
 	let (invoice_request, reply_path) = extract_invoice_request(alice, &onion_message);
-	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
+	assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(10_000_000));
 	assert_ne!(invoice_request.payer_signing_pubkey(), david_id);
 	assert!(check_dummy_hopped_path_length(&reply_path, david, charlie_id, DUMMY_HOPS_PATH_LENGTH));
 
@@ -1728,7 +1728,7 @@ fn fails_authentication_when_handling_invoice_for_offer() {
 	alice.onion_messenger.handle_onion_message(bob_id, &onion_message);
 
 	let (invoice_request, reply_path) = extract_invoice_request(alice, &onion_message);
-	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
+	assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(10_000_000));
 	assert_ne!(invoice_request.payer_signing_pubkey(), david_id);
 	assert!(check_dummy_hopped_path_length(&reply_path, david, charlie_id, DUMMY_HOPS_PATH_LENGTH));
 

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -28,6 +28,7 @@ use crate::offers::currency::CurrencyConversion;
 use crate::offers::invoice::{Bolt12Invoice, DerivedSigningPubkey, InvoiceBuilder};
 use crate::offers::invoice_request::InvoiceRequest;
 use crate::offers::nonce::Nonce;
+use crate::offers::parse::Bolt12SemanticError;
 use crate::offers::static_invoice::StaticInvoice;
 use crate::routing::router::{
 	BlindedTail, InFlightHtlcs, Path, PaymentParameters, Route, RouteParameters,
@@ -670,6 +671,28 @@ pub enum Bolt12PaymentError {
 	UnexpectedInvoice,
 	/// Payment for an invoice with the corresponding [`PaymentId`] was already initiated.
 	DuplicateInvoice,
+	/// The invoice was valid for the corresponding [`PaymentId`], but its amount
+	/// could not be verified.
+	///
+	/// This occurs for currency-denominated offers without an explicitly requested
+	/// amount when the offer amount could not be converted to msats because the
+	/// currency was unsupported or the converted amount exceeded supported bounds.
+	UnverifiableAmount,
+	/// The invoice was valid for the corresponding [`PaymentId`], but its amount
+	/// was lower than the minimum acceptable amount derived from the underlying
+	/// offer.
+	///
+	/// This occurs for currency-denominated offers with an explicitly requested
+	/// amount when the requested invoice amount was lower than the minimum amount
+	/// the payee was willing to accept after currency conversion.
+	InsufficientAmount,
+	/// The invoice was valid for the corresponding [`PaymentId`], but its amount
+	/// exceeded the maximum acceptable amount derived from the underlying offer.
+	///
+	/// This occurs for currency-denominated offers without an explicitly requested
+	/// amount when the invoice amount was higher than the payer was willing to pay
+	/// after currency conversion.
+	ExcessiveAmount,
 	/// The invoice was valid for the corresponding [`PaymentId`], but required unknown features.
 	UnknownRequiredFeatures,
 	/// The invoice was valid for the corresponding [`PaymentId`], but sending the payment failed.
@@ -1305,6 +1328,15 @@ impl OutboundPayments {
 						invreq, converter,
 					) {
 						Ok(amt) => amt,
+						Err(Bolt12SemanticError::UnsupportedCurrency)
+						| Err(Bolt12SemanticError::InvalidAmount) => {
+							abandon_with_entry!(entry, PaymentFailureReason::UnexpectedError);
+							return Err(Bolt12PaymentError::UnverifiableAmount);
+						},
+						Err(Bolt12SemanticError::InsufficientAmount) => {
+							abandon_with_entry!(entry, PaymentFailureReason::UnexpectedError);
+							return Err(Bolt12PaymentError::InsufficientAmount);
+						},
 						Err(_) => {
 							// We check this during invoice request parsing, when constructing the invreq's
 							// contents from its TLV stream.

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -24,6 +24,7 @@ use crate::ln::channelmanager::{
 use crate::ln::msgs::DecodeError;
 use crate::ln::onion_utils;
 use crate::ln::onion_utils::{DecodedOnionFailure, HTLCFailReason};
+use crate::offers::currency::CurrencyConversion;
 use crate::offers::invoice::{Bolt12Invoice, DerivedSigningPubkey, InvoiceBuilder};
 use crate::offers::invoice_request::InvoiceRequest;
 use crate::offers::nonce::Nonce;
@@ -1251,9 +1252,10 @@ impl OutboundPayments {
 		Ok(())
 	}
 
-	pub(super) fn static_invoice_received<ES: EntropySource>(
-		&self, invoice: &StaticInvoice, payment_id: PaymentId, features: Bolt12InvoiceFeatures,
-		best_block_height: u32, duration_since_epoch: Duration, entropy_source: ES,
+	pub(super) fn static_invoice_received<ES: EntropySource, CC: CurrencyConversion>(
+		&self, invoice: &StaticInvoice, payment_id: PaymentId, converter: &CC,
+		features: Bolt12InvoiceFeatures, best_block_height: u32, duration_since_epoch: Duration,
+		entropy_source: ES,
 		pending_events: &Mutex<VecDeque<(events::Event, Option<EventCompletionAction>)>>,
 	) -> Result<(), Bolt12PaymentError> {
 		macro_rules! abandon_with_entry {
@@ -1300,7 +1302,7 @@ impl OutboundPayments {
 					}
 
 					let amount_msat = match InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(
-						invreq,
+						invreq, converter,
 					) {
 						Ok(amt) => amt,
 						Err(_) => {
@@ -3277,7 +3279,7 @@ mod tests {
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
 			.build_and_sign().unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), created_at).unwrap()
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), created_at).unwrap()
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 
@@ -3326,7 +3328,7 @@ mod tests {
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
 			.build_and_sign().unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now()).unwrap()
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now()).unwrap()
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 
@@ -3391,7 +3393,7 @@ mod tests {
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
 			.build_and_sign().unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now()).unwrap()
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now()).unwrap()
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -2882,6 +2882,8 @@ mod tests {
 		RetryableSendFailure, StaleExpiration,
 	};
 	#[cfg(feature = "std")]
+	use crate::offers::currency::NullCurrencyConversion;
+	#[cfg(feature = "std")]
 	use crate::offers::invoice::DEFAULT_RELATIVE_EXPIRY;
 	use crate::offers::invoice_request::InvoiceRequest;
 	use crate::offers::nonce::Nonce;
@@ -3271,7 +3273,7 @@ mod tests {
 		assert!(outbound_payments.has_pending_payments());
 
 		let created_at = now() - DEFAULT_RELATIVE_EXPIRY;
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
@@ -3320,7 +3322,7 @@ mod tests {
 		let payment_id = PaymentId([0; 32]);
 		let expiration = StaleExpiration::AbsoluteTimeout(Duration::from_secs(100));
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
@@ -3385,7 +3387,7 @@ mod tests {
 		let payment_id = PaymentId([0; 32]);
 		let expiration = StaleExpiration::AbsoluteTimeout(Duration::from_secs(100));
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
@@ -3474,7 +3476,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		OfferBuilder::new(recipient_pubkey())
+		OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -2881,7 +2881,6 @@ mod tests {
 		Bolt12PaymentError, OutboundPayments, PendingOutboundPayment, RecipientCustomTlvs, Retry,
 		RetryableSendFailure, StaleExpiration,
 	};
-	#[cfg(feature = "std")]
 	use crate::offers::currency::NullCurrencyConversion;
 	#[cfg(feature = "std")]
 	use crate::offers::invoice::DEFAULT_RELATIVE_EXPIRY;

--- a/lightning/src/ln/reload_tests.rs
+++ b/lightning/src/ln/reload_tests.rs
@@ -426,7 +426,7 @@ fn test_manager_serialize_deserialize_inconsistent_monitor() {
 
 	let mut nodes_0_read = &nodes_0_serialized[..];
 	if let Err(msgs::DecodeError::DangerousValue) =
-		<(BlockLocator, ChannelManager<&test_utils::TestChainMonitor, &test_utils::TestBroadcaster, &test_utils::TestKeysInterface, &test_utils::TestKeysInterface, &test_utils::TestKeysInterface, &test_utils::TestFeeEstimator, &test_utils::TestRouter, &test_utils::TestMessageRouter, &test_utils::TestLogger>)>::read(&mut nodes_0_read, ChannelManagerReadArgs {
+		<(BlockLocator, ChannelManager<&test_utils::TestChainMonitor, &test_utils::TestBroadcaster, &test_utils::TestKeysInterface, &test_utils::TestKeysInterface, &test_utils::TestKeysInterface, &test_utils::TestFeeEstimator, &test_utils::TestRouter, &test_utils::TestMessageRouter, &test_utils::TestCurrencyConversion, &test_utils::TestLogger>)>::read(&mut nodes_0_read, ChannelManagerReadArgs {
 		config: UserConfig::default(),
 		entropy_source: keys_manager,
 		node_signer: keys_manager,
@@ -434,6 +434,7 @@ fn test_manager_serialize_deserialize_inconsistent_monitor() {
 		fee_estimator: &fee_estimator,
 		router: &nodes[0].router,
 		message_router: &nodes[0].message_router,
+		currency_conversion: &nodes[0].currency_conversion,
 		chain_monitor: nodes[0].chain_monitor,
 		tx_broadcaster: nodes[0].tx_broadcaster,
 		logger: &logger,
@@ -445,7 +446,7 @@ fn test_manager_serialize_deserialize_inconsistent_monitor() {
 
 	let mut nodes_0_read = &nodes_0_serialized[..];
 	let (_, nodes_0_deserialized_tmp) =
-		<(BlockLocator, ChannelManager<&test_utils::TestChainMonitor, &test_utils::TestBroadcaster, &test_utils::TestKeysInterface, &test_utils::TestKeysInterface, &test_utils::TestKeysInterface, &test_utils::TestFeeEstimator, &test_utils::TestRouter, &test_utils::TestMessageRouter, &test_utils::TestLogger>)>::read(&mut nodes_0_read, ChannelManagerReadArgs {
+		<(BlockLocator, ChannelManager<&test_utils::TestChainMonitor, &test_utils::TestBroadcaster, &test_utils::TestKeysInterface, &test_utils::TestKeysInterface, &test_utils::TestKeysInterface, &test_utils::TestFeeEstimator, &test_utils::TestRouter, &test_utils::TestMessageRouter, &test_utils::TestCurrencyConversion, &test_utils::TestLogger>)>::read(&mut nodes_0_read, ChannelManagerReadArgs {
 		config: UserConfig::default(),
 		entropy_source: keys_manager,
 		node_signer: keys_manager,
@@ -453,6 +454,7 @@ fn test_manager_serialize_deserialize_inconsistent_monitor() {
 		fee_estimator: &fee_estimator,
 		router: nodes[0].router,
 		message_router: &nodes[0].message_router,
+		currency_conversion: &nodes[0].currency_conversion,
 		chain_monitor: nodes[0].chain_monitor,
 		tx_broadcaster: nodes[0].tx_broadcaster,
 		logger: &logger,

--- a/lightning/src/offers/currency.rs
+++ b/lightning/src/offers/currency.rs
@@ -1,0 +1,251 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Data structures and encoding for currency conversion support.
+
+use crate::offers::offer::CurrencyCode;
+#[allow(unused_imports)]
+use crate::prelude::*;
+
+use core::cmp::Ordering;
+use core::num::NonZeroU64;
+use core::ops::Deref;
+
+/// An exchange rate represented as `msats / minor_units`.
+///
+/// Most exchange rates should be constructed with [`ExchangeRate::new`], which
+/// represents a whole number of millisatoshis per one minor currency unit.
+/// [`ExchangeRate::from_parts`] is available for rates that require fractional
+/// precision.
+///
+/// ## Minor Units
+///
+/// Minor units are the smallest unit of an ISO 4217 currency.
+///
+/// For example:
+/// - USD (exponent 2) uses cents (0.01 USD)
+/// - JPY (exponent 0) uses yen
+///
+/// ## Fractional Precision
+///
+/// For example,
+///
+/// ExchangeRate::from_parts(123, NonZeroU64::new(1_000_000).unwrap())
+///
+/// represents `123 millisatoshis per 1,000,000 minor currency units`.
+#[derive(Clone, Copy, Debug)]
+pub struct ExchangeRate {
+	msats: u64,
+	minor_units: NonZeroU64,
+}
+
+impl ExchangeRate {
+	/// Creates a new exchange rate in millisatoshis per one minor currency unit.
+	pub fn new(msats_per_minor_unit: u64) -> Self {
+		Self { msats: msats_per_minor_unit, minor_units: NonZeroU64::MIN }
+	}
+
+	/// Creates a new exchange rate represented as `msats / minor_units`.
+	///
+	/// This should only be used when the exchange rate cannot be represented as a
+	/// whole number of millisatoshis per one minor currency unit.
+	pub fn from_parts(msats: u64, minor_units: NonZeroU64) -> Self {
+		Self { msats, minor_units }
+	}
+
+	/// The millisatoshi numerator of the exchange-rate ratio.
+	pub fn msats(&self) -> u64 {
+		self.msats
+	}
+
+	/// The fiat minor-unit denominator of the exchange-rate ratio.
+	pub fn minor_units(&self) -> NonZeroU64 {
+		self.minor_units
+	}
+}
+
+impl PartialEq for ExchangeRate {
+	fn eq(&self, other: &Self) -> bool {
+		self.cmp(other) == Ordering::Equal
+	}
+}
+
+impl Eq for ExchangeRate {}
+
+impl PartialOrd for ExchangeRate {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl Ord for ExchangeRate {
+	fn cmp(&self, other: &Self) -> Ordering {
+		let lhs = u128::from(self.msats) * u128::from(other.minor_units.get());
+		let rhs = u128::from(other.msats) * u128::from(self.minor_units.get());
+
+		lhs.cmp(&rhs)
+	}
+}
+
+/// A tolerance applied to an [`ExchangeRate`] when determining acceptable
+/// conversion rates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Tolerance {
+	/// A tolerance expressed in basis points relative to the exchange rate.
+	///
+	/// One basis point is equal to 0.01%.
+	///
+	/// For example, `BasisPoints(100)` represents a tolerance of ±1%.
+	BasisPoints(u16),
+
+	/// A tolerance expressed as an absolute exchange-rate deviation.
+	///
+	/// For example, `AbsoluteMsats(10)` permits a deviation of up to
+	/// 10 millisatoshis per minor currency unit.
+	AbsoluteMsats(u64),
+}
+
+/// An exchange rate together with acceptable lower and upper tolerances.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExchangeRateBound {
+	/// The reference exchange rate.
+	rate: ExchangeRate,
+
+	/// The maximum tolerated deviation below the reference exchange rate.
+	lower_tolerance: Tolerance,
+
+	/// The maximum tolerated deviation above the reference exchange rate.
+	upper_tolerance: Tolerance,
+}
+
+impl ExchangeRateBound {
+	/// Constructs a new exchange rate bound from a reference rate and its
+	/// tolerated lower and upper deviations.
+	///
+	/// The tolerances may be asymmetric. For example, a caller may accept an
+	/// exchange rate up to 1% below the reference rate while only accepting an
+	/// exchange rate up to 0.1% above it.
+	///
+	/// The tolerances can be expressed either in basis points relative to the
+	/// exchange rate or as absolute exchange-rate deviations.
+	///
+	/// Lower tolerances must keep the minimum accepted exchange rate non-negative.
+	/// Upper tolerances greater than or equal to 100% are permitted, provided the
+	/// resulting maximum exchange rate can be represented without overflow.
+	///
+	/// Returns `Err(())` if:
+	/// - the lower basis-points tolerance is greater than or equal to 100%,
+	/// - the lower absolute tolerance would make the minimum exchange rate
+	///   negative, or
+	/// - computing either tolerance bound would overflow.
+	pub fn new(
+		rate: ExchangeRate, lower_tolerance: Tolerance, upper_tolerance: Tolerance,
+	) -> Result<Self, ()> {
+		let bound = Self { rate, lower_tolerance, upper_tolerance };
+		ExchangeRange::from_exchange_rate_bound(bound)?;
+		Ok(bound)
+	}
+
+	/// Converts this bound into the corresponding accepted exchange-rate range.
+	pub(crate) fn to_range(self) -> ExchangeRange {
+		ExchangeRange::from_exchange_rate_bound(self)
+			.expect("exchange-rate bound is checked during construction")
+	}
+}
+
+/// A range of accepted exchange rates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ExchangeRange {
+	/// The minimum accepted exchange rate.
+	pub(crate) minimum: ExchangeRate,
+
+	/// The maximum accepted exchange rate.
+	pub(crate) maximum: ExchangeRate,
+}
+
+impl ExchangeRange {
+	fn from_exchange_rate_bound(bound: ExchangeRateBound) -> Result<Self, ()> {
+		let lower_tolerance_msats = match bound.lower_tolerance {
+			Tolerance::BasisPoints(bps) => {
+				if bps >= 10_000 {
+					return Err(());
+				}
+
+				u128::from(bound.rate.msats)
+					.checked_mul(u128::from(bps))
+					.and_then(|v| v.checked_div(10_000))
+					.and_then(|v| v.try_into().ok())
+					.ok_or(())?
+			},
+			Tolerance::AbsoluteMsats(msats_per_minor_unit) => u128::from(msats_per_minor_unit)
+				.checked_mul(u128::from(bound.rate.minor_units.get()))
+				.and_then(|v| v.try_into().ok())
+				.ok_or(())?,
+		};
+
+		// Ensure the maximum exchange rate can be represented.
+		//
+		// ExchangeRate stores the rate as `msats / minor_units`, with `msats` as the
+		// numerator. Validate that applying the upper tolerance does not overflow the
+		// resulting numerator.
+		let upper_tolerance_msats = match bound.upper_tolerance {
+			Tolerance::BasisPoints(bps) => u128::from(bound.rate.msats)
+				.checked_mul(u128::from(bps))
+				.and_then(|v| v.checked_div(10_000))
+				.and_then(|v| v.try_into().ok())
+				.ok_or(())?,
+			Tolerance::AbsoluteMsats(msats_per_minor_unit) => u128::from(msats_per_minor_unit)
+				.checked_mul(u128::from(bound.rate.minor_units.get()))
+				.and_then(|v| v.try_into().ok())
+				.ok_or(())?,
+		};
+
+		let minimum_rate = ExchangeRate {
+			msats: bound.rate.msats.checked_sub(lower_tolerance_msats).ok_or(())?,
+			minor_units: bound.rate.minor_units,
+		};
+
+		let maximum_rate = ExchangeRate {
+			msats: bound.rate.msats.checked_add(upper_tolerance_msats).ok_or(())?,
+			minor_units: bound.rate.minor_units,
+		};
+
+		Ok(Self { minimum: minimum_rate, maximum: maximum_rate })
+	}
+}
+
+/// A trait for retrieving fiat-to-bitcoin conversion ranges.
+///
+/// The returned range defines the minimum and maximum accepted exchange
+/// rates for converting fiat minor units into millisatoshis.
+///
+/// Exchange rates are represented as:
+///
+/// `msats / minor_units`
+pub trait CurrencyConversion {
+	/// Returns the accepted conversion range for the given currency.
+	fn conversion_range(&self, currency: CurrencyCode) -> Result<ExchangeRateBound, ()>;
+}
+
+impl<T: CurrencyConversion + ?Sized, CC: Deref<Target = T>> CurrencyConversion for CC {
+	fn conversion_range(&self, currency: CurrencyCode) -> Result<ExchangeRateBound, ()> {
+		self.deref().conversion_range(currency)
+	}
+}
+
+/// A [`CurrencyConversion`] implementation that does not support
+/// any fiat currency conversions.
+#[derive(Clone, Copy, Debug)]
+pub struct NullCurrencyConversion;
+
+impl CurrencyConversion for NullCurrencyConversion {
+	fn conversion_range(&self, _currency: CurrencyCode) -> Result<ExchangeRateBound, ()> {
+		Err(())
+	}
+}

--- a/lightning/src/offers/currency.rs
+++ b/lightning/src/offers/currency.rs
@@ -249,3 +249,84 @@ impl CurrencyConversion for NullCurrencyConversion {
 		Err(())
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use crate::offers::currency::{ExchangeRate, ExchangeRateBound, Tolerance};
+	use core::num::NonZeroU64;
+
+	#[test]
+	fn creates_fractional_basis_points_exchange_rate_range() {
+		// A fractional rate keeps the denominator unchanged and applies
+		// basis-point tolerances to the numerator. The selected values exercise
+		// truncating integer division while still producing a range around the
+		// reference rate.
+		let rate = ExchangeRate::from_parts(101, NonZeroU64::new(4).unwrap());
+		let bound =
+			ExchangeRateBound::new(rate, Tolerance::BasisPoints(100), Tolerance::BasisPoints(200))
+				.unwrap();
+
+		let range = bound.to_range();
+		assert_eq!(range.minimum.msats(), 100);
+		assert_eq!(range.minimum.minor_units(), NonZeroU64::new(4).unwrap());
+		assert_eq!(range.maximum.msats(), 103);
+		assert_eq!(range.maximum.minor_units(), NonZeroU64::new(4).unwrap());
+		assert!(range.minimum < rate);
+		assert!(rate < range.maximum);
+	}
+
+	#[test]
+	fn creates_absolute_exchange_rate_range() {
+		// Absolute tolerances are expressed per minor unit. For fractional rates,
+		// they must be scaled by the exchange-rate denominator before being
+		// applied to the numerator.
+		let rate = ExchangeRate::from_parts(1000, NonZeroU64::new(4).unwrap());
+		let bound =
+			ExchangeRateBound::new(rate, Tolerance::AbsoluteMsats(3), Tolerance::AbsoluteMsats(5))
+				.unwrap();
+
+		let range = bound.to_range();
+		assert_eq!(range.minimum.msats(), 988);
+		assert_eq!(range.minimum.minor_units(), NonZeroU64::new(4).unwrap());
+		assert_eq!(range.maximum.msats(), 1020);
+		assert_eq!(range.maximum.minor_units(), NonZeroU64::new(4).unwrap());
+	}
+
+	#[test]
+	fn rejects_invalid_exchange_rate_ranges() {
+		// A lower basis-points tolerance of 100% or more is rejected so the
+		// minimum accepted exchange rate cannot become zero or negative.
+		assert!(ExchangeRateBound::new(
+			ExchangeRate::new(1000),
+			Tolerance::BasisPoints(10_000),
+			Tolerance::BasisPoints(0),
+		)
+		.is_err());
+
+		// Absolute lower tolerances are scaled by the denominator before being
+		// subtracted from the numerator, and must not underflow the reference rate.
+		assert!(ExchangeRateBound::new(
+			ExchangeRate::from_parts(5, NonZeroU64::new(2).unwrap()),
+			Tolerance::AbsoluteMsats(3),
+			Tolerance::BasisPoints(0),
+		)
+		.is_err());
+
+		// Basis-point upper tolerances must not overflow the resulting numerator.
+		assert!(ExchangeRateBound::new(
+			ExchangeRate::new(u64::MAX),
+			Tolerance::BasisPoints(0),
+			Tolerance::BasisPoints(1),
+		)
+		.is_err());
+
+		// Absolute upper tolerances are also scaled by the denominator and must
+		// leave the resulting numerator representable as a u64.
+		assert!(ExchangeRateBound::new(
+			ExchangeRate::from_parts(u64::MAX - 1, NonZeroU64::new(2).unwrap()),
+			Tolerance::BasisPoints(0),
+			Tolerance::AbsoluteMsats(1),
+		)
+		.is_err());
+	}
+}

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -606,6 +606,9 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	///
 	/// Returns an error if the parameterized [`Router`] is unable to create a blinded path for the offer.
 	///
+	/// Currency-denominated amounts set on the returned builder are validated
+	/// with `converter` when the offer is built.
+	///
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// [`DefaultMessageRouter`]: crate::onion_message::messenger::DefaultMessageRouter

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -27,7 +27,6 @@ use crate::blinded_path::payment::{
 	PaymentConstraints, PaymentContext, ReceiveTlvs,
 };
 use crate::chain::channelmonitor::LATENCY_GRACE_PERIOD_BLOCKS;
-
 #[allow(unused_imports)]
 use crate::prelude::*;
 

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -990,9 +990,14 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	/// Returns a [`Bolt12SemanticError`] if:
 	/// - Valid blinded payment paths could not be generated for the [`Bolt12Invoice`].
 	/// - The [`InvoiceBuilder`] could not be created from the [`InvoiceRequest`].
-	pub fn create_invoice_builder_from_invoice_request_with_keys<'a, R: Router, F>(
+	pub fn create_invoice_builder_from_invoice_request_with_keys<
+		'a,
+		R: Router,
+		CC: CurrencyConversion,
+		F,
+	>(
 		&self, router: &R, invoice_request: &'a VerifiedInvoiceRequest<DerivedSigningPubkey>,
-		usable_channels: Vec<ChannelDetails>, get_payment_info: F,
+		converter: &'a CC, usable_channels: Vec<ChannelDetails>, get_payment_info: F,
 		payment_metadata: Option<BTreeMap<u64, Vec<u8>>>,
 	) -> Result<(InvoiceBuilder<'a, DerivedSigningPubkey>, MessageContext), Bolt12SemanticError>
 	where
@@ -1000,8 +1005,10 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	{
 		let relative_expiry = DEFAULT_RELATIVE_EXPIRY.as_secs() as u32;
 
-		let amount_msats =
-			InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(&invoice_request.inner)?;
+		let amount_msats = InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(
+			&invoice_request.inner,
+			converter,
+		)?;
 
 		let (payment_hash, payment_secret) = get_payment_info(amount_msats, relative_expiry)?;
 
@@ -1023,14 +1030,21 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 			.map_err(|_| Bolt12SemanticError::MissingPaths)?;
 
 		#[cfg(all(feature = "std", not(fuzzing)))]
-		let builder = invoice_request.respond_using_derived_keys(payment_paths, payment_hash);
+		let created_at = std::time::SystemTime::now()
+			.duration_since(std::time::SystemTime::UNIX_EPOCH)
+			.expect("time must be after unix epoch");
+
 		#[cfg(any(not(feature = "std"), fuzzing))]
-		let builder = invoice_request.respond_using_derived_keys_no_std(
-			payment_paths,
-			payment_hash,
-			Duration::from_secs(self.highest_seen_timestamp.load(Ordering::Acquire) as u64),
-		);
-		let builder = builder.map(|b| InvoiceBuilder::from(b).allow_mpp())?;
+		let created_at = Duration::from_secs(self.highest_seen_timestamp.load(Ordering::Acquire) as u64);
+
+		let builder = invoice_request
+			.respond_using_derived_keys_with_amount(
+				amount_msats,
+				payment_paths,
+				payment_hash,
+				created_at,
+			)
+			.map(|b| InvoiceBuilder::from(b).allow_mpp())?;
 
 		let context = MessageContext::Offers(OffersContext::InboundPayment { payment_hash });
 
@@ -1051,9 +1065,14 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	/// Returns a [`Bolt12SemanticError`] if:
 	/// - Valid blinded payment paths could not be generated for the [`Bolt12Invoice`].
 	/// - The [`InvoiceBuilder`] could not be created from the [`InvoiceRequest`].
-	pub fn create_invoice_builder_from_invoice_request_without_keys<'a, R: Router, F>(
+	pub fn create_invoice_builder_from_invoice_request_without_keys<
+		'a,
+		R: Router,
+		CC: CurrencyConversion,
+		F,
+	>(
 		&self, router: &R, invoice_request: &'a VerifiedInvoiceRequest<ExplicitSigningPubkey>,
-		usable_channels: Vec<ChannelDetails>, get_payment_info: F,
+		converter: &'a CC, usable_channels: Vec<ChannelDetails>, get_payment_info: F,
 		payment_metadata: Option<BTreeMap<u64, Vec<u8>>>,
 	) -> Result<(InvoiceBuilder<'a, ExplicitSigningPubkey>, MessageContext), Bolt12SemanticError>
 	where
@@ -1061,8 +1080,10 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	{
 		let relative_expiry = DEFAULT_RELATIVE_EXPIRY.as_secs() as u32;
 
-		let amount_msats =
-			InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(&invoice_request.inner)?;
+		let amount_msats = InvoiceBuilder::<DerivedSigningPubkey>::amount_msats(
+			&invoice_request.inner,
+			converter,
+		)?;
 
 		let (payment_hash, payment_secret) = get_payment_info(amount_msats, relative_expiry)?;
 
@@ -1084,15 +1105,16 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 			.map_err(|_| Bolt12SemanticError::MissingPaths)?;
 
 		#[cfg(all(feature = "std", not(fuzzing)))]
-		let builder = invoice_request.respond_with(payment_paths, payment_hash);
-		#[cfg(any(not(feature = "std"), fuzzing))]
-		let builder = invoice_request.respond_with_no_std(
-			payment_paths,
-			payment_hash,
-			Duration::from_secs(self.highest_seen_timestamp.load(Ordering::Acquire) as u64),
-		);
+		let created_at = std::time::SystemTime::now()
+			.duration_since(std::time::SystemTime::UNIX_EPOCH)
+			.expect("time must be after unix epoch");
 
-		let builder = builder.map(|b| InvoiceBuilder::from(b).allow_mpp())?;
+		#[cfg(any(not(feature = "std"), fuzzing))]
+		let created_at = Duration::from_secs(self.highest_seen_timestamp.load(Ordering::Acquire) as u64);
+
+		let builder = invoice_request
+			.respond_with_amount(amount_msats, payment_paths, payment_hash, created_at)
+			.map(|b| InvoiceBuilder::from(b).allow_mpp())?;
 
 		let context = MessageContext::Offers(OffersContext::InboundPayment { payment_hash });
 

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -487,19 +487,25 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	/// Verifies a [`Bolt12Invoice`] using the invoice's payer metadata, returning the
 	/// corresponding [`PaymentId`] if successful.
 	///
+	/// This also verifies that the invoice amount is consistent with the underlying
+	/// offer or refund. For currency-denominated offers, this includes validating
+	/// the invoice amount against the payable amount derived using the provided
+	/// [`CurrencyConversion`] when the invoice request did not carry an explicit
+	/// amount.
+	///
 	/// - If an [`OffersContext::OutboundPaymentForOffer`] or
 	///   [`OffersContext::OutboundPaymentForRefund`] is provided, the extracted [`PaymentId`] must
 	///   also match the context's `payment_id`.
 	/// - If no context is provided, the invoice must correspond to a [`Refund`] without blinded
 	///   paths.
 	/// - If neither condition is met, verification fails.
-	pub fn verify_bolt12_invoice(
-		&self, invoice: &Bolt12Invoice, context: Option<&OffersContext>,
-	) -> Result<PaymentId, ()> {
+	pub fn verify_bolt12_invoice<CC: CurrencyConversion>(
+		&self, invoice: &Bolt12Invoice, converter: &CC, context: Option<&OffersContext>,
+	) -> Result<PaymentId, Bolt12SemanticError> {
 		let secp_ctx = &self.secp_ctx;
 		let expanded_key = &self.inbound_payment_key;
 
-		match context {
+		let payment_id = match context {
 			None if invoice.is_for_refund_without_paths() => {
 				invoice.verify_using_metadata(expanded_key, secp_ctx)
 			},
@@ -523,6 +529,11 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 			},
 			_ => Err(()),
 		}
+		.map_err(|_| Bolt12SemanticError::UnexpectedAmount)?;
+
+		invoice.verify_amount_acceptable_for_payment(converter)?;
+
+		Ok(payment_id)
 	}
 
 	/// Verifies the provided [`AsyncPaymentsContext`] for an inbound [`HeldHtlcAvailable`] message.

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -27,6 +27,7 @@ use crate::blinded_path::payment::{
 	PaymentConstraints, PaymentContext, ReceiveTlvs,
 };
 use crate::chain::channelmonitor::LATENCY_GRACE_PERIOD_BLOCKS;
+use crate::offers::currency::CurrencyConversion;
 #[allow(unused_imports)]
 use crate::prelude::*;
 
@@ -547,9 +548,9 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 		}
 	}
 
-	fn create_offer_builder_intern<ES: EntropySource, PF, I>(
-		&self, entropy_source: ES, make_paths: PF,
-	) -> Result<(OfferBuilder<'_, DerivedMetadata, secp256k1::All>, Nonce), Bolt12SemanticError>
+	fn create_offer_builder_intern<'a, ES: EntropySource, CC: CurrencyConversion, PF, I>(
+		&'a self, entropy_source: ES, converter: &'a CC, make_paths: PF,
+	) -> Result<(OfferBuilder<'a, DerivedMetadata, secp256k1::All, CC>, Nonce), Bolt12SemanticError>
 	where
 		PF: FnOnce(
 			PublicKey,
@@ -567,9 +568,14 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 		let context =
 			MessageContext::Offers(OffersContext::InvoiceRequest { nonce, payment_metadata: None });
 
-		let mut builder =
-			OfferBuilder::deriving_signing_pubkey(node_id, expanded_key, nonce, secp_ctx)
-				.chain_hash(self.chain_hash);
+		let mut builder = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			expanded_key,
+			nonce,
+			converter,
+			secp_ctx,
+		)
+		.chain_hash(self.chain_hash);
 
 		for path in make_paths(node_id, context, secp_ctx)? {
 			builder = builder.path(path)
@@ -603,10 +609,10 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// [`DefaultMessageRouter`]: crate::onion_message::messenger::DefaultMessageRouter
-	pub fn create_offer_builder<ES: EntropySource>(
-		&self, entropy_source: ES, peers: Vec<MessageForwardNode>,
-	) -> Result<OfferBuilder<'_, DerivedMetadata, secp256k1::All>, Bolt12SemanticError> {
-		self.create_offer_builder_intern(&entropy_source, |_, context, _| {
+	pub fn create_offer_builder<'a, ES: EntropySource, CC: CurrencyConversion>(
+		&'a self, entropy_source: ES, converter: &'a CC, peers: Vec<MessageForwardNode>,
+	) -> Result<OfferBuilder<'a, DerivedMetadata, secp256k1::All, CC>, Bolt12SemanticError> {
+		self.create_offer_builder_intern(&entropy_source, converter, |_, context, _| {
 			self.create_blinded_paths(peers, context)
 				.map(|paths| paths.into_iter().take(1))
 				.map_err(|_| Bolt12SemanticError::MissingPaths)
@@ -623,16 +629,25 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 	///
 	/// See [`Self::create_offer_builder`] for more details on usage.
-	pub fn create_offer_builder_using_router<ME: MessageRouter, ES: EntropySource>(
-		&self, router: ME, entropy_source: ES, peers: Vec<MessageForwardNode>,
-	) -> Result<OfferBuilder<'_, DerivedMetadata, secp256k1::All>, Bolt12SemanticError> {
+	pub fn create_offer_builder_using_router<
+		'a,
+		ME: MessageRouter,
+		ES: EntropySource,
+		CC: CurrencyConversion,
+	>(
+		&'a self, router: ME, entropy_source: ES, converter: &'a CC, peers: Vec<MessageForwardNode>,
+	) -> Result<OfferBuilder<'a, DerivedMetadata, secp256k1::All, CC>, Bolt12SemanticError> {
 		let receive_key = self.get_receive_auth_key();
-		self.create_offer_builder_intern(&entropy_source, |node_id, context, secp_ctx| {
-			router
-				.create_blinded_paths(node_id, receive_key, context, peers, secp_ctx)
-				.map(|paths| paths.into_iter().take(1))
-				.map_err(|_| Bolt12SemanticError::MissingPaths)
-		})
+		self.create_offer_builder_intern(
+			&entropy_source,
+			converter,
+			|node_id, context, secp_ctx| {
+				router
+					.create_blinded_paths(node_id, receive_key, context, peers, secp_ctx)
+					.map(|paths| paths.into_iter().take(1))
+					.map_err(|_| Bolt12SemanticError::MissingPaths)
+			},
+		)
 		.map(|(builder, _)| builder)
 	}
 
@@ -646,10 +661,12 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	///    aforementioned always-online node.
 	///
 	/// This is not exported to bindings users as builder patterns don't map outside of move semantics.
-	pub fn create_async_receive_offer_builder<ES: EntropySource>(
-		&self, entropy_source: ES, message_paths_to_always_online_node: Vec<BlindedMessagePath>,
-	) -> Result<(OfferBuilder<'_, DerivedMetadata, secp256k1::All>, Nonce), Bolt12SemanticError> {
-		self.create_offer_builder_intern(&entropy_source, |_, _, _| {
+	pub fn create_async_receive_offer_builder<'a, ES: EntropySource, CC: CurrencyConversion>(
+		&'a self, entropy_source: ES, converter: &'a CC,
+		message_paths_to_always_online_node: Vec<BlindedMessagePath>,
+	) -> Result<(OfferBuilder<'a, DerivedMetadata, secp256k1::All, CC>, Nonce), Bolt12SemanticError>
+	{
+		self.create_offer_builder_intern(&entropy_source, converter, |_, _, _| {
 			Ok(message_paths_to_always_online_node)
 		})
 	}
@@ -662,11 +679,11 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	/// See [`Self::create_offer_builder`] for more details on privacy and limitations.
 	///
 	/// [`ExpandedKey`]: inbound_payment::ExpandedKey
-	pub fn create_phantom_offer_builder<ES: EntropySource>(
-		&self, entropy_source: ES, per_node_peers: Vec<(PublicKey, Vec<MessageForwardNode>)>,
-		path_count_limit: usize,
-	) -> Result<OfferBuilder<'_, DerivedMetadata, secp256k1::All>, Bolt12SemanticError> {
-		self.create_offer_builder_intern(entropy_source, |_, context, _| {
+	pub fn create_phantom_offer_builder<'a, ES: EntropySource, CC: CurrencyConversion>(
+		&'a self, entropy_source: ES, converter: &'a CC,
+		per_node_peers: Vec<(PublicKey, Vec<MessageForwardNode>)>, path_count_limit: usize,
+	) -> Result<OfferBuilder<'a, DerivedMetadata, secp256k1::All, CC>, Bolt12SemanticError> {
+		self.create_offer_builder_intern(entropy_source, converter, |_, context, _| {
 			self.blinded_paths_for_phantom_offer(per_node_peers, path_count_limit, context)
 				.map_err(|_| Bolt12SemanticError::MissingPaths)
 		})
@@ -1528,10 +1545,10 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 	///
 	/// Returns `None` if we have enough offers cached already, verification of `message` fails, or we
 	/// fail to create blinded paths.
-	pub fn handle_offer_paths<ES: EntropySource, R: Router>(
-		&self, message: OfferPaths, context: AsyncPaymentsContext, responder: Responder,
+	pub fn handle_offer_paths<'a, ES: EntropySource, CC: CurrencyConversion, R: Router>(
+		&'a self, message: OfferPaths, context: AsyncPaymentsContext, responder: Responder,
 		peers: Vec<MessageForwardNode>, usable_channels: Vec<ChannelDetails>, entropy: ES,
-		router: R,
+		converter: &'a CC, router: R,
 	) -> Option<(ServeStaticInvoice, MessageContext)> {
 		let duration_since_epoch = self.duration_since_epoch();
 		let invoice_slot = match context {
@@ -1559,7 +1576,7 @@ impl<MR: MessageRouter, L: Logger> OffersMessageFlow<MR, L> {
 		}
 
 		let (mut offer_builder, offer_nonce) =
-			match self.create_async_receive_offer_builder(&entropy, message.paths) {
+			match self.create_async_receive_offer_builder(&entropy, converter, message.paths) {
 				Ok((builder, nonce)) => (builder, nonce),
 				Err(_) => return None, // Only reachable if OfferPaths::paths is empty
 			};

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -121,6 +121,7 @@ use crate::io;
 use crate::ln::channelmanager::PaymentId;
 use crate::ln::inbound_payment::{ExpandedKey, IV_LEN};
 use crate::ln::msgs::DecodeError;
+use crate::offers::currency::NullCurrencyConversion;
 #[cfg(test)]
 use crate::offers::invoice_macros::invoice_builder_methods_test_common;
 use crate::offers::invoice_macros::{invoice_accessors_common, invoice_builder_methods_common};
@@ -1755,7 +1756,9 @@ impl TryFrom<PartialInvoiceTlvStream> for InvoiceContents {
 				experimental_invoice_request_tlv_stream,
 			))?;
 
-			if let Some(requested_amount_msats) = invoice_request.amount_msats() {
+			if let Ok(requested_amount_msats) =
+				invoice_request.payable_amount_msats(&NullCurrencyConversion)
+			{
 				if amount_msats != requested_amount_msats {
 					return Err(Bolt12SemanticError::InvalidAmount);
 				}

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1830,6 +1830,7 @@ mod tests {
 	use crate::ln::channelmanager::PaymentId;
 	use crate::ln::inbound_payment::ExpandedKey;
 	use crate::ln::msgs::DecodeError;
+	use crate::offers::currency::NullCurrencyConversion;
 	use crate::offers::invoice_request::{
 		ExperimentalInvoiceRequestTlvStreamRef, InvoiceRequestTlvStreamRef,
 		InvoiceRequestVerifiedFromOffer,
@@ -1884,7 +1885,7 @@ mod tests {
 		let payment_paths = payment_paths();
 		let payment_hash = payment_hash();
 		let now = now();
-		let unsigned_invoice = OfferBuilder::new(recipient_pubkey())
+		let unsigned_invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2142,6 +2143,8 @@ mod tests {
 	#[cfg(feature = "std")]
 	#[test]
 	fn builds_invoice_from_offer_with_expiration() {
+		use crate::offers::currency::NullCurrencyConversion;
+
 		let expanded_key = ExpandedKey::new([42; 32]);
 		let entropy = FixedEntropy {};
 		let nonce = Nonce::from_entropy_source(&entropy);
@@ -2151,7 +2154,7 @@ mod tests {
 		let future_expiry = Duration::from_secs(u64::max_value());
 		let past_expiry = Duration::from_secs(0);
 
-		if let Err(e) = OfferBuilder::new(recipient_pubkey())
+		if let Err(e) = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.absolute_expiry(future_expiry)
 			.build()
@@ -2167,7 +2170,7 @@ mod tests {
 			panic!("error building invoice: {:?}", e);
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.absolute_expiry(past_expiry)
 			.build()
@@ -2236,17 +2239,22 @@ mod tests {
 
 		#[cfg(c_bindings)]
 		use crate::offers::offer::OfferWithDerivedMetadataBuilder as OfferBuilder;
-		let invoice_request =
-			OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-				.amount_msats(1000)
-				.path(blinded_path)
-				.experimental_foo(42)
-				.build()
-				.unwrap()
-				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-				.unwrap()
-				.build_and_sign()
-				.unwrap();
+		let invoice_request = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.amount_msats(1000)
+		.path(blinded_path)
+		.experimental_foo(42)
+		.build()
+		.unwrap()
+		.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+		.unwrap()
+		.build_and_sign()
+		.unwrap();
 
 		let verified_request = invoice_request
 			.clone()
@@ -2350,7 +2358,7 @@ mod tests {
 		let now = now();
 		let one_hour = Duration::from_secs(3600);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2371,7 +2379,7 @@ mod tests {
 		assert_eq!(invoice.relative_expiry(), one_hour);
 		assert_eq!(tlv_stream.relative_expiry, Some(one_hour.as_secs() as u32));
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2401,7 +2409,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2430,7 +2438,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2451,7 +2459,7 @@ mod tests {
 		assert_eq!(invoice.amount_msats(), 2000);
 		assert_eq!(tlv_stream.amount, Some(2000));
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2481,7 +2489,7 @@ mod tests {
 		let x_only_pubkey = XOnlyPublicKey::from_keypair(&recipient_keys()).0;
 		let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(x_only_pubkey);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2537,7 +2545,7 @@ mod tests {
 		let mut features = Bolt12InvoiceFeatures::empty();
 		features.set_basic_mpp_optional();
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2565,7 +2573,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2583,7 +2591,7 @@ mod tests {
 			Err(e) => assert_eq!(e, SignError::Signing),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2610,7 +2618,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2687,7 +2695,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2731,7 +2739,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2764,7 +2772,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2808,7 +2816,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2850,7 +2858,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2892,7 +2900,7 @@ mod tests {
 		let x_only_pubkey = XOnlyPublicKey::from_keypair(&recipient_keys()).0;
 		let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(x_only_pubkey);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2956,7 +2964,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3040,7 +3048,7 @@ mod tests {
 			Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
 		};
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.clear_issuer_signing_pubkey()
 			.amount_msats(1000)
 			.path(paths[0].clone())
@@ -3070,7 +3078,7 @@ mod tests {
 			panic!("error parsing invoice: {:?}", e);
 		}
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.clear_issuer_signing_pubkey()
 			.amount_msats(1000)
 			.path(paths[0].clone())
@@ -3115,7 +3123,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3142,7 +3150,7 @@ mod tests {
 			),
 		}
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3208,7 +3216,7 @@ mod tests {
 		let payment_id = PaymentId([1; 32]);
 
 		let mut buffer = Vec::new();
-		OfferBuilder::new(recipient_pubkey())
+		OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3241,7 +3249,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let mut invoice = OfferBuilder::new(recipient_pubkey())
+		let mut invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3284,7 +3292,7 @@ mod tests {
 
 		let secp_ctx = Secp256k1::new();
 		let keys = Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
-		let mut unsigned_invoice = OfferBuilder::new(keys.public_key())
+		let mut unsigned_invoice = OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3323,7 +3331,7 @@ mod tests {
 		const UNKNOWN_EVEN_TYPE: u64 = INVOICE_TYPES.end - 2;
 		assert!(UNKNOWN_EVEN_TYPE % 2 == 0);
 
-		let mut unsigned_invoice = OfferBuilder::new(keys.public_key())
+		let mut unsigned_invoice = OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3369,7 +3377,7 @@ mod tests {
 
 		let secp_ctx = Secp256k1::new();
 		let keys = Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
-		let invoice = OfferBuilder::new(keys.public_key())
+		let invoice = OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3395,7 +3403,7 @@ mod tests {
 		const UNKNOWN_ODD_TYPE: u64 = EXPERIMENTAL_INVOICE_TYPES.start + 1;
 		assert!(UNKNOWN_ODD_TYPE % 2 == 1);
 
-		let mut unsigned_invoice = OfferBuilder::new(keys.public_key())
+		let mut unsigned_invoice = OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3436,7 +3444,7 @@ mod tests {
 		const UNKNOWN_EVEN_TYPE: u64 = EXPERIMENTAL_INVOICE_TYPES.start;
 		assert!(UNKNOWN_EVEN_TYPE % 2 == 0);
 
-		let mut unsigned_invoice = OfferBuilder::new(keys.public_key())
+		let mut unsigned_invoice = OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3474,7 +3482,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12ParseError::Decode(DecodeError::UnknownRequiredFeature)),
 		}
 
-		let invoice = OfferBuilder::new(keys.public_key())
+		let invoice = OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3515,7 +3523,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3550,7 +3558,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice = OfferBuilder::new(recipient_pubkey())
+		let invoice = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3595,7 +3603,10 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let offer = OfferBuilder::new(recipient_pubkey()).amount_msats(1000).build().unwrap();
+		let offer = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
+			.amount_msats(1000)
+			.build()
+			.unwrap();
 
 		let offer_id = offer.id();
 
@@ -3643,7 +3654,8 @@ mod tests {
 		let now = Duration::from_secs(123456);
 		let payment_id = PaymentId([1; 32]);
 
-		let offer = OfferBuilder::new(node_id).amount_msats(1000).build().unwrap();
+		let offer =
+			OfferBuilder::new(node_id, &NullCurrencyConversion).amount_msats(1000).build().unwrap();
 
 		let invoice_request = offer
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -123,7 +123,7 @@ use crate::blinded_path::BlindedPath;
 use crate::io;
 use crate::ln::channelmanager::PaymentId;
 use crate::ln::inbound_payment::{ExpandedKey, IV_LEN};
-use crate::ln::msgs::DecodeError;
+use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
 use crate::offers::currency::{CurrencyConversion, NullCurrencyConversion};
 #[cfg(test)]
 use crate::offers::invoice_macros::invoice_builder_methods_test_common;
@@ -399,14 +399,26 @@ macro_rules! invoice_builder_methods {
 		pub(crate) fn amount_msats<CC: CurrencyConversion>(
 			invoice_request: &InvoiceRequest, converter: &CC,
 		) -> Result<u64, Bolt12SemanticError> {
-			match invoice_request.contents.inner.amount_msats() {
-				Some(amount_msats) => Ok(amount_msats),
-				None => match invoice_request.contents.inner.offer.amount() {
-					Some(Amount::Bitcoin { amount_msats }) => amount_msats
+			let requested_amount = invoice_request.amount_msats();
+
+			match invoice_request.amount() {
+				None => requested_amount.ok_or(Bolt12SemanticError::MissingAmount),
+				Some(offer_amount) => {
+					let (minimum_unit_msats, _maximum_unit_msats) =
+						offer_amount.to_msats_range(converter)?;
+
+					let minimum_msats = minimum_unit_msats
 						.checked_mul(invoice_request.quantity().unwrap_or(1))
-						.ok_or(Bolt12SemanticError::InvalidAmount),
-					Some(Amount::Currency { .. }) => Err(Bolt12SemanticError::UnsupportedCurrency),
-					None => Err(Bolt12SemanticError::MissingAmount),
+						.filter(|msats| *msats <= MAX_VALUE_MSAT)
+						.ok_or(Bolt12SemanticError::InvalidAmount)?;
+
+					match requested_amount {
+						Some(amount) if amount < minimum_msats => {
+							Err(Bolt12SemanticError::InsufficientAmount)
+						},
+						Some(amount) => Ok(amount),
+						None => Ok(minimum_msats),
+					}
 				},
 			}
 		}

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -29,6 +29,7 @@
 //! use lightning::util::ser::Writeable;
 //!
 //! # use lightning::types::payment::PaymentHash;
+//! # use lightning::offers::currency::NullCurrencyConversion;
 //! # use lightning::offers::invoice::{ExplicitSigningPubkey, InvoiceBuilder};
 //! # use lightning::blinded_path::payment::{BlindedPayInfo, BlindedPaymentPath};
 //! #
@@ -44,19 +45,21 @@
 //! let wpubkey_hash = bitcoin::key::PublicKey::new(pubkey).wpubkey_hash().unwrap();
 //! let mut buffer = Vec::new();
 //!
+//! let converter = NullCurrencyConversion;
+//!
 //! // Invoice for the "offer to be paid" flow.
 //! # <InvoiceBuilder<ExplicitSigningPubkey>>::from(
 //! InvoiceRequest::try_from(bytes)?
 #![cfg_attr(
 	feature = "std",
 	doc = "
-    .respond_with(payment_paths, payment_hash)?
+    .respond_with(&converter, payment_paths, payment_hash)?
 "
 )]
 #![cfg_attr(
 	not(feature = "std"),
 	doc = "
-    .respond_with_no_std(payment_paths, payment_hash, core::time::Duration::from_secs(0))?
+    .respond_with_no_std(&converter, payment_paths, payment_hash, core::time::Duration::from_secs(0))?
 "
 )]
 //! # )
@@ -121,7 +124,7 @@ use crate::io;
 use crate::ln::channelmanager::PaymentId;
 use crate::ln::inbound_payment::{ExpandedKey, IV_LEN};
 use crate::ln::msgs::DecodeError;
-use crate::offers::currency::NullCurrencyConversion;
+use crate::offers::currency::{CurrencyConversion, NullCurrencyConversion};
 #[cfg(test)]
 use crate::offers::invoice_macros::invoice_builder_methods_test_common;
 use crate::offers::invoice_macros::{invoice_accessors_common, invoice_builder_methods_common};
@@ -242,10 +245,10 @@ macro_rules! invoice_explicit_signing_pubkey_builder_methods {
 	($self: ident, $self_type: ty) => {
 		#[cfg_attr(c_bindings, allow(dead_code))]
 		pub(super) fn for_offer(
-			invoice_request: &'a InvoiceRequest, payment_paths: Vec<BlindedPaymentPath>,
-			created_at: Duration, payment_hash: PaymentHash, signing_pubkey: PublicKey,
+			invoice_request: &'a InvoiceRequest, amount_msats: u64,
+			payment_paths: Vec<BlindedPaymentPath>, created_at: Duration,
+			payment_hash: PaymentHash, signing_pubkey: PublicKey,
 		) -> Result<Self, Bolt12SemanticError> {
-			let amount_msats = Self::amount_msats(invoice_request)?;
 			let contents = InvoiceContents::ForOffer {
 				invoice_request: invoice_request.contents.clone(),
 				fields: Self::fields(
@@ -314,10 +317,10 @@ macro_rules! invoice_derived_signing_pubkey_builder_methods {
 	($self: ident, $self_type: ty) => {
 		#[cfg_attr(c_bindings, allow(dead_code))]
 		pub(super) fn for_offer_using_keys(
-			invoice_request: &'a InvoiceRequest, payment_paths: Vec<BlindedPaymentPath>,
-			created_at: Duration, payment_hash: PaymentHash, keys: Keypair,
+			invoice_request: &'a InvoiceRequest, amount_msats: u64,
+			payment_paths: Vec<BlindedPaymentPath>, created_at: Duration,
+			payment_hash: PaymentHash, keys: Keypair,
 		) -> Result<Self, Bolt12SemanticError> {
-			let amount_msats = Self::amount_msats(invoice_request)?;
 			let signing_pubkey = keys.public_key();
 			let contents = InvoiceContents::ForOffer {
 				invoice_request: invoice_request.contents.clone(),
@@ -393,8 +396,8 @@ macro_rules! invoice_builder_methods {
 	(
 	$self: ident, $self_type: ty, $return_type: ty, $return_value: expr, $type_param: ty $(, $self_mut: tt)?
 ) => {
-		pub(crate) fn amount_msats(
-			invoice_request: &InvoiceRequest,
+		pub(crate) fn amount_msats<CC: CurrencyConversion>(
+			invoice_request: &InvoiceRequest, converter: &CC,
 		) -> Result<u64, Bolt12SemanticError> {
 			match invoice_request.contents.inner.amount_msats() {
 				Some(amount_msats) => Ok(amount_msats),
@@ -1896,7 +1899,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths.clone(), payment_hash, now)
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths.clone(), payment_hash, now)
 			.unwrap()
 			.build()
 			.unwrap();
@@ -2166,7 +2169,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with(payment_paths(), payment_hash())
+			.respond_with(&NullCurrencyConversion, payment_paths(), payment_hash())
 			.unwrap()
 			.build()
 		{
@@ -2181,7 +2184,7 @@ mod tests {
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
 			.unwrap()
 			.build_unchecked_and_sign()
-			.respond_with(payment_paths(), payment_hash())
+			.respond_with(&NullCurrencyConversion, payment_paths(), payment_hash())
 			.unwrap()
 			.build()
 		{
@@ -2267,7 +2270,12 @@ mod tests {
 		match verified_request {
 			InvoiceRequestVerifiedFromOffer::DerivedKeys(req) => {
 				let invoice = req
-					.respond_using_derived_keys_no_std(payment_paths(), payment_hash(), now())
+					.respond_using_derived_keys_no_std(
+						&NullCurrencyConversion,
+						payment_paths(),
+						payment_hash(),
+						now(),
+					)
 					.unwrap()
 					.build_and_sign(&secp_ctx);
 
@@ -2369,7 +2377,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now)
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now)
 			.unwrap()
 			.relative_expiry(one_hour.as_secs() as u32)
 			.build()
@@ -2390,7 +2398,12 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now - one_hour)
+			.respond_with_no_std(
+				&NullCurrencyConversion,
+				payment_paths(),
+				payment_hash(),
+				now - one_hour,
+			)
 			.unwrap()
 			.relative_expiry(one_hour.as_secs() as u32 - 1)
 			.build()
@@ -2422,7 +2435,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2452,7 +2465,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2472,7 +2485,7 @@ mod tests {
 			.quantity(u64::max_value())
 			.unwrap()
 			.build_unchecked_and_sign()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 		{
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
@@ -2500,7 +2513,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.fallback_v0_p2wsh(&script.wscript_hash())
 			.fallback_v0_p2wpkh(&pubkey.wpubkey_hash().unwrap())
@@ -2556,7 +2569,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.allow_mpp()
 			.build()
@@ -2584,7 +2597,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2602,7 +2615,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2629,7 +2642,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2706,7 +2719,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2750,7 +2763,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.relative_expiry(3600)
 			.build()
@@ -2783,7 +2796,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2827,7 +2840,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2869,7 +2882,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.allow_mpp()
 			.build()
@@ -2912,11 +2925,13 @@ mod tests {
 			.build_and_sign()
 			.unwrap();
 		#[cfg(not(c_bindings))]
-		let invoice_builder =
-			invoice_request.respond_with_no_std(payment_paths(), payment_hash(), now()).unwrap();
+		let invoice_builder = invoice_request
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
+			.unwrap();
 		#[cfg(c_bindings)]
-		let mut invoice_builder =
-			invoice_request.respond_with_no_std(payment_paths(), payment_hash(), now()).unwrap();
+		let mut invoice_builder = invoice_request
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
+			.unwrap();
 		let invoice_builder = invoice_builder
 			.fallback_v0_p2wsh(&script.wscript_hash())
 			.fallback_v0_p2wpkh(&pubkey.wpubkey_hash().unwrap())
@@ -2975,7 +2990,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3063,6 +3078,7 @@ mod tests {
 			.build_and_sign()
 			.unwrap()
 			.respond_with_no_std_using_signing_pubkey(
+				&NullCurrencyConversion,
 				payment_paths(),
 				payment_hash(),
 				now(),
@@ -3093,6 +3109,7 @@ mod tests {
 			.build_and_sign()
 			.unwrap()
 			.respond_with_no_std_using_signing_pubkey(
+				&NullCurrencyConversion,
 				payment_paths(),
 				payment_hash(),
 				now(),
@@ -3134,7 +3151,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.amount_msats_unchecked(2000)
 			.build()
@@ -3163,7 +3180,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.amount_msats_unchecked(2000)
 			.build()
@@ -3227,7 +3244,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3260,7 +3277,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3303,7 +3320,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap();
@@ -3342,7 +3359,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap();
@@ -3388,7 +3405,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.experimental_baz(42)
 			.build()
@@ -3414,7 +3431,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap();
@@ -3455,7 +3472,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap();
@@ -3493,7 +3510,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3534,7 +3551,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3569,7 +3586,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3620,7 +3637,7 @@ mod tests {
 			.unwrap();
 
 		let invoice = invoice_request
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3667,7 +3684,7 @@ mod tests {
 			.unwrap();
 
 		let invoice = invoice_request
-			.respond_with_no_std(payment_paths, payment_hash(), now)
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths, payment_hash(), now)
 			.unwrap()
 			.build()
 			.unwrap()

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1034,6 +1034,42 @@ impl Bolt12Invoice {
 		self.contents.verify(&self.bytes, metadata, key, iv_bytes, secp_ctx)
 	}
 
+	/// Verifies that the invoice amount is acceptable for payment relative to the
+	/// underlying offer.
+	///
+	/// For currency-denominated offers where the invoice request did not carry an
+	/// explicit amount, this checks that the invoice amount does not exceed the
+	/// maximum payable amount derived from the provided currency conversion.
+	///
+	/// Invoices for refunds or invoice requests with explicit amounts are assumed
+	/// to have already been validated during parsing.
+	pub fn verify_amount_acceptable_for_payment<CC: CurrencyConversion>(
+		&self, converter: &CC,
+	) -> Result<(), Bolt12SemanticError> {
+		if let InvoiceContents::ForOffer { invoice_request, .. } = &self.contents {
+			if invoice_request.amount_msats().is_none() {
+				let offer_amount = invoice_request
+					.inner
+					.offer
+					.amount()
+					.ok_or(Bolt12SemanticError::MissingAmount)?;
+
+				let (_minimum_unit_msats, maximum_unit_msats) =
+					offer_amount.to_msats_range(converter)?;
+
+				let maximum_msats = maximum_unit_msats
+					.saturating_mul(self.quantity().unwrap_or(1))
+					.min(MAX_VALUE_MSAT);
+
+				if self.amount_msats() > maximum_msats {
+					return Err(Bolt12SemanticError::ExcessiveAmount);
+				}
+			}
+		}
+
+		Ok(())
+	}
+
 	pub(crate) fn as_tlv_stream(&self) -> FullInvoiceTlvStreamRef<'_> {
 		let (
 			payer_tlv_stream,

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1901,6 +1901,7 @@ mod tests {
 	use crate::types::features::{Bolt12InvoiceFeatures, InvoiceRequestFeatures, OfferFeatures};
 	use crate::types::string::PrintableString;
 	use crate::util::ser::{BigSize, Iterable, Writeable};
+	use crate::util::test_utils::TestCurrencyConversion;
 	#[cfg(not(c_bindings))]
 	use {crate::offers::offer::OfferBuilder, crate::offers::refund::RefundBuilder};
 	#[cfg(c_bindings)]
@@ -2538,6 +2539,121 @@ mod tests {
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
 		}
+	}
+
+	#[test]
+	fn rejects_excessive_amount_for_currency_offer() {
+		let expanded_key = ExpandedKey::new([42; 32]);
+		let entropy = FixedEntropy {};
+		let nonce = Nonce::from_entropy_source(&entropy);
+		let secp_ctx = Secp256k1::new();
+		let payment_id = PaymentId([1; 32]);
+		let converter = TestCurrencyConversion {};
+
+		let invoice = OfferBuilder::new(recipient_pubkey(), &converter)
+			.amount(Amount::Currency {
+				iso4217_code: crate::offers::offer::CurrencyCode::new(*b"USD").unwrap(),
+				amount: 10,
+			})
+			.build()
+			.unwrap()
+			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+			.unwrap()
+			.build_and_sign()
+			.unwrap()
+			.respond_with_no_std(&converter, payment_paths(), payment_hash(), now())
+			.unwrap()
+			.amount_msats_unchecked(10_001)
+			.build()
+			.unwrap()
+			.sign(recipient_sign)
+			.unwrap();
+
+		assert_eq!(
+			invoice.verify_amount_acceptable_for_payment(&converter),
+			Err(Bolt12SemanticError::ExcessiveAmount),
+		);
+	}
+
+	#[test]
+	fn fails_verifying_currency_offer_invoice_without_conversion_support() {
+		let expanded_key = ExpandedKey::new([42; 32]);
+		let entropy = FixedEntropy {};
+		let nonce = Nonce::from_entropy_source(&entropy);
+		let secp_ctx = Secp256k1::new();
+		let payment_id = PaymentId([1; 32]);
+		let converter = TestCurrencyConversion {};
+
+		let invoice = OfferBuilder::new(recipient_pubkey(), &converter)
+			.amount(Amount::Currency {
+				iso4217_code: crate::offers::offer::CurrencyCode::new(*b"USD").unwrap(),
+				amount: 10,
+			})
+			.build()
+			.unwrap()
+			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+			.unwrap()
+			.build_and_sign()
+			.unwrap()
+			.respond_with_no_std(&converter, payment_paths(), payment_hash(), now())
+			.unwrap()
+			.build()
+			.unwrap()
+			.sign(recipient_sign)
+			.unwrap();
+
+		assert_eq!(
+			invoice.verify_amount_acceptable_for_payment(&NullCurrencyConversion),
+			Err(Bolt12SemanticError::UnsupportedCurrency),
+		);
+	}
+
+	#[test]
+	fn verifies_currency_offer_invoice_amount_with_quantity() {
+		let expanded_key = ExpandedKey::new([42; 32]);
+		let entropy = FixedEntropy {};
+		let nonce = Nonce::from_entropy_source(&entropy);
+		let secp_ctx = Secp256k1::new();
+		let payment_id = PaymentId([1; 32]);
+		let converter = TestCurrencyConversion {};
+
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &converter)
+			.amount(Amount::Currency {
+				iso4217_code: crate::offers::offer::CurrencyCode::new(*b"USD").unwrap(),
+				amount: 10,
+			})
+			.supported_quantity(Quantity::Unbounded)
+			.build()
+			.unwrap()
+			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+			.unwrap()
+			.quantity(2)
+			.unwrap()
+			.build_and_sign()
+			.unwrap();
+
+		let invoice = invoice_request
+			.respond_with_no_std(&converter, payment_paths(), payment_hash(), now())
+			.unwrap()
+			.build()
+			.unwrap()
+			.sign(recipient_sign)
+			.unwrap();
+		assert_eq!(invoice.amount_msats(), 20_000);
+		assert_eq!(invoice.verify_amount_acceptable_for_payment(&converter), Ok(()));
+
+		let invoice = invoice_request
+			.respond_with_no_std(&converter, payment_paths(), payment_hash(), now())
+			.unwrap()
+			.amount_msats_unchecked(20_001)
+			.build()
+			.unwrap()
+			.sign(recipient_sign)
+			.unwrap();
+		assert_eq!(
+			invoice.verify_amount_acceptable_for_payment(&converter),
+			Err(Bolt12SemanticError::ExcessiveAmount),
+		);
 	}
 
 	#[test]

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -70,15 +70,16 @@ use crate::blinded_path::payment::BlindedPaymentPath;
 use crate::io;
 use crate::ln::channelmanager::PaymentId;
 use crate::ln::inbound_payment::{ExpandedKey, IV_LEN};
-use crate::ln::msgs::DecodeError;
+use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
+use crate::offers::currency::CurrencyConversion;
 use crate::offers::invoice::{DerivedSigningPubkey, ExplicitSigningPubkey, SigningPubkeyStrategy};
 use crate::offers::merkle::{
 	self, SignError, SignFn, SignatureTlvStream, SignatureTlvStreamRef, TaggedHash, TlvStream,
 };
 use crate::offers::nonce::Nonce;
 use crate::offers::offer::{
-	Amount, ExperimentalOfferTlvStream, ExperimentalOfferTlvStreamRef, Offer, OfferContents,
-	OfferId, OfferTlvStream, OfferTlvStreamRef, EXPERIMENTAL_OFFER_TYPES, OFFER_TYPES,
+	ExperimentalOfferTlvStream, ExperimentalOfferTlvStreamRef, Offer, OfferContents, OfferId,
+	OfferTlvStream, OfferTlvStreamRef, EXPERIMENTAL_OFFER_TYPES, OFFER_TYPES,
 };
 use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError, ParsedMessage};
 use crate::offers::payer::{PayerContents, PayerTlvStream, PayerTlvStreamRef};
@@ -708,21 +709,27 @@ macro_rules! invoice_request_accessors { ($self: ident, $contents: expr) => {
 		$contents.chain()
 	}
 
-	/// The amount to pay in msats (i.e., the minimum lightning-payable unit for [`chain`]), which
-	/// must be greater than or equal to [`Offer::amount`], converted if necessary.
-	///
-	/// [`chain`]: Self::chain
+	/// Returns the amount explicitly requested in the invoice request,
+	/// in millisatoshis.
 	pub fn amount_msats(&$self) -> Option<u64> {
 		$contents.amount_msats()
 	}
 
-	/// Returns whether an amount was set in the request; otherwise, if [`amount_msats`] is `Some`
-	/// then it was inferred from the [`Offer::amount`] and [`quantity`].
+	/// Returns the amount payable for this invoice request, in millisatoshis.
 	///
-	/// [`amount_msats`]: Self::amount_msats
-	/// [`quantity`]: Self::quantity
-	pub fn has_amount_msats(&$self) -> bool {
-		$contents.has_amount_msats()
+	/// The payable amount is determined as follows:
+	///
+	/// - If the invoice request explicitly specifies an amount, that amount is returned.
+	/// - Otherwise, the amount is inferred from the [`Offer`] amount and the requested
+	///   quantity.
+	///
+	/// Returns an error if:
+	///
+	/// - no payable amount can be determined,
+	/// - the offer amount cannot be converted to Bitcoin, or
+	/// - the amount is semantically invalid.
+	pub fn payable_amount_msats<CC: CurrencyConversion>(&$self, converter: &CC) -> Result<u64, Bolt12SemanticError> {
+		$contents.payable_amount_msats(converter)
 	}
 
 	/// Features pertaining to requesting an invoice.
@@ -1147,20 +1154,33 @@ impl InvoiceRequestContents {
 	}
 
 	pub(super) fn amount_msats(&self) -> Option<u64> {
-		self.inner.amount_msats().or_else(|| match self.inner.offer.amount() {
-			Some(Amount::Bitcoin { amount_msats }) => {
-				Some(amount_msats.saturating_mul(self.quantity().unwrap_or(1)))
-			},
-			Some(Amount::Currency { .. }) => None,
-			None => {
-				debug_assert!(false);
-				None
-			},
-		})
+		self.inner.amount_msats()
 	}
 
-	pub(super) fn has_amount_msats(&self) -> bool {
-		self.inner.amount_msats().is_some()
+	pub(super) fn payable_amount_msats<CC: CurrencyConversion>(
+		&self, converter: &CC,
+	) -> Result<u64, Bolt12SemanticError> {
+		if let Some(amount_msats) = self.inner.amount_msats() {
+			return Ok(amount_msats);
+		}
+
+		match self.inner.offer.amount() {
+			Some(amount) => {
+				// Use the lower bound when choosing the concrete payable amount. The range
+				// represents the payee's accepted exchange-rate uncertainty, and choosing the
+				// minimum avoids overcharging the payer.
+				let (minimum_msats, _maximum_msats) = amount.to_msats_range(converter)?;
+
+				minimum_msats
+					.checked_mul(self.quantity().unwrap_or(1))
+					.filter(|msats| *msats <= MAX_VALUE_MSAT)
+					.ok_or(Bolt12SemanticError::InvalidAmount)
+			},
+			None => {
+				debug_assert!(false);
+				Err(Bolt12SemanticError::MissingAmount)
+			},
+		}
 	}
 
 	pub(super) fn features(&self) -> &InvoiceRequestFeatures {
@@ -1626,7 +1646,7 @@ mod tests {
 		assert_eq!(invoice_request.supported_quantity(), Quantity::One);
 		assert_eq!(invoice_request.issuer_signing_pubkey(), Some(recipient_pubkey()));
 		assert_eq!(invoice_request.chain(), ChainHash::using_genesis_block(Network::Bitcoin));
-		assert_eq!(invoice_request.amount_msats(), Some(1000));
+		assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(1000));
 		assert_eq!(invoice_request.invoice_request_features(), &InvoiceRequestFeatures::empty());
 		assert_eq!(invoice_request.quantity(), None);
 		assert_eq!(invoice_request.payer_note(), None);
@@ -1942,7 +1962,6 @@ mod tests {
 			.build_and_sign()
 			.unwrap();
 		let (_, _, tlv_stream, _, _, _) = invoice_request.as_tlv_stream();
-		assert!(invoice_request.has_amount_msats());
 		assert_eq!(invoice_request.amount_msats(), Some(1000));
 		assert_eq!(tlv_stream.amount, Some(1000));
 
@@ -1959,7 +1978,6 @@ mod tests {
 			.build_and_sign()
 			.unwrap();
 		let (_, _, tlv_stream, _, _, _) = invoice_request.as_tlv_stream();
-		assert!(invoice_request.has_amount_msats());
 		assert_eq!(invoice_request.amount_msats(), Some(1000));
 		assert_eq!(tlv_stream.amount, Some(1000));
 
@@ -1974,7 +1992,6 @@ mod tests {
 			.build_and_sign()
 			.unwrap();
 		let (_, _, tlv_stream, _, _, _) = invoice_request.as_tlv_stream();
-		assert!(invoice_request.has_amount_msats());
 		assert_eq!(invoice_request.amount_msats(), Some(1001));
 		assert_eq!(tlv_stream.amount, Some(1001));
 
@@ -2085,8 +2102,8 @@ mod tests {
 			.build_and_sign()
 			.unwrap();
 		let (_, _, tlv_stream, _, _, _) = invoice_request.as_tlv_stream();
-		assert!(!invoice_request.has_amount_msats());
-		assert_eq!(invoice_request.amount_msats(), Some(1000));
+		assert!(invoice_request.amount_msats().is_none());
+		assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(1000));
 		assert_eq!(tlv_stream.amount, None);
 
 		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
@@ -2101,8 +2118,8 @@ mod tests {
 			.build_and_sign()
 			.unwrap();
 		let (_, _, tlv_stream, _, _, _) = invoice_request.as_tlv_stream();
-		assert!(!invoice_request.has_amount_msats());
-		assert_eq!(invoice_request.amount_msats(), Some(2000));
+		assert!(invoice_request.amount_msats().is_none());
+		assert_eq!(invoice_request.payable_amount_msats(&NullCurrencyConversion), Ok(2000));
 		assert_eq!(tlv_stream.amount, None);
 
 		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
@@ -2115,8 +2132,11 @@ mod tests {
 			.unwrap()
 			.build_unchecked_and_sign();
 		let (_, _, tlv_stream, _, _, _) = invoice_request.as_tlv_stream();
-		assert!(!invoice_request.has_amount_msats());
-		assert_eq!(invoice_request.amount_msats(), None);
+		assert!(invoice_request.amount_msats().is_none());
+		assert_eq!(
+			invoice_request.payable_amount_msats(&NullCurrencyConversion),
+			Err(Bolt12SemanticError::UnsupportedCurrency)
+		);
 		assert_eq!(tlv_stream.amount, None);
 	}
 

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1556,6 +1556,7 @@ mod tests {
 	use crate::ln::channelmanager::PaymentId;
 	use crate::ln::inbound_payment::ExpandedKey;
 	use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
+	use crate::offers::currency::NullCurrencyConversion;
 	use crate::offers::invoice::{Bolt12Invoice, SIGNATURE_TAG as INVOICE_SIGNATURE_TAG};
 	use crate::offers::invoice_request::string_truncate_safe;
 	use crate::offers::merkle::{self, SignatureTlvStreamRef, TaggedHash, TlvStream};
@@ -1591,7 +1592,7 @@ mod tests {
 		let mut payer_metadata = encrypted_payment_id.to_vec();
 		payer_metadata.extend_from_slice(nonce.as_slice());
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -1683,7 +1684,7 @@ mod tests {
 		let future_expiry = Duration::from_secs(u64::max_value());
 		let past_expiry = Duration::from_secs(0);
 
-		if let Err(e) = OfferBuilder::new(recipient_pubkey())
+		if let Err(e) = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.absolute_expiry(future_expiry)
 			.build()
@@ -1695,7 +1696,7 @@ mod tests {
 			panic!("error building invoice_request: {:?}", e);
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.absolute_expiry(past_expiry)
 			.build()
@@ -1717,7 +1718,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let offer = OfferBuilder::new(recipient_pubkey())
+		let offer = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.experimental_foo(42)
 			.build()
@@ -1826,7 +1827,7 @@ mod tests {
 		let mainnet = ChainHash::using_genesis_block(Network::Bitcoin);
 		let testnet = ChainHash::using_genesis_block(Network::Testnet);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -1840,7 +1841,7 @@ mod tests {
 		assert_eq!(invoice_request.chain(), mainnet);
 		assert_eq!(tlv_stream.chain, None);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.chain(Network::Testnet)
 			.build()
@@ -1855,7 +1856,7 @@ mod tests {
 		assert_eq!(invoice_request.chain(), testnet);
 		assert_eq!(tlv_stream.chain, Some(&testnet));
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.chain(Network::Bitcoin)
 			.chain(Network::Testnet)
@@ -1871,7 +1872,7 @@ mod tests {
 		assert_eq!(invoice_request.chain(), mainnet);
 		assert_eq!(tlv_stream.chain, None);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.chain(Network::Bitcoin)
 			.chain(Network::Testnet)
@@ -1889,7 +1890,7 @@ mod tests {
 		assert_eq!(invoice_request.chain(), testnet);
 		assert_eq!(tlv_stream.chain, Some(&testnet));
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.chain(Network::Testnet)
 			.build()
@@ -1902,7 +1903,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::UnsupportedChain),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.chain(Network::Testnet)
 			.build()
@@ -1924,7 +1925,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -1939,7 +1940,7 @@ mod tests {
 		assert_eq!(invoice_request.amount_msats(), Some(1000));
 		assert_eq!(tlv_stream.amount, Some(1000));
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -1956,7 +1957,7 @@ mod tests {
 		assert_eq!(invoice_request.amount_msats(), Some(1000));
 		assert_eq!(tlv_stream.amount, Some(1000));
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -1971,7 +1972,7 @@ mod tests {
 		assert_eq!(invoice_request.amount_msats(), Some(1001));
 		assert_eq!(tlv_stream.amount, Some(1001));
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -1983,7 +1984,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InsufficientAmount),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -1998,7 +1999,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InsufficientAmount),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2010,7 +2011,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2027,7 +2028,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InsufficientAmount),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.build()
 			.unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
@@ -2039,12 +2040,13 @@ mod tests {
 		}
 
 		// An offer with amount_msats(0) must be rejected by the builder per BOLT 12.
-		match OfferBuilder::new(recipient_pubkey()).amount_msats(0).build() {
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion).amount_msats(0).build()
+		{
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2068,7 +2070,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2081,7 +2083,7 @@ mod tests {
 		assert_eq!(invoice_request.amount_msats(), Some(1000));
 		assert_eq!(tlv_stream.amount, None);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2097,7 +2099,7 @@ mod tests {
 		assert_eq!(invoice_request.amount_msats(), Some(2000));
 		assert_eq!(tlv_stream.amount, None);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount(Amount::Currency {
 				iso4217_code: CurrencyCode::new(*b"USD").unwrap(),
 				amount: 10,
@@ -2120,7 +2122,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2133,7 +2135,7 @@ mod tests {
 		assert_eq!(invoice_request.invoice_request_features(), &InvoiceRequestFeatures::unknown());
 		assert_eq!(tlv_stream.features, Some(&InvoiceRequestFeatures::unknown()));
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2159,7 +2161,7 @@ mod tests {
 		let one = NonZeroU64::new(1).unwrap();
 		let ten = NonZeroU64::new(10).unwrap();
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::One)
 			.build()
@@ -2172,7 +2174,7 @@ mod tests {
 		assert_eq!(invoice_request.quantity(), None);
 		assert_eq!(tlv_stream.quantity, None);
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::One)
 			.build()
@@ -2187,7 +2189,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::UnexpectedQuantity),
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Bounded(ten))
 			.build()
@@ -2204,7 +2206,7 @@ mod tests {
 		assert_eq!(invoice_request.amount_msats(), Some(10_000));
 		assert_eq!(tlv_stream.amount, Some(10_000));
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Bounded(ten))
 			.build()
@@ -2219,7 +2221,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidQuantity),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Bounded(ten))
 			.build()
@@ -2232,7 +2234,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidQuantity),
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2249,7 +2251,7 @@ mod tests {
 		assert_eq!(invoice_request.amount_msats(), Some(2_000));
 		assert_eq!(tlv_stream.amount, Some(2_000));
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2262,7 +2264,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::MissingQuantity),
 		}
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Bounded(one))
 			.build()
@@ -2284,7 +2286,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2297,7 +2299,7 @@ mod tests {
 		assert_eq!(invoice_request.payer_note(), Some(PrintableString("bar")));
 		assert_eq!(tlv_stream.payer_note, Some(&String::from("bar")));
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2320,7 +2322,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		match OfferBuilder::new(recipient_pubkey())
+		match OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2344,7 +2346,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2369,7 +2371,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2387,7 +2389,7 @@ mod tests {
 			panic!("error parsing invoice_request: {:?}", e);
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2416,7 +2418,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2432,7 +2434,7 @@ mod tests {
 			panic!("error parsing invoice_request: {:?}", e);
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.build()
 			.unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
@@ -2449,7 +2451,7 @@ mod tests {
 			panic!("error parsing invoice_request: {:?}", e);
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.build()
 			.unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
@@ -2467,7 +2469,7 @@ mod tests {
 			),
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2487,7 +2489,7 @@ mod tests {
 			),
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.description("foo".to_string())
 			.amount(Amount::Currency {
 				iso4217_code: CurrencyCode::new(*b"USD").unwrap(),
@@ -2511,7 +2513,7 @@ mod tests {
 			},
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2545,7 +2547,7 @@ mod tests {
 		let one = NonZeroU64::new(1).unwrap();
 		let ten = NonZeroU64::new(10).unwrap();
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::One)
 			.build()
@@ -2562,7 +2564,7 @@ mod tests {
 			panic!("error parsing invoice_request: {:?}", e);
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::One)
 			.build()
@@ -2587,7 +2589,7 @@ mod tests {
 			},
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Bounded(ten))
 			.build()
@@ -2608,7 +2610,7 @@ mod tests {
 			panic!("error parsing invoice_request: {:?}", e);
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Bounded(ten))
 			.build()
@@ -2631,7 +2633,7 @@ mod tests {
 			),
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2652,7 +2654,7 @@ mod tests {
 			panic!("error parsing invoice_request: {:?}", e);
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)
 			.build()
@@ -2672,7 +2674,7 @@ mod tests {
 			),
 		}
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Bounded(one))
 			.build()
@@ -2701,13 +2703,14 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let unsigned_invoice_request = OfferBuilder::new(recipient_pubkey())
-			.amount_msats(1000)
-			.build()
-			.unwrap()
-			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-			.unwrap()
-			.build_unchecked();
+		let unsigned_invoice_request =
+			OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
+				.amount_msats(1000)
+				.build()
+				.unwrap()
+				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+				.unwrap()
+				.build_unchecked();
 		let mut tlv_stream = unsigned_invoice_request.contents.as_tlv_stream();
 		tlv_stream.0.metadata = None;
 
@@ -2733,13 +2736,14 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let unsigned_invoice_request = OfferBuilder::new(recipient_pubkey())
-			.amount_msats(1000)
-			.build()
-			.unwrap()
-			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-			.unwrap()
-			.build_unchecked();
+		let unsigned_invoice_request =
+			OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
+				.amount_msats(1000)
+				.build()
+				.unwrap()
+				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+				.unwrap()
+				.build_unchecked();
 		let mut tlv_stream = unsigned_invoice_request.contents.as_tlv_stream();
 		tlv_stream.2.payer_id = None;
 
@@ -2763,13 +2767,14 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let unsigned_invoice_request = OfferBuilder::new(recipient_pubkey())
-			.amount_msats(1000)
-			.build()
-			.unwrap()
-			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-			.unwrap()
-			.build_unchecked();
+		let unsigned_invoice_request =
+			OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
+				.amount_msats(1000)
+				.build()
+				.unwrap()
+				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+				.unwrap()
+				.build_unchecked();
 		let mut tlv_stream = unsigned_invoice_request.contents.as_tlv_stream();
 		tlv_stream.1.issuer_id = None;
 
@@ -2798,7 +2803,7 @@ mod tests {
 		let payment_id = PaymentId([1; 32]);
 
 		let mut buffer = Vec::new();
-		OfferBuilder::new(recipient_pubkey())
+		OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2826,7 +2831,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let mut invoice_request = OfferBuilder::new(recipient_pubkey())
+		let mut invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -2863,13 +2868,14 @@ mod tests {
 
 		let secp_ctx = Secp256k1::new();
 		let keys = Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
-		let (mut unsigned_invoice_request, payer_keys, _) = OfferBuilder::new(keys.public_key())
-			.amount_msats(1000)
-			.build()
-			.unwrap()
-			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-			.unwrap()
-			.build_without_checks();
+		let (mut unsigned_invoice_request, payer_keys, _) =
+			OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
+				.amount_msats(1000)
+				.build()
+				.unwrap()
+				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+				.unwrap()
+				.build_without_checks();
 
 		let mut unknown_bytes = Vec::new();
 		BigSize(UNKNOWN_ODD_TYPE).write(&mut unknown_bytes).unwrap();
@@ -2898,13 +2904,14 @@ mod tests {
 		const UNKNOWN_EVEN_TYPE: u64 = INVOICE_REQUEST_TYPES.end - 2;
 		assert!(UNKNOWN_EVEN_TYPE % 2 == 0);
 
-		let (mut unsigned_invoice_request, payer_keys, _) = OfferBuilder::new(keys.public_key())
-			.amount_msats(1000)
-			.build()
-			.unwrap()
-			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-			.unwrap()
-			.build_without_checks();
+		let (mut unsigned_invoice_request, payer_keys, _) =
+			OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
+				.amount_msats(1000)
+				.build()
+				.unwrap()
+				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+				.unwrap()
+				.build_without_checks();
 
 		let mut unknown_bytes = Vec::new();
 		BigSize(UNKNOWN_EVEN_TYPE).write(&mut unknown_bytes).unwrap();
@@ -2943,13 +2950,14 @@ mod tests {
 
 		let secp_ctx = Secp256k1::new();
 		let keys = Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
-		let (mut unsigned_invoice_request, payer_keys, _) = OfferBuilder::new(keys.public_key())
-			.amount_msats(1000)
-			.build()
-			.unwrap()
-			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-			.unwrap()
-			.build_without_checks();
+		let (mut unsigned_invoice_request, payer_keys, _) =
+			OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
+				.amount_msats(1000)
+				.build()
+				.unwrap()
+				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+				.unwrap()
+				.build_without_checks();
 
 		let mut unknown_bytes = Vec::new();
 		BigSize(UNKNOWN_ODD_TYPE).write(&mut unknown_bytes).unwrap();
@@ -2981,13 +2989,14 @@ mod tests {
 		const UNKNOWN_EVEN_TYPE: u64 = EXPERIMENTAL_INVOICE_REQUEST_TYPES.start;
 		assert!(UNKNOWN_EVEN_TYPE % 2 == 0);
 
-		let (mut unsigned_invoice_request, payer_keys, _) = OfferBuilder::new(keys.public_key())
-			.amount_msats(1000)
-			.build()
-			.unwrap()
-			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-			.unwrap()
-			.build_without_checks();
+		let (mut unsigned_invoice_request, payer_keys, _) =
+			OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
+				.amount_msats(1000)
+				.build()
+				.unwrap()
+				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+				.unwrap()
+				.build_without_checks();
 
 		let mut unknown_bytes = Vec::new();
 		BigSize(UNKNOWN_EVEN_TYPE).write(&mut unknown_bytes).unwrap();
@@ -3016,7 +3025,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12ParseError::Decode(DecodeError::UnknownRequiredFeature)),
 		}
 
-		let invoice_request = OfferBuilder::new(keys.public_key())
+		let invoice_request = OfferBuilder::new(keys.public_key(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3049,7 +3058,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey())
+		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.amount_msats(1000)
 			.build()
 			.unwrap()
@@ -3094,12 +3103,18 @@ mod tests {
 
 		#[cfg(c_bindings)]
 		use crate::offers::offer::OfferWithDerivedMetadataBuilder as OfferBuilder;
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.chain(Network::Testnet)
-			.amount_msats(1000)
-			.supported_quantity(Quantity::Unbounded)
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.chain(Network::Testnet)
+		.amount_msats(1000)
+		.supported_quantity(Quantity::Unbounded)
+		.build()
+		.unwrap();
 		assert_eq!(offer.issuer_signing_pubkey(), Some(node_id));
 
 		// UTF-8 payer note that we can't naively `.truncate(PAYER_NOTE_LIMIT)`

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -217,6 +217,8 @@ macro_rules! invoice_request_builder_methods { (
 
 	/// Sets the [`InvoiceRequest::amount_msats`] for paying an invoice. Errors if `amount_msats` is
 	/// not at least the expected invoice amount (i.e., [`Offer::amount`] times [`quantity`]).
+	/// Currency-denominated offers are not checked here because the final millisatoshi amount is
+	/// resolved by the payee when creating the invoice.
 	///
 	/// Successive calls to this method will override the previous setting.
 	///
@@ -279,6 +281,8 @@ macro_rules! invoice_request_builder_methods { (
 		}
 
 		$self.invoice_request.offer.check_quantity($self.invoice_request.quantity)?;
+		// Currency-denominated offer amounts are checked by the payee when
+		// responding with an invoice, after applying their conversion rate.
 		$self.invoice_request.offer.check_amount_msats_for_quantity(
 			$self.invoice_request.amount_msats, $self.invoice_request.quantity
 		)?;
@@ -1457,6 +1461,8 @@ impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 		}
 
 		offer.check_quantity(quantity)?;
+		// Currency-denominated offer amounts are checked by the payee when
+		// responding with an invoice, after applying their conversion rate.
 		offer.check_amount_msats_for_quantity(amount, quantity)?;
 
 		let features = features.unwrap_or_else(InvoiceRequestFeatures::empty);
@@ -2503,14 +2509,8 @@ mod tests {
 		let mut buffer = Vec::new();
 		invoice_request.write(&mut buffer).unwrap();
 
-		match InvoiceRequest::try_from(buffer) {
-			Ok(_) => panic!("expected error"),
-			Err(e) => {
-				assert_eq!(
-					e,
-					Bolt12ParseError::InvalidSemantics(Bolt12SemanticError::UnsupportedCurrency)
-				);
-			},
+		if let Err(e) = InvoiceRequest::try_from(buffer) {
+			panic!("error parsing invoice_request: {:?}", e);
 		}
 
 		let invoice_request = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1599,10 +1599,12 @@ impl Readable for InvoiceRequestFields {
 mod tests {
 	use super::{
 		ExperimentalInvoiceRequestTlvStreamRef, InvoiceRequest, InvoiceRequestFields,
-		InvoiceRequestTlvStreamRef, UnsignedInvoiceRequest, EXPERIMENTAL_INVOICE_REQUEST_TYPES,
-		INVOICE_REQUEST_TYPES, PAYER_NOTE_LIMIT, SIGNATURE_TAG,
+		InvoiceRequestTlvStreamRef, InvoiceRequestVerifiedFromOffer, UnsignedInvoiceRequest,
+		EXPERIMENTAL_INVOICE_REQUEST_TYPES, INVOICE_REQUEST_TYPES, PAYER_NOTE_LIMIT, SIGNATURE_TAG,
 	};
 
+	use crate::blinded_path::message::BlindedMessagePath;
+	use crate::blinded_path::BlindedHop;
 	use crate::ln::channelmanager::PaymentId;
 	use crate::ln::inbound_payment::ExpandedKey;
 	use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
@@ -1624,6 +1626,7 @@ mod tests {
 	use crate::types::features::{InvoiceRequestFeatures, OfferFeatures};
 	use crate::types::string::{PrintableString, UntrustedString};
 	use crate::util::ser::{BigSize, Readable, Writeable};
+	use crate::util::test_utils::TestCurrencyConversion;
 	use bitcoin::constants::ChainHash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::{self, Keypair, Secp256k1, SecretKey};
@@ -2386,6 +2389,123 @@ mod tests {
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::UnknownRequiredFeatures),
 		}
+	}
+
+	#[test]
+	fn responds_to_invoice_request_using_currency_conversion() {
+		let expanded_key = ExpandedKey::new([42; 32]);
+		let entropy = FixedEntropy {};
+		let nonce = Nonce::from_entropy_source(&entropy);
+		let secp_ctx = Secp256k1::new();
+		let payment_id = PaymentId([1; 32]);
+		let converter = TestCurrencyConversion {};
+
+		let invoice = OfferBuilder::new(recipient_pubkey(), &converter)
+			.amount(Amount::Currency {
+				iso4217_code: CurrencyCode::new(*b"USD").unwrap(),
+				amount: 10,
+			})
+			.build()
+			.unwrap()
+			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+			.unwrap()
+			.build_and_sign()
+			.unwrap()
+			.respond_with_no_std(&converter, payment_paths(), payment_hash(), now())
+			.unwrap()
+			.build()
+			.unwrap()
+			.sign(recipient_sign)
+			.unwrap();
+
+		assert_eq!(invoice.amount_msats(), 10_000);
+		assert_eq!(invoice.verify_using_metadata(&expanded_key, &secp_ctx), Ok(payment_id),);
+	}
+
+	#[test]
+	fn fails_responding_to_invoice_request_with_insufficient_amount_for_currency_offer() {
+		let expanded_key = ExpandedKey::new([42; 32]);
+		let entropy = FixedEntropy {};
+		let nonce = Nonce::from_entropy_source(&entropy);
+		let secp_ctx = Secp256k1::new();
+		let payment_id = PaymentId([1; 32]);
+		let converter = TestCurrencyConversion {};
+
+		match OfferBuilder::new(recipient_pubkey(), &converter)
+			.amount(Amount::Currency {
+				iso4217_code: CurrencyCode::new(*b"USD").unwrap(),
+				amount: 10,
+			})
+			.build()
+			.unwrap()
+			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+			.unwrap()
+			.amount_msats(9_999)
+			.unwrap()
+			.build_and_sign()
+			.unwrap()
+			.respond_with_no_std(&converter, payment_paths(), payment_hash(), now())
+		{
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12SemanticError::InsufficientAmount),
+		}
+	}
+
+	#[test]
+	fn responds_to_invoice_request_using_derived_keys_with_currency_conversion() {
+		let expanded_key = ExpandedKey::new([42; 32]);
+		let entropy = FixedEntropy {};
+		let nonce = Nonce::from_entropy_source(&entropy);
+		let secp_ctx = Secp256k1::new();
+		let payment_id = PaymentId([1; 32]);
+		let converter = TestCurrencyConversion {};
+		let blinded_path = BlindedMessagePath::from_blinded_path(
+			pubkey(40),
+			pubkey(41),
+			vec![
+				BlindedHop { blinded_node_id: pubkey(42), encrypted_payload: vec![0; 43] },
+				BlindedHop { blinded_node_id: recipient_pubkey(), encrypted_payload: vec![0; 44] },
+			],
+		);
+
+		#[cfg(c_bindings)]
+		use crate::offers::offer::OfferWithDerivedMetadataBuilder as OfferBuilder;
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			recipient_pubkey(),
+			&expanded_key,
+			nonce,
+			&converter,
+			&secp_ctx,
+		)
+		.amount(Amount::Currency { iso4217_code: CurrencyCode::new(*b"USD").unwrap(), amount: 10 })
+		.path(blinded_path)
+		.build()
+		.unwrap();
+
+		let invoice_request = offer
+			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+			.unwrap()
+			.build_and_sign()
+			.unwrap();
+		let verified_invoice_request =
+			invoice_request.verify_using_recipient_data(nonce, &expanded_key, &secp_ctx).unwrap();
+
+		let invoice = match verified_invoice_request {
+			InvoiceRequestVerifiedFromOffer::DerivedKeys(request) => request
+				.respond_using_derived_keys_no_std(
+					&converter,
+					payment_paths(),
+					payment_hash(),
+					now(),
+				)
+				.unwrap()
+				.build_and_sign(&secp_ctx)
+				.unwrap(),
+			InvoiceRequestVerifiedFromOffer::ExplicitKeys(_) => panic!("expected derived keys"),
+		};
+
+		assert_eq!(invoice.amount_msats(), 10_000);
+		assert_eq!(invoice.verify_using_metadata(&expanded_key, &secp_ctx), Ok(payment_id),);
 	}
 
 	#[test]

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -776,14 +776,16 @@ macro_rules! invoice_request_respond_with_explicit_signing_pubkey_methods { (
 	///
 	/// [`Duration`]: core::time::Duration
 	#[cfg(feature = "std")]
-	pub fn respond_with(
-		&$self, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash
+	pub fn respond_with<'a, CC: CurrencyConversion>(
+		&'a $self, converter: &'a CC, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash
 	) -> Result<$builder, Bolt12SemanticError> {
+		let amount_msats = <$builder>::amount_msats(&$contents, converter)?;
+
 		let created_at = std::time::SystemTime::now()
 			.duration_since(std::time::SystemTime::UNIX_EPOCH)
 			.expect("SystemTime::now() should come after SystemTime::UNIX_EPOCH");
 
-		$contents.respond_with_no_std(payment_paths, payment_hash, created_at)
+		$contents.respond_with_amount(amount_msats, payment_paths, payment_hash, created_at)
 	}
 
 	/// Creates an [`InvoiceBuilder`] for the request with the given required fields.
@@ -811,8 +813,17 @@ macro_rules! invoice_request_respond_with_explicit_signing_pubkey_methods { (
 	///
 	/// [`Bolt12Invoice::created_at`]: crate::offers::invoice::Bolt12Invoice::created_at
 	/// [`OfferBuilder::deriving_signing_pubkey`]: crate::offers::offer::OfferBuilder::deriving_signing_pubkey
-	pub fn respond_with_no_std(
-		&$self, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
+	pub fn respond_with_no_std<'a, CC: CurrencyConversion>(
+		&'a $self, converter: &'a CC, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
+		created_at: core::time::Duration
+	) -> Result<$builder, Bolt12SemanticError> {
+		let amount_msats = <$builder>::amount_msats(&$contents, converter)?;
+
+		$contents.respond_with_amount(amount_msats, payment_paths, payment_hash, created_at)
+	}
+
+	pub(crate) fn respond_with_amount<'a>(
+		&'a $self, amount_msats: u64, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
 		created_at: core::time::Duration
 	) -> Result<$builder, Bolt12SemanticError> {
 		if $contents.invoice_request_features().requires_unknown_bits() {
@@ -824,13 +835,13 @@ macro_rules! invoice_request_respond_with_explicit_signing_pubkey_methods { (
 			None => return Err(Bolt12SemanticError::MissingIssuerSigningPubkey),
 		};
 
-		<$builder>::for_offer(&$contents, payment_paths, created_at, payment_hash, signing_pubkey)
+		<$builder>::for_offer(&$contents, amount_msats, payment_paths, created_at, payment_hash, signing_pubkey)
 	}
 
 	#[cfg(test)]
 	#[allow(dead_code)]
-	pub(super) fn respond_with_no_std_using_signing_pubkey(
-		&$self, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
+	pub(super) fn respond_with_no_std_using_signing_pubkey<'a, CC: CurrencyConversion>(
+		&'a $self, converter: &'a CC, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
 		created_at: core::time::Duration, signing_pubkey: PublicKey
 	) -> Result<$builder, Bolt12SemanticError> {
 		debug_assert!($contents.contents.inner.offer.issuer_signing_pubkey().is_none());
@@ -839,7 +850,9 @@ macro_rules! invoice_request_respond_with_explicit_signing_pubkey_methods { (
 			return Err(Bolt12SemanticError::UnknownRequiredFeatures);
 		}
 
-		<$builder>::for_offer(&$contents, payment_paths, created_at, payment_hash, signing_pubkey)
+		let amount_msats = <$builder>::amount_msats(&$contents, converter)?;
+
+		<$builder>::for_offer(&$contents, amount_msats, payment_paths, created_at, payment_hash, signing_pubkey)
 	}
 } }
 
@@ -942,7 +955,7 @@ impl InvoiceRequest {
 	invoice_request_respond_with_explicit_signing_pubkey_methods!(
 		self,
 		self,
-		InvoiceBuilder<'_, ExplicitSigningPubkey>
+		InvoiceBuilder<'a, ExplicitSigningPubkey>
 	);
 	invoice_request_verify_method!(self, Self);
 
@@ -1008,14 +1021,16 @@ macro_rules! invoice_request_respond_with_derived_signing_pubkey_methods { (
 	///
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
 	#[cfg(feature = "std")]
-	pub fn respond_using_derived_keys(
-		&$self, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash
+	pub fn respond_using_derived_keys<'a, CC: CurrencyConversion>(
+		&'a $self, converter: &'a CC, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash
 	) -> Result<$builder, Bolt12SemanticError> {
+		let amount_msats = <$builder>::amount_msats(&$self.inner, converter)?;
+
 		let created_at = std::time::SystemTime::now()
 			.duration_since(std::time::SystemTime::UNIX_EPOCH)
 			.expect("SystemTime::now() should come after SystemTime::UNIX_EPOCH");
 
-		$self.respond_using_derived_keys_no_std(payment_paths, payment_hash, created_at)
+		$self.respond_using_derived_keys_with_amount(amount_msats, payment_paths, payment_hash, created_at)
 	}
 
 	/// Creates an [`InvoiceBuilder`] for the request using the given required fields and that uses
@@ -1025,8 +1040,17 @@ macro_rules! invoice_request_respond_with_derived_signing_pubkey_methods { (
 	/// See [`InvoiceRequest::respond_with_no_std`] for further details.
 	///
 	/// [`Bolt12Invoice`]: crate::offers::invoice::Bolt12Invoice
-	pub fn respond_using_derived_keys_no_std(
-		&$self, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
+	pub fn respond_using_derived_keys_no_std<'a, CC: CurrencyConversion>(
+		&'a $self, converter: &'a CC, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
+		created_at: core::time::Duration
+	) -> Result<$builder, Bolt12SemanticError> {
+		let amount_msats = <$builder>::amount_msats(&$self.inner, converter)?;
+
+		$self.respond_using_derived_keys_with_amount(amount_msats, payment_paths, payment_hash, created_at)
+	}
+
+	pub(crate) fn respond_using_derived_keys_with_amount<'a>(
+		&'a $self, amount_msats: u64, payment_paths: Vec<BlindedPaymentPath>, payment_hash: PaymentHash,
 		created_at: core::time::Duration
 	) -> Result<$builder, Bolt12SemanticError> {
 		if $self.inner.invoice_request_features().requires_unknown_bits() {
@@ -1041,7 +1065,7 @@ macro_rules! invoice_request_respond_with_derived_signing_pubkey_methods { (
 		}
 
 		<$builder>::for_offer_using_keys(
-			&$self.inner, payment_paths, created_at, payment_hash, keys
+			&$self.inner, amount_msats, payment_paths, created_at, payment_hash, keys
 		)
 	}
 } }
@@ -1088,7 +1112,7 @@ impl VerifiedInvoiceRequest<DerivedSigningPubkey> {
 	invoice_request_respond_with_derived_signing_pubkey_methods!(
 		self,
 		self.inner,
-		InvoiceBuilder<'_, DerivedSigningPubkey>
+		InvoiceBuilder<'a, DerivedSigningPubkey>
 	);
 	#[cfg(c_bindings)]
 	invoice_request_respond_with_derived_signing_pubkey_methods!(
@@ -1107,7 +1131,7 @@ impl VerifiedInvoiceRequest<ExplicitSigningPubkey> {
 	invoice_request_respond_with_explicit_signing_pubkey_methods!(
 		self,
 		self.inner,
-		InvoiceBuilder<'_, ExplicitSigningPubkey>
+		InvoiceBuilder<'a, ExplicitSigningPubkey>
 	);
 	#[cfg(c_bindings)]
 	invoice_request_respond_with_explicit_signing_pubkey_methods!(
@@ -1757,7 +1781,7 @@ mod tests {
 			.unwrap();
 
 		let invoice = invoice_request
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 			.unwrap()
 			.experimental_baz(42)
 			.build()
@@ -2357,7 +2381,7 @@ mod tests {
 			.features_unchecked(InvoiceRequestFeatures::unknown())
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with_no_std(&NullCurrencyConversion, payment_paths(), payment_hash(), now())
 		{
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::UnknownRequiredFeatures),

--- a/lightning/src/offers/merkle.rs
+++ b/lightning/src/offers/merkle.rs
@@ -286,6 +286,7 @@ mod tests {
 
 	use crate::ln::channelmanager::PaymentId;
 	use crate::ln::inbound_payment::ExpandedKey;
+	use crate::offers::currency::NullCurrencyConversion;
 	use crate::offers::invoice_request::{InvoiceRequest, UnsignedInvoiceRequest};
 	use crate::offers::nonce::Nonce;
 	use crate::offers::offer::{Amount, CurrencyCode, OfferBuilder};
@@ -354,7 +355,7 @@ mod tests {
 		};
 
 		// BOLT 12 test vectors
-		let invoice_request = OfferBuilder::new(recipient_pubkey)
+		let invoice_request = OfferBuilder::new(recipient_pubkey, &NullCurrencyConversion)
 			.description("A Mathematical Treatise".into())
 			.amount(Amount::Currency {
 				iso4217_code: CurrencyCode::new(*b"USD").unwrap(),
@@ -395,14 +396,15 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		let unsigned_invoice_request = OfferBuilder::new(recipient_pubkey())
-			.amount_msats(1000)
-			.build()
-			.unwrap()
-			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
-			.unwrap()
-			.payer_note("bar".into())
-			.build_unchecked();
+		let unsigned_invoice_request =
+			OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
+				.amount_msats(1000)
+				.build()
+				.unwrap()
+				.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+				.unwrap()
+				.payer_note("bar".into())
+				.build_unchecked();
 
 		// Simply test that we can grab the tag and merkle root exposed by the accessor
 		// functions, then use them to succesfully compute a tagged hash.
@@ -427,7 +429,7 @@ mod tests {
 			Keypair::from_secret_key(&secp_ctx, &secret_key).public_key()
 		};
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey)
+		let invoice_request = OfferBuilder::new(recipient_pubkey, &NullCurrencyConversion)
 			.amount_msats(100)
 			.build_unchecked()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
@@ -461,7 +463,7 @@ mod tests {
 			Keypair::from_secret_key(&secp_ctx, &secret_key).public_key()
 		};
 
-		let invoice_request = OfferBuilder::new(recipient_pubkey)
+		let invoice_request = OfferBuilder::new(recipient_pubkey, &NullCurrencyConversion)
 			.amount_msats(100)
 			.build_unchecked()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)

--- a/lightning/src/offers/mod.rs
+++ b/lightning/src/offers/mod.rs
@@ -16,6 +16,8 @@
 pub mod offer;
 pub mod flow;
 
+pub mod currency;
+
 pub mod async_receive_offer_cache;
 pub mod invoice;
 pub mod invoice_error;

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -25,6 +25,7 @@
 //! use core::time::Duration;
 //!
 //! use bitcoin::secp256k1::{Keypair, PublicKey, Secp256k1, SecretKey};
+//! use lightning::offers::currency::NullCurrencyConversion;
 //! use lightning::offers::offer::{Offer, OfferBuilder, Quantity};
 //! use lightning::offers::parse::Bolt12ParseError;
 //! use lightning::util::ser::{Readable, Writeable};
@@ -41,9 +42,10 @@
 //! let secp_ctx = Secp256k1::new();
 //! let keys = Keypair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42; 32]).unwrap());
 //! let pubkey = PublicKey::from(keys);
+//! let converter = NullCurrencyConversion;
 //!
 //! let expiration = SystemTime::now() + Duration::from_secs(24 * 60 * 60);
-//! let offer = OfferBuilder::new(pubkey)
+//! let offer = OfferBuilder::new(pubkey, &converter)
 //!     .description("coffee, large".to_string())
 //!     .amount_msats(20_000)
 //!     .supported_quantity(Quantity::Unbounded)
@@ -82,6 +84,7 @@ use crate::io;
 use crate::ln::channelmanager::PaymentId;
 use crate::ln::inbound_payment::{ExpandedKey, IV_LEN};
 use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
+use crate::offers::currency::CurrencyConversion;
 use crate::offers::merkle::{TaggedHash, TlvRecord, TlvStream};
 use crate::offers::nonce::Nonce;
 use crate::offers::parse::{Bech32Encode, Bolt12ParseError, Bolt12SemanticError, ParsedMessage};
@@ -167,8 +170,9 @@ impl Readable for OfferId {
 /// This is not exported to bindings users as builder patterns don't map outside of move semantics.
 ///
 /// [module-level documentation]: self
-pub struct OfferBuilder<'a, M: MetadataStrategy, T: secp256k1::Signing> {
+pub struct OfferBuilder<'a, M: MetadataStrategy, T: secp256k1::Signing, CC: CurrencyConversion> {
 	offer: OfferContents,
+	converter: &'a CC,
 	metadata_strategy: core::marker::PhantomData<M>,
 	secp_ctx: Option<&'a Secp256k1<T>>,
 }
@@ -180,8 +184,9 @@ pub struct OfferBuilder<'a, M: MetadataStrategy, T: secp256k1::Signing> {
 /// [module-level documentation]: self
 #[cfg(c_bindings)]
 #[derive(Clone)]
-pub struct OfferWithExplicitMetadataBuilder<'a> {
+pub struct OfferWithExplicitMetadataBuilder<'a, CC: CurrencyConversion> {
 	offer: OfferContents,
+	converter: &'a CC,
 	metadata_strategy: core::marker::PhantomData<ExplicitMetadata>,
 	secp_ctx: Option<&'a Secp256k1<secp256k1::All>>,
 }
@@ -193,8 +198,9 @@ pub struct OfferWithExplicitMetadataBuilder<'a> {
 /// [module-level documentation]: self
 #[cfg(c_bindings)]
 #[derive(Clone)]
-pub struct OfferWithDerivedMetadataBuilder<'a> {
+pub struct OfferWithDerivedMetadataBuilder<'a, CC: CurrencyConversion> {
 	offer: OfferContents,
+	converter: &'a CC,
 	metadata_strategy: core::marker::PhantomData<DerivedMetadata>,
 	secp_ctx: Option<&'a Secp256k1<secp256k1::All>>,
 }
@@ -234,7 +240,7 @@ macro_rules! offer_explicit_metadata_builder_methods {
 		///
 		/// [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
 		/// [`ChannelManager::create_offer_builder`]: crate::ln::channelmanager::ChannelManager::create_offer_builder
-		pub fn new(signing_pubkey: PublicKey) -> Self {
+		pub fn new(signing_pubkey: PublicKey, converter: &'a CC) -> Self {
 			Self {
 				offer: OfferContents {
 					chains: None,
@@ -250,6 +256,7 @@ macro_rules! offer_explicit_metadata_builder_methods {
 					#[cfg(test)]
 					experimental_foo: None,
 				},
+				converter,
 				metadata_strategy: core::marker::PhantomData,
 				secp_ctx: None,
 			}
@@ -284,7 +291,7 @@ macro_rules! offer_derived_metadata_builder_methods {
 		/// [`InvoiceRequest::verify_using_recipient_data`]: crate::offers::invoice_request::InvoiceRequest::verify_using_recipient_data
 		/// [`ExpandedKey`]: crate::ln::inbound_payment::ExpandedKey
 		pub fn deriving_signing_pubkey(
-			node_id: PublicKey, expanded_key: &ExpandedKey, nonce: Nonce,
+			node_id: PublicKey, expanded_key: &ExpandedKey, nonce: Nonce, converter: &'a CC,
 			secp_ctx: &'a Secp256k1<$secp_context>,
 		) -> Self {
 			let derivation_material = MetadataMaterial::new(nonce, expanded_key, None);
@@ -304,6 +311,7 @@ macro_rules! offer_derived_metadata_builder_methods {
 					#[cfg(test)]
 					experimental_foo: None,
 				},
+				converter,
 				metadata_strategy: core::marker::PhantomData,
 				secp_ctx: Some(secp_ctx),
 			}
@@ -515,66 +523,69 @@ macro_rules! offer_builder_test_methods { (
 	}
 } }
 
-impl<'a, M: MetadataStrategy, T: secp256k1::Signing> OfferBuilder<'a, M, T> {
+impl<'a, M: MetadataStrategy, T: secp256k1::Signing, CC: CurrencyConversion>
+	OfferBuilder<'a, M, T, CC>
+{
 	offer_builder_methods!(self, Self, Self, self, mut);
 
 	#[cfg(test)]
 	offer_builder_test_methods!(self, Self, Self, self, mut);
 }
 
-impl<'a> OfferBuilder<'a, ExplicitMetadata, secp256k1::SignOnly> {
+impl<'a, CC: CurrencyConversion> OfferBuilder<'a, ExplicitMetadata, secp256k1::SignOnly, CC> {
 	offer_explicit_metadata_builder_methods!(self, Self, Self, self, mut);
 }
 
-impl<'a, T: secp256k1::Signing> OfferBuilder<'a, DerivedMetadata, T> {
+impl<'a, T: secp256k1::Signing, CC: CurrencyConversion> OfferBuilder<'a, DerivedMetadata, T, CC> {
 	offer_derived_metadata_builder_methods!(T);
 }
 
 #[cfg(all(c_bindings, not(test)))]
-impl<'a> OfferWithExplicitMetadataBuilder<'a> {
+impl<'a, CC: CurrencyConversion> OfferWithExplicitMetadataBuilder<'a, CC> {
 	offer_explicit_metadata_builder_methods!(self, &mut Self, (), ());
 	offer_builder_methods!(self, &mut Self, (), ());
 }
 
 #[cfg(all(c_bindings, test))]
-impl<'a> OfferWithExplicitMetadataBuilder<'a> {
+impl<'a, CC: CurrencyConversion> OfferWithExplicitMetadataBuilder<'a, CC> {
 	offer_explicit_metadata_builder_methods!(self, &mut Self, &mut Self, self);
 	offer_builder_methods!(self, &mut Self, &mut Self, self);
 	offer_builder_test_methods!(self, &mut Self, &mut Self, self);
 }
 
 #[cfg(all(c_bindings, not(test)))]
-impl<'a> OfferWithDerivedMetadataBuilder<'a> {
+impl<'a, CC: CurrencyConversion> OfferWithDerivedMetadataBuilder<'a, CC> {
 	offer_derived_metadata_builder_methods!(secp256k1::All);
 	offer_builder_methods!(self, &mut Self, (), ());
 }
 
 #[cfg(all(c_bindings, test))]
-impl<'a> OfferWithDerivedMetadataBuilder<'a> {
+impl<'a, CC: CurrencyConversion> OfferWithDerivedMetadataBuilder<'a, CC> {
 	offer_derived_metadata_builder_methods!(secp256k1::All);
 	offer_builder_methods!(self, &mut Self, &mut Self, self);
 	offer_builder_test_methods!(self, &mut Self, &mut Self, self);
 }
 
 #[cfg(c_bindings)]
-impl<'a> From<OfferBuilder<'a, DerivedMetadata, secp256k1::All>>
-	for OfferWithDerivedMetadataBuilder<'a>
+impl<'a, CC: CurrencyConversion> From<OfferBuilder<'a, DerivedMetadata, secp256k1::All, CC>>
+	for OfferWithDerivedMetadataBuilder<'a, CC>
 {
-	fn from(builder: OfferBuilder<'a, DerivedMetadata, secp256k1::All>) -> Self {
-		let OfferBuilder { offer, metadata_strategy, secp_ctx } = builder;
+	fn from(builder: OfferBuilder<'a, DerivedMetadata, secp256k1::All, CC>) -> Self {
+		let OfferBuilder { offer, converter, metadata_strategy, secp_ctx } = builder;
 
-		Self { offer, metadata_strategy, secp_ctx }
+		Self { offer, converter, metadata_strategy, secp_ctx }
 	}
 }
 
 #[cfg(c_bindings)]
-impl<'a> From<OfferWithDerivedMetadataBuilder<'a>>
-	for OfferBuilder<'a, DerivedMetadata, secp256k1::All>
+impl<'a, CC: CurrencyConversion> From<OfferWithDerivedMetadataBuilder<'a, CC>>
+	for OfferBuilder<'a, DerivedMetadata, secp256k1::All, CC>
 {
-	fn from(builder: OfferWithDerivedMetadataBuilder<'a>) -> Self {
-		let OfferWithDerivedMetadataBuilder { offer, metadata_strategy, secp_ctx } = builder;
+	fn from(builder: OfferWithDerivedMetadataBuilder<'a, CC>) -> Self {
+		let OfferWithDerivedMetadataBuilder { offer, converter, metadata_strategy, secp_ctx } =
+			builder;
 
-		Self { offer, metadata_strategy, secp_ctx }
+		Self { offer, converter, metadata_strategy, secp_ctx }
 	}
 }
 
@@ -1395,6 +1406,7 @@ mod tests {
 	use crate::ln::channelmanager::PaymentId;
 	use crate::ln::inbound_payment::ExpandedKey;
 	use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
+	use crate::offers::currency::NullCurrencyConversion;
 	use crate::offers::nonce::Nonce;
 	use crate::offers::offer::CurrencyCode;
 	use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError};
@@ -1410,7 +1422,7 @@ mod tests {
 
 	#[test]
 	fn builds_offer_with_defaults() {
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 
 		let mut buffer = Vec::new();
 		offer.write(&mut buffer).unwrap();
@@ -1461,17 +1473,23 @@ mod tests {
 		let mainnet = ChainHash::using_genesis_block(Network::Bitcoin);
 		let testnet = ChainHash::using_genesis_block(Network::Testnet);
 
-		let offer = OfferBuilder::new(pubkey(42)).chain(Network::Bitcoin).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.chain(Network::Bitcoin)
+			.build()
+			.unwrap();
 		assert!(offer.supports_chain(mainnet));
 		assert_eq!(offer.chains(), vec![mainnet]);
 		assert_eq!(offer.as_tlv_stream().0.chains, None);
 
-		let offer = OfferBuilder::new(pubkey(42)).chain(Network::Testnet).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.chain(Network::Testnet)
+			.build()
+			.unwrap();
 		assert!(offer.supports_chain(testnet));
 		assert_eq!(offer.chains(), vec![testnet]);
 		assert_eq!(offer.as_tlv_stream().0.chains, Some(&vec![testnet]));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.chain(Network::Testnet)
 			.chain(Network::Testnet)
 			.build()
@@ -1480,7 +1498,7 @@ mod tests {
 		assert_eq!(offer.chains(), vec![testnet]);
 		assert_eq!(offer.as_tlv_stream().0.chains, Some(&vec![testnet]));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.chain(Network::Bitcoin)
 			.chain(Network::Testnet)
 			.build()
@@ -1493,11 +1511,15 @@ mod tests {
 
 	#[test]
 	fn builds_offer_with_metadata() {
-		let offer = OfferBuilder::new(pubkey(42)).metadata(vec![42; 32]).unwrap().build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.metadata(vec![42; 32])
+			.unwrap()
+			.build()
+			.unwrap();
 		assert_eq!(offer.metadata(), Some(&vec![42; 32]));
 		assert_eq!(offer.as_tlv_stream().0.metadata, Some(&vec![42; 32]));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.metadata(vec![42; 32])
 			.unwrap()
 			.metadata(vec![43; 32])
@@ -1519,11 +1541,17 @@ mod tests {
 
 		#[cfg(c_bindings)]
 		use super::OfferWithDerivedMetadataBuilder as OfferBuilder;
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.amount_msats(1000)
-			.experimental_foo(42)
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.amount_msats(1000)
+		.experimental_foo(42)
+		.build()
+		.unwrap();
 		assert!(offer.metadata().is_some());
 		assert_eq!(offer.issuer_signing_pubkey(), Some(node_id));
 
@@ -1599,12 +1627,18 @@ mod tests {
 
 		#[cfg(c_bindings)]
 		use super::OfferWithDerivedMetadataBuilder as OfferBuilder;
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.amount_msats(1000)
-			.path(blinded_path)
-			.experimental_foo(42)
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.amount_msats(1000)
+		.path(blinded_path)
+		.experimental_foo(42)
+		.build()
+		.unwrap();
 		assert!(offer.metadata().is_none());
 		assert_ne!(offer.issuer_signing_pubkey(), Some(node_id));
 
@@ -1668,16 +1702,20 @@ mod tests {
 		let currency_amount =
 			Amount::Currency { iso4217_code: CurrencyCode::new(*b"USD").unwrap(), amount: 10 };
 
-		let offer = OfferBuilder::new(pubkey(42)).amount_msats(1000).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.amount_msats(1000)
+			.build()
+			.unwrap();
 		let tlv_stream = offer.as_tlv_stream();
 		assert_eq!(offer.amount(), Some(bitcoin_amount));
 		assert_eq!(tlv_stream.0.amount, Some(1000));
 		assert_eq!(tlv_stream.0.currency, None);
 
 		#[cfg(not(c_bindings))]
-		let builder = OfferBuilder::new(pubkey(42)).amount(currency_amount.clone());
+		let builder =
+			OfferBuilder::new(pubkey(42), &NullCurrencyConversion).amount(currency_amount.clone());
 		#[cfg(c_bindings)]
-		let mut builder = OfferBuilder::new(pubkey(42));
+		let mut builder = OfferBuilder::new(pubkey(42), &NullCurrencyConversion);
 		#[cfg(c_bindings)]
 		builder.amount(currency_amount.clone());
 		let tlv_stream = builder.offer.as_tlv_stream();
@@ -1689,7 +1727,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::UnsupportedCurrency),
 		}
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.amount(currency_amount.clone())
 			.amount(bitcoin_amount.clone())
 			.build()
@@ -1699,13 +1737,14 @@ mod tests {
 		assert_eq!(tlv_stream.0.currency, None);
 
 		let invalid_amount = Amount::Bitcoin { amount_msats: MAX_VALUE_MSAT + 1 };
-		match OfferBuilder::new(pubkey(42)).amount(invalid_amount).build() {
+		match OfferBuilder::new(pubkey(42), &NullCurrencyConversion).amount(invalid_amount).build()
+		{
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
 		}
 
 		// An amount of 0 must be rejected per BOLT 12.
-		match OfferBuilder::new(pubkey(42)).amount_msats(0).build() {
+		match OfferBuilder::new(pubkey(42), &NullCurrencyConversion).amount_msats(0).build() {
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
 		}
@@ -1713,11 +1752,14 @@ mod tests {
 
 	#[test]
 	fn builds_offer_with_description() {
-		let offer = OfferBuilder::new(pubkey(42)).description("foo".into()).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.description("foo".into())
+			.build()
+			.unwrap();
 		assert_eq!(offer.description(), Some(PrintableString("foo")));
 		assert_eq!(offer.as_tlv_stream().0.description, Some(&String::from("foo")));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.description("foo".into())
 			.description("bar".into())
 			.build()
@@ -1725,21 +1767,24 @@ mod tests {
 		assert_eq!(offer.description(), Some(PrintableString("bar")));
 		assert_eq!(offer.as_tlv_stream().0.description, Some(&String::from("bar")));
 
-		let offer = OfferBuilder::new(pubkey(42)).amount_msats(1000).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.amount_msats(1000)
+			.build()
+			.unwrap();
 		assert_eq!(offer.description(), Some(PrintableString("")));
 		assert_eq!(offer.as_tlv_stream().0.description, Some(&String::from("")));
 	}
 
 	#[test]
 	fn builds_offer_with_features() {
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.features_unchecked(OfferFeatures::unknown())
 			.build()
 			.unwrap();
 		assert_eq!(offer.offer_features(), &OfferFeatures::unknown());
 		assert_eq!(offer.as_tlv_stream().0.features, Some(&OfferFeatures::unknown()));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.features_unchecked(OfferFeatures::unknown())
 			.features_unchecked(OfferFeatures::empty())
 			.build()
@@ -1754,14 +1799,17 @@ mod tests {
 		let past_expiry = Duration::from_secs(0);
 		let now = future_expiry - Duration::from_secs(1_000);
 
-		let offer = OfferBuilder::new(pubkey(42)).absolute_expiry(future_expiry).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.absolute_expiry(future_expiry)
+			.build()
+			.unwrap();
 		#[cfg(feature = "std")]
 		assert!(!offer.is_expired());
 		assert!(!offer.is_expired_no_std(now));
 		assert_eq!(offer.absolute_expiry(), Some(future_expiry));
 		assert_eq!(offer.as_tlv_stream().0.absolute_expiry, Some(future_expiry.as_secs()));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.absolute_expiry(future_expiry)
 			.absolute_expiry(past_expiry)
 			.build()
@@ -1794,7 +1842,7 @@ mod tests {
 			),
 		];
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.path(paths[0].clone())
 			.path(paths[1].clone())
 			.build()
@@ -1809,11 +1857,14 @@ mod tests {
 
 	#[test]
 	fn builds_offer_with_issuer() {
-		let offer = OfferBuilder::new(pubkey(42)).issuer("foo".into()).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.issuer("foo".into())
+			.build()
+			.unwrap();
 		assert_eq!(offer.issuer(), Some(PrintableString("foo")));
 		assert_eq!(offer.as_tlv_stream().0.issuer, Some(&String::from("foo")));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.issuer("foo".into())
 			.issuer("bar".into())
 			.build()
@@ -1827,21 +1878,25 @@ mod tests {
 		let one = NonZeroU64::new(1).unwrap();
 		let ten = NonZeroU64::new(10).unwrap();
 
-		let offer =
-			OfferBuilder::new(pubkey(42)).supported_quantity(Quantity::One).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.supported_quantity(Quantity::One)
+			.build()
+			.unwrap();
 		let tlv_stream = offer.as_tlv_stream();
 		assert!(!offer.expects_quantity());
 		assert_eq!(offer.supported_quantity(), Quantity::One);
 		assert_eq!(tlv_stream.0.quantity_max, None);
 
-		let offer =
-			OfferBuilder::new(pubkey(42)).supported_quantity(Quantity::Unbounded).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.supported_quantity(Quantity::Unbounded)
+			.build()
+			.unwrap();
 		let tlv_stream = offer.as_tlv_stream();
 		assert!(offer.expects_quantity());
 		assert_eq!(offer.supported_quantity(), Quantity::Unbounded);
 		assert_eq!(tlv_stream.0.quantity_max, Some(0));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.supported_quantity(Quantity::Bounded(ten))
 			.build()
 			.unwrap();
@@ -1850,7 +1905,7 @@ mod tests {
 		assert_eq!(offer.supported_quantity(), Quantity::Bounded(ten));
 		assert_eq!(tlv_stream.0.quantity_max, Some(10));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.supported_quantity(Quantity::Bounded(one))
 			.build()
 			.unwrap();
@@ -1859,7 +1914,7 @@ mod tests {
 		assert_eq!(offer.supported_quantity(), Quantity::Bounded(one));
 		assert_eq!(tlv_stream.0.quantity_max, Some(1));
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.supported_quantity(Quantity::Bounded(ten))
 			.supported_quantity(Quantity::One)
 			.build()
@@ -1878,7 +1933,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 		let payment_id = PaymentId([1; 32]);
 
-		match OfferBuilder::new(pubkey(42))
+		match OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.features_unchecked(OfferFeatures::unknown())
 			.build()
 			.unwrap()
@@ -1891,7 +1946,7 @@ mod tests {
 
 	#[test]
 	fn parses_offer_with_chains() {
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.chain(Network::Bitcoin)
 			.chain(Network::Testnet)
 			.build()
@@ -1903,7 +1958,7 @@ mod tests {
 
 	#[test]
 	fn parses_offer_with_amount() {
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.amount(Amount::Bitcoin { amount_msats: 1000 })
 			.build()
 			.unwrap();
@@ -2038,12 +2093,12 @@ mod tests {
 
 	#[test]
 	fn parses_offer_with_description() {
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 		if let Err(e) = offer.to_string().parse::<Offer>() {
 			panic!("error parsing offer: {:?}", e);
 		}
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.description("foo".to_string())
 			.amount_msats(1000)
 			.build()
@@ -2071,7 +2126,7 @@ mod tests {
 
 	#[test]
 	fn parses_offer_with_paths() {
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.path(BlindedMessagePath::from_blinded_path(
 				pubkey(40),
 				pubkey(41),
@@ -2094,7 +2149,7 @@ mod tests {
 			panic!("error parsing offer: {:?}", e);
 		}
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.path(BlindedMessagePath::from_blinded_path(
 				pubkey(40),
 				pubkey(41),
@@ -2110,7 +2165,7 @@ mod tests {
 			panic!("error parsing offer: {:?}", e);
 		}
 
-		let mut builder = OfferBuilder::new(pubkey(42));
+		let mut builder = OfferBuilder::new(pubkey(42), &NullCurrencyConversion);
 		builder.offer.issuer_signing_pubkey = None;
 		builder.offer.paths = Some(vec![]);
 
@@ -2128,19 +2183,23 @@ mod tests {
 
 	#[test]
 	fn parses_offer_with_quantity() {
-		let offer =
-			OfferBuilder::new(pubkey(42)).supported_quantity(Quantity::One).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.supported_quantity(Quantity::One)
+			.build()
+			.unwrap();
 		if let Err(e) = offer.to_string().parse::<Offer>() {
 			panic!("error parsing offer: {:?}", e);
 		}
 
-		let offer =
-			OfferBuilder::new(pubkey(42)).supported_quantity(Quantity::Unbounded).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
+			.supported_quantity(Quantity::Unbounded)
+			.build()
+			.unwrap();
 		if let Err(e) = offer.to_string().parse::<Offer>() {
 			panic!("error parsing offer: {:?}", e);
 		}
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.supported_quantity(Quantity::Bounded(NonZeroU64::new(10).unwrap()))
 			.build()
 			.unwrap();
@@ -2148,7 +2207,7 @@ mod tests {
 			panic!("error parsing offer: {:?}", e);
 		}
 
-		let offer = OfferBuilder::new(pubkey(42))
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.supported_quantity(Quantity::Bounded(NonZeroU64::new(1).unwrap()))
 			.build()
 			.unwrap();
@@ -2159,7 +2218,7 @@ mod tests {
 
 	#[test]
 	fn parses_offer_with_issuer_id() {
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 		if let Err(e) = offer.to_string().parse::<Offer>() {
 			panic!("error parsing offer: {:?}", e);
 		}
@@ -2188,7 +2247,7 @@ mod tests {
 		const UNKNOWN_ODD_TYPE: u64 = OFFER_TYPES.end - 1;
 		assert!(UNKNOWN_ODD_TYPE % 2 == 1);
 
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 
 		let mut encoded_offer = Vec::new();
 		offer.write(&mut encoded_offer).unwrap();
@@ -2204,7 +2263,7 @@ mod tests {
 		const UNKNOWN_EVEN_TYPE: u64 = OFFER_TYPES.end - 2;
 		assert!(UNKNOWN_EVEN_TYPE % 2 == 0);
 
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 
 		let mut encoded_offer = Vec::new();
 		offer.write(&mut encoded_offer).unwrap();
@@ -2220,7 +2279,7 @@ mod tests {
 
 	#[test]
 	fn parses_offer_with_experimental_tlv_records() {
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 
 		let mut encoded_offer = Vec::new();
 		offer.write(&mut encoded_offer).unwrap();
@@ -2233,7 +2292,7 @@ mod tests {
 			Err(e) => panic!("error parsing offer: {:?}", e),
 		}
 
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 
 		let mut encoded_offer = Vec::new();
 		offer.write(&mut encoded_offer).unwrap();
@@ -2249,7 +2308,7 @@ mod tests {
 
 	#[test]
 	fn fails_parsing_offer_with_out_of_range_tlv_records() {
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 
 		let mut encoded_offer = Vec::new();
 		offer.write(&mut encoded_offer).unwrap();
@@ -2262,7 +2321,7 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12ParseError::Decode(DecodeError::InvalidValue)),
 		}
 
-		let offer = OfferBuilder::new(pubkey(42)).build().unwrap();
+		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion).build().unwrap();
 
 		let mut encoded_offer = Vec::new();
 		offer.write(&mut encoded_offer).unwrap();

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -233,6 +233,10 @@ macro_rules! offer_explicit_metadata_builder_methods {
 		///
 		/// Use a different pubkey per offer to avoid correlating offers.
 		///
+		/// The `converter` is used when building offers with currency-denominated
+		/// amounts. Use [`NullCurrencyConversion`] for offers that do not use
+		/// currency conversion.
+		///
 		/// # Note
 		///
 		/// If constructing an [`Offer`] for use with a [`ChannelManager`], use
@@ -240,6 +244,7 @@ macro_rules! offer_explicit_metadata_builder_methods {
 		///
 		/// [`ChannelManager`]: crate::ln::channelmanager::ChannelManager
 		/// [`ChannelManager::create_offer_builder`]: crate::ln::channelmanager::ChannelManager::create_offer_builder
+		/// [`NullCurrencyConversion`]: crate::offers::currency::NullCurrencyConversion
 		pub fn new(signing_pubkey: PublicKey, converter: &'a CC) -> Self {
 			Self {
 				offer: OfferContents {
@@ -356,8 +361,11 @@ macro_rules! offer_builder_methods { (
 
 	/// Sets the [`Offer::amount`].
 	///
+	/// If the amount is currency-denominated, [`OfferBuilder::build`] validates
+	/// it with the converter provided when constructing the builder.
+	///
 	/// Successive calls to this method will override the previous setting.
-	pub(super) fn amount($($self_mut)* $self: $self_type, amount: Amount) -> $return_type {
+	pub fn amount($($self_mut)* $self: $self_type, amount: Amount) -> $return_type {
 		$self.offer.amount = Some(amount);
 		$return_value
 	}
@@ -407,15 +415,25 @@ macro_rules! offer_builder_methods { (
 	}
 
 	/// Builds an [`Offer`] from the builder's settings.
+	///
+	/// Returns [`Bolt12SemanticError::UnsupportedCurrency`] if the offer uses a
+	/// currency-denominated amount not supported by the builder's converter.
+	///
+	/// Returns [`Bolt12SemanticError::InvalidAmount`] if the amount is not payable
+	/// in millisatoshis.
 	pub fn build($($self_mut)* $self: $self_type) -> Result<Offer, Bolt12SemanticError> {
 		match $self.offer.amount {
-			Some(Amount::Bitcoin { amount_msats }) => {
-				if amount_msats == 0 || amount_msats > MAX_VALUE_MSAT {
+			None => {},
+			Some(amount) => {
+				// Validate that the offer amount resolves to a non-zero
+				// millisatoshi range within the maximum msats allowed.
+				let (minimum_msats, _maximum_msats) = amount
+					.to_msats_range($self.converter)?;
+
+				if minimum_msats == 0 {
 					return Err(Bolt12SemanticError::InvalidAmount);
 				}
-			},
-			Some(Amount::Currency { .. }) => return Err(Bolt12SemanticError::UnsupportedCurrency),
-			None => {},
+			}
 		}
 
 		if $self.offer.amount.is_some() && $self.offer.description.is_none() {
@@ -1134,6 +1152,61 @@ pub enum Amount {
 		/// The amount in the currency unit adjusted by the ISO 4217 exponent (e.g., USD cents).
 		amount: u64,
 	},
+}
+
+impl Amount {
+	/// Returns the accepted millisatoshi range for this amount.
+	///
+	/// Bitcoin-denominated amounts return an exact range where the minimum
+	/// and maximum values are equal.
+	///
+	/// Currency-denominated amounts are converted using the exchange-rate
+	/// bounds provided by the given [`CurrencyConversion`] implementation.
+	pub fn to_msats_range<CC: CurrencyConversion>(
+		&self, converter: &CC,
+	) -> Result<(u64, u64), Bolt12SemanticError> {
+		match *self {
+			Amount::Bitcoin { amount_msats } => {
+				if amount_msats > MAX_VALUE_MSAT {
+					return Err(Bolt12SemanticError::InvalidAmount);
+				}
+
+				Ok((amount_msats, amount_msats))
+			},
+			Amount::Currency { iso4217_code, amount } => {
+				let range = converter
+					.conversion_range(iso4217_code)
+					.map(|rate_bound| rate_bound.to_range())
+					.map_err(|_| Bolt12SemanticError::UnsupportedCurrency)?;
+
+				// Ensure the lower bound is payable. If it exceeds `MAX_VALUE_MSAT`,
+				// no valid payment amount can satisfy the range.
+				let minimum_msats = u128::from(amount)
+					.checked_mul(u128::from(range.minimum.msats()))
+					.and_then(|numerator| {
+						numerator.checked_div(u128::from(range.minimum.minor_units().get()))
+					})
+					.and_then(|amount_msats| amount_msats.try_into().ok())
+					.filter(|msats| *msats <= MAX_VALUE_MSAT)
+					.ok_or(Bolt12SemanticError::InvalidAmount)?;
+
+				// Overflow when computing the upper bound implies an amount larger than
+				// the maximum representable payment amount is acceptable by the node.
+				// In that case, saturate to MAX_VALUE_MSAT since any larger value would
+				// be rejected anyway.
+				let maximum_msats = u128::from(amount)
+					.checked_mul(u128::from(range.maximum.msats()))
+					.and_then(|numerator| {
+						numerator.checked_div(u128::from(range.maximum.minor_units().get()))
+					})
+					.and_then(|amount_msats| amount_msats.try_into().ok())
+					.unwrap_or(u64::MAX)
+					.min(MAX_VALUE_MSAT);
+
+				Ok((minimum_msats, maximum_msats))
+			},
+		}
+	}
 }
 
 /// An ISO 4217 three-letter currency code (e.g., USD).

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -965,7 +965,26 @@ impl OfferContents {
 		let offer_amount_msats = match self.amount {
 			None => 0,
 			Some(Amount::Bitcoin { amount_msats }) => amount_msats,
-			Some(Amount::Currency { .. }) => return Err(Bolt12SemanticError::UnsupportedCurrency),
+			Some(Amount::Currency { .. }) => {
+				// This function is used by invoice request build checkers and parsers
+				// to ensure that the `InvoiceRequest::amount_msats()` is sufficient
+				// compared to the offer's amount.
+				//
+				// However, if the `Offer::Amount` is specified in a fiat currency,
+				// we, as the payer, skip this local validation. We instead defer
+				// to the payee's ultimate judgment when they verify our request
+				// and issue the corresponding invoice.
+				//
+				// With this approach, we leave it to the payee (offer creator)
+				// to decide whether the amount we specified is reasonable relative
+				// to their fiat offer, or—if we omitted the amount—to dictate the
+				// final msat total in the invoice themselves.
+				//
+				// Deferring this validation rightly leaves the onus of currency conversion
+				// and precise verification to the invoice creator.
+
+				return Ok(());
+			},
 		};
 
 		if !self.expects_quantity() || quantity.is_some() {

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -1479,7 +1479,9 @@ mod tests {
 	use crate::ln::channelmanager::PaymentId;
 	use crate::ln::inbound_payment::ExpandedKey;
 	use crate::ln::msgs::{DecodeError, MAX_VALUE_MSAT};
-	use crate::offers::currency::NullCurrencyConversion;
+	use crate::offers::currency::{
+		CurrencyConversion, ExchangeRate, ExchangeRateBound, NullCurrencyConversion, Tolerance,
+	};
 	use crate::offers::nonce::Nonce;
 	use crate::offers::offer::CurrencyCode;
 	use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError};
@@ -1487,11 +1489,27 @@ mod tests {
 	use crate::types::features::OfferFeatures;
 	use crate::types::string::PrintableString;
 	use crate::util::ser::{BigSize, Writeable};
+	use crate::util::test_utils::TestCurrencyConversion;
 	use bitcoin::constants::ChainHash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::Secp256k1;
 	use core::num::NonZeroU64;
 	use core::time::Duration;
+
+	struct FixedCurrencyConversion {
+		rate: ExchangeRate,
+	}
+
+	impl CurrencyConversion for FixedCurrencyConversion {
+		fn conversion_range(&self, currency: CurrencyCode) -> Result<ExchangeRateBound, ()> {
+			if currency.as_str() == "USD" {
+				let tolerance = Tolerance::BasisPoints(0);
+				ExchangeRateBound::new(self.rate, tolerance, tolerance)
+			} else {
+				Err(())
+			}
+		}
+	}
 
 	#[test]
 	fn builds_offer_with_defaults() {
@@ -1800,6 +1818,15 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::UnsupportedCurrency),
 		}
 
+		let offer = OfferBuilder::new(pubkey(42), &TestCurrencyConversion {})
+			.amount(currency_amount.clone())
+			.build()
+			.unwrap();
+		let tlv_stream = offer.as_tlv_stream();
+		assert_eq!(offer.amount(), Some(currency_amount.clone()));
+		assert_eq!(tlv_stream.0.amount, Some(10));
+		assert_eq!(tlv_stream.0.currency, Some(b"USD"));
+
 		let offer = OfferBuilder::new(pubkey(42), &NullCurrencyConversion)
 			.amount(currency_amount.clone())
 			.amount(bitcoin_amount.clone())
@@ -1818,6 +1845,32 @@ mod tests {
 
 		// An amount of 0 must be rejected per BOLT 12.
 		match OfferBuilder::new(pubkey(42), &NullCurrencyConversion).amount_msats(0).build() {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
+		}
+
+		let converter = FixedCurrencyConversion {
+			rate: ExchangeRate::from_parts(1, NonZeroU64::new(2).unwrap()),
+		};
+		match OfferBuilder::new(pubkey(42), &converter)
+			.amount(Amount::Currency {
+				iso4217_code: CurrencyCode::new(*b"USD").unwrap(),
+				amount: 1,
+			})
+			.build()
+		{
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
+		}
+
+		let converter = FixedCurrencyConversion { rate: ExchangeRate::new(1) };
+		match OfferBuilder::new(pubkey(42), &converter)
+			.amount(Amount::Currency {
+				iso4217_code: CurrencyCode::new(*b"USD").unwrap(),
+				amount: MAX_VALUE_MSAT + 1,
+			})
+			.build()
+		{
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
 		}

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -180,6 +180,8 @@ pub enum Bolt12SemanticError {
 	InvalidCurrencyCode,
 	/// An amount was provided but was not sufficient in value.
 	InsufficientAmount,
+	/// An amount was provided but exceeded the acceptable value.
+	ExcessiveAmount,
 	/// An amount was provided but was not expected.
 	UnexpectedAmount,
 	/// A currency was provided that is not supported.

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -741,6 +741,7 @@ mod tests {
 	use crate::blinded_path::BlindedHop;
 	use crate::ln::inbound_payment::ExpandedKey;
 	use crate::ln::msgs::DecodeError;
+	use crate::offers::currency::NullCurrencyConversion;
 	use crate::offers::invoice::{
 		ExperimentalInvoiceTlvStreamRef, InvoiceTlvStreamRef, EXPERIMENTAL_INVOICE_TYPES,
 		INVOICE_TYPES,
@@ -817,10 +818,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&offer,
@@ -857,10 +864,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		let invoice = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&offer,
@@ -957,12 +970,17 @@ mod tests {
 		let future_expiry = Duration::from_secs(u64::max_value());
 		let past_expiry = Duration::from_secs(0);
 
-		let valid_offer =
-			OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-				.path(blinded_path())
-				.absolute_expiry(future_expiry)
-				.build()
-				.unwrap();
+		let valid_offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.absolute_expiry(future_expiry)
+		.build()
+		.unwrap();
 
 		let invoice = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&valid_offer,
@@ -979,12 +997,17 @@ mod tests {
 		assert!(!invoice.is_expired());
 		assert_eq!(invoice.absolute_expiry(), Some(future_expiry));
 
-		let expired_offer =
-			OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-				.path(blinded_path())
-				.absolute_expiry(past_expiry)
-				.build()
-				.unwrap();
+		let expired_offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.absolute_expiry(past_expiry)
+		.build()
+		.unwrap();
 		if let Err(e) = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&expired_offer,
 			payment_paths(),
@@ -1017,10 +1040,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		let invoice = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&offer,
@@ -1049,11 +1078,17 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.experimental_foo(42)
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.experimental_foo(42)
+		.build()
+		.unwrap();
 
 		if let Err(e) = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&offer,
@@ -1095,11 +1130,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let valid_offer =
-			OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-				.path(blinded_path())
-				.build()
-				.unwrap();
+		let valid_offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		// Error if payment paths are missing.
 		if let Err(e) = StaticInvoiceBuilder::for_offer_using_derived_keys(
@@ -1162,11 +1202,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let valid_offer =
-			OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-				.path(blinded_path())
-				.build()
-				.unwrap();
+		let valid_offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		let mut offer_missing_issuer_id = valid_offer.clone();
 		let (mut offer_tlv_stream, _) = offer_missing_issuer_id.as_tlv_stream();
@@ -1198,7 +1243,7 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::new(recipient_pubkey())
+		let offer = OfferBuilder::new(recipient_pubkey(), &NullCurrencyConversion)
 			.path(blinded_path())
 			.metadata(vec![42; 32])
 			.unwrap()
@@ -1228,13 +1273,18 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer_with_extra_chain =
-			OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-				.path(blinded_path())
-				.chain(Network::Bitcoin)
-				.chain(Network::Testnet)
-				.build()
-				.unwrap();
+		let offer_with_extra_chain = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.chain(Network::Bitcoin)
+		.chain(Network::Testnet)
+		.build()
+		.unwrap();
 
 		if let Err(e) = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&offer_with_extra_chain,
@@ -1261,10 +1311,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		const TEST_RELATIVE_EXPIRY: u32 = 3600;
 		let invoice = StaticInvoiceBuilder::for_offer_using_derived_keys(
@@ -1303,10 +1359,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		let invoice = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&offer,
@@ -1440,10 +1502,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		const UNKNOWN_ODD_TYPE: u64 = INVOICE_TYPES.end - 1;
 		assert!(UNKNOWN_ODD_TYPE % 2 == 1);
@@ -1534,10 +1602,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		let invoice = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&offer,
@@ -1640,10 +1714,16 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12ParseError::Decode(DecodeError::UnknownRequiredFeature)),
 		}
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		let invoice = StaticInvoiceBuilder::for_offer_using_derived_keys(
 			&offer,
@@ -1734,10 +1814,16 @@ mod tests {
 		let nonce = Nonce::from_entropy_source(&entropy);
 		let secp_ctx = Secp256k1::new();
 
-		let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-			.path(blinded_path())
-			.build()
-			.unwrap();
+		let offer = OfferBuilder::deriving_signing_pubkey(
+			node_id,
+			&expanded_key,
+			nonce,
+			&NullCurrencyConversion,
+			&secp_ctx,
+		)
+		.path(blinded_path())
+		.build()
+		.unwrap();
 
 		let offer_id = offer.id();
 

--- a/lightning/src/offers/test_utils.rs
+++ b/lightning/src/offers/test_utils.rs
@@ -16,6 +16,7 @@ use crate::blinded_path::message::BlindedMessagePath;
 use crate::blinded_path::payment::{BlindedPayInfo, BlindedPaymentPath};
 use crate::blinded_path::BlindedHop;
 use crate::ln::inbound_payment::ExpandedKey;
+use crate::offers::currency::NullCurrencyConversion;
 use crate::offers::merkle::TaggedHash;
 use crate::sign::EntropySource;
 use crate::types::features::BlindedHopFeatures;
@@ -147,10 +148,16 @@ pub fn dummy_static_invoice() -> StaticInvoice {
 	let nonce = Nonce::from_entropy_source(&entropy);
 	let secp_ctx = Secp256k1::new();
 
-	let offer = OfferBuilder::deriving_signing_pubkey(node_id, &expanded_key, nonce, &secp_ctx)
-		.path(blinded_path())
-		.build()
-		.unwrap();
+	let offer = OfferBuilder::deriving_signing_pubkey(
+		node_id,
+		&expanded_key,
+		nonce,
+		&NullCurrencyConversion,
+		&secp_ctx,
+	)
+	.path(blinded_path())
+	.build()
+	.unwrap();
 
 	StaticInvoiceBuilder::for_offer_using_derived_keys(
 		&offer,

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -33,7 +33,9 @@ use crate::ln::msgs::{BaseMessageHandler, MessageSendEvent};
 use crate::ln::script::ShutdownScript;
 use crate::ln::types::ChannelId;
 use crate::ln::{msgs, wire};
+use crate::offers::currency::{CurrencyConversion, ExchangeRate, ExchangeRateBound, Tolerance};
 use crate::offers::invoice::UnsignedBolt12Invoice;
+use crate::offers::offer::CurrencyCode;
 use crate::onion_message::messenger::{
 	DefaultMessageRouter, Destination, MessageRouter, NodeIdMessageRouter, OnionMessagePath,
 };
@@ -460,6 +462,20 @@ impl<'a> MessageRouter for TestMessageRouter<'a> {
 				peers,
 				secp_ctx,
 			),
+		}
+	}
+}
+
+pub struct TestCurrencyConversion {}
+
+impl CurrencyConversion for TestCurrencyConversion {
+	fn conversion_range(&self, currency: CurrencyCode) -> Result<ExchangeRateBound, ()> {
+		if currency.as_str() == "USD" {
+			let exchange_rate = ExchangeRate::new(1000);
+			let tolerance = Tolerance::BasisPoints(0);
+			ExchangeRateBound::new(exchange_rate, tolerance, tolerance)
+		} else {
+			Err(())
 		}
 	}
 }

--- a/pending_changelog/3833-bolt12-currency-conversion.txt
+++ b/pending_changelog/3833-bolt12-currency-conversion.txt
@@ -1,0 +1,15 @@
+# API Updates
+
+ * BOLT 12 offers may now use ISO 4217 currency-denominated amounts. Users who
+   create or pay such offers must provide a `CurrencyConversion` implementation
+   so LDK can convert the currency amount to millisatoshis and verify returned
+   invoice amounts.
+
+ * `ChannelManager::new` and `ChannelManagerReadArgs` now take a
+   `currency_conversion` argument. Users who do not support currency conversion
+   may use `NullCurrencyConversion`.
+
+ * BOLT 12 offer and invoice builders now thread currency conversion through
+   their construction paths. Unsupported currencies or invalid converted amounts
+   fail offer, invoice request, or invoice construction instead of being
+   accepted without conversion.


### PR DESCRIPTION
This PR adds support for **currency-denominated Offers** in LDK’s BOLT 12 offer-handling flow.

Previously, Offers could only specify their amount in millisatoshis. However, BOLT 12 allows Offers to be denominated in other currencies such as fiat. Supporting this requires converting those currency amounts into millisatoshis at runtime when validating payments and constructing invoices.

Because exchange rates are external, time-dependent, and application-specific, LDK cannot perform these conversions itself. Instead, this PR introduces a `CurrencyConversion` trait which allows applications to provide their own logic for resolving currency-denominated amounts into millisatoshis. LDK remains exchange-rate agnostic and simply invokes this trait whenever a currency amount must be resolved.

To make this conversion logic available throughout the BOLT 12 flow, `OffersMessageFlow` is parameterized over a `CurrencyConversion` implementation and the abstraction is threaded through the offer handling pipeline.

With this in place:

- `OfferBuilder` can now create Offers whose amounts are denominated in currencies instead of millisatoshis

• `InvoiceRequest` handling can resolve Offer amounts when validating requests

• `InvoiceBuilder` enforces that the final invoice amount satisfies the Offer’s requirements after resolving any currency denomination

Currency validation is intentionally deferred until invoice construction when necessary, keeping earlier stages focused on structural validation while ensuring the final payable amount is correct.

Tests are added to cover the complete Offer → InvoiceRequest → Invoice flow when the original Offer amount is specified in a currency.