### PR TITLE
[RFC] events: add `InvoiceSent` event for BOLT12 payee

### DIFF
--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -1186,7 +1186,7 @@ fn pays_bolt12_invoice_asynchronously() {
 	let onion_message = alice.onion_messenger.next_onion_message_for_peer(bob_id).unwrap();
 	bob.onion_messenger.handle_onion_message(alice_id, &onion_message);
 
-	// Re-process the same onion message to ensure idempotency — 
+	// Re-process the same onion message to ensure idempotency —
 	// we should not generate a duplicate `InvoiceReceived` event.
 	bob.onion_messenger.handle_onion_message(alice_id, &onion_message);
 

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -919,6 +919,21 @@ pub struct UserConfig {
 	/// [`ChannelManager::send_payment_for_bolt12_invoice`]: crate::ln::channelmanager::ChannelManager::send_payment_for_bolt12_invoice
 	/// [`ChannelManager::abandon_payment`]: crate::ln::channelmanager::ChannelManager::abandon_payment
 	pub manually_handle_bolt12_invoices: bool,
+	/// If this is set to `true`, the user will receive [`Event::InvoiceSent`] events when a
+	/// BOLT12 invoice is created and sent to a payer.
+	///
+	/// This provides symmetrical functionality to [`Event::InvoiceReceived`] but for the payee side,
+	/// allowing nodes to track and access invoices they have created. This can be useful for
+	/// accounting, proof of invoice creation, or debugging purposes.
+	///
+	/// When set to `true`, [`Event::InvoiceSent`] will be generated whenever a BOLT12 invoice
+	/// is successfully created and sent in response to an invoice request.
+	///
+	/// Default value: `false`
+	///
+	/// [`Event::InvoiceSent`]: crate::events::Event::InvoiceSent
+	/// [`Event::InvoiceReceived`]: crate::events::Event::InvoiceReceived
+	pub notify_bolt12_invoice_sent: bool,
 	/// If this is set to `true`, dual-funded channels will be enabled.
 	///
 	/// Default value: `false`
@@ -936,6 +951,7 @@ impl Default for UserConfig {
 			manually_accept_inbound_channels: false,
 			accept_intercept_htlcs: false,
 			manually_handle_bolt12_invoices: false,
+			notify_bolt12_invoice_sent: false,
 			enable_dual_funded_channels: false,
 		}
 	}
@@ -956,6 +972,7 @@ impl Readable for UserConfig {
 			manually_accept_inbound_channels: Readable::read(reader)?,
 			accept_intercept_htlcs: Readable::read(reader)?,
 			manually_handle_bolt12_invoices: Readable::read(reader)?,
+			notify_bolt12_invoice_sent: Readable::read(reader)?,
 			enable_dual_funded_channels: Readable::read(reader)?,
 		})
 	}


### PR DESCRIPTION
When processing BOLT12 payments, there was an asymmetry in the API where payer nodes receive `InvoiceReceived` events but payee nodes had no way to access the invoices they created and sent as far I know.

This commit adds:
- New `Event::InvoiceSent` event generated when a BOLT12 invoice is created and sent in response to an invoice request
- New `notify_bolt12_invoice_sent` configuration parameter in UserConfig (defaults to false) to enable/disable the event generation

The InvoiceSent event provides the payee with access to:
- The created BOLT12 invoice
- The context of the BlindedMessagePath
- The payment hash and payment secret