### PR TITLE
Reduce CI fuzz iterations

### DIFF
--- a/fuzz/ci-fuzz.sh
+++ b/fuzz/ci-fuzz.sh
@@ -34,13 +34,13 @@ for TARGET in src/bin/*.rs; do
 	FILE="${FILENAME%.*}"
 	HFUZZ_RUN_ARGS="--exit_upon_crash -v -n2"
 	if [ "$FILE" = "chanmon_consistency_target" ]; then
-		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -F 64 -N5000"
+		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -F 64 -N1000"
 	elif [ "$FILE" = "process_network_graph_target" -o "$FILE" = "full_stack_target" -o "$FILE" = "router_target" ]; then
-		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -N50000"
+		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -N10000"
 	elif [ "$FILE" = "indexedmap_target" ]; then
-		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -N500000"
+		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -N100000"
 	else
-		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -N2500000"
+		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -N1000000"
 	fi
 	export HFUZZ_RUN_ARGS
 	cargo --color always hfuzz run $FILE


### PR DESCRIPTION
In b1c6d5284791ddb4790ee565b4bd0897df4555a1 we reduced the number of fuzz iterations we did in CI. This brought us back within the passing envelope, but sadly we're now falling behind in jobs during the day (and barely catching up at night).

Here we reduce the fuzz iteration count in CI even more, in the hopes that it helps.