### PR TITLE
[Docs] LSPS2: Improve invoice_parameters_generated docs

### DIFF
--- a/lightning-liquidity/src/lsps2/event.rs
+++ b/lightning-liquidity/src/lsps2/event.rs
@@ -126,8 +126,11 @@ pub enum LSPS2ServiceEvent {
 	/// If `payment_size_msat` is [`Option::Some`] then the payer is allowed to use MPP.
 	/// If `payment_size_msat` is [`Option::None`] then the payer cannot use MPP.
 	///
-	/// You must generate an intercept scid and `cltv_expiry_delta` for them to use
-	/// and call [`LSPS2ServiceHandler::invoice_parameters_generated`].
+	/// You must generate a `cltv_expiry_delta` and obtain an intercept scid using
+	/// [`ChannelManager::get_intercept_scid`] for them to use and then call
+	/// [`LSPS2ServiceHandler::invoice_parameters_generated`].
+	///
+	/// [`ChannelManager::get_intercept_scid`]: lightning::ln::channelmanager::ChannelManager::get_intercept_scid
 	///
 	/// [`LSPS2ServiceHandler::invoice_parameters_generated`]: crate::lsps2::service::LSPS2ServiceHandler::invoice_parameters_generated
 	BuyRequest {

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -695,10 +695,13 @@ where
 		result
 	}
 
-	/// Used by LSP to provide client with the intercept scid and cltv_expiry_delta to use in their invoice.
+	/// Used by LSP to provide the client with the intercept scid and
+	/// `cltv_expiry_delta` to include in their invoice. The intercept scid
+	/// must be retrieved from [`ChannelManager::get_intercept_scid`].
 	///
 	/// Should be called in response to receiving a [`LSPS2ServiceEvent::BuyRequest`] event.
 	///
+	/// [`ChannelManager::get_intercept_scid`]: lightning::ln::channelmanager::ChannelManager::get_intercept_scid
 	/// [`LSPS2ServiceEvent::BuyRequest`]: crate::lsps2::event::LSPS2ServiceEvent::BuyRequest
 	pub fn invoice_parameters_generated(
 		&self, counterparty_node_id: &PublicKey, request_id: LSPSRequestId, intercept_scid: u64,


### PR DESCRIPTION
Closes https://github.com/lightningdevkit/rust-lightning/issues/3478

On invoice_parameters_generated, explicitly mention that the intercept SCID needs to be retrieved from ChannelManager::get_intercept_scid

This PR documents and matches exactly what ldk-node is doing here https://github.com/lightningdevkit/ldk-node/blob/main/src/liquidity.rs#L554-L586