### PR TITLE
Ignore `start_batch` for missing or unexpected `message_type`

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -2204,8 +2204,8 @@ where
 				.into());
 			}
 
-			const COMMITMENT_SIGNED_BATCH_LIMIT: usize = 20;
-			if batch_size > COMMITMENT_SIGNED_BATCH_LIMIT {
+			const BATCH_SIZE_LIMIT: usize = 20;
+			if batch_size > BATCH_SIZE_LIMIT {
 				let error = format!(
 					"Peer {} sent start_batch for channel {} exceeding the limit",
 					log_pubkey!(their_node_id),

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -2227,19 +2227,13 @@ where
 					MessageBatchImpl::CommitmentSigned(messages)
 				},
 				_ => {
-					let error = format!(
-						"Peer {} sent start_batch for channel {} without a known message type",
+					log_debug!(
+						logger,
+						"Peer {} sent start_batch for channel {} without a known message type; ignoring",
 						log_pubkey!(their_node_id),
-						&msg.channel_id
+						&msg.channel_id,
 					);
-					log_debug!(logger, "{}", error);
-					return Err(LightningError {
-						err: error.clone(),
-						action: msgs::ErrorAction::DisconnectPeerWithWarning {
-							msg: msgs::WarningMessage { channel_id: msg.channel_id, data: error },
-						},
-					}
-					.into());
+					return Ok(None);
 				},
 			};
 


### PR DESCRIPTION
The spec was updated to ignore `start_batch` if `message_type` is missing or not that of `commitment_signed`.