### PR TITLE
Drop the need for fork headers when calling Listen's disconnect

### DIFF
--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -343,8 +343,9 @@ impl<'a> MoneyLossDetector<'a> {
 				self.header_hashes[self.height - 1].0,
 				self.header_hashes[self.height].1,
 			);
-			self.manager.block_disconnected(&header, self.height as u32);
-			self.monitor.block_disconnected(&header, self.height as u32);
+			let best_block = BestBlock::new(header.prev_blockhash, self.height as u32 - 1);
+			self.manager.blocks_disconnected(best_block);
+			self.monitor.blocks_disconnected(best_block);
 			self.height -= 1;
 			let removal_height = self.height;
 			self.txids_confirmed.retain(|_, height| removal_height != *height);

--- a/lightning-liquidity/src/manager.rs
+++ b/lightning-liquidity/src/manager.rs
@@ -767,14 +767,11 @@ where
 		self.best_block_updated(header, height);
 	}
 
-	fn block_disconnected(&self, header: &bitcoin::block::Header, height: u32) {
-		let new_height = height - 1;
+	fn blocks_disconnected(&self, fork_point: BestBlock) {
 		if let Some(best_block) = self.best_block.write().unwrap().as_mut() {
-			assert_eq!(best_block.block_hash, header.block_hash(),
-				"Blocks must be disconnected in chain-order - the disconnected header must be the last connected header");
-			assert_eq!(best_block.height, height,
-				"Blocks must be disconnected in chain-order - the disconnected block must have the correct height");
-			*best_block = BestBlock::new(header.prev_blockhash, new_height)
+			assert!(best_block.height > fork_point.height,
+				"Blocks disconnected must indicate disconnection from the current best height, i.e. the new chain tip must be lower than the previous best height");
+			*best_block = fork_point;
 		}
 
 		// TODO: Call block_disconnected on all sub-modules that require it, e.g., LSPS1MessageHandler.

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -35,7 +35,7 @@ use crate::chain::channelmonitor::{
 	WithChannelMonitor,
 };
 use crate::chain::transaction::{OutPoint, TransactionData};
-use crate::chain::{ChannelMonitorUpdateStatus, Filter, WatchedOutput};
+use crate::chain::{BestBlock, ChannelMonitorUpdateStatus, Filter, WatchedOutput};
 use crate::events::{self, Event, EventHandler, ReplayEvent};
 use crate::ln::channel_state::ChannelDetails;
 #[cfg(peer_storage)]
@@ -1008,18 +1008,17 @@ where
 		self.event_notifier.notify();
 	}
 
-	fn block_disconnected(&self, header: &Header, height: u32) {
+	fn blocks_disconnected(&self, fork_point: BestBlock) {
 		let monitor_states = self.monitors.read().unwrap();
 		log_debug!(
 			self.logger,
-			"Latest block {} at height {} removed via block_disconnected",
-			header.block_hash(),
-			height
+			"Block(s) removed to height {} via blocks_disconnected. New best block is {}",
+			fork_point.height,
+			fork_point.block_hash,
 		);
 		for monitor_state in monitor_states.values() {
-			monitor_state.monitor.block_disconnected(
-				header,
-				height,
+			monitor_state.monitor.blocks_disconnected(
+				fork_point,
 				&*self.broadcaster,
 				&*self.fee_estimator,
 				&self.logger,

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -2297,14 +2297,8 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 
 	/// Determines if the disconnected block contained any transactions of interest and updates
 	/// appropriately.
-	#[rustfmt::skip]
-	pub fn block_disconnected<B: Deref, F: Deref, L: Deref>(
-		&self,
-		header: &Header,
-		height: u32,
-		broadcaster: B,
-		fee_estimator: F,
-		logger: &L,
+	pub fn blocks_disconnected<B: Deref, F: Deref, L: Deref>(
+		&self, fork_point: BestBlock, broadcaster: B, fee_estimator: F, logger: &L,
 	) where
 		B::Target: BroadcasterInterface,
 		F::Target: FeeEstimator,
@@ -2312,8 +2306,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 	{
 		let mut inner = self.inner.lock().unwrap();
 		let logger = WithChannelMonitor::from_impl(logger, &*inner, None);
-		inner.block_disconnected(
-			header, height, broadcaster, fee_estimator, &logger)
+		inner.blocks_disconnected(fork_point, broadcaster, fee_estimator, &logger)
 	}
 
 	/// Processes transactions confirmed in a block with the given header and height, returning new
@@ -2347,10 +2340,10 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 
 	/// Processes a transaction that was reorganized out of the chain.
 	///
-	/// Used instead of [`block_disconnected`] by clients that are notified of transactions rather
+	/// Used instead of [`blocks_disconnected`] by clients that are notified of transactions rather
 	/// than blocks. See [`chain::Confirm`] for calling expectations.
 	///
-	/// [`block_disconnected`]: Self::block_disconnected
+	/// [`blocks_disconnected`]: Self::blocks_disconnected
 	#[rustfmt::skip]
 	pub fn transaction_unconfirmed<B: Deref, F: Deref, L: Deref>(
 		&self,
@@ -5441,12 +5434,12 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 							!unmatured_htlcs.contains(&source),
 							"An unmature HTLC transaction conflicts with a maturing one; failed to \
 							 call either transaction_unconfirmed for the conflicting transaction \
-							 or block_disconnected for a block containing it.");
+							 or blocks_disconnected for a block before it.");
 						debug_assert!(
 							!matured_htlcs.contains(&source),
 							"A matured HTLC transaction conflicts with a maturing one; failed to \
 							 call either transaction_unconfirmed for the conflicting transaction \
-							 or block_disconnected for a block containing it.");
+							 or blocks_disconnected for a block before it.");
 						matured_htlcs.push(source.clone());
 					}
 
@@ -5594,23 +5587,26 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 	}
 
 	#[rustfmt::skip]
-	fn block_disconnected<B: Deref, F: Deref, L: Deref>(
-		&mut self, header: &Header, height: u32, broadcaster: B, fee_estimator: F, logger: &WithChannelMonitor<L>
+	fn blocks_disconnected<B: Deref, F: Deref, L: Deref>(
+		&mut self, fork_point: BestBlock, broadcaster: B, fee_estimator: F, logger: &WithChannelMonitor<L>
 	) where B::Target: BroadcasterInterface,
 		F::Target: FeeEstimator,
 		L::Target: Logger,
 	{
-		log_trace!(logger, "Block {} at height {} disconnected", header.block_hash(), height);
+		let new_height = fork_point.height;
+		log_trace!(logger, "Block(s) disconnected to height {}", new_height);
+		assert!(self.best_block.height > fork_point.height,
+			"Blocks disconnected must indicate disconnection from the current best height, i.e. the new chain tip must be lower than the previous best height");
 
 		//We may discard:
 		//- htlc update there as failure-trigger tx (revoked commitment tx, non-revoked commitment tx, HTLC-timeout tx) has been disconnected
 		//- maturing spendable output has transaction paying us has been disconnected
-		self.onchain_events_awaiting_threshold_conf.retain(|ref entry| entry.height < height);
+		self.onchain_events_awaiting_threshold_conf.retain(|ref entry| entry.height <= new_height);
 
 		// TODO: Replace with `take_if` once our MSRV is >= 1.80.
 		let mut should_broadcast_commitment = false;
 		if let Some((_, conf_height)) = self.alternative_funding_confirmed.as_ref() {
-			if *conf_height == height {
+			if *conf_height > new_height {
 				self.alternative_funding_confirmed.take();
 				if self.holder_tx_signed || self.funding_spend_seen {
 					// Cancel any previous claims that are no longer valid as they stemmed from a
@@ -5627,7 +5623,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 		let bounded_fee_estimator = LowerBoundedFeeEstimator::new(fee_estimator);
 		let conf_target = self.closure_conf_target();
 		self.onchain_tx_handler.block_disconnected(
-			height, &broadcaster, conf_target, &self.destination_script, &bounded_fee_estimator, logger
+			new_height + 1, &broadcaster, conf_target, &self.destination_script, &bounded_fee_estimator, logger
 		);
 
 		// Only attempt to broadcast the new commitment after the `block_disconnected` call above so that
@@ -5636,7 +5632,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 			self.queue_latest_holder_commitment_txn_for_broadcast(&broadcaster, &bounded_fee_estimator, logger);
 		}
 
-		self.best_block = BestBlock::new(header.prev_blockhash, height - 1);
+		self.best_block = fork_point;
 	}
 
 	#[rustfmt::skip]
@@ -6110,8 +6106,8 @@ where
 		self.0.block_connected(header, txdata, height, &*self.1, &*self.2, &self.3);
 	}
 
-	fn block_disconnected(&self, header: &Header, height: u32) {
-		self.0.block_disconnected(header, height, &*self.1, &*self.2, &self.3);
+	fn blocks_disconnected(&self, fork_point: BestBlock) {
+		self.0.blocks_disconnected(fork_point, &*self.1, &*self.2, &self.3);
 	}
 }
 

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -5106,8 +5106,8 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 			log_trace!(logger, "Best block re-orged, replaced with new block {} at height {}", block_hash, height);
 			self.onchain_events_awaiting_threshold_conf.retain(|ref entry| entry.height <= height);
 			let conf_target = self.closure_conf_target();
-			self.onchain_tx_handler.block_disconnected(
-				height + 1, &broadcaster, conf_target, &self.destination_script, fee_estimator, logger,
+			self.onchain_tx_handler.blocks_disconnected(
+				height, &broadcaster, conf_target, &self.destination_script, fee_estimator, logger,
 			);
 			Vec::new()
 		} else { Vec::new() }
@@ -5622,8 +5622,8 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 
 		let bounded_fee_estimator = LowerBoundedFeeEstimator::new(fee_estimator);
 		let conf_target = self.closure_conf_target();
-		self.onchain_tx_handler.block_disconnected(
-			new_height + 1, &broadcaster, conf_target, &self.destination_script, &bounded_fee_estimator, logger
+		self.onchain_tx_handler.blocks_disconnected(
+			new_height, &broadcaster, conf_target, &self.destination_script, &bounded_fee_estimator, logger
 		);
 
 		// Only attempt to broadcast the new commitment after the `block_disconnected` call above so that

--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -73,6 +73,24 @@ impl_writeable_tlv_based!(BestBlock, {
 /// By using [`Listen::filtered_block_connected`] this interface supports clients fetching the
 /// entire header chain and only blocks with matching transaction data using BIP 157 filters or
 /// other similar filtering.
+///
+/// # Requirements
+///
+/// Each block must be connected in chain order with one call to either
+/// [`Listen::block_connected`] or [`Listen::filtered_block_connected`]. If a call to the
+/// [`Filter`] interface was made during block processing and further transaction(s) from the same
+/// block now match the filter, a second call to [`Listen::filtered_block_connected`] should be
+/// made immediately for the same block (prior to any other calls to the [`Listen`] interface).
+///
+/// In case of a reorg, you must call [`Listen::blocks_disconnected`] once with information on the
+/// "fork point" block, i.e. the highest block that is in both forks. You may call
+/// [`Listen::blocks_disconnected`] multiple times as you walk the chain backwards, but each must
+/// include a fork point block that is before the last.
+///
+/// # Object Birthday
+///
+/// Note that most implementations take a [`BestBlock`] on construction and blocks only need to be
+/// applied starting from that point.
 pub trait Listen {
 	/// Notifies the listener that a block was added at the given height, with the transaction data
 	/// possibly filtered.

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -10550,8 +10550,8 @@ where
 	/// May return some HTLCs (and their payment_hash) which have timed out and should be failed
 	/// back.
 	pub fn best_block_updated<NS: Deref, L: Deref>(
-		&mut self, height: u32, highest_header_time: u32, chain_hash: ChainHash, node_signer: &NS,
-		user_config: &UserConfig, logger: &L,
+		&mut self, height: u32, highest_header_time: Option<u32>, chain_hash: ChainHash,
+		node_signer: &NS, user_config: &UserConfig, logger: &L,
 	) -> Result<BestBlockUpdatedRes, ClosureReason>
 	where
 		NS::Target: NodeSigner,
@@ -10567,7 +10567,7 @@ where
 
 	#[rustfmt::skip]
 	fn do_best_block_updated<NS: Deref, L: Deref>(
-		&mut self, height: u32, highest_header_time: u32,
+		&mut self, height: u32, highest_header_time: Option<u32>,
 		chain_node_signer: Option<(ChainHash, &NS, &UserConfig)>, logger: &L
 	) -> Result<(Option<FundingConfirmedMessage>, Vec<(HTLCSource, PaymentHash)>, Option<msgs::AnnouncementSignatures>), ClosureReason>
 	where
@@ -10591,7 +10591,9 @@ where
 			}
 		});
 
-		self.context.update_time_counter = cmp::max(self.context.update_time_counter, highest_header_time);
+		if let Some(time) = highest_header_time {
+			self.context.update_time_counter = cmp::max(self.context.update_time_counter, time);
+		}
 
 		// Check if the funding transaction was unconfirmed
 		let funding_tx_confirmations = self.funding.get_funding_tx_confirmations(height);
@@ -10747,12 +10749,9 @@ where
 				// We handle the funding disconnection by calling best_block_updated with a height one
 				// below where our funding was connected, implying a reorg back to conf_height - 1.
 				let reorg_height = funding.funding_tx_confirmation_height - 1;
-				// We use the time field to bump the current time we set on channel updates if its
-				// larger. If we don't know that time has moved forward, we can just set it to the last
-				// time we saw and it will be ignored.
-				let best_time = self.context.update_time_counter;
 
-				match self.do_best_block_updated(reorg_height, best_time, None::<(ChainHash, &&dyn NodeSigner, &UserConfig)>, logger) {
+				let signer_config = None::<(ChainHash, &&dyn NodeSigner, &UserConfig)>;
+				match self.do_best_block_updated(reorg_height, None, signer_config, logger) {
 					Ok((channel_ready, timed_out_htlcs, announcement_sigs)) => {
 						assert!(channel_ready.is_none(), "We can't generate a funding with 0 confirmations?");
 						assert!(timed_out_htlcs.is_empty(), "We can't have accepted HTLCs with a timeout before our funding confirmation?");

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -428,8 +428,9 @@ pub fn disconnect_blocks<'a, 'b, 'c, 'd>(node: &'a Node<'b, 'c, 'd>, count: u32)
 
 		match *node.connect_style.borrow() {
 			ConnectStyle::FullBlockViaListen => {
-				node.chain_monitor.chain_monitor.block_disconnected(&orig.0.header, orig.1);
-				Listen::block_disconnected(node.node, &orig.0.header, orig.1);
+				let best_block = BestBlock::new(orig.0.header.prev_blockhash, orig.1 - 1);
+				node.chain_monitor.chain_monitor.blocks_disconnected(best_block);
+				Listen::blocks_disconnected(node.node, best_block);
 			},
 			ConnectStyle::BestBlockFirstSkippingBlocks
 			| ConnectStyle::TransactionsFirstSkippingBlocks

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -2328,11 +2328,15 @@ pub fn test_htlc_ignore_latest_remote_commitment() {
 	let node_a_id = nodes[0].node.get_our_node_id();
 	let node_b_id = nodes[1].node.get_our_node_id();
 
-	if *nodes[1].connect_style.borrow() == ConnectStyle::FullBlockViaListen {
-		// We rely on the ability to connect a block redundantly, which isn't allowed via
-		// `chain::Listen`, so we never run the test if we randomly get assigned that
-		// connect_style.
-		return;
+	match *nodes[1].connect_style.borrow() {
+		ConnectStyle::FullBlockViaListen
+		| ConnectStyle::FullBlockDisconnectionsSkippingViaListen => {
+			// We rely on the ability to connect a block redundantly, which isn't allowed via
+			// `chain::Listen`, so we never run the test if we randomly get assigned that
+			// connect_style.
+			return;
+		},
+		_ => {},
 	}
 	let funding_tx = create_announced_chan_between_nodes(&nodes, 0, 1).3;
 	let message = "Channel force-closed".to_owned();

--- a/lightning/src/util/sweep.rs
+++ b/lightning/src/util/sweep.rs
@@ -281,16 +281,6 @@ impl OutputSpendStatus {
 		}
 	}
 
-	fn confirmation_hash(&self) -> Option<BlockHash> {
-		match self {
-			Self::PendingInitialBroadcast { .. } => None,
-			Self::PendingFirstConfirmation { .. } => None,
-			Self::PendingThresholdConfirmations { confirmation_hash, .. } => {
-				Some(*confirmation_hash)
-			},
-		}
-	}
-
 	fn latest_spending_tx(&self) -> Option<&Transaction> {
 		match self {
 			Self::PendingInitialBroadcast { .. } => None,
@@ -759,21 +749,15 @@ where
 		self.best_block_updated_internal(&mut state_lock, header, height);
 	}
 
-	fn block_disconnected(&self, header: &Header, height: u32) {
+	fn blocks_disconnected(&self, fork_point: BestBlock) {
 		let mut state_lock = self.sweeper_state.lock().unwrap();
 
-		let new_height = height - 1;
-		let block_hash = header.block_hash();
-
-		assert_eq!(state_lock.best_block.block_hash, block_hash,
-		"Blocks must be disconnected in chain-order - the disconnected header must be the last connected header");
-		assert_eq!(state_lock.best_block.height, height,
-			"Blocks must be disconnected in chain-order - the disconnected block must have the correct height");
-		state_lock.best_block = BestBlock::new(header.prev_blockhash, new_height);
+		assert!(state_lock.best_block.height > fork_point.height,
+			"Blocks disconnected must indicate disconnection from the current best height, i.e. the new chain tip must be lower than the previous best height");
+		state_lock.best_block = fork_point;
 
 		for output_info in state_lock.outputs.iter_mut() {
-			if output_info.status.confirmation_hash() == Some(block_hash) {
-				debug_assert_eq!(output_info.status.confirmation_height(), Some(height));
+			if output_info.status.confirmation_height() > Some(fork_point.height) {
 				output_info.status.unconfirmed();
 			}
 		}


### PR DESCRIPTION
The `Listen::block_disconnected` method is nice in that listeners
learn about each block disconnected in series. Further, it included
the header of the block that is being disconnected to allow the
listeners to do some checking that the interface is being used
correctly (namely, asserting that the header's block hash matches
their current understanding of the best chain).

However, this interface has some substantial drawbacks. Namely, the
requirement that fork headers be passed in means that restarting
with a new node that has no idea about a previous fork leaves us
unable to replay the chain at all. Further, while when various
listeners were initially written learning about each block
disconnected in series seemed useful, but now we no longer rely on
that anyway because the `Confirm` interface does not allow for it.

Thus, here, we replace `Listen::block_disconnected` with a new
`Listen::blocks_disconnected`, taking only information about the
fork point/new best chain tip (in the form of its block hash and
height) rather than information about previous fork blocks and only
requiring a single call to complete multiple block disconnections
during a reorg.

This requires removing some assertions on block disconnection
ordering, but because we now provide `lightning-block-sync` and
expect users to use it when using the `Listen` interface, these
assertions are much less critical.