### PR TITLE
[Key derivation V2] Attach a version byte to `channel_keys_id`

### DIFF
--- a/lightning/src/util/sweep.rs
+++ b/lightning/src/util/sweep.rs
@@ -61,7 +61,7 @@ impl TrackedSpendableOutput {
 	fn to_watched_output(&self, cur_hash: BlockHash) -> WatchedOutput {
 		let block_hash = self.status.first_broadcast_hash().or(Some(cur_hash));
 		match &self.descriptor {
-			SpendableOutputDescriptor::StaticOutput { outpoint, output, channel_keys_id: _ } => {
+			SpendableOutputDescriptor::StaticOutput { outpoint, output, .. } => {
 				WatchedOutput {
 					block_hash,
 					outpoint: *outpoint,


### PR DESCRIPTION
Early, broken draft of a PR that would allow us to understand which key derivation we used for a particular `channel_keys_id`.

After this PR, we would ship a new derivation for `to_remote` outputs such that they may be recovered solely from the seed in case of loss of all channel state (including the `channel_keys_id` of the channel - which currently is required to derive the `to_remote` key).

An alternative approach could assume a certain byte in `channel_keys_id` has never been used, and we would rely on that byte to understand which key derivation to use. I've heard this assumption would break some downstream users, so pushed this approach instead.