### PR TITLE
Use `cost / path amt limit` as the pathfinding score, not `cost`

### DIFF
--- a/lightning/src/routing/test_utils.rs
+++ b/lightning/src/routing/test_utils.rs
@@ -112,7 +112,7 @@ pub(crate) fn update_channel(
 
 	match gossip_sync.handle_channel_update(Some(node_pubkey), &valid_channel_update) {
 		Ok(res) => assert!(res),
-		Err(_) => panic!()
+		Err(e) => panic!("{e:?}")
 	};
 }
 


### PR DESCRIPTION
    While walking nodes in our Dijkstra's pathfinding, we may find a
    channel which is amount-limited to less than the amount we're
    currently trying to send. This is fine, and when we encounter such
    nodes we simply limit the amount we'd send in this path if we pick
    the channel.

    When we encounter such a path, we keep summing the cost across hops
    as we go, keeping whatever scores we assigned to channels between
    the amount-limited one and the recipient, but using the new limited
    amount for any channels we look at later as we walk towards the
    sender.

    This leads to somewhat inconsistent scores, especially as our
    scorer assigns a large portion of its penalties and a portion of
    network fees are proportional to the amount. Thus, we end up with a
    somewhat higher score than we "should" for this path as later hops
    use a high proportional cost. We accepted this as a simple way to
    bias against small-value paths and many MPP parts.

    Sadly, in practice it appears our bias is not strong enough, as
    several users have reported that we often attempt far too many MPP
    parts. In practice, if we encounter a channel with a small limit
    early in the Dijkstra's pass (towards the end of the path), we may
    prefer it over many other paths as we start assigning very low
    costs early on before we've accumulated much cost from larger
    channels.

    Here, we swap the `cost` Dijkstra's score for `cost / path amount`.
    This should bias much stronger against many MPP parts by preferring
    larger paths proportionally to their amount.

    This somewhat better aligns with our goal - if we have to pick
    multiple paths, we should be searching for paths the optimize
    fee-per-sat-sent, not strictly the fee paid.

    However, it might bias us against smaller paths somewhat stronger
    than we want - because we're still using the fees/scores calculated
    with the sought amount for hops processed already, but are now
    dividing by a smaller sent amount when walking further hops, we
    will bias "incorrectly" (and fairly strongly) against smaller
    parts.

    Still, because of the complaints on pathfinding performance due to
    too many MPP paths, it seems like a worthwhile tradeoff, as
    ultimately MPP splitting is always the domain of heuristics anyway.

I'm somewhat optimistically labeling this "backport 0.1", since we've been doing rather large pathfinding changes in backports anyway, and this directly addresses a major user complaint (with a rather small patch), so it seems worth backporting. However, it does come with some potential for tradeoffs, so open to discussion here.