### PR TITLE
Use inbound SCID alias for blinded path creation

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -9403,6 +9403,12 @@ where
 		false
 	}
 
+	/// Gets the latest inbound SCID alias from our peer, or if none exists, the channel's real
+	/// SCID.
+	pub fn get_inbound_scid(&self) -> Option<u64> {
+		self.context.latest_inbound_scid_alias.or(self.funding.get_short_channel_id())
+	}
+
 	/// Returns true if our channel_ready has been sent
 	pub fn is_our_channel_ready(&self) -> bool {
 		matches!(self.context.channel_state, ChannelState::AwaitingChannelReady(flags) if flags.is_set(AwaitingChannelReadyFlags::OUR_CHANNEL_READY))

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11524,8 +11524,9 @@ where
 					.channel_by_id
 					.iter()
 					.filter(|(_, channel)| channel.context().is_usable())
-					.min_by_key(|(_, channel)| channel.context().channel_creation_height)
-					.and_then(|(_, channel)| channel.funding().get_short_channel_id()),
+					.filter_map(|(_, channel)| channel.as_funded())
+					.min_by_key(|funded_channel| funded_channel.context.channel_creation_height)
+					.and_then(|funded_channel| funded_channel.get_inbound_scid()),
 			})
 			.collect::<Vec<_>>()
 	}


### PR DESCRIPTION
When we generate a compact blinded path to ourselves, we currently use the real SCID of our channels to tell our peers where to forward to. This is fine for short-lived blinded paths where we expect the channel to still be around, but post-splicing this may spuriously invalidate blinded paths just because we spliced.

Instead, here, we default to using inbound SCID aliases where possible. We also avoid one more reference to the channel's internal `FundingContext` in `channelmanager.rs`.