### PR TITLE
Expose `reply_path` from `Responder` in onion messenger

### DIFF
--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -413,6 +413,11 @@ impl Responder {
 		Responder { reply_path }
 	}
 
+	/// Returns the reply path for this [`Responder`].
+	pub fn reply_path(&self) -> &BlindedMessagePath {
+		&self.reply_path
+	}
+
 	/// Creates a [`ResponseInstruction`] for responding without including a reply path.
 	///
 	/// Use when the recipient doesn't need to send back a reply to us.


### PR DESCRIPTION
## Context

When using responder from `OnionMessenger` and using an external process to interact with the messages (our case in LNDK, using LND) we need to try to connect to the introduction node before responding to the message itself.

## What it is implemented

Just exposing the reply path from the responder.