### PR TITLE
Refactor `PendingSplice`

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -6671,7 +6671,8 @@ where
 	/// This field is cleared once our counterparty sends a `channel_ready`.
 	pub interactive_tx_signing_session: Option<InteractiveTxSigningSession>,
 	holder_commitment_point: HolderCommitmentPoint,
-	/// Info about an in-progress, pending splice (if any), on the pre-splice channel
+
+	/// Information about any pending splice candidates, including RBF attempts.
 	pending_splice: Option<PendingFunding>,
 
 	/// Once we become quiescent, if we're the initiator, there's some action we'll want to take.


### PR DESCRIPTION
`FundedChannel::pending_funding` and `FundedChannel::pending_splice` were developed independently, but the former will only contain values when the latter is set. This PR moves the former into `PendingSplice` and renames it to `negotiated_candidates`. It also removes unnecessary checks for `FundedChannel::pending_splice` and renames `PendingSplice` to `PendingFunding`. This allows for using `PendingFunding` for V2 channel establishment in order to support RBF.