### PR TITLE
Remove deprecated `lightning::util::string` re-exports

### DIFF
--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -24,8 +24,8 @@ use lightning::offers::parse::Bolt12SemanticError;
 use lightning::sign::EntropySource;
 use lightning::types::features::BlindedHopFeatures;
 use lightning::types::payment::{PaymentHash, PaymentSecret};
+use lightning::types::string::UntrustedString;
 use lightning::util::ser::Writeable;
-use lightning::util::string::UntrustedString;
 
 #[inline]
 pub fn do_test<Out: test_logger::Output>(data: &[u8], _out: Out) {

--- a/lightning-persister/src/fs_store.rs
+++ b/lightning-persister/src/fs_store.rs
@@ -1,8 +1,8 @@
 //! Objects related to [`FilesystemStore`] live here.
 use crate::utils::{check_namespace_key_validity, is_valid_kvstore_str};
 
+use lightning::types::string::PrintableString;
 use lightning::util::persist::{KVStore, MigratableKVStore};
-use lightning::util::string::PrintableString;
 
 use std::collections::HashMap;
 use std::fs;

--- a/lightning-persister/src/utils.rs
+++ b/lightning-persister/src/utils.rs
@@ -1,5 +1,5 @@
+use lightning::types::string::PrintableString;
 use lightning::util::persist::{KVSTORE_NAMESPACE_KEY_ALPHABET, KVSTORE_NAMESPACE_KEY_MAX_LEN};
-use lightning::util::string::PrintableString;
 
 pub(crate) fn is_valid_kvstore_str(key: &str) -> bool {
 	key.len() <= KVSTORE_NAMESPACE_KEY_MAX_LEN

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -35,12 +35,12 @@ use crate::routing::router::{BlindedTail, Path, RouteHop, RouteParameters};
 use crate::sign::SpendableOutputDescriptor;
 use crate::types::features::ChannelTypeFeatures;
 use crate::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
+use crate::types::string::UntrustedString;
 use crate::util::errors::APIError;
 use crate::util::ser::{
 	BigSize, FixedLengthReader, MaybeReadable, Readable, RequiredWrapper, UpgradableRequired,
 	WithoutLength, Writeable, Writer,
 };
-use crate::util::string::UntrustedString;
 
 use crate::io;
 use crate::sync::Arc;
@@ -315,7 +315,7 @@ pub enum ClosureReason {
 		/// a security vulnerability in the terminal emulator or the logging subsystem.
 		/// To be safe, use `Display` on `UntrustedString`
 		///
-		/// [`UntrustedString`]: crate::util::string::UntrustedString
+		/// [`UntrustedString`]: crate::types::string::UntrustedString
 		peer_msg: UntrustedString,
 	},
 	/// Closure generated from [`ChannelManager::force_close_channel`], called by the user.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -119,6 +119,7 @@ use crate::types::features::{
 	Bolt12InvoiceFeatures, ChannelFeatures, ChannelTypeFeatures, InitFeatures, NodeFeatures,
 };
 use crate::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
+use crate::types::string::UntrustedString;
 use crate::util::config::{ChannelConfig, ChannelConfigOverrides, ChannelConfigUpdate, UserConfig};
 use crate::util::errors::APIError;
 use crate::util::logger::{Level, Logger, WithContext};
@@ -127,7 +128,6 @@ use crate::util::ser::{
 	BigSize, FixedLengthReader, LengthReadable, MaybeReadable, Readable, ReadableArgs, VecWriter,
 	Writeable, Writer,
 };
-use crate::util::string::UntrustedString;
 use crate::util::wakers::{Future, Notifier};
 
 #[cfg(all(test, async_payments))]

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -52,13 +52,13 @@ use crate::routing::router::{
 use crate::sign::{EntropySource, OutputSpender, SignerProvider};
 use crate::types::features::{ChannelFeatures, ChannelTypeFeatures, NodeFeatures};
 use crate::types::payment::{PaymentHash, PaymentSecret};
+use crate::types::string::UntrustedString;
 use crate::util::config::{
 	ChannelConfigOverrides, ChannelConfigUpdate, ChannelHandshakeConfigUpdate, MaxDustHTLCExposure,
 	UserConfig,
 };
 use crate::util::errors::APIError;
 use crate::util::ser::{ReadableArgs, Writeable};
-use crate::util::string::UntrustedString;
 use crate::util::test_channel_signer::TestChannelSigner;
 use crate::util::test_utils::{self, TestLogger, WatchtowerPersister};
 

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -44,9 +44,9 @@ use crate::routing::scoring::ChannelUsage;
 use crate::sign::EntropySource;
 use crate::types::features::{Bolt11InvoiceFeatures, ChannelTypeFeatures};
 use crate::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
+use crate::types::string::UntrustedString;
 use crate::util::errors::APIError;
 use crate::util::ser::Writeable;
-use crate::util::string::UntrustedString;
 use crate::util::test_utils;
 
 use bitcoin::hashes::sha256::Hash as Sha256;

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -45,10 +45,10 @@ use crate::onion_message::packet::OnionMessageContents;
 use crate::routing::gossip::{NodeAlias, NodeId};
 use crate::sign::{NodeSigner, Recipient};
 use crate::types::features::{InitFeatures, NodeFeatures};
+use crate::types::string::PrintableString;
 use crate::util::atomic_counter::AtomicCounter;
 use crate::util::logger::{Level, Logger, WithContext};
 use crate::util::ser::{VecWriter, Writeable, Writer};
-use crate::util::string::PrintableString;
 
 #[allow(unused_imports)]
 use crate::prelude::*;

--- a/lightning/src/ln/reload_tests.rs
+++ b/lightning/src/ln/reload_tests.rs
@@ -509,7 +509,7 @@ fn test_manager_serialize_deserialize_inconsistent_monitor() {
 #[cfg(feature = "std")]
 fn do_test_data_loss_protect(reconnect_panicing: bool, substantially_old: bool, not_stale: bool) {
 	use crate::ln::channelmanager::Retry;
-	use crate::util::string::UntrustedString;
+	use crate::types::string::UntrustedString;
 	// When we get a data_loss_protect proving we're behind, we immediately panic as the
 	// chain::Watch API requirements have been violated (e.g. the user restored from a backup). The
 	// panic message informs the user they should force-close without broadcasting, which is tested

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -19,8 +19,8 @@ use crate::events::{Event, ClosureReason, HTLCHandlingFailureType};
 use crate::ln::msgs::{BaseMessageHandler, ChannelMessageHandler, Init, MessageSendEvent};
 use crate::ln::types::ChannelId;
 use crate::sign::OutputSpender;
+use crate::types::string::UntrustedString;
 use crate::util::ser::Writeable;
-use crate::util::string::UntrustedString;
 
 use bitcoin::script::Builder;
 use bitcoin::opcodes;

--- a/lightning/src/ln/shutdown_tests.rs
+++ b/lightning/src/ln/shutdown_tests.rs
@@ -23,9 +23,9 @@ use crate::ln::types::ChannelId;
 use crate::prelude::*;
 use crate::routing::router::{get_route, PaymentParameters, RouteParameters};
 use crate::sign::{EntropySource, SignerProvider};
+use crate::types::string::UntrustedString;
 use crate::util::config::UserConfig;
 use crate::util::errors::APIError;
-use crate::util::string::UntrustedString;
 use crate::util::test_utils;
 use crate::util::test_utils::OnGetShutdownScriptpubkey;
 

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -147,11 +147,11 @@ use crate::offers::refund::{
 use crate::offers::signer::{self, Metadata};
 use crate::types::features::{Bolt12InvoiceFeatures, InvoiceRequestFeatures, OfferFeatures};
 use crate::types::payment::PaymentHash;
+use crate::types::string::PrintableString;
 use crate::util::ser::{
 	CursorReadable, HighZeroBytesDroppedBigSize, Iterable, LengthLimitedRead, LengthReadable,
 	WithoutLength, Writeable, Writer,
 };
-use crate::util::string::PrintableString;
 use bitcoin::address::Address;
 use bitcoin::constants::ChainHash;
 use bitcoin::secp256k1::schnorr::Signature;
@@ -1802,8 +1802,8 @@ mod tests {
 	use crate::offers::test_utils::*;
 	use crate::prelude::*;
 	use crate::types::features::{Bolt12InvoiceFeatures, InvoiceRequestFeatures, OfferFeatures};
+	use crate::types::string::PrintableString;
 	use crate::util::ser::{BigSize, Iterable, Writeable};
-	use crate::util::string::PrintableString;
 	#[cfg(not(c_bindings))]
 	use {crate::offers::offer::OfferBuilder, crate::offers::refund::RefundBuilder};
 	#[cfg(c_bindings)]

--- a/lightning/src/offers/invoice_error.rs
+++ b/lightning/src/offers/invoice_error.rs
@@ -13,8 +13,8 @@ use crate::io;
 use crate::ln::msgs::DecodeError;
 use crate::offers::merkle::SignError;
 use crate::offers::parse::Bolt12SemanticError;
+use crate::types::string::UntrustedString;
 use crate::util::ser::{HighZeroBytesDroppedBigSize, Readable, WithoutLength, Writeable, Writer};
-use crate::util::string::UntrustedString;
 
 #[allow(unused_imports)]
 use crate::prelude::*;
@@ -123,10 +123,10 @@ mod tests {
 	use super::{ErroneousField, InvoiceError};
 
 	use crate::ln::msgs::DecodeError;
+	use crate::types::string::UntrustedString;
 	use crate::util::ser::{
 		HighZeroBytesDroppedBigSize, Readable, VecWriter, WithoutLength, Writeable,
 	};
-	use crate::util::string::UntrustedString;
 
 	#[test]
 	fn parses_invoice_error_without_erroneous_field() {

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -85,11 +85,11 @@ use crate::offers::signer::{Metadata, MetadataMaterial};
 use crate::onion_message::dns_resolution::HumanReadableName;
 use crate::types::features::InvoiceRequestFeatures;
 use crate::types::payment::PaymentHash;
+use crate::types::string::{PrintableString, UntrustedString};
 use crate::util::ser::{
 	CursorReadable, HighZeroBytesDroppedBigSize, LengthLimitedRead, LengthReadable, Readable,
 	WithoutLength, Writeable, Writer,
 };
-use crate::util::string::{PrintableString, UntrustedString};
 use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 use bitcoin::secp256k1::schnorr::Signature;
@@ -1474,8 +1474,8 @@ mod tests {
 	use crate::offers::payer::PayerTlvStreamRef;
 	use crate::offers::test_utils::*;
 	use crate::types::features::{InvoiceRequestFeatures, OfferFeatures};
+	use crate::types::string::{PrintableString, UntrustedString};
 	use crate::util::ser::{BigSize, Readable, Writeable};
-	use crate::util::string::{PrintableString, UntrustedString};
 	use bitcoin::constants::ChainHash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::{self, Keypair, Secp256k1, SecretKey};

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -87,11 +87,11 @@ use crate::offers::nonce::Nonce;
 use crate::offers::parse::{Bech32Encode, Bolt12ParseError, Bolt12SemanticError, ParsedMessage};
 use crate::offers::signer::{self, Metadata, MetadataMaterial};
 use crate::types::features::OfferFeatures;
+use crate::types::string::PrintableString;
 use crate::util::ser::{
 	CursorReadable, HighZeroBytesDroppedBigSize, LengthLimitedRead, LengthReadable, Readable,
 	WithoutLength, Writeable, Writer,
 };
-use crate::util::string::PrintableString;
 use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 use bitcoin::secp256k1::{self, Keypair, PublicKey, Secp256k1};
@@ -646,7 +646,7 @@ macro_rules! offer_accessors { ($self: ident, $contents: expr) => {
 
 	/// A complete description of the purpose of the payment. Intended to be displayed to the user
 	/// but with the caveat that it has not been verified in any way.
-	pub fn description(&$self) -> Option<$crate::util::string::PrintableString> {
+	pub fn description(&$self) -> Option<$crate::types::string::PrintableString> {
 		$contents.description()
 	}
 
@@ -664,7 +664,7 @@ macro_rules! offer_accessors { ($self: ident, $contents: expr) => {
 
 	/// The issuer of the offer, possibly beginning with `user@domain` or `domain`. Intended to be
 	/// displayed to the user but with the caveat that it has not been verified in any way.
-	pub fn issuer(&$self) -> Option<$crate::util::string::PrintableString> {
+	pub fn issuer(&$self) -> Option<$crate::types::string::PrintableString> {
 		$contents.issuer()
 	}
 
@@ -1349,8 +1349,8 @@ mod tests {
 	use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError};
 	use crate::offers::test_utils::*;
 	use crate::types::features::OfferFeatures;
+	use crate::types::string::PrintableString;
 	use crate::util::ser::{BigSize, Writeable};
-	use crate::util::string::PrintableString;
 	use bitcoin::constants::ChainHash;
 	use bitcoin::network::Network;
 	use bitcoin::secp256k1::Secp256k1;

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -102,10 +102,10 @@ use crate::offers::signer::{self, Metadata, MetadataMaterial};
 use crate::sign::EntropySource;
 use crate::types::features::InvoiceRequestFeatures;
 use crate::types::payment::PaymentHash;
+use crate::types::string::PrintableString;
 use crate::util::ser::{
 	CursorReadable, LengthLimitedRead, LengthReadable, WithoutLength, Writeable, Writer,
 };
-use crate::util::string::PrintableString;
 use bitcoin::constants::ChainHash;
 use bitcoin::network::Network;
 use bitcoin::secp256k1::{self, PublicKey, Secp256k1};
@@ -1055,8 +1055,8 @@ mod tests {
 	use crate::offers::test_utils::*;
 	use crate::prelude::*;
 	use crate::types::features::{InvoiceRequestFeatures, OfferFeatures};
+	use crate::types::string::PrintableString;
 	use crate::util::ser::{BigSize, Writeable};
-	use crate::util::string::PrintableString;
 
 	trait ToBytes {
 		fn to_bytes(&self) -> Vec<u8>;

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -33,10 +33,10 @@ use crate::offers::offer::{
 };
 use crate::offers::parse::{Bolt12ParseError, Bolt12SemanticError, ParsedMessage};
 use crate::types::features::{Bolt12InvoiceFeatures, OfferFeatures};
+use crate::types::string::PrintableString;
 use crate::util::ser::{
 	CursorReadable, Iterable, LengthLimitedRead, LengthReadable, WithoutLength, Writeable, Writer,
 };
-use crate::util::string::PrintableString;
 use bitcoin::address::Address;
 use bitcoin::constants::ChainHash;
 use bitcoin::secp256k1::schnorr::Signature;

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -36,11 +36,11 @@ use crate::ln::msgs::{
 use crate::ln::types::ChannelId;
 use crate::routing::utxo::{self, UtxoLookup, UtxoResolver};
 use crate::types::features::{ChannelFeatures, InitFeatures, NodeFeatures};
+use crate::types::string::PrintableString;
 use crate::util::indexed_map::{Entry as IndexedMapEntry, IndexedMap};
 use crate::util::logger::{Level, Logger};
 use crate::util::scid_utils::{block_from_scid, scid_from_parts, MAX_SCID_BLOCK};
 use crate::util::ser::{MaybeReadable, Readable, ReadableArgs, RequiredWrapper, Writeable, Writer};
-use crate::util::string::PrintableString;
 
 use crate::io;
 use crate::io_extras::{copy, sink};

--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -59,15 +59,6 @@ pub mod test_utils;
 #[cfg(any(test, feature = "_test_utils"))]
 pub mod test_channel_signer;
 
-pub mod string {
-	//! Utilities to wrap untrusted strings and handle them (more) safely
-	//!
-	//! These re-exports are deprecated in favor of [`lightning::types::string`].
-	//!
-	//! [`lightning::types::string`]: crate::types::string
-	pub use lightning_types::string::{PrintableString, UntrustedString};
-}
-
 /// A macro to delegate trait implementations to a field of a struct.
 ///
 /// For example:

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -50,10 +50,10 @@ use crate::chain::ClaimId;
 use crate::ln::msgs::PartialSignatureWithNonce;
 use crate::ln::msgs::{DecodeError, SerialId};
 use crate::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
-use core::time::Duration;
-
+use crate::types::string::UntrustedString;
 use crate::util::byte_utils::{be48_to_array, slice_to_be48};
-use crate::util::string::UntrustedString;
+
+use core::time::Duration;
 
 /// serialization buffer size
 pub const MAX_BUF_SIZE: usize = 64 * 1024;


### PR DESCRIPTION
These were deprecated in 0.1 in favor of the `lightning::types` re-export of the `lightning-types` crate.

Fixes #3251.