### PR TITLE
Remove invalid `debug_assert`s in `peer_connected`/`peer_disconnected`

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11917,7 +11917,12 @@ where
 				debug_assert!(peer_state.is_connected, "A disconnected peer cannot disconnect");
 				peer_state.is_connected = false;
 				peer_state.ok_to_remove(true)
-			} else { debug_assert!(false, "Unconnected peer disconnected"); true }
+			} else {
+				// Note that the peer might already be marked as disconnected as we might have
+				// called this function already via a different callpath (i.e., other
+				// implementation of `BaseMessageHandler`.
+				false
+			}
 		};
 		if remove_peer {
 			per_peer_state.remove(&counterparty_node_id);
@@ -11981,7 +11986,9 @@ where
 							return NotifyOption::SkipPersistNoEvents;
 						}
 
-						debug_assert!(!peer_state.is_connected, "A peer shouldn't be connected twice");
+						// Note that the peer might already be marked as connected as we might have
+						// called this function already via a different callpath (i.e., other
+						// implementation of `BaseMessageHandler`.
 						peer_state.is_connected = true;
 					},
 				}


### PR DESCRIPTION
In commit 7d56270216dc4e7c08c67b27c715a45661a9d4cf, we decided to call `peer_connected`/`peer_disconnected` on the previously-added `send_only_message_handler`.

However, in practice `send_only_message_handler` will be implemented via `ChannelManager`, having us call `ChannelManager::peer_connected`/`peer_disconnected` at least twice (also for `ChannelMessageHandler`), resulting in hitting the `A peer shouldn't be connected twice` and `Unconnected peer disconnected` debug assertions.

Here, we simply drop these outdated assertions.