### PR TITLE
Introduce `SendOnlyMessageHandler` trait

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -36,7 +36,7 @@ use crate::chain::transaction::{OutPoint, TransactionData};
 use crate::chain::{ChannelMonitorUpdateStatus, Filter, WatchedOutput};
 use crate::events::{self, Event, EventHandler, ReplayEvent};
 use crate::ln::channel_state::ChannelDetails;
-use crate::ln::msgs::{self, BaseMessageHandler, Init, MessageSendEvent};
+use crate::ln::msgs::{self, BaseMessageHandler, Init, MessageSendEvent, SendOnlyMessageHandler};
 use crate::ln::our_peer_storage::DecryptedOurPeerStorage;
 use crate::ln::types::ChannelId;
 use crate::prelude::*;
@@ -864,6 +864,25 @@ where
 	) -> Result<(), ()> {
 		Ok(())
 	}
+}
+
+impl<
+		ChannelSigner: EcdsaChannelSigner,
+		C: Deref,
+		T: Deref,
+		F: Deref,
+		L: Deref,
+		P: Deref,
+		ES: Deref,
+	> SendOnlyMessageHandler for ChainMonitor<ChannelSigner, C, T, F, L, P, ES>
+where
+	C::Target: chain::Filter,
+	T::Target: BroadcasterInterface,
+	F::Target: FeeEstimator,
+	L::Target: Logger,
+	P::Target: Persist<ChannelSigner>,
+	ES::Target: EntropySource,
+{
 }
 
 impl<

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -2177,6 +2177,13 @@ pub trait OnionMessageHandler: BaseMessageHandler {
 	fn timer_tick_occurred(&self);
 }
 
+/// A handler which can only be used to send messages.
+///
+/// This is implemented by [`ChainMonitor`].
+///
+/// [`ChainMonitor`]: crate::chain::chainmonitor::ChainMonitor
+pub trait SendOnlyMessageHandler: BaseMessageHandler {}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Information communicated in the onion to the recipient for multi-part tracking and proof that
 /// the payment is associated with an invoice.


### PR DESCRIPTION
Previously, we introduced a new `send_only_message_handler: BaseMessageHandler` field to `MessageHandler`, which we expect to only ever be implemented by `ChainMonitor`.

However, given that more objects implement `BaseMessageHandler`, the API allowed to plugin different objects, such as `ChannelManager`, resulting in unexpected behavior.

Here, we resolve this by introducing a new super trait `SendOnlyMessageHandler` that is only implemented by `ChainMonitor`.

(cc @adi2011)