### PR TITLE
Use channel's real funding amounts when processing RGS data

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -2521,6 +2521,7 @@ mod tests {
 				.network_graph
 				.add_channel_from_partial_announcement(
 					42,
+					None,
 					53,
 					features,
 					$nodes[0].node.get_our_node_id().into(),

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -2006,8 +2006,8 @@ where
 	///
 	/// All other parameters as used in [`msgs::UnsignedChannelAnnouncement`] fields.
 	pub fn add_channel_from_partial_announcement(
-		&self, short_channel_id: u64, timestamp: u64, features: ChannelFeatures, node_id_1: NodeId,
-		node_id_2: NodeId,
+		&self, short_channel_id: u64, capacity_sats: Option<u64>, timestamp: u64,
+		features: ChannelFeatures, node_id_1: NodeId, node_id_2: NodeId,
 	) -> Result<(), LightningError> {
 		if node_id_1 == node_id_2 {
 			return Err(LightningError {
@@ -2022,7 +2022,7 @@ where
 			one_to_two: None,
 			node_two: node_id_2,
 			two_to_one: None,
-			capacity_sats: None,
+			capacity_sats,
 			announcement_message: None,
 			announcement_received_time: timestamp,
 			node_one_counter: u32::max_value(),


### PR DESCRIPTION
Neither `channel_announcement`s nor `channel_update`s contain a channel's actual funding amount, complicating scoring as nodes may set an `htlc_maximum_msat` to something less than the funding amount. When scoring, we use `htlc_maximum_msat` anyway if we don't know the funding amount, but its not a perfect proxy.

In
https://github.com/lightningdevkit/rapid-gossip-sync-server/pull/102 we started including a channel's real funding amount in RGS data, and here we start parsing it and including it in our network graph.

Fixes #1559