### PR TITLE
Drop `incremental-mutants` CI job (main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,9 +215,9 @@ jobs:
           git fetch upstream
           export GIT_COMMITTER_EMAIL="rl-ci@example.com"
           export GIT_COMMITTER_NAME="RL CI"
-          git rebase upstream/main
+          git rebase upstream/${{ github.base_ref }}
       - name: For each commit, run cargo check (including in fuzz)
-        run: ci/check-each-commit.sh upstream/main
+        run: ci/check-each-commit.sh upstream/${{ github.base_ref }}
 
   check_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #3948.

Previously, the `incremental-mutants` CI job was failing on ~every PR that made actual logic changes, and nobody seemed to really make any effort to address the failures. The failing CI jobs therefore just resulted in additional which in turn could have us getting used to failing CI, introducing some risk of acutal failures slipping through. Of course, it also took up some (considerable?) time in the CI queue that might be better spent on other jobs if no contributors are actually benefitting from the CI job.

Here we therefore drop `incremental-mutants` from our CI for the time being.