### PR TITLE
Skip beta builds on macos an windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,10 @@ jobs:
         exclude:
           - platform: windows-latest
             toolchain: 1.63.0
+          - platform: windows-latest
+            toolchain: beta
+          - platform: macos-latest
+            toolchain: beta
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code


### PR DESCRIPTION
While we should keep testing MacOS and Windows builds (especially Winblowz since its somehow still cooperative multitasking within a process in 2025), there's not a lot of need to test rustc beta builds on them, which we mostly do just to ensure we aren't going to be broken by a future rustc update that breaks some API (which is exceedingly rare).

This should get our CI queueing times back close to zero on all jobs.