### PR TITLE
Move `check_commits` CI to dedicated workflow (main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,28 +201,6 @@ jobs:
           cd bench
           RUSTFLAGS="--cfg=ldk_bench --cfg=require_route_graph_test" cargo bench
 
-  check_commits:
-    runs-on: self-hosted
-    env:
-      TOOLCHAIN: stable
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
-      - name: Fetch full tree and rebase on upstream
-        run: |
-          git remote add upstream https://github.com/lightningdevkit/rust-lightning
-          git fetch upstream
-          export GIT_COMMITTER_EMAIL="rl-ci@example.com"
-          export GIT_COMMITTER_NAME="RL CI"
-          git rebase upstream/${{ github.base_ref }}
-      - name: For each commit, run cargo check (including in fuzz)
-        run: ci/check-each-commit.sh upstream/${{ github.base_ref }}
-
   check_release:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/check_commits.yml
+++ b/.github/workflows/check_commits.yml
@@ -1,0 +1,34 @@
+name: CI check_commits
+
+on:
+  pull_request:
+    branches-ignore:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check_commits:
+    runs-on: self-hosted
+    env:
+      TOOLCHAIN: stable
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
+      - name: Fetch full tree and rebase on upstream
+        run: |
+          git remote add upstream https://github.com/lightningdevkit/rust-lightning
+          git fetch upstream
+          export GIT_COMMITTER_EMAIL="rl-ci@example.com"
+          export GIT_COMMITTER_NAME="RL CI"
+          git rebase upstream/${{ github.base_ref }}
+      - name: For each commit, run cargo check (including in fuzz)
+        run: ci/check-each-commit.sh upstream/${{ github.base_ref }}
+


### PR DESCRIPTION
Previously, we introduced a chance dynamically determining the base
branch for the `check_commits` CI job. Unfortunately it used the base_ref
variable, which is only set for pull_requests, not for pushes. Here, we
hence move `check_commits` to a dedicated workflow that only is run on
PRs.