### PR TITLE
Limit fuzz builds in CI to 8 parallel tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Sanity check fuzz targets on Rust ${{ env.TOOLCHAIN }}
         run: |
           cd fuzz
-          RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz" cargo test --verbose --color always --lib --bins
+          RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz" cargo test --verbose --color always --lib --bins -j8
           cargo clean
       - name: Run fuzzers
         run: cd fuzz && ./ci-fuzz.sh && cd ..

--- a/contrib/generate_fuzz_coverage.sh
+++ b/contrib/generate_fuzz_coverage.sh
@@ -62,7 +62,7 @@ if [ "$OUTPUT_CODECOV_JSON" = "0" ]; then
     cargo llvm-cov --html --ignore-filename-regex "fuzz/" --output-dir "$OUTPUT_DIR"
     echo "Coverage report generated in $OUTPUT_DIR/html/index.html"
 else
-    cargo llvm-cov --codecov --ignore-filename-regex "fuzz/" --output-path "$OUTPUT_DIR/fuzz-codecov.json"
+    cargo llvm-cov -j8 --codecov --ignore-filename-regex "fuzz/" --output-path "$OUTPUT_DIR/fuzz-codecov.json"
     echo "Fuzz codecov report available at $OUTPUT_DIR/fuzz-codecov.json"
 fi
 

--- a/fuzz/ci-fuzz.sh
+++ b/fuzz/ci-fuzz.sh
@@ -29,7 +29,7 @@ sed -i 's/lto = true//' Cargo.toml
 
 export HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz"
 
-cargo --color always hfuzz build
+cargo --color always hfuzz build -j8
 for TARGET in src/bin/*.rs; do
 	FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"


### PR DESCRIPTION
`cargo` can get excited seeing it has many available cores and will happily spawn core-count `ld` processes to link all the fuzzing binaries, using substantial very-short-term memory. This can cause issues in CI runners with many cores but not a ton of memory (eg 32 cores and only 16GiB of memory available).