### PR TITLE
Rename `Event::PaymentClaimable::via_channel_ids` to `receiving_..`

### DIFF
--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -255,18 +255,18 @@ fn mpp_to_one_hop_blinded_path() {
 		Some(payment_secret), ev.clone(), true, None);
 
 	match event.unwrap() {
-		Event::PaymentClaimable { mut via_channel_ids, .. } => {
-			let mut expected_via_channel_ids = nodes[3].node.list_channels()
+		Event::PaymentClaimable { mut receiving_channel_ids, .. } => {
+			let mut expected_receiving_channel_ids = nodes[3].node.list_channels()
 				.iter()
 				.map(|d| (d.channel_id, Some(d.user_channel_id)))
 				.collect::<Vec<(_, _)>>();
 
 			// `list_channels` returns channels in arbitrary order, so we sort both vectors
 			// to ensure the comparison is order-agnostic.
-			via_channel_ids.sort();
-			expected_via_channel_ids.sort();
+			receiving_channel_ids.sort();
+			expected_receiving_channel_ids.sort();
 
-			assert_eq!(via_channel_ids, expected_via_channel_ids);
+			assert_eq!(receiving_channel_ids, expected_receiving_channel_ids);
 		}
 		_ => panic!("Unexpected event"),
 	}

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -218,13 +218,13 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 			ref purpose,
 			amount_msat,
 			receiver_node_id,
-			ref via_channel_ids,
+			ref receiving_channel_ids,
 			..
 		} => {
 			assert_eq!(payment_hash_1, *payment_hash);
 			assert_eq!(amount_msat, 1_000_000);
 			assert_eq!(receiver_node_id.unwrap(), node_b_id);
-			assert_eq!(*via_channel_ids, &[(channel_id, Some(user_channel_id))]);
+			assert_eq!(*receiving_channel_ids, &[(channel_id, Some(user_channel_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage, payment_secret, ..
@@ -660,13 +660,13 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 			ref purpose,
 			amount_msat,
 			receiver_node_id,
-			ref via_channel_ids,
+			ref receiving_channel_ids,
 			..
 		} => {
 			assert_eq!(payment_hash_2, *payment_hash);
 			assert_eq!(amount_msat, 1_000_000);
 			assert_eq!(receiver_node_id.unwrap(), node_b_id);
-			assert_eq!(*via_channel_ids, [(channel_id, Some(user_channel_id))]);
+			assert_eq!(*receiving_channel_ids, [(channel_id, Some(user_channel_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage, payment_secret, ..
@@ -795,13 +795,13 @@ fn test_monitor_update_fail_cs() {
 			ref purpose,
 			amount_msat,
 			receiver_node_id,
-			ref via_channel_ids,
+			ref receiving_channel_ids,
 			..
 		} => {
 			assert_eq!(payment_hash, our_payment_hash);
 			assert_eq!(amount_msat, 1_000_000);
 			assert_eq!(receiver_node_id.unwrap(), node_b_id);
-			assert_eq!(*via_channel_ids, [(channel_id, Some(user_channel_id))]);
+			assert_eq!(*receiving_channel_ids, [(channel_id, Some(user_channel_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage, payment_secret, ..
@@ -1906,13 +1906,13 @@ fn test_monitor_update_fail_claim() {
 			ref purpose,
 			amount_msat,
 			receiver_node_id,
-			ref via_channel_ids,
+			ref receiving_channel_ids,
 			..
 		} => {
 			assert_eq!(payment_hash_2, *payment_hash);
 			assert_eq!(1_000_000, amount_msat);
 			assert_eq!(receiver_node_id.unwrap(), node_a_id);
-			assert_eq!(*via_channel_ids.last().unwrap(), (channel_id, Some(42)));
+			assert_eq!(*receiving_channel_ids.last().unwrap(), (channel_id, Some(42)));
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage, payment_secret, ..
@@ -1931,13 +1931,13 @@ fn test_monitor_update_fail_claim() {
 			ref purpose,
 			amount_msat,
 			receiver_node_id,
-			ref via_channel_ids,
+			ref receiving_channel_ids,
 			..
 		} => {
 			assert_eq!(payment_hash_3, *payment_hash);
 			assert_eq!(1_000_000, amount_msat);
 			assert_eq!(receiver_node_id.unwrap(), node_a_id);
-			assert_eq!(*via_channel_ids, [(channel_id, Some(42))]);
+			assert_eq!(*receiving_channel_ids, [(channel_id, Some(42))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage, payment_secret, ..

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -960,7 +960,7 @@ impl ClaimablePayment {
 	/// Returns the inbound `(channel_id, user_channel_id)` pairs for all HTLCs associated with the payment.
 	///
 	/// Note: The `user_channel_id` will be `None` for HTLCs created using LDK version 0.0.117 or prior.
-	fn via_channel_ids(&self) -> Vec<(ChannelId, Option<u128>)> {
+	fn receiving_channel_ids(&self) -> Vec<(ChannelId, Option<u128>)> {
 		self.htlcs
 			.iter()
 			.map(|htlc| (htlc.prev_hop.channel_id, htlc.prev_hop.user_channel_id))
@@ -7168,7 +7168,7 @@ where
 									purpose: $purpose,
 									amount_msat,
 									counterparty_skimmed_fee_msat,
-									via_channel_ids: claimable_payment.via_channel_ids(),
+									receiving_channel_ids: claimable_payment.receiving_channel_ids(),
 									claim_deadline: Some(earliest_expiry - HTLC_FAIL_BACK_BUFFER),
 									onion_fields: claimable_payment.onion_fields.clone(),
 									payment_id: Some(payment_id),

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -3357,7 +3357,7 @@ pub fn do_pass_along_path<'a, 'b, 'c>(args: PassAlongPathArgs) -> Option<Event> 
 						ref purpose,
 						amount_msat,
 						receiver_node_id,
-						ref via_channel_ids,
+						ref receiving_channel_ids,
 						claim_deadline,
 						onion_fields,
 						..
@@ -3421,7 +3421,7 @@ pub fn do_pass_along_path<'a, 'b, 'c>(args: PassAlongPathArgs) -> Option<Event> 
 						}
 						assert_eq!(*amount_msat, recv_value);
 						let channels = node.node.list_channels();
-						for (chan_id, user_chan_id) in via_channel_ids {
+						for (chan_id, user_chan_id) in receiving_channel_ids {
 							let chan = channels
 								.iter()
 								.find(|details| &details.channel_id == chan_id)

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -3174,13 +3174,13 @@ fn do_test_drop_messages_peer_disconnect(messages_delivered: u8, simulate_broken
 			ref purpose,
 			amount_msat,
 			receiver_node_id,
-			ref via_channel_ids,
+			ref receiving_channel_ids,
 			..
 		} => {
 			assert_eq!(payment_hash_1, *payment_hash);
 			assert_eq!(amount_msat, 1_000_000);
 			assert_eq!(receiver_node_id.unwrap(), node_b_id);
-			assert_eq!(*via_channel_ids, vec![(channel_id, Some(user_channel_id))]);
+			assert_eq!(*receiving_channel_ids, vec![(channel_id, Some(user_channel_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage, payment_secret, ..

--- a/lightning/src/ln/htlc_reserve_unit_tests.rs
+++ b/lightning/src/ln/htlc_reserve_unit_tests.rs
@@ -375,13 +375,13 @@ pub fn test_channel_reserve_holding_cell_htlcs() {
 			ref purpose,
 			amount_msat,
 			receiver_node_id,
-			ref via_channel_ids,
+			ref receiving_channel_ids,
 			..
 		} => {
 			assert_eq!(our_payment_hash_21, *payment_hash);
 			assert_eq!(recv_value_21, amount_msat);
 			assert_eq!(node_c_id, receiver_node_id.unwrap());
-			assert_eq!(*via_channel_ids, vec![(chan_2.2, Some(chan_2_user_id))]);
+			assert_eq!(*receiving_channel_ids, vec![(chan_2.2, Some(chan_2_user_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage, payment_secret, ..
@@ -400,13 +400,13 @@ pub fn test_channel_reserve_holding_cell_htlcs() {
 			ref purpose,
 			amount_msat,
 			receiver_node_id,
-			ref via_channel_ids,
+			ref receiving_channel_ids,
 			..
 		} => {
 			assert_eq!(our_payment_hash_22, *payment_hash);
 			assert_eq!(recv_value_22, amount_msat);
 			assert_eq!(node_c_id, receiver_node_id.unwrap());
-			assert_eq!(*via_channel_ids, vec![(chan_2.2, Some(chan_2_user_id))]);
+			assert_eq!(*receiving_channel_ids, vec![(chan_2.2, Some(chan_2_user_id))]);
 			match &purpose {
 				PaymentPurpose::Bolt11InvoicePayment {
 					payment_preimage, payment_secret, ..


### PR DESCRIPTION
In 60540f70c5dc8bb4db9691178d2de703f0c42a47 we renamed `Event::PaymentClaimable::inbound_channel_ids` back to `via_channel_ids` which was changed in
c62aa23b7919d62f49bceb7ce1f87967fc5de077. However, it was pointed out that while `inbound_channel_ids` was confusing, so was `via_channel_ids` (which can be easily interpreted as the hops that a payment took, rather than the last hops it took to get to us in an MPP payment).

Thus, here, we rename it yet again to `receiving_channel_ids`, which is hopefully less ambiguous.