### PR TITLE
Split out `receive_htlcs` from the forwarding pipeline

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2557,6 +2557,8 @@ pub struct ChannelManager<
 
 	/// SCID/SCID Alias -> forward infos.
 	///
+	/// Note that key of 0 means it's a trampoline payment.
+	///
 	/// Note that because we may have an SCID Alias as the key we can have two entries per channel,
 	/// though in practice we probably won't be receiving HTLCs for a channel both via the alias
 	/// and via the classic SCID.

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -1553,6 +1553,7 @@ fn test_overshoot_final_cltv() {
 	commitment_signed_dance!(nodes[1], nodes[0], &update_0.commitment_signed, false, true);
 
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
+	nodes[1].node.process_pending_update_add_htlcs();
 	for (_, pending_forwards) in nodes[1].node.forward_htlcs.lock().unwrap().iter_mut() {
 		for f in pending_forwards.iter_mut() {
 			match f {

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -636,8 +636,8 @@ fn test_reject_mpp_keysend_htlc_mismatching_secret() {
 	nodes[3].node.process_pending_update_add_htlcs();
 
 	assert!(nodes[3].node.get_and_clear_pending_msg_events().is_empty());
-	assert_eq!(nodes[3].node.forward_htlcs.lock().unwrap().len(), 1);
-	match nodes[3].node.forward_htlcs.lock().unwrap().get_mut(&0).unwrap().get_mut(0).unwrap() {
+	assert_eq!(nodes[3].node.receive_htlcs.lock().unwrap().len(), 1);
+	match nodes[3].node.receive_htlcs.lock().unwrap().get_mut(0).unwrap() {
 		&mut HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo { ref mut forward_info, .. }) => {
 			match forward_info.routing {
 				PendingHTLCRouting::ReceiveKeysend { ref mut payment_data, .. } => {
@@ -683,8 +683,8 @@ fn test_reject_mpp_keysend_htlc_mismatching_secret() {
 	assert!(nodes[3].node.get_and_clear_pending_events().is_empty());
 	assert!(nodes[3].node.get_and_clear_pending_msg_events().is_empty());
 	nodes[3].node.process_pending_update_add_htlcs();
-	assert_eq!(nodes[3].node.forward_htlcs.lock().unwrap().len(), 1);
-	match nodes[3].node.forward_htlcs.lock().unwrap().get_mut(&0).unwrap().get_mut(0).unwrap() {
+	assert_eq!(nodes[3].node.receive_htlcs.lock().unwrap().len(), 1);
+	match nodes[3].node.receive_htlcs.lock().unwrap().get_mut(0).unwrap() {
 		&mut HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo { ref mut forward_info, .. }) => {
 			match forward_info.routing {
 				PendingHTLCRouting::ReceiveKeysend { ref mut payment_data, .. } => {

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -636,12 +636,14 @@ fn test_reject_mpp_keysend_htlc_mismatching_secret() {
 	nodes[3].node.process_pending_update_add_htlcs();
 
 	assert!(nodes[3].node.get_and_clear_pending_msg_events().is_empty());
-	for (_, pending_forwards) in nodes[3].node.forward_htlcs.lock().unwrap().iter_mut() {
-		for f in pending_forwards.iter_mut() {
-			match f {
-				&mut HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo {
-					ref mut forward_info, ..
-				}) => match forward_info.routing {
+	assert_eq!(nodes[3].node.forward_htlcs.lock().unwrap().len(), 1);
+	if let Some((_, pending_forwards)) =
+		nodes[3].node.forward_htlcs.lock().unwrap().iter_mut().next()
+	{
+		assert_eq!(pending_forwards.len(), 1);
+		match pending_forwards.get_mut(0).unwrap() {
+			&mut HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo { ref mut forward_info, .. }) => {
+				match forward_info.routing {
 					PendingHTLCRouting::ReceiveKeysend { ref mut payment_data, .. } => {
 						*payment_data = Some(msgs::FinalOnionHopData {
 							payment_secret: PaymentSecret([42; 32]),
@@ -649,11 +651,15 @@ fn test_reject_mpp_keysend_htlc_mismatching_secret() {
 						});
 					},
 					_ => panic!("Expected PendingHTLCRouting::ReceiveKeysend"),
-				},
-				_ => {},
-			}
+				}
+			},
+			_ => {
+				panic!("Unexpected HTLCForwardInfo");
+			},
 		}
-	}
+	} else {
+		panic!("Expected pending receive");
+	};
 	nodes[3].node.process_pending_htlc_forwards();
 
 	// Pay along nodes[2]
@@ -685,26 +691,30 @@ fn test_reject_mpp_keysend_htlc_mismatching_secret() {
 	nodes[3].node.process_pending_update_add_htlcs();
 
 	assert!(nodes[3].node.get_and_clear_pending_msg_events().is_empty());
-	for (_, pending_forwards) in nodes[3].node.forward_htlcs.lock().unwrap().iter_mut() {
-		for f in pending_forwards.iter_mut() {
-			match f {
-				&mut HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo {
-					ref mut forward_info, ..
-				}) => {
-					match forward_info.routing {
-						PendingHTLCRouting::ReceiveKeysend { ref mut payment_data, .. } => {
-							*payment_data = Some(msgs::FinalOnionHopData {
-								payment_secret: PaymentSecret([43; 32]), // Doesn't match the secret used above
-								total_msat: amount * 2,
-							});
-						},
-						_ => panic!("Expected PendingHTLCRouting::ReceiveKeysend"),
-					}
-				},
-				_ => {},
-			}
+	assert_eq!(nodes[3].node.forward_htlcs.lock().unwrap().len(), 1);
+	if let Some((_, pending_forwards)) =
+		nodes[3].node.forward_htlcs.lock().unwrap().iter_mut().next()
+	{
+		assert_eq!(pending_forwards.len(), 1);
+		match pending_forwards.get_mut(0).unwrap() {
+			&mut HTLCForwardInfo::AddHTLC(PendingAddHTLCInfo { ref mut forward_info, .. }) => {
+				match forward_info.routing {
+					PendingHTLCRouting::ReceiveKeysend { ref mut payment_data, .. } => {
+						*payment_data = Some(msgs::FinalOnionHopData {
+							payment_secret: PaymentSecret([43; 32]), // Doesn't match the secret used above
+							total_msat: amount * 2,
+						});
+					},
+					_ => panic!("Expected PendingHTLCRouting::ReceiveKeysend"),
+				}
+			},
+			_ => {
+				panic!("Unexpected HTLCForwardInfo");
+			},
 		}
-	}
+	} else {
+		panic!("Expected pending receive");
+	};
 	nodes[3].node.process_pending_htlc_forwards();
 	let fail_type = HTLCHandlingFailureType::Receive { payment_hash };
 	expect_and_process_pending_htlcs_and_htlc_handling_failed(&nodes[3], &[fail_type]);


### PR DESCRIPTION
This is another preparatory step for receiver-side delays that we split out to err on the side of smaller, more reviewable PRs, especially since these changes are a nice cleanup in any case, IMO.

Previously, we'd store receiving HTLCs side-by-side with HTLCs forwards in the `forwards_htlcs` map under SCID 0.
Here, we opt to split out a separate `receive_htlcs` field which cleans up the logic, also omitting the 0 magic value.

Moreover, some of the tests manipulating `forward_htlcs` were previously just iterating, but not actually checking whether the expected entries were present and they were actually changed. Here we make these test cases stricter to ensure they'd able to catch any unwanted behavior we'd introduce while introducing  `receive_htlcs`.