### PR TITLE
Trampoline Forwarding: Enforce trampoline constraints

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5091,7 +5091,7 @@ where
 		)
 	}
 
-	#[cfg(all(test, async_payments))]
+	#[cfg(all(test))]
 	pub(crate) fn test_modify_pending_payment<Fn>(&self, payment_id: &PaymentId, mut callback: Fn)
 	where
 		Fn: FnMut(&mut PendingOutboundPayment),

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -22,6 +22,7 @@ use crate::sign::{NodeSigner, Recipient};
 use crate::types::features::BlindedHopFeatures;
 use crate::types::payment::PaymentHash;
 use crate::util::logger::Logger;
+use crate::util::ser::Writeable;
 
 #[allow(unused_imports)]
 use crate::prelude::*;
@@ -72,6 +73,24 @@ fn check_blinded_forward(
 
 	if features.requires_unknown_bits_from(&BlindedHopFeatures::empty()) { return Err(()) }
 	Ok((amt_to_forward, outgoing_cltv_value))
+}
+
+fn check_trampoline_onion_constraints(
+	outer_hop_data: &msgs::InboundTrampolineEntrypointPayload, trampoline_cltv_value: u32,
+	trampoline_amount: u64,
+) -> Result<(), LocalHTLCFailureReason> {
+	if outer_hop_data.outgoing_cltv_value < trampoline_cltv_value {
+		return Err(LocalHTLCFailureReason::FinalIncorrectCLTVExpiry);
+	}
+	let outgoing_amount = outer_hop_data
+		.multipath_trampoline_data
+		.as_ref()
+		.map_or(outer_hop_data.amt_to_forward, |mtd| mtd.total_msat);
+	if outgoing_amount < trampoline_amount {
+		return Err(LocalHTLCFailureReason::FinalIncorrectHTLCAmount);
+	}
+
+	Ok(())
 }
 
 enum RoutingInfo {
@@ -135,7 +154,25 @@ pub(super) fn create_fwd_pending_htlc_info(
 				reason: LocalHTLCFailureReason::InvalidOnionPayload,
 				err_data: Vec::new(),
 			}),
-		onion_utils::Hop::TrampolineForward { next_trampoline_hop_data, next_trampoline_hop_hmac, new_trampoline_packet_bytes, trampoline_shared_secret, .. } => {
+		onion_utils::Hop::TrampolineForward { ref outer_hop_data, next_trampoline_hop_data, next_trampoline_hop_hmac, new_trampoline_packet_bytes, trampoline_shared_secret, .. } => {
+			check_trampoline_onion_constraints(outer_hop_data, next_trampoline_hop_data.outgoing_cltv_value, next_trampoline_hop_data.amt_to_forward).map_err(|reason| {
+				let mut err_data = Vec::new();
+				match reason {
+					LocalHTLCFailureReason::FinalIncorrectCLTVExpiry => {
+						outer_hop_data.outgoing_cltv_value.write(&mut err_data).unwrap();
+					}
+					LocalHTLCFailureReason::FinalIncorrectHTLCAmount => {
+						outer_hop_data.amt_to_forward.write(&mut err_data).unwrap();
+					}
+					_ => unreachable!()
+				}
+				// The Trampoline onion's amt and CLTV values cannot exceed the outer onion's
+				InboundHTLCErr {
+					reason,
+					err_data,
+					msg: "Underflow calculating outbound amount or CLTV value for Trampoline forward",
+				}
+			})?;
 			(
 				RoutingInfo::Trampoline {
 					next_trampoline: next_trampoline_hop_data.next_trampoline,
@@ -150,7 +187,7 @@ pub(super) fn create_fwd_pending_htlc_info(
 				None
 			)
 		},
-		onion_utils::Hop::TrampolineBlindedForward { outer_hop_data, next_trampoline_hop_data, next_trampoline_hop_hmac, new_trampoline_packet_bytes, trampoline_shared_secret, .. } => {
+		onion_utils::Hop::TrampolineBlindedForward { ref outer_hop_data, next_trampoline_hop_data, next_trampoline_hop_hmac, new_trampoline_packet_bytes, trampoline_shared_secret, .. } => {
 			let (amt_to_forward, outgoing_cltv_value) = check_blinded_forward(
 				msg.amount_msat, msg.cltv_expiry, &next_trampoline_hop_data.payment_relay, &next_trampoline_hop_data.payment_constraints, &next_trampoline_hop_data.features
 			).map_err(|()| {
@@ -160,6 +197,15 @@ pub(super) fn create_fwd_pending_htlc_info(
 					msg: "Underflow calculating outbound amount or cltv value for blinded forward",
 					reason: LocalHTLCFailureReason::InvalidOnionBlinding,
 					err_data: vec![0; 32],
+				}
+			})?;
+			check_trampoline_onion_constraints(outer_hop_data, outgoing_cltv_value, amt_to_forward).map_err(|_| {
+				// The Trampoline onion's amt and CLTV values cannot exceed the outer onion's, but
+				// we're inside a blinded path
+				InboundHTLCErr {
+					reason: LocalHTLCFailureReason::InvalidOnionBlinding,
+					err_data: vec![0; 32],
+					msg: "Underflow calculating outbound amount or CLTV value for Trampoline forward",
 				}
 			})?;
 			(
@@ -281,14 +327,35 @@ pub(super) fn create_recv_pending_htlc_info(
 			 intro_node_blinding_point.is_none(), true, invoice_request)
 		}
 		onion_utils::Hop::TrampolineReceive {
+			ref outer_hop_data,
 			trampoline_hop_data: msgs::InboundOnionReceivePayload {
 				payment_data, keysend_preimage, custom_tlvs, sender_intended_htlc_amt_msat,
 				cltv_expiry_height, payment_metadata, ..
 			}, ..
-		} =>
+		} => {
+			check_trampoline_onion_constraints(outer_hop_data, cltv_expiry_height, sender_intended_htlc_amt_msat).map_err(|reason| {
+				let mut err_data = Vec::new();
+				match reason {
+					LocalHTLCFailureReason::FinalIncorrectCLTVExpiry => {
+						outer_hop_data.outgoing_cltv_value.write(&mut err_data).unwrap();
+					}
+					LocalHTLCFailureReason::FinalIncorrectHTLCAmount => {
+						outer_hop_data.amt_to_forward.write(&mut err_data).unwrap();
+					}
+					_ => unreachable!()
+				}
+				// The Trampoline onion's amt and CLTV values cannot exceed the outer onion's
+				InboundHTLCErr {
+					reason,
+					err_data,
+					msg: "Underflow calculating skimmable amount or CLTV value for Trampoline receive",
+				}
+			})?;
 			(payment_data, keysend_preimage, custom_tlvs, sender_intended_htlc_amt_msat,
-				cltv_expiry_height, payment_metadata, None, false, keysend_preimage.is_none(), None),
+				cltv_expiry_height, payment_metadata, None, false, keysend_preimage.is_none(), None)
+		}
 		onion_utils::Hop::TrampolineBlindedReceive {
+			ref outer_hop_data,
 			trampoline_hop_data: msgs::InboundOnionBlindedReceivePayload {
 				sender_intended_htlc_amt_msat, total_msat, cltv_expiry_height, payment_secret,
 				intro_node_blinding_point, payment_constraints, payment_context, keysend_preimage,
@@ -306,6 +373,15 @@ pub(super) fn create_recv_pending_htlc_info(
 					}
 				})?;
 			let payment_data = msgs::FinalOnionHopData { payment_secret, total_msat };
+			check_trampoline_onion_constraints(outer_hop_data, cltv_expiry_height, sender_intended_htlc_amt_msat).map_err(|_| {
+				// The Trampoline onion's amt and CLTV values cannot exceed the outer onion's, but
+				// we're inside a blinded path
+				InboundHTLCErr {
+					reason: LocalHTLCFailureReason::InvalidOnionBlinding,
+					err_data: vec![0; 32],
+					msg: "Underflow calculating skimmable amount or CLTV value for Trampoline receive",
+				}
+			})?;
 			(Some(payment_data), keysend_preimage, custom_tlvs,
 				sender_intended_htlc_amt_msat, cltv_expiry_height, None, Some(payment_context),
 				intro_node_blinding_point.is_none(), true, invoice_request)
@@ -593,6 +669,25 @@ where
 			})
 		}
 		onion_utils::Hop::TrampolineForward { next_trampoline_hop_data: msgs::InboundTrampolineForwardPayload { amt_to_forward, outgoing_cltv_value, next_trampoline }, trampoline_shared_secret, incoming_trampoline_public_key, .. } => {
+			let next_trampoline_packet_pubkey = onion_utils::next_hop_pubkey(secp_ctx,
+				incoming_trampoline_public_key, &trampoline_shared_secret.secret_bytes());
+			Some(NextPacketDetails {
+				next_packet_pubkey: next_trampoline_packet_pubkey,
+				outgoing_connector: HopConnector::Trampoline(next_trampoline),
+				outgoing_amt_msat: amt_to_forward,
+				outgoing_cltv_value,
+			})
+		}
+		onion_utils::Hop::TrampolineBlindedForward { next_trampoline_hop_data: msgs::InboundTrampolineBlindedForwardPayload { next_trampoline, ref payment_relay, ref payment_constraints, ref features, .. }, outer_shared_secret, trampoline_shared_secret, incoming_trampoline_public_key, .. } => {
+			let (amt_to_forward, outgoing_cltv_value) = match check_blinded_forward(
+				msg.amount_msat, msg.cltv_expiry, &payment_relay, &payment_constraints, &features
+			) {
+				Ok((amt, cltv)) => (amt, cltv),
+				Err(()) => {
+					return encode_relay_error("Underflow calculating outbound amount or cltv value for blinded forward",
+						LocalHTLCFailureReason::InvalidOnionBlinding, outer_shared_secret.secret_bytes(), Some(trampoline_shared_secret.secret_bytes()), &[0; 32]);
+				}
+			};
 			let next_trampoline_packet_pubkey = onion_utils::next_hop_pubkey(secp_ctx,
 				incoming_trampoline_public_key, &trampoline_shared_secret.secret_bytes());
 			Some(NextPacketDetails {

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1678,6 +1678,13 @@ pub enum LocalHTLCFailureReason {
 	HTLCMaximum,
 	/// The HTLC was failed because our remote peer is offline.
 	PeerOffline,
+	/// We have been unable to forward a payment to the next Trampoline node but may be able to
+	/// do it later.
+	TemporaryTrampolineFailure,
+	/// The amount or CLTV expiry were insufficient to route the payment to the next Trampoline.
+	TrampolineFeeOrExpiryInsufficient,
+	/// The specified next Trampoline node cannot be reached from our node.
+	UnkonwnNextTrampoline,
 }
 
 impl LocalHTLCFailureReason {
@@ -1718,6 +1725,9 @@ impl LocalHTLCFailureReason {
 			Self::InvalidOnionPayload | Self::InvalidTrampolinePayload => PERM | 22,
 			Self::MPPTimeout => 23,
 			Self::InvalidOnionBlinding => BADONION | PERM | 24,
+			Self::TemporaryTrampolineFailure => PERM | 25,
+			Self::TrampolineFeeOrExpiryInsufficient => PERM | 26,
+			Self::UnkonwnNextTrampoline => PERM | 27,
 			Self::UnknownFailureCode { code } => *code,
 		}
 	}
@@ -1852,6 +1862,9 @@ impl_writeable_tlv_based_enum!(LocalHTLCFailureReason,
 	(79, HTLCMinimum) => {},
 	(81, HTLCMaximum) => {},
 	(83, PeerOffline) => {},
+	(85, TemporaryTrampolineFailure) => {},
+	(87, TrampolineFeeOrExpiryInsufficient) => {},
+	(89, UnkonwnNextTrampoline) => {},
 );
 
 impl From<&HTLCFailReason> for HTLCHandlingFailureReason {
@@ -2018,6 +2031,11 @@ impl HTLCFailReason {
 					debug_assert!(false, "Unknown failure code: {}", code)
 				}
 			},
+			LocalHTLCFailureReason::TemporaryTrampolineFailure => debug_assert!(data.is_empty()),
+			LocalHTLCFailureReason::TrampolineFeeOrExpiryInsufficient => {
+				debug_assert!(data.is_empty())
+			},
+			LocalHTLCFailureReason::UnkonwnNextTrampoline => debug_assert!(data.is_empty()),
 		}
 
 		Self(HTLCFailReasonRepr::Reason { data, failure_reason })


### PR DESCRIPTION
This PR is part of 1/N PRs in order to split up #3976

 This commit checks amount and CLTV of the trampoline to the outer hop. If exceeds limitations we fail the forward using a `InboundHTLCErr` with specified local reason.