### PR TITLE
Detect and fail-back monitor-blocked un-forwarded HTLCs at close

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -5340,6 +5340,50 @@ where
 				_ => {},
 			}
 		}
+
+		// Once we're closed, the `ChannelMonitor` is responsible for resolving any remaining
+		// HTLCs. However, in the specific case of us pushing new HTLC(s) to the counterparty in
+		// the latest commitment transaction that we haven't actually sent due to a block
+		// `ChannelMonitorUpdate`, we may have some HTLCs that the `ChannelMonitor` won't know
+		// about and thus really need to be included in `dropped_outbound_htlcs`.
+		'htlc_iter: for htlc in self.pending_outbound_htlcs.iter() {
+			if let OutboundHTLCState::LocalAnnounced(_) = htlc.state {
+				for update in self.blocked_monitor_updates.iter() {
+					for update in update.update.updates.iter() {
+						let have_htlc = match update {
+							ChannelMonitorUpdateStep::LatestCounterpartyCommitment {
+								htlc_data,
+								..
+							} => {
+								let dust =
+									htlc_data.dust_htlcs.iter().map(|(_, source)| source.as_ref());
+								let nondust =
+									htlc_data.nondust_htlc_sources.iter().map(|s| Some(s));
+								dust.chain(nondust).any(|source| source == Some(&htlc.source))
+							},
+							ChannelMonitorUpdateStep::LatestCounterpartyCommitmentTXInfo {
+								htlc_outputs,
+								..
+							} => htlc_outputs.iter().any(|(_, source)| {
+								source.as_ref().map(|s| &**s) == Some(&htlc.source)
+							}),
+							_ => continue,
+						};
+						debug_assert!(have_htlc);
+						if have_htlc {
+							dropped_outbound_htlcs.push((
+								htlc.source.clone(),
+								htlc.payment_hash,
+								counterparty_node_id,
+								self.channel_id,
+							));
+						}
+						continue 'htlc_iter;
+					}
+				}
+			}
+		}
+
 		let monitor_update = if let Some(funding_txo) = funding.get_funding_txo() {
 			// If we haven't yet exchanged funding signatures (ie channel_state < AwaitingChannelReady),
 			// returning a channel monitor update here would imply a channel monitor update before


### PR DESCRIPTION
If we have pending HTLCs which we intended to forward, but which were waiting on a `ChannelMonitorUpdate` to be forwarded when we closed, they will neither be in the `ChannelMonitor` nor in the `Channel` in a state which indicates they need to be failed (i.e. in the holding cell). As a result, we previously did not fail such HTLCs back. Note that the catch-all
fail-back-before-channel-closure logic is run by the ChannelMonitor so is also unaware of these HTLCs.

Here we fix this by detecting the specific case - HTLCs which are in `LocalSent` (i.e. the counterparty has not provided an RAA yet) and we have a blocked `ChannelMonitorUpdate` containing a remote commitment transaction update (which will always contain the HTLC).

In such a case, we can be confident the counterparty does not have a commitment transaction containing the HTLC, and can fail it back immediately.