### PR TITLE
Bump `electrum-client` to v0.24.0

### DIFF
--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -36,15 +36,15 @@ lightning-macros = { version = "0.2", path = "../lightning-macros", default-feat
 bitcoin = { version = "0.32.2", default-features = false }
 futures = { version = "0.3", optional = true }
 esplora-client = { version = "0.12", default-features = false, optional = true }
-electrum-client = { version = "0.23.1", optional = true, default-features = false, features = ["proxy"] }
+electrum-client = { version = "0.24.0", optional = true, default-features = false, features = ["proxy"] }
 
 [dev-dependencies]
 lightning = { version = "0.2.0", path = "../lightning", default-features = false, features = ["std", "_test_utils"] }
 tokio = { version = "1.35.0", features = ["macros"] }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
-electrsd = { version = "0.34.0", default-features = false, features = ["legacy"] }
-corepc-node = { version = "0.7.0", default-features = false, features = ["28_0"] }
+electrsd = { version = "0.35.0", default-features = false, features = ["legacy"] }
+corepc-node = { version = "0.8.0", default-features = false, features = ["28_0"] }
 
 [lints.rust.unexpected_cfgs]
 level = "forbid"


### PR DESCRIPTION
We bump the `electrum-client` dependency to the recently-introduced version v0.24.0.