### PR TITLE
Add LSPS5 DOS protections.

### DIFF
--- a/lightning-liquidity/src/lsps1/service.rs
+++ b/lightning-liquidity/src/lsps1/service.rs
@@ -174,6 +174,20 @@ where
 		&self.config
 	}
 
+	/// Returns whether the peer currently has any active LSPS1 order flows.
+	///
+	/// An order is considered active only after we have validated the client's
+	/// `CreateOrder` request and replied with a `CreateOrder` response containing
+	/// an `order_id`.
+	/// Pending requests that are still awaiting our response are deliberately NOT counted.
+	pub(crate) fn has_active_requests(&self, counterparty_node_id: &PublicKey) -> bool {
+		let outer_state_lock = self.per_peer_state.read().unwrap();
+		outer_state_lock.get(counterparty_node_id).map_or(false, |inner| {
+			let peer_state = inner.lock().unwrap();
+			!peer_state.outbound_channels_by_order_id.is_empty()
+		})
+	}
+
 	fn handle_get_info_request(
 		&self, request_id: LSPSRequestId, counterparty_node_id: &PublicKey,
 	) -> Result<(), LightningError> {

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -566,6 +566,15 @@ where
 		&self.config
 	}
 
+	/// Returns whether the peer has any active LSPS2 requests.
+	pub(crate) fn has_active_requests(&self, counterparty_node_id: &PublicKey) -> bool {
+		let outer_state_lock = self.per_peer_state.read().unwrap();
+		outer_state_lock.get(counterparty_node_id).map_or(false, |inner| {
+			let peer_state = inner.lock().unwrap();
+			!peer_state.outbound_channels_by_intercept_scid.is_empty()
+		})
+	}
+
 	/// Used by LSP to inform a client requesting a JIT Channel the token they used is invalid.
 	///
 	/// Should be called in response to receiving a [`LSPS2ServiceEvent::GetInfo`] event.

--- a/lightning-liquidity/src/lsps5/client.rs
+++ b/lightning-liquidity/src/lsps5/client.rs
@@ -185,6 +185,9 @@ where
 	/// Also ensure the URL is valid, has HTTPS protocol, its length does not exceed [`MAX_WEBHOOK_URL_LENGTH`]
 	/// and that the URL points to a public host.
 	///
+	/// Your request may fail if you recently opened a channel or started an LSPS1 / LSPS2 flow.
+	/// Please retry shortly.
+	///
 	/// [`MAX_WEBHOOK_URL_LENGTH`]: super::msgs::MAX_WEBHOOK_URL_LENGTH
 	/// [`MAX_APP_NAME_LENGTH`]: super::msgs::MAX_APP_NAME_LENGTH
 	/// [`WebhookRegistered`]: super::event::LSPS5ClientEvent::WebhookRegistered


### PR DESCRIPTION
When handling an incoming LSPS5 request, the manager will check
if the counterparty is 'engaged' in some way before responding.
`Engaged` meaning = active channel | LSPS2 active operation | LSPS1 active operation.

Logic: `If not engaged then reject request;`

A single test is added only checking for the active channel condition,
because it's not super easy to get LSPS1-2 on the correct state to check this (yet).
Other tangential work is happening that will make this easier and more tests will come in the near future.

~~A few decisions that could be changed:~~

~~- the DOS protections are optional (default true). maybe this should not be configurable?~~
~~- I made the `dos_protection_enforcer` generic _enough_ so it would be possible to add more behavior in the future. also some logic could be moved here like the `ignored_peers` logic from the manager, which could make sense to move to the dos enforcer~~

thoughts @tnull ?