### PR TITLE
Add a method to avoid re-persisting monitors during startup

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -825,6 +825,53 @@ where
 
 		self.pending_send_only_events.lock().unwrap().push(send_peer_storage_event)
 	}
+
+	/// Loads a [`ChannelMonitor`] which already exists on disk after startup.
+	///
+	/// Using this over [`chain::Watch::watch_channel`] avoids re-persisting a [`ChannelMonitor`]
+	/// that hasn't changed, slowing down startup.
+	///
+	/// Note that this method *can* be used if additional blocks were replayed against the
+	/// [`ChannelMonitor`] or if a [`ChannelMonitorUpdate`] loaded from disk was replayed such that
+	/// it will replayed on startup, and in general can only *not* be used if you directly accessed
+	/// the [`ChannelMonitor`] and changed its state in some way that will not be replayed again on
+	/// a restart. Such direct access should generally never occur for most LDK-based nodes.
+	///
+	/// For [`ChannelMonitor`]s which were last serialized by an LDK version prior to 0.1 this will
+	/// fall back to calling [`chain::Watch::watch_channel`] and persisting the [`ChannelMonitor`].
+	/// See the release notes for LDK 0.1 for more information on this requirement.
+	///
+	/// [`ChannelMonitor`]s which do not need to be persisted (i.e. were last written by LDK 0.1 or
+	/// later) will be loaded without persistence and this method will return
+	/// [`ChannelMonitorUpdateStatus::Completed`].
+	pub fn load_existing_monitor(
+		&self, channel_id: ChannelId, monitor: ChannelMonitor<ChannelSigner>,
+	) -> Result<ChannelMonitorUpdateStatus, ()> {
+		if !monitor.written_by_0_1_or_later() {
+			return chain::Watch::watch_channel(self, channel_id, monitor);
+		}
+
+		let logger = WithChannelMonitor::from(&self.logger, &monitor, None);
+		let mut monitors = self.monitors.write().unwrap();
+		let entry = match monitors.entry(channel_id) {
+			hash_map::Entry::Occupied(_) => {
+				log_error!(logger, "Failed to add new channel data: channel monitor for given channel ID is already present");
+				return Err(());
+			},
+			hash_map::Entry::Vacant(e) => e,
+		};
+		log_trace!(
+			logger,
+			"Loaded existing ChannelMonitor for channel {}",
+			log_funding_info!(monitor)
+		);
+		if let Some(ref chain_source) = self.chain_source {
+			monitor.load_outputs_to_watch(chain_source, &self.logger);
+		}
+		entry.insert(MonitorHolder { monitor, pending_monitor_updates: Mutex::new(Vec::new()) });
+
+		Ok(ChannelMonitorUpdateStatus::Completed)
+	}
 }
 
 impl<

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1300,6 +1300,11 @@ pub(crate) struct ChannelMonitorImpl<Signer: EcdsaChannelSigner> {
 	// found at `Self::funding`. We don't use the term "renegotiated", as the currently locked
 	// `FundingScope` could be one that was renegotiated.
 	alternative_funding_confirmed: Option<(Txid, u32)>,
+
+	/// [`ChannelMonitor`]s written by LDK prior to 0.1 need to be re-persisted after startup. To
+	/// make deciding whether to do so simple, here we track whether this monitor was last written
+	/// prior to 0.1.
+	written_by_0_1_or_later: bool,
 }
 
 // Macro helper to access holder commitment HTLC data (including both non-dust and dust) while
@@ -1803,6 +1808,8 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 			prev_holder_htlc_data: None,
 
 			alternative_funding_confirmed: None,
+
+			written_by_0_1_or_later: true,
 		})
 	}
 
@@ -1934,6 +1941,10 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 	/// Gets the funding transaction outpoint of the channel this ChannelMonitor is monitoring for.
 	pub fn get_funding_txo(&self) -> OutPoint {
 		self.inner.lock().unwrap().get_funding_txo()
+	}
+
+	pub(crate) fn written_by_0_1_or_later(&self) -> bool {
+		self.inner.lock().unwrap().written_by_0_1_or_later
 	}
 
 	/// Gets the funding script of the channel this ChannelMonitor is monitoring for.
@@ -6080,6 +6091,9 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			(32, pending_funding, optional_vec),
 			(34, alternative_funding_confirmed, option),
 		});
+		// Note that `payment_preimages_with_info` was added (and is always written) in LDK 0.1, so
+		// we can use it to determine if this monitor was last written by LDK 0.1 or later.
+		let written_by_0_1_or_later = payment_preimages_with_info.is_some();
 		if let Some(payment_preimages_with_info) = payment_preimages_with_info {
 			if payment_preimages_with_info.len() != payment_preimages.len() {
 				return Err(DecodeError::InvalidValue);
@@ -6250,6 +6264,8 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			prev_holder_htlc_data,
 
 			alternative_funding_confirmed,
+
+			written_by_0_1_or_later,
 		})))
 	}
 }

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -15396,9 +15396,13 @@ impl Readable for VecDeque<(Event, Option<EventCompletionAction>)> {
 ///    This is important if you have replayed a nontrivial number of blocks in step (4), allowing
 ///    you to avoid having to replay the same blocks if you shut down quickly after startup. It is
 ///    otherwise not required.
+///
 ///    Note that if you're using a [`ChainMonitor`] for your [`chain::Watch`] implementation, you
 ///    will likely accomplish this as a side-effect of calling [`chain::Watch::watch_channel`] in
 ///    the next step.
+///
+///    If you wish to avoid this for performance reasons, use
+///    [`ChainMonitor::load_existing_monitor`].
 /// 7) Move the [`ChannelMonitor`]s into your local [`chain::Watch`]. If you're using a
 ///    [`ChainMonitor`], this is done by calling [`chain::Watch::watch_channel`].
 ///
@@ -15413,6 +15417,7 @@ impl Readable for VecDeque<(Event, Option<EventCompletionAction>)> {
 /// which you've already broadcasted the transaction.
 ///
 /// [`ChainMonitor`]: crate::chain::chainmonitor::ChainMonitor
+/// [`ChainMonitor::load_existing_monitor`]: crate::chain::chainmonitor::ChainMonitor::load_existing_monitor
 pub struct ChannelManagerReadArgs<
 	'a,
 	M: Deref,

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1324,8 +1324,8 @@ pub fn _reload_node<'a, 'b, 'c>(
 	for monitor in monitors_read.drain(..) {
 		let channel_id = monitor.channel_id();
 		assert_eq!(
-			node.chain_monitor.watch_channel(channel_id, monitor),
-			Ok(ChannelMonitorUpdateStatus::Completed)
+			node.chain_monitor.load_existing_monitor(channel_id, monitor),
+			Ok(ChannelMonitorUpdateStatus::Completed),
 		);
 		check_added_monitors!(node, 1);
 	}


### PR DESCRIPTION
Prior to LDK 0.1, in rare cases we could replay payment claims to `ChannelMonitor`s on startup, which we then expected to be persisted prior to normal node operation. This required re-persisting `ChannelMonitor`s after deserializing the `ChannelManager`, delaying startup in some cases substantially.

In 0.1 we fixed this, moving claim replays to the background to run after the `ChannelManager` starts operating (and only updating/persisting changes to the `ChannelMonitor`s which need it). However, we didn't actually enable this meaningfully in our API - nearly all users use our `ChainMonitor` and the only way to get a chanel into `ChainMonitor` is through the normal flow which expects to persist.

Here we add a simple method to load `ChannelMonitor`s into the `ChainMonitor` without persisting them.


I'm kinda on the fence about backporting this. On the one hand its a pretty nontrivial speedup for users who switch to the new interface. On the other hand, it is a "feature" and its kinda weird to backport a feature.