### PR TITLE
Always emit bump events, even when fees are sufficient

### DIFF
--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -1051,6 +1051,9 @@ fn do_test_async_holder_signatures(anchors: bool, remote_commitment: bool) {
 			&nodes[0].logger,
 		);
 	}
+	if anchors {
+		handle_bump_close_event(closing_node);
+	}
 
 	let commitment_tx = {
 		let mut txn = closing_node.tx_broadcaster.txn_broadcast();


### PR DESCRIPTION
Currently, the anchor commitment bump events are bypassed when the commitment transaction has sufficient fees. However, this makes it difficult for users to defer force-closures to a trusted party (such as an LSP) while not maintaining reserves. Broadcasting a commitment transaction without maintaining reserves would make HTLCs unclaimable against that commitment transaction.

In this change, anchor commitment bump events will always be emitted so users can capture and choose not to process them.

Fixes #3496.