### PR TITLE
Make `full_stack_target` more stable in the face of LDK changes

### DIFF
--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -1626,10 +1626,10 @@ mod tests {
 	#[test]
 	fn test_no_existing_test_breakage() {
 		// To avoid accidentally causing all existing fuzz test cases to be useless by making minor
-		// changes (such as requesting feerate info in a new place), we run a pretty full
-		// step-through with two peers and HTLC forwarding here. Obviously this is pretty finicky,
-		// so this should be updated pretty liberally, but at least we'll know when changes occur.
-		// If nothing else, this test serves as a pretty great initial full_stack_target seed.
+		// changes, we run a pretty full step-through with two peers and HTLC forwarding here.
+		// Obviously this can be somewhat finicky, so this should be updated pretty liberally, but
+		// at least we'll know when changes occur. If nothing else, this test serves as a pretty
+		// great initial full_stack_target seed.
 
 		let test = super::two_peer_forwarding_seed();
 
@@ -1662,10 +1662,9 @@ mod tests {
 	#[test]
 	fn test_gossip_exchange_breakage() {
 		// To avoid accidentally causing all existing fuzz test cases to be useless by making minor
-		// changes (such as requesting feerate info in a new place), we exchange some gossip
-		// messages. Obviously this is pretty finicky, so this should be updated pretty liberally,
-		// but at least we'll know when changes occur.
-		// This test serves as a pretty good full_stack_target seed.
+		// changes, we exchange some gossip messages. Obviously this is somewhat finicky, so this
+		// should be updated pretty liberally, but at least we'll know when changes occur.
+		// This test serves as a helpful additional full_stack_target seed.
 
 		let test = super::gossip_exchange_seed();
 


### PR DESCRIPTION
We regularly make changes to LDK which results in changes to the `full_stack_target` input to reach a given codepath, invalidating existing fuzzing corpuses and breaking the `test_no_existing_test_breakage` test (which is somewhat annoying to fix). Instead of reading every time we get a fee estimate request or counting for RNG, use static values to ensure they're robust against changes in LDK that request more/less fee estimates or more/less RNG output.