### PR TITLE
offer: fix path validation to only require non-empty paths when issuer_id is missing

### DIFF
--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -1287,7 +1287,9 @@ impl TryFrom<FullOfferTlvStream> for OfferContents {
 
 		let (issuer_signing_pubkey, paths) = match (issuer_id, paths) {
 			(None, None) => return Err(Bolt12SemanticError::MissingIssuerSigningPubkey),
-			(_, Some(paths)) if paths.is_empty() => return Err(Bolt12SemanticError::MissingPaths),
+			(None, Some(paths)) if paths.is_empty() => {
+				return Err(Bolt12SemanticError::MissingPaths)
+			},
 			(issuer_id, paths) => (issuer_id, paths),
 		};
 
@@ -2001,6 +2003,7 @@ mod tests {
 		}
 
 		let mut builder = OfferBuilder::new(pubkey(42));
+		builder.offer.issuer_signing_pubkey = None;
 		builder.offer.paths = Some(vec![]);
 
 		let offer = builder.build().unwrap();


### PR DESCRIPTION
When an offer has an `issuer_id`, empty paths should be allowed since the `issuer_id` can be used for signing. Only when `issuer_id` is `None` should we require non-empty paths to extract the blinded node ID for signing.

Find through differential fuzzing where c-lightning is accepting an offer with empty `offer_paths` and with `issuer_id` while rust-lightning is rejecting it, even though it's a valid offer.

offer: `lno1zqqpyqtezcss8qpgggggggggggggggwjqgll03wgqgll03wgggg8ylllpgpqppqqq`