### PR TITLE
test: add test for offer parsing with empty paths and valid issuer

### DIFF
--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -2003,6 +2003,13 @@ mod tests {
 		}
 
 		let mut builder = OfferBuilder::new(pubkey(42));
+		builder.offer.paths = Some(vec![]);
+		let offer = builder.build().unwrap();
+		if let Err(e) = offer.to_string().parse::<Offer>() {
+			panic!("error parsing offer: {:?}", e);
+		}
+
+		let mut builder = OfferBuilder::new(pubkey(42));
 		builder.offer.issuer_signing_pubkey = None;
 		builder.offer.paths = Some(vec![]);
 


### PR DESCRIPTION
Verifies that offers with empty paths are accepted as long as the `issuer_id` is set.

Follow-up: #4018