### PR TITLE
Clean up and split up `is_pre_funded_state`

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -15242,7 +15242,7 @@ where
 				number_of_funded_channels += peer_state.channel_by_id
 					.values()
 					.filter_map(Channel::as_funded)
-					.filter(|chan| chan.context.is_funding_broadcast())
+					.filter(|chan| chan.context.can_resume_on_restart())
 					.count();
 			}
 
@@ -15254,7 +15254,7 @@ where
 				for channel in peer_state.channel_by_id
 					.values()
 					.filter_map(Channel::as_funded)
-					.filter(|channel| channel.context.is_funding_broadcast())
+					.filter(|channel| channel.context.can_resume_on_restart())
 				{
 					channel.write(writer)?;
 				}


### PR DESCRIPTION
This turns out to have been kinda buggy, and impossible to read the code, so clean it up a bunch.