### PR TITLE
Trampoline forwarding [2]:  HTLCSource variant refactors

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -2649,6 +2649,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 				let outbound_payment = match source {
 					None => panic!("Outbound HTLCs should have a source"),
 					Some(&HTLCSource::PreviousHopData(_)) => false,
+					Some(&HTLCSource::TrampolineForward { .. }) => false,
 					Some(&HTLCSource::OutboundRoute { .. }) => true,
 				};
 				return Some(Balance::MaybeTimeoutClaimableHTLC {
@@ -2858,6 +2859,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 					let outbound_payment = match source {
 						None => panic!("Outbound HTLCs should have a source"),
 						Some(HTLCSource::PreviousHopData(_)) => false,
+						Some(&HTLCSource::TrampolineForward { .. }) => false,
 						Some(HTLCSource::OutboundRoute { .. }) => true,
 					};
 					if outbound_payment {

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -545,6 +545,14 @@ pub enum HTLCHandlingFailureType {
 		/// Short channel id we are requesting to forward an HTLC to.
 		requested_forward_scid: u64,
 	},
+	/// We couldn't forward to the next Trampoline node. That may happen if we cannot find a route,
+	/// or if the route we found didn't work out.
+	FailedTrampolineForward {
+		/// The node ID of the next Trampoline hop we tried forwarding to.
+		requested_next_node_id: PublicKey,
+		/// The channel we tried forwarding over, if we have settled to one.
+		forward_scid: Option<u64>,
+	},
 	/// We couldn't decode the incoming onion to obtain the forwarding details.
 	InvalidOnion,
 	/// Failure scenario where an HTLC may have been forwarded to be intended for us,
@@ -578,6 +586,10 @@ impl_writeable_tlv_based_enum_upgradable!(HTLCHandlingFailureType,
 	(4, Receive) => {
 		(0, payment_hash, required),
 	},
+	(5, FailedTrampolineForward) => {
+		(0, requested_next_node_id, required),
+		(2, forward_scid, option),
+	}
 );
 
 /// The reason for HTLC failures in [`Event::HTLCHandlingFailed`].

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -2086,7 +2086,7 @@ fn do_test_trampoline_single_hop_receive(success: bool) {
 						pubkey: carol_node_id,
 						node_features: Features::empty(),
 						fee_msat: amt_msat,
-						cltv_expiry_delta: 24,
+						cltv_expiry_delta: 104,
 					},
 				],
 				hops: carol_blinded_hops,
@@ -2206,9 +2206,13 @@ fn test_trampoline_single_hop_receive() {
 	do_test_trampoline_single_hop_receive(false);
 }
 
-#[test]
-fn test_trampoline_unblinded_receive() {
-	// Simulate a payment of A (0) -> B (1) -> C(Trampoline) (2)
+fn do_test_trampoline_unblinded_receive(underpay: bool) {
+	// Test trampoline payment receipt with unblinded final hop.
+	// Creates custom onion packet where the final trampoline hop uses unblinded receive format
+	// (not natively supported) to validate payment amount verification.
+	// - When underpay=false: Payment succeeds with correct amount
+	// - When underpay=true: Payment fails due to amount mismatch (sends 1/2 expected amount)
+	// Topology: A (0) -> B (1) C  -> (Trampoline receiver) (2)
 
 	const TOTAL_NODE_COUNT: usize = 3;
 	let secp_ctx = Secp256k1::new();
@@ -2277,7 +2281,7 @@ fn test_trampoline_unblinded_receive() {
 					node_features: NodeFeatures::empty(),
 					short_channel_id: bob_carol_scid,
 					channel_features: ChannelFeatures::empty(),
-					fee_msat: 0,
+					fee_msat: 0, // no routing fees because it's the final hop
 					cltv_expiry_delta: 48,
 					maybe_announced_channel: false,
 				}
@@ -2288,8 +2292,8 @@ fn test_trampoline_unblinded_receive() {
 					TrampolineHop {
 						pubkey: carol_node_id,
 						node_features: Features::empty(),
-						fee_msat: amt_msat,
-						cltv_expiry_delta: 24,
+						fee_msat: 0, // no trampoline fee because we are receiving.
+						cltv_expiry_delta: 72, // blinded hop cltv to be used building the outer onion.
 					},
 				],
 				hops: carol_blinded_hops,
@@ -2301,6 +2305,8 @@ fn test_trampoline_unblinded_receive() {
 		route_params: None,
 	};
 
+	let payment_id = PaymentId(payment_hash.0);
+
 	nodes[0].node.send_payment_with_route(route.clone(), payment_hash, RecipientOnionFields::spontaneous_empty(), PaymentId(payment_hash.0)).unwrap();
 
 	let replacement_onion = {
@@ -2311,17 +2317,19 @@ fn test_trampoline_unblinded_receive() {
 		let recipient_onion_fields = RecipientOnionFields::spontaneous_empty();
 
 		let blinded_tail = route.paths[0].blinded_tail.clone().unwrap();
-		let (mut trampoline_payloads, outer_total_msat, outer_starting_htlc_offset) = onion_utils::build_trampoline_onion_payloads(&blinded_tail, amt_msat, &recipient_onion_fields, 32, &None).unwrap();
 
+		let (mut trampoline_payloads, outer_total_msat, outer_starting_htlc_offset) = onion_utils::build_trampoline_onion_payloads(&blinded_tail, amt_msat, &recipient_onion_fields, 32, &None).unwrap();
 		// pop the last dummy hop
 		trampoline_payloads.pop();
+		let replacement_payload_amount = if underpay { amt_msat * 2 } else { amt_msat };
 
 		trampoline_payloads.push(msgs::OutboundTrampolinePayload::Receive {
 			payment_data: Some(msgs::FinalOnionHopData {
 				payment_secret,
-				total_msat: amt_msat,
+				total_msat: replacement_payload_amount,
 			}),
-			sender_intended_htlc_amt_msat: amt_msat,
+			sender_intended_htlc_amt_msat: replacement_payload_amount,
+			// We will use the same cltv to the outer onion: 72 (blinded tail) + 32 (offset).
 			cltv_expiry_height: 104,
 		});
 
@@ -2334,10 +2342,264 @@ fn test_trampoline_unblinded_receive() {
 			None,
 		).unwrap();
 
-		// Use a different session key to construct the replacement onion packet. Note that the sender isn't aware of
-		// this and won't be able to decode the fulfill hold times.
-		let outer_session_priv = secret_from_hex("e52c20461ed7acd46c4e7b591a37610519179482887bd73bf3b94617f8f03677");
+		// Get the original inner session private key that the ChannelManager generated so we can
+		// re-use it for the outer session private key. This way HMAC validation in attributable
+		// errors does not makes the test fail.
+		let mut orig_inner_priv_bytes = [0u8; 32];
+		nodes[0].node.test_modify_pending_payment(&payment_id, |pmt| {
+			if let crate::ln::outbound_payment::PendingOutboundPayment::Retryable { session_privs, .. } = pmt {
+				orig_inner_priv_bytes = *session_privs.iter().next().unwrap();
+			}
+		});
+		let inner_session_priv = SecretKey::from_slice(&orig_inner_priv_bytes).unwrap();
 
+		// Derive the outer session private key from the inner one.
+		let outer_session_priv_hash = Sha256::hash(&inner_session_priv.secret_bytes());
+		let outer_session_priv = SecretKey::from_slice(&outer_session_priv_hash.to_byte_array()).unwrap();
+		let (outer_payloads, _, _) = onion_utils::build_onion_payloads(&route.paths[0], outer_total_msat, &recipient_onion_fields, outer_starting_htlc_offset, &None, None, Some(trampoline_packet)).unwrap();
+		let outer_onion_keys = onion_utils::construct_onion_keys(&secp_ctx, &route.clone().paths[0], &outer_session_priv);
+		let outer_packet = onion_utils::construct_onion_packet(
+			outer_payloads,
+			outer_onion_keys,
+			prng_seed.secret_bytes(),
+			&payment_hash,
+		).unwrap();
+
+		outer_packet
+	};
+
+	check_added_monitors!(&nodes[0], 1);
+
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let mut first_message_event = remove_first_msg_event_to_node(&nodes[1].node.get_our_node_id(), &mut events);
+	let mut update_message = match first_message_event {
+		MessageSendEvent::UpdateHTLCs { ref mut updates, .. } => {
+			assert_eq!(updates.update_add_htlcs.len(), 1);
+			updates.update_add_htlcs.get_mut(0)
+		},
+		_ => panic!()
+	};
+	update_message.map(|msg| {
+		msg.onion_routing_packet = replacement_onion.clone();
+	});
+
+	let route: &[&Node] = &[&nodes[1], &nodes[2]];
+	let args = PassAlongPathArgs::new(&nodes[0], route, amt_msat, payment_hash, first_message_event);
+
+	let args = if underpay {
+		args.with_payment_preimage(payment_preimage)
+				.without_claimable_event()
+				.expect_failure(HTLCHandlingFailureType::Receive { payment_hash })
+	} else {
+			args.with_payment_secret(payment_secret)
+		};
+
+	do_pass_along_path(args);
+
+	if underpay {
+		{
+			let unblinded_node_updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+			nodes[1].node.handle_update_fail_htlc(
+				nodes[2].node.get_our_node_id(), &unblinded_node_updates.update_fail_htlcs[0]
+			);
+			do_commitment_signed_dance(&nodes[1], &nodes[2], &unblinded_node_updates.commitment_signed, true, false);
+		}
+		{
+			let unblinded_node_updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
+			nodes[0].node.handle_update_fail_htlc(
+				nodes[1].node.get_our_node_id(), &unblinded_node_updates.update_fail_htlcs[0]
+			);
+			do_commitment_signed_dance(&nodes[0], &nodes[1], &unblinded_node_updates.commitment_signed, false, false);
+		}
+		{
+			let expected_error_data = amt_msat.to_be_bytes();
+			let payment_failed_conditions = PaymentFailedConditions::new()
+				.expected_htlc_error_data(LocalHTLCFailureReason::FinalIncorrectHTLCAmount, &expected_error_data);
+			expect_payment_failed_conditions(&nodes[0], payment_hash, false, payment_failed_conditions);
+		}
+	} else {
+		claim_payment(&nodes[0], &[&nodes[1], &nodes[2]], payment_preimage);
+	}
+}
+
+#[test]
+fn test_trampoline_unblinded_receive_underpay() {
+    do_test_trampoline_unblinded_receive(true);
+}
+
+#[test]
+fn test_trampoline_unblinded_receive_normal() {
+    do_test_trampoline_unblinded_receive(false);
+}
+
+#[derive(PartialEq)]
+enum TrampolineConstraintFailureScenarios {
+	TrampolineCLTVGreaterThanOnion,
+	#[allow(dead_code)]
+	// TODO: To test amount greater than onion we need the ability
+	// to forward Trampoline payments.
+	TrampolineAmountGreaterThanOnion,
+}
+
+fn do_test_trampoline_unblinded_receive_constraint_failure(failure_scenario: TrampolineConstraintFailureScenarios) {
+	// Test trampoline payment constraint validation failures with unblinded receive format.
+	// Creates deliberately invalid trampoline payments to verify constraint enforcement:
+	// - TrampolineCLTVGreaterThanOnion: Trampoline CLTV exceeds outer onion requirements
+	// - TrampolineAmountGreaterThanOnion: Trampoline amount exceeds outer onion value
+	// Uses custom onion construction to simulate constraint violations that should trigger
+	// specific HTLC failure codes (FinalIncorrectCLTVExpiry or FinalIncorrectHTLCAmount).
+	// Topology: A (0) -> B (1) -> C (Trampoline receiver) (2)
+
+	const TOTAL_NODE_COUNT: usize = 3;
+	let secp_ctx = Secp256k1::new();
+
+	let chanmon_cfgs = create_chanmon_cfgs(TOTAL_NODE_COUNT);
+	let node_cfgs = create_node_cfgs(TOTAL_NODE_COUNT, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(TOTAL_NODE_COUNT, &node_cfgs, &vec![None; TOTAL_NODE_COUNT]);
+	let mut nodes = create_network(TOTAL_NODE_COUNT, &node_cfgs, &node_chanmgrs);
+
+	let (_, _, chan_id_alice_bob, _) = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	let (_, _, chan_id_bob_carol, _) = create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0);
+
+	for i in 0..TOTAL_NODE_COUNT { // connect all nodes' blocks
+		connect_blocks(&nodes[i], (TOTAL_NODE_COUNT as u32) * CHAN_CONFIRM_DEPTH + 1 - nodes[i].best_block_info().1);
+	}
+
+	let alice_node_id = nodes[0].node().get_our_node_id();
+	let bob_node_id = nodes[1].node().get_our_node_id();
+	let carol_node_id = nodes[2].node().get_our_node_id();
+
+	let alice_bob_scid = nodes[0].node().list_channels().iter().find(|c| c.channel_id == chan_id_alice_bob).unwrap().short_channel_id.unwrap();
+	let bob_carol_scid = nodes[1].node().list_channels().iter().find(|c| c.channel_id == chan_id_bob_carol).unwrap().short_channel_id.unwrap();
+
+	let amt_msat = 1000;
+	let (payment_preimage, payment_hash, payment_secret) = get_payment_preimage_hash(&nodes[2], Some(amt_msat), None);
+	let payee_tlvs = blinded_path::payment::TrampolineForwardTlvs {
+		next_trampoline: alice_node_id,
+		payment_constraints: PaymentConstraints {
+			max_cltv_expiry: u32::max_value(),
+			htlc_minimum_msat: amt_msat,
+		},
+		features: BlindedHopFeatures::empty(),
+		payment_relay: PaymentRelay {
+			cltv_expiry_delta: 0,
+			fee_proportional_millionths: 0,
+			fee_base_msat: 0,
+		},
+		next_blinding_override: None,
+	};
+
+	let carol_unblinded_tlvs = payee_tlvs.encode();
+	let path = [((carol_node_id, None), WithoutLength(&carol_unblinded_tlvs))];
+	let carol_alice_trampoline_session_priv = secret_from_hex("a0f4b8d7b6c2d0ffdfaf718f76e9decaef4d9fb38a8c4addb95c4007cc3eee03");
+	let carol_blinding_point = PublicKey::from_secret_key(&secp_ctx, &carol_alice_trampoline_session_priv);
+	let carol_blinded_hops = blinded_path::utils::construct_blinded_hops(
+		&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv,
+	).unwrap();
+
+	// We decide an arbitrary ctlv delta for the blinded hop that will be the only cltv delta
+	// in the blinded tail.
+	let blinded_hop_cltv = if failure_scenario == TrampolineConstraintFailureScenarios::TrampolineCLTVGreaterThanOnion { 52 } else { 72 };
+	// Then when building the trampoline hop we use an arbitrary cltv delta offset to be used
+	// when re-building the outer trampoline onion.
+	let starting_cltv_offset_trampoline = 32;
+	// Finally we decide a forced cltv delta expiry for the trampoline hop itself.
+	// This one will be compared against the outer onion ctlv delta.
+	let forced_trampoline_cltv_delta = 104;
+	let route = Route {
+		paths: vec![Path {
+			hops: vec![
+				// Bob
+				RouteHop {
+					pubkey: bob_node_id,
+					node_features: NodeFeatures::empty(),
+					short_channel_id: alice_bob_scid,
+					channel_features: ChannelFeatures::empty(),
+					fee_msat: 1000,
+					cltv_expiry_delta: 48,
+					maybe_announced_channel: false,
+				},
+
+				// Carol
+				RouteHop {
+					pubkey: carol_node_id,
+					node_features: NodeFeatures::empty(),
+					short_channel_id: bob_carol_scid,
+					channel_features: ChannelFeatures::empty(),
+					fee_msat: 0, // no routing fees because it's the final hop
+					cltv_expiry_delta: 48,
+					maybe_announced_channel: false,
+				}
+			],
+			blinded_tail: Some(BlindedTail {
+				trampoline_hops: vec![
+					// Carol
+					TrampolineHop {
+						pubkey: carol_node_id,
+						node_features: Features::empty(),
+						fee_msat: amt_msat,
+						cltv_expiry_delta: blinded_hop_cltv, // blinded tail ctlv delta.
+					},
+				],
+				hops: carol_blinded_hops,
+				blinding_point: carol_blinding_point,
+				// This will be ignored because we force the cltv_expiry of the trampoline hop.
+				excess_final_cltv_expiry_delta: 39,
+				final_value_msat: amt_msat,
+			})
+		}],
+		route_params: None,
+	};
+
+	let payment_id = PaymentId(payment_hash.0);
+
+	nodes[0].node.send_payment_with_route(route.clone(), payment_hash, RecipientOnionFields::spontaneous_empty(), PaymentId(payment_hash.0)).unwrap();
+
+	let replacement_onion = {
+		// create a substitute onion where the last Trampoline hop is an unblinded receive, which we
+		// (deliberately) do not support out of the box, therefore necessitating this workaround
+		let trampoline_secret_key = secret_from_hex("0134928f7b7ca6769080d70f16be84c812c741f545b49a34db47ce338a205799");
+		let prng_seed = secret_from_hex("fe02b4b9054302a3ddf4e1e9f7c411d644aebbd295218ab009dca94435f775a9");
+		let recipient_onion_fields = RecipientOnionFields::spontaneous_empty();
+
+		let blinded_tail = route.paths[0].blinded_tail.clone().unwrap();
+
+		let (mut trampoline_payloads, outer_total_msat, outer_starting_htlc_offset) = onion_utils::build_trampoline_onion_payloads(&blinded_tail, amt_msat, &recipient_onion_fields, starting_cltv_offset_trampoline, &None).unwrap();
+		// pop the last dummy hop
+		trampoline_payloads.pop();
+		trampoline_payloads.push(msgs::OutboundTrampolinePayload::Receive {
+			payment_data: Some(msgs::FinalOnionHopData {
+				payment_secret,
+				total_msat: amt_msat,
+			}),
+			sender_intended_htlc_amt_msat: amt_msat,
+			cltv_expiry_height: forced_trampoline_cltv_delta,
+		});
+
+		let trampoline_onion_keys = onion_utils::construct_trampoline_onion_keys(&secp_ctx, &route.paths[0].blinded_tail.as_ref().unwrap(), &trampoline_secret_key);
+		let trampoline_packet = onion_utils::construct_trampoline_onion_packet(
+			trampoline_payloads,
+			trampoline_onion_keys,
+			prng_seed.secret_bytes(),
+			&payment_hash,
+			None,
+		).unwrap();
+
+		// Get the original inner session private key that the ChannelManager generated so we can
+		// re-use it for the outer session private key. This way HMAC validation in attributable
+		// errors does not makes the test fail.
+		let mut orig_inner_priv_bytes = [0u8; 32];
+		nodes[0].node.test_modify_pending_payment(&payment_id, |pmt| {
+			if let crate::ln::outbound_payment::PendingOutboundPayment::Retryable { session_privs, .. } = pmt {
+				orig_inner_priv_bytes = *session_privs.iter().next().unwrap();
+			}
+		});
+		let inner_session_priv = SecretKey::from_slice(&orig_inner_priv_bytes).unwrap();
+
+		// Derive the outer session private key from the inner one.
+		let outer_session_priv_hash = Sha256::hash(&inner_session_priv.secret_bytes());
+		let outer_session_priv = SecretKey::from_slice(&outer_session_priv_hash.to_byte_array()).unwrap();
 		let (outer_payloads, _, _) = onion_utils::build_onion_payloads(&route.paths[0], outer_total_msat, &recipient_onion_fields, outer_starting_htlc_offset, &None, None, Some(trampoline_packet)).unwrap();
 		let outer_onion_keys = onion_utils::construct_onion_keys(&secp_ctx, &route.clone().paths[0], &outer_session_priv);
 		let outer_packet = onion_utils::construct_onion_packet(
@@ -2368,10 +2630,199 @@ fn test_trampoline_unblinded_receive() {
 
 	let route: &[&Node] = &[&nodes[1], &nodes[2]];
 	let args = PassAlongPathArgs::new(&nodes[0], route, amt_msat, payment_hash, first_message_event)
-		.with_payment_secret(payment_secret);
-	do_pass_along_path(args);
+		.with_payment_preimage(payment_preimage)
+		.without_claimable_event()
+		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash });
 
-	claim_payment(&nodes[0], &[&nodes[1], &nodes[2]], payment_preimage);
+	do_pass_along_path(args);
+	{
+		let unblinded_node_updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+		nodes[1].node.handle_update_fail_htlc(
+			nodes[2].node.get_our_node_id(), &unblinded_node_updates.update_fail_htlcs[0]
+		);
+		do_commitment_signed_dance(&nodes[1], &nodes[2], &unblinded_node_updates.commitment_signed, true, false);
+	}
+	{
+		let unblinded_node_updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
+		nodes[0].node.handle_update_fail_htlc(
+			nodes[1].node.get_our_node_id(), &unblinded_node_updates.update_fail_htlcs[0]
+		);
+		do_commitment_signed_dance(&nodes[0], &nodes[1], &unblinded_node_updates.commitment_signed, false, false);
+	}
+
+	match failure_scenario {
+		TrampolineConstraintFailureScenarios::TrampolineAmountGreaterThanOnion => {
+			let expected_error_data = amt_msat.to_be_bytes();
+			let payment_failed_conditions = PaymentFailedConditions::new()
+					.expected_htlc_error_data(LocalHTLCFailureReason::FinalIncorrectHTLCAmount, &expected_error_data);
+			expect_payment_failed_conditions(&nodes[0], payment_hash, false, payment_failed_conditions);
+		},
+		TrampolineConstraintFailureScenarios::TrampolineCLTVGreaterThanOnion => {
+			// The amount of the outer onion cltv delta plus the trampoline offset.
+			let expected_error_data = (blinded_hop_cltv + starting_cltv_offset_trampoline).to_be_bytes();
+			let payment_failed_conditions = PaymentFailedConditions::new()
+				.expected_htlc_error_data(LocalHTLCFailureReason::FinalIncorrectCLTVExpiry, &expected_error_data);
+			expect_payment_failed_conditions(&nodes[0], payment_hash, false, payment_failed_conditions);
+		}
+	}
+}
+
+fn do_test_trampoline_blinded_receive_constraint_failure(failure_scenario: TrampolineConstraintFailureScenarios) {
+	// Test trampoline payment constraint validation failures with blinded receive format.
+	// Creates deliberately invalid trampoline payments to verify constraint enforcement:
+	// - TrampolineCLTVGreaterThanOnion: Trampoline CLTV exceeds outer onion requirements
+	// - TrampolineAmountGreaterThanOnion: Trampoline amount exceeds outer onion value
+	// Topology: A (0) -> B (1) -> C (Trampoline receiver inside blinded path) (2)
+
+	const TOTAL_NODE_COUNT: usize = 3;
+	let secp_ctx = Secp256k1::new();
+
+	let chanmon_cfgs = create_chanmon_cfgs(TOTAL_NODE_COUNT);
+	let node_cfgs = create_node_cfgs(TOTAL_NODE_COUNT, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(TOTAL_NODE_COUNT, &node_cfgs, &vec![None; TOTAL_NODE_COUNT]);
+	let mut nodes = create_network(TOTAL_NODE_COUNT, &node_cfgs, &node_chanmgrs);
+
+	let (_, _, chan_id_alice_bob, _) = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	let (_, _, chan_id_bob_carol, _) = create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0);
+
+	for i in 0..TOTAL_NODE_COUNT { // connect all nodes' blocks
+		connect_blocks(&nodes[i], (TOTAL_NODE_COUNT as u32) * CHAN_CONFIRM_DEPTH + 1 - nodes[i].best_block_info().1);
+	}
+
+	let bob_node_id = nodes[1].node().get_our_node_id();
+	let carol_node_id = nodes[2].node().get_our_node_id();
+
+	let alice_bob_scid = nodes[0].node().list_channels().iter().find(|c| c.channel_id == chan_id_alice_bob).unwrap().short_channel_id.unwrap();
+	let bob_carol_scid = nodes[1].node().list_channels().iter().find(|c| c.channel_id == chan_id_bob_carol).unwrap().short_channel_id.unwrap();
+	let amt_msat = 1000;
+	let (payment_preimage, payment_hash, payment_secret) = get_payment_preimage_hash(&nodes[2], Some(amt_msat), None);
+
+	let alice_carol_trampoline_shared_secret = secret_from_hex("a0f4b8d7b6c2d0ffdfaf718f76e9decaef4d9fb38a8c4addb95c4007cc3eee03");
+	let carol_blinding_point = PublicKey::from_secret_key(&secp_ctx, &alice_carol_trampoline_shared_secret);
+	let payee_tlvs = UnauthenticatedReceiveTlvs {
+		payment_secret,
+		payment_constraints: PaymentConstraints {
+			max_cltv_expiry: u32::max_value(),
+			htlc_minimum_msat: amt_msat,
+		},
+		payment_context: PaymentContext::Bolt12Refund(Bolt12RefundContext {}),
+	};
+
+	let nonce = Nonce([42u8; 16]);
+	let expanded_key = nodes[2].keys_manager.get_inbound_payment_key();
+	let payee_tlvs = payee_tlvs.authenticate(nonce, &expanded_key);
+	let carol_unblinded_tlvs = payee_tlvs.encode();
+
+	// Blinded path is Carol as recipient.
+	let path = [((carol_node_id, None), WithoutLength(&carol_unblinded_tlvs))];
+	let blinded_hops = blinded_path::utils::construct_blinded_hops(
+		&secp_ctx, path.into_iter(), &alice_carol_trampoline_shared_secret,
+	).unwrap();
+
+	// We decide an arbitrary ctlv delta for the blinded hop that will be the only cltv delta
+	// in the blinded tail.
+	let blinded_hop_cltv = if failure_scenario == TrampolineConstraintFailureScenarios::TrampolineCLTVGreaterThanOnion { 2 } else { 144 };
+
+	let route = Route {
+		paths: vec![Path {
+			hops: vec![
+				// Bob
+				RouteHop {
+					pubkey: bob_node_id,
+					node_features: NodeFeatures::empty(),
+					short_channel_id: alice_bob_scid,
+					channel_features: ChannelFeatures::empty(),
+					fee_msat: 1000, // forwarding fee to Carol
+					cltv_expiry_delta: 48,
+					maybe_announced_channel: false,
+				},
+
+				// Carol
+				RouteHop {
+					pubkey: carol_node_id,
+					node_features: NodeFeatures::empty(),
+					short_channel_id: bob_carol_scid,
+					channel_features: ChannelFeatures::empty(),
+					// fee for the usage of the entire blinded path, including Trampoline.
+					// In this case is zero as we are the recipient of the payment.
+					fee_msat: 0,
+					cltv_expiry_delta: 48,
+					maybe_announced_channel: false,
+				}
+			],
+			blinded_tail: Some(BlindedTail {
+				trampoline_hops: vec![
+            // Carol
+            TrampolineHop {
+                pubkey: carol_node_id,
+                node_features: Features::empty(),
+                fee_msat: amt_msat,
+                cltv_expiry_delta: blinded_hop_cltv,
+            },
+
+        ],
+				hops: blinded_hops,
+				blinding_point: carol_blinding_point,
+				excess_final_cltv_expiry_delta: 39,
+				final_value_msat: amt_msat,
+			})
+		}],
+		route_params: None,
+	};
+
+	nodes[0].node.send_payment_with_route(route.clone(), payment_hash, RecipientOnionFields::spontaneous_empty(), PaymentId(payment_hash.0)).unwrap();
+	check_added_monitors!(&nodes[0], 1);
+
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let first_message_event = remove_first_msg_event_to_node(&nodes[1].node.get_our_node_id(), &mut events);
+
+	let route: &[&Node] = &[&nodes[1], &nodes[2]];
+	let args = PassAlongPathArgs::new(&nodes[0], route, amt_msat, payment_hash, first_message_event)
+		.with_payment_preimage(payment_preimage)
+		.without_claimable_event()
+		.expect_failure(HTLCHandlingFailureType::Receive { payment_hash });
+
+	do_pass_along_path(args);
+	{
+		let unblinded_node_updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+		nodes[1].node.handle_update_fail_htlc(
+			nodes[2].node.get_our_node_id(), &unblinded_node_updates.update_fail_htlcs[0]
+		);
+		do_commitment_signed_dance(&nodes[1], &nodes[2], &unblinded_node_updates.commitment_signed, true, false);
+	}
+	{
+		let unblinded_node_updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
+		nodes[0].node.handle_update_fail_htlc(
+			nodes[1].node.get_our_node_id(), &unblinded_node_updates.update_fail_htlcs[0]
+		);
+		do_commitment_signed_dance(&nodes[0], &nodes[1], &unblinded_node_updates.commitment_signed, false, false);
+	}
+
+	// We don't share the error data when receiving inside a blinded path.
+	let expected_error_data = [0; 32];
+	match failure_scenario {
+		TrampolineConstraintFailureScenarios::TrampolineAmountGreaterThanOnion => {
+			let payment_failed_conditions = PaymentFailedConditions::new()
+					.expected_htlc_error_data(LocalHTLCFailureReason::InvalidOnionBlinding, &expected_error_data);
+			expect_payment_failed_conditions(&nodes[0], payment_hash, false, payment_failed_conditions);
+		},
+		TrampolineConstraintFailureScenarios::TrampolineCLTVGreaterThanOnion => {
+			let payment_failed_conditions = PaymentFailedConditions::new()
+				.expected_htlc_error_data(LocalHTLCFailureReason::InvalidOnionBlinding, &expected_error_data);
+			expect_payment_failed_conditions(&nodes[0], payment_hash, false, payment_failed_conditions);
+		}
+	}
+}
+
+#[test]
+fn test_trampoline_enforced_constraint_cltv() {
+    do_test_trampoline_unblinded_receive_constraint_failure(TrampolineConstraintFailureScenarios::TrampolineCLTVGreaterThanOnion);
+}
+
+#[test]
+fn test_trampoline_blinded_receive_enforced_constraint_cltv() {
+    do_test_trampoline_blinded_receive_constraint_failure(TrampolineConstraintFailureScenarios::TrampolineCLTVGreaterThanOnion);
 }
 
 #[test]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5121,7 +5121,7 @@ where
 		)
 	}
 
-	#[cfg(all(test, async_payments))]
+	#[cfg(test)]
 	pub(crate) fn test_modify_pending_payment<Fn>(&self, payment_id: &PaymentId, mut callback: Fn)
 	where
 		Fn: FnMut(&mut PendingOutboundPayment),

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7923,54 +7923,80 @@ where
 					&payment_hash,
 					onion_error
 				);
-				let failure = match blinded_failure {
-					Some(BlindedFailure::FromIntroductionNode) => {
-						let blinded_onion_error = HTLCFailReason::reason(
-							LocalHTLCFailureReason::InvalidOnionBlinding,
-							vec![0; 32],
-						);
-						let err_packet = blinded_onion_error.get_encrypted_failure_packet(
-							incoming_packet_shared_secret,
-							phantom_shared_secret,
-						);
-						HTLCForwardInfo::FailHTLC { htlc_id: *htlc_id, err_packet }
-					},
-					Some(BlindedFailure::FromBlindedNode) => HTLCForwardInfo::FailMalformedHTLC {
-						htlc_id: *htlc_id,
-						failure_code: LocalHTLCFailureReason::InvalidOnionBlinding.failure_code(),
-						sha256_of_onion: [0; 32],
-					},
-					None => {
-						let err_packet = onion_error.get_encrypted_failure_packet(
-							incoming_packet_shared_secret,
-							phantom_shared_secret,
-						);
-						HTLCForwardInfo::FailHTLC { htlc_id: *htlc_id, err_packet }
-					},
-				};
-
-				let mut forward_htlcs = self.forward_htlcs.lock().unwrap();
-				match forward_htlcs.entry(*short_channel_id) {
-					hash_map::Entry::Occupied(mut entry) => {
-						entry.get_mut().push(failure);
-					},
-					hash_map::Entry::Vacant(entry) => {
-						entry.insert(vec![failure]);
-					},
-				}
-				mem::drop(forward_htlcs);
-				let mut pending_events = self.pending_events.lock().unwrap();
-				pending_events.push_back((
-					events::Event::HTLCHandlingFailed {
-						prev_channel_id: *channel_id,
-						failure_type,
-						failure_reason: Some(onion_error.into()),
-					},
-					None,
-				));
+				let htlc_failure_reason = self.get_htlc_failure_from_blinded_failure_forward(
+					blinded_failure,
+					onion_error,
+					incoming_packet_shared_secret,
+					phantom_shared_secret,
+					htlc_id,
+				);
+				self.fail_htlc_backwards_from_forward(
+					&onion_error,
+					failure_type,
+					short_channel_id,
+					channel_id,
+					htlc_failure_reason,
+				);
 			},
 			HTLCSource::TrampolineForward { .. } => todo!(),
 		}
+	}
+
+	fn get_htlc_failure_from_blinded_failure_forward(
+		&self, blinded_failure: &Option<BlindedFailure>, onion_error: &HTLCFailReason,
+		incoming_packet_shared_secret: &[u8; 32], secondary_shared_secret: &Option<[u8; 32]>,
+		htlc_id: &u64,
+	) -> HTLCForwardInfo {
+		match blinded_failure {
+			Some(BlindedFailure::FromIntroductionNode) => {
+				let blinded_onion_error = HTLCFailReason::reason(
+					LocalHTLCFailureReason::InvalidOnionBlinding,
+					vec![0; 32],
+				);
+				let err_packet = blinded_onion_error.get_encrypted_failure_packet(
+					incoming_packet_shared_secret,
+					secondary_shared_secret,
+				);
+				HTLCForwardInfo::FailHTLC { htlc_id: *htlc_id, err_packet }
+			},
+			Some(BlindedFailure::FromBlindedNode) => HTLCForwardInfo::FailMalformedHTLC {
+				htlc_id: *htlc_id,
+				failure_code: LocalHTLCFailureReason::InvalidOnionBlinding.failure_code(),
+				sha256_of_onion: [0; 32],
+			},
+			None => {
+				let err_packet = onion_error.get_encrypted_failure_packet(
+					incoming_packet_shared_secret,
+					secondary_shared_secret,
+				);
+				HTLCForwardInfo::FailHTLC { htlc_id: *htlc_id, err_packet }
+			},
+		}
+	}
+
+	fn fail_htlc_backwards_from_forward(
+		&self, onion_error: &HTLCFailReason, failure_type: HTLCHandlingFailureType,
+		short_channel_id: &u64, channel_id: &ChannelId, failure: HTLCForwardInfo,
+	) {
+		let mut forward_htlcs = self.forward_htlcs.lock().unwrap();
+		match forward_htlcs.entry(*short_channel_id) {
+			hash_map::Entry::Occupied(mut entry) => {
+				entry.get_mut().push(failure);
+			},
+			hash_map::Entry::Vacant(entry) => {
+				entry.insert(vec![failure]);
+			},
+		}
+		mem::drop(forward_htlcs);
+		let mut pending_events = self.pending_events.lock().unwrap();
+		pending_events.push_back((
+			events::Event::HTLCHandlingFailed {
+				prev_channel_id: *channel_id,
+				failure_type,
+				failure_reason: Some(onion_error.into()),
+			},
+			None,
+		));
 	}
 
 	/// Provides a payment preimage in response to [`Event::PaymentClaimable`], generating any

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -16565,7 +16565,20 @@ where
 									monitor.channel_id(),
 								);
 							},
-							HTLCSource::TrampolineForward { .. } => todo!(),
+							HTLCSource::TrampolineForward { previous_hop_data, .. } => {
+								for current_previous_hop_data in previous_hop_data {
+									channel_monitor_recovery_internal(
+										&mut forward_htlcs,
+										&mut pending_events_read,
+										&mut pending_intercepted_htlcs,
+										&mut decode_update_add_htlcs,
+										current_previous_hop_data,
+										&logger,
+										htlc.payment_hash,
+										monitor.channel_id(),
+									);
+								}
+							},
 							HTLCSource::OutboundRoute {
 								payment_id,
 								session_priv,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8582,141 +8582,166 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					&self.logger,
 				);
 			},
-			HTLCSource::PreviousHopData(hop_data) => {
-				let prev_channel_id = hop_data.channel_id;
-				let prev_user_channel_id = hop_data.user_channel_id;
-				let prev_node_id = hop_data.counterparty_node_id;
-				let completed_blocker =
-					RAAMonitorUpdateBlockingAction::from_prev_hop_data(&hop_data);
-
-				// Obtain hold time, if available.
-				let hold_time = hold_time_since(send_timestamp).unwrap_or(0);
-
-				// If attribution data was received from downstream, we shift it and get it ready for adding our hold
-				// time. Note that fulfilled HTLCs take a fast path to the incoming side. We don't need to wait for RAA
-				// to record the hold time like we do for failed HTLCs.
-				let attribution_data = process_fulfill_attribution_data(
-					attribution_data,
-					&hop_data.incoming_packet_shared_secret,
-					hold_time,
-				);
-
-				#[cfg(test)]
-				let claiming_chan_funding_outpoint = hop_data.outpoint;
-				self.claim_funds_from_hop(
-					hop_data,
-					payment_preimage,
-					None,
-					Some(attribution_data),
-					|htlc_claim_value_msat, definitely_duplicate| {
-						let chan_to_release = Some(EventUnblockedChannel {
-							counterparty_node_id: next_channel_counterparty_node_id,
-							funding_txo: next_channel_outpoint,
-							channel_id: next_channel_id,
-							blocking_action: completed_blocker,
-						});
-
-						if definitely_duplicate && startup_replay {
-							// On startup we may get redundant claims which are related to
-							// monitor updates still in flight. In that case, we shouldn't
-							// immediately free, but instead let that monitor update complete
-							// in the background.
-							#[cfg(test)]
-							{
-								let per_peer_state = self.per_peer_state.deadlocking_read();
-								// The channel we'd unblock should already be closed, or...
-								let channel_closed = per_peer_state
-									.get(&next_channel_counterparty_node_id)
-									.map(|lck| lck.deadlocking_lock())
-									.map(|peer| !peer.channel_by_id.contains_key(&next_channel_id))
-									.unwrap_or(true);
-								let background_events =
-									self.pending_background_events.lock().unwrap();
-								// there should be a `BackgroundEvent` pending...
-								let matching_bg_event =
-									background_events.iter().any(|ev| {
-										match ev {
-											// to apply a monitor update that blocked the claiming channel,
-											BackgroundEvent::MonitorUpdateRegeneratedOnStartup {
-												funding_txo, update, ..
-											} => {
-												if *funding_txo == claiming_chan_funding_outpoint {
-													assert!(update.updates.iter().any(|upd|
-														if let ChannelMonitorUpdateStep::PaymentPreimage {
-															payment_preimage: update_preimage, ..
-														} = upd {
-															payment_preimage == *update_preimage
-														} else { false }
-													), "{:?}", update);
-													true
-												} else { false }
-											},
-											// or the monitor update has completed and will unblock
-											// immediately once we get going.
-											BackgroundEvent::MonitorUpdatesComplete {
-												channel_id, ..
-											} =>
-												*channel_id == prev_channel_id,
-										}
-									});
-								assert!(
-									channel_closed || matching_bg_event,
-									"{:?}",
-									*background_events
-								);
-							}
-							(None, None)
-						} else if definitely_duplicate {
-							if let Some(other_chan) = chan_to_release {
-								(Some(MonitorUpdateCompletionAction::FreeOtherChannelImmediately {
-									downstream_counterparty_node_id: other_chan.counterparty_node_id,
-									downstream_channel_id: other_chan.channel_id,
-									blocking_action: other_chan.blocking_action,
-								}), None)
-							} else {
-								(None, None)
-							}
-						} else {
-							let total_fee_earned_msat =
-								if let Some(forwarded_htlc_value) = forwarded_htlc_value_msat {
-									if let Some(claimed_htlc_value) = htlc_claim_value_msat {
-										Some(claimed_htlc_value - forwarded_htlc_value)
-									} else {
-										None
-									}
-								} else {
-									None
-								};
-							debug_assert!(
-								skimmed_fee_msat <= total_fee_earned_msat,
-								"skimmed_fee_msat must always be included in total_fee_earned_msat"
-							);
-							(
-								Some(MonitorUpdateCompletionAction::EmitEventAndFreeOtherChannel {
-									event: events::Event::PaymentForwarded {
-										prev_channel_id: Some(prev_channel_id),
-										next_channel_id: Some(next_channel_id),
-										prev_user_channel_id,
-										next_user_channel_id,
-										prev_node_id,
-										next_node_id: Some(next_channel_counterparty_node_id),
-										total_fee_earned_msat,
-										skimmed_fee_msat,
-										claim_from_onchain_tx: from_onchain,
-										outbound_amount_forwarded_msat: forwarded_htlc_value_msat,
-									},
-									downstream_counterparty_and_funding_outpoint: chan_to_release,
-								}),
-								None,
-							)
-						}
-					},
-				);
-			},
+			HTLCSource::PreviousHopData(hop_data) => self.claim_funds_from_previous_hop_internal(
+				payment_preimage,
+				forwarded_htlc_value_msat,
+				skimmed_fee_msat,
+				from_onchain,
+				startup_replay,
+				next_channel_counterparty_node_id,
+				next_channel_outpoint,
+				next_channel_id,
+				next_user_channel_id,
+				hop_data,
+				attribution_data,
+				send_timestamp,
+			),
 			HTLCSource::TrampolineForward { .. } => todo!(),
 		}
 	}
 
+	fn claim_funds_from_previous_hop_internal(
+		&self, payment_preimage: PaymentPreimage, forwarded_htlc_value_msat: Option<u64>,
+		skimmed_fee_msat: Option<u64>, from_onchain: bool, startup_replay: bool,
+		next_channel_counterparty_node_id: PublicKey, next_channel_outpoint: OutPoint,
+		next_channel_id: ChannelId, next_user_channel_id: Option<u128>,
+		hop_data: HTLCPreviousHopData, attribution_data: Option<AttributionData>,
+		send_timestamp: Option<Duration>,
+	) {
+		let prev_channel_id = hop_data.channel_id;
+		let prev_user_channel_id = hop_data.user_channel_id;
+		let prev_node_id = hop_data.counterparty_node_id;
+		let completed_blocker = RAAMonitorUpdateBlockingAction::from_prev_hop_data(&hop_data);
+
+		// Obtain hold time, if available.
+		let hold_time = hold_time_since(send_timestamp).unwrap_or(0);
+
+		// If attribution data was received from downstream, we shift it and get it ready for adding our hold
+		// time. Note that fulfilled HTLCs take a fast path to the incoming side. We don't need to wait for RAA
+		// to record the hold time like we do for failed HTLCs.
+		let attribution_data = process_fulfill_attribution_data(
+			attribution_data,
+			&hop_data.incoming_packet_shared_secret,
+			hold_time,
+		);
+
+		#[cfg(test)]
+		let claiming_chan_funding_outpoint = hop_data.outpoint;
+		self.claim_funds_from_hop(
+			hop_data,
+			payment_preimage,
+			None,
+			Some(attribution_data),
+			|htlc_claim_value_msat, definitely_duplicate| {
+				let chan_to_release = Some(EventUnblockedChannel {
+					counterparty_node_id: next_channel_counterparty_node_id,
+					funding_txo: next_channel_outpoint,
+					channel_id: next_channel_id,
+					blocking_action: completed_blocker,
+				});
+
+				if definitely_duplicate && startup_replay {
+					// On startup we may get redundant claims which are related to
+					// monitor updates still in flight. In that case, we shouldn't
+					// immediately free, but instead let that monitor update complete
+					// in the background.
+					#[cfg(test)]
+					{
+						let per_peer_state = self.per_peer_state.deadlocking_read();
+						// The channel we'd unblock should already be closed, or...
+						let channel_closed = per_peer_state
+							.get(&next_channel_counterparty_node_id)
+							.map(|lck| lck.deadlocking_lock())
+							.map(|peer| !peer.channel_by_id.contains_key(&next_channel_id))
+							.unwrap_or(true);
+						let background_events = self.pending_background_events.lock().unwrap();
+						// there should be a `BackgroundEvent` pending...
+						let matching_bg_event =
+							background_events.iter().any(|ev| {
+								match ev {
+									// to apply a monitor update that blocked the claiming channel,
+									BackgroundEvent::MonitorUpdateRegeneratedOnStartup {
+										funding_txo,
+										update,
+										..
+									} => {
+										if *funding_txo == claiming_chan_funding_outpoint {
+											assert!(
+												update.updates.iter().any(|upd| {
+													if let ChannelMonitorUpdateStep::PaymentPreimage {
+															payment_preimage: update_preimage, ..
+														} = upd {
+															payment_preimage == *update_preimage
+														} else { false }
+												}),
+												"{:?}",
+												update
+											);
+											true
+										} else {
+											false
+										}
+									},
+									// or the monitor update has completed and will unblock
+									// immediately once we get going.
+									BackgroundEvent::MonitorUpdatesComplete {
+										channel_id, ..
+									} => *channel_id == prev_channel_id,
+								}
+							});
+						assert!(channel_closed || matching_bg_event, "{:?}", *background_events);
+					}
+					(None, None)
+				} else if definitely_duplicate {
+					if let Some(other_chan) = chan_to_release {
+						(
+							Some(MonitorUpdateCompletionAction::FreeOtherChannelImmediately {
+								downstream_counterparty_node_id: other_chan.counterparty_node_id,
+								downstream_channel_id: other_chan.channel_id,
+								blocking_action: other_chan.blocking_action,
+							}),
+							None,
+						)
+					} else {
+						(None, None)
+					}
+				} else {
+					let total_fee_earned_msat =
+						if let Some(forwarded_htlc_value) = forwarded_htlc_value_msat {
+							if let Some(claimed_htlc_value) = htlc_claim_value_msat {
+								Some(claimed_htlc_value - forwarded_htlc_value)
+							} else {
+								None
+							}
+						} else {
+							None
+						};
+					debug_assert!(
+						skimmed_fee_msat <= total_fee_earned_msat,
+						"skimmed_fee_msat must always be included in total_fee_earned_msat"
+					);
+					(
+						Some(MonitorUpdateCompletionAction::EmitEventAndFreeOtherChannel {
+							event: events::Event::PaymentForwarded {
+								prev_channel_id: Some(prev_channel_id),
+								next_channel_id: Some(next_channel_id),
+								prev_user_channel_id,
+								next_user_channel_id,
+								prev_node_id,
+								next_node_id: Some(next_channel_counterparty_node_id),
+								total_fee_earned_msat,
+								skimmed_fee_msat,
+								claim_from_onchain_tx: from_onchain,
+								outbound_amount_forwarded_msat: forwarded_htlc_value_msat,
+							},
+							downstream_counterparty_and_funding_outpoint: chan_to_release,
+						}),
+						None,
+					)
+				}
+			},
+		)
+	}
 	/// Gets the node_id held by this ChannelManager
 	pub fn get_our_node_id(&self) -> PublicKey {
 		self.our_network_pubkey

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -653,6 +653,7 @@ impl SentHTLCId {
 				short_channel_id: hop_data.short_channel_id,
 				htlc_id: hop_data.htlc_id,
 			},
+			HTLCSource::TrampolineForward { .. } => todo!(),
 			HTLCSource::OutboundRoute { session_priv, .. } => {
 				Self::OutboundRoute { session_priv: session_priv.secret_bytes() }
 			},
@@ -676,6 +677,8 @@ type PerSourcePendingForward =
 type FailedHTLCForward = (HTLCSource, PaymentHash, HTLCFailReason, HTLCHandlingFailureType);
 
 mod fuzzy_channelmanager {
+	use crate::routing::router::RouteHop;
+
 	use super::*;
 
 	/// Tracks the inbound corresponding to an outbound HTLC
@@ -683,6 +686,16 @@ mod fuzzy_channelmanager {
 	#[derive(Clone, Debug, PartialEq, Eq)]
 	pub enum HTLCSource {
 		PreviousHopData(HTLCPreviousHopData),
+		TrampolineForward {
+			/// We might be forwarding an incoming payment that was received over MPP, and therefore
+			/// need to store the vector of corresponding `HTLCPreviousHopId` values.
+			previous_hop_data: Vec<HTLCPreviousHopData>,
+			incoming_trampoline_shared_secret: [u8; 32],
+			hops: Vec<RouteHop>,
+			/// In order to decode inter-Trampoline errors, we need to store the session_priv key
+			/// given we're effectively creating new outbound routes.
+			session_priv: SecretKey,
+		},
 		OutboundRoute {
 			path: Path,
 			session_priv: SecretKey,
@@ -744,6 +757,18 @@ impl core::hash::Hash for HTLCSource {
 				payment_id.hash(hasher);
 				first_hop_htlc_msat.hash(hasher);
 				bolt12_invoice.hash(hasher);
+			},
+			HTLCSource::TrampolineForward {
+				previous_hop_data,
+				incoming_trampoline_shared_secret,
+				hops,
+				session_priv,
+			} => {
+				2u8.hash(hasher);
+				previous_hop_data.hash(hasher);
+				incoming_trampoline_shared_secret.hash(hasher);
+				hops.hash(hasher);
+				session_priv[..].hash(hasher);
 			},
 		}
 	}
@@ -7944,6 +7969,7 @@ where
 					None,
 				));
 			},
+			HTLCSource::TrampolineForward { .. } => todo!(),
 		}
 	}
 
@@ -8661,6 +8687,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					},
 				);
 			},
+			HTLCSource::TrampolineForward { .. } => todo!(),
 		}
 	}
 
@@ -14952,6 +14979,24 @@ impl Readable for HTLCSource {
 				})
 			}
 			1 => Ok(HTLCSource::PreviousHopData(Readable::read(reader)?)),
+			2 => {
+				let mut previous_hop_data = Vec::new();
+				let mut incoming_trampoline_shared_secret: crate::util::ser::RequiredWrapper<[u8; 32]> = crate::util::ser::RequiredWrapper(None);
+				let mut session_priv: crate::util::ser::RequiredWrapper<SecretKey> = crate::util::ser::RequiredWrapper(None);
+				let mut hops = Vec::new();
+				read_tlv_fields!(reader, {
+					(0, previous_hop_data, required_vec),
+					(2, incoming_trampoline_shared_secret, required),
+					(4, session_priv, required),
+					(6, hops, required_vec),
+				});
+				Ok(HTLCSource::TrampolineForward {
+					previous_hop_data,
+					incoming_trampoline_shared_secret: incoming_trampoline_shared_secret.0.unwrap(),
+					hops,
+					session_priv: session_priv.0.unwrap(),
+				})
+			},
 			_ => Err(DecodeError::UnknownRequiredFeature),
 		}
 	}
@@ -14983,6 +15028,22 @@ impl Writeable for HTLCSource {
 			HTLCSource::PreviousHopData(ref field) => {
 				1u8.write(writer)?;
 				field.write(writer)?;
+			},
+			HTLCSource::TrampolineForward {
+				previous_hop_data: previous_hop_data_ref,
+				ref incoming_trampoline_shared_secret,
+				ref session_priv,
+				hops: hops_ref,
+			} => {
+				2u8.write(writer)?;
+				let previous_hop_data = previous_hop_data_ref.clone();
+				let hops = hops_ref.clone();
+				write_tlv_fields!(writer, {
+					(0, previous_hop_data, required_vec),
+					(2, incoming_trampoline_shared_secret, required),
+					(4, session_priv, required),
+					(6, hops, required_vec),
+				});
 			},
 		}
 		Ok(())
@@ -16427,6 +16488,7 @@ where
 									} else { true }
 								});
 							},
+							HTLCSource::TrampolineForward { .. } => todo!(),
 							HTLCSource::OutboundRoute {
 								payment_id,
 								session_priv,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8637,7 +8637,27 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 				attribution_data,
 				send_timestamp,
 			),
-			HTLCSource::TrampolineForward { .. } => todo!(),
+			// TODO: This branch should be tested when Trampoline Forwarding is implemented.
+			HTLCSource::TrampolineForward { previous_hop_data, .. } => {
+				for current_previous_hop_data in previous_hop_data {
+					self.claim_funds_from_previous_hop_internal(
+						payment_preimage,
+						forwarded_htlc_value_msat,
+						skimmed_fee_msat,
+						from_onchain,
+						startup_replay,
+						next_channel_counterparty_node_id,
+						next_channel_outpoint,
+						next_channel_id,
+						next_user_channel_id,
+						current_previous_hop_data,
+						// Clone the attribution data because it is going to be updated using the
+						// current_previous_hop_data respectively.
+						attribution_data.clone(),
+						send_timestamp,
+					);
+				}
+			},
 		}
 	}
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -16554,51 +16554,16 @@ where
 						);
 						match htlc_source {
 							HTLCSource::PreviousHopData(prev_hop_data) => {
-								let pending_forward_matches_htlc = |info: &PendingAddHTLCInfo| {
-									info.prev_funding_outpoint == prev_hop_data.outpoint
-										&& info.prev_htlc_id == prev_hop_data.htlc_id
-								};
-								// The ChannelMonitor is now responsible for this HTLC's
-								// failure/success and will let us know what its outcome is. If we
-								// still have an entry for this HTLC in `forward_htlcs` or
-								// `pending_intercepted_htlcs`, we were apparently not persisted after
-								// the monitor was when forwarding the payment.
-								decode_update_add_htlcs.retain(|scid, update_add_htlcs| {
-									update_add_htlcs.retain(|update_add_htlc| {
-										let matches = *scid == prev_hop_data.short_channel_id &&
-											update_add_htlc.htlc_id == prev_hop_data.htlc_id;
-										if matches {
-											log_info!(logger, "Removing pending to-decode HTLC with hash {} as it was forwarded to the closed channel {}",
-												&htlc.payment_hash, &monitor.channel_id());
-										}
-										!matches
-									});
-									!update_add_htlcs.is_empty()
-								});
-								forward_htlcs.retain(|_, forwards| {
-									forwards.retain(|forward| {
-										if let HTLCForwardInfo::AddHTLC(htlc_info) = forward {
-											if pending_forward_matches_htlc(&htlc_info) {
-												log_info!(logger, "Removing pending to-forward HTLC with hash {} as it was forwarded to the closed channel {}",
-													&htlc.payment_hash, &monitor.channel_id());
-												false
-											} else { true }
-										} else { true }
-									});
-									!forwards.is_empty()
-								});
-								pending_intercepted_htlcs.as_mut().unwrap().retain(|intercepted_id, htlc_info| {
-									if pending_forward_matches_htlc(&htlc_info) {
-										log_info!(logger, "Removing pending intercepted HTLC with hash {} as it was forwarded to the closed channel {}",
-											&htlc.payment_hash, &monitor.channel_id());
-										pending_events_read.retain(|(event, _)| {
-											if let Event::HTLCIntercepted { intercept_id: ev_id, .. } = event {
-												intercepted_id != ev_id
-											} else { true }
-										});
-										false
-									} else { true }
-								});
+								channel_monitor_recovery_internal(
+									&mut forward_htlcs,
+									&mut pending_events_read,
+									&mut pending_intercepted_htlcs,
+									&mut decode_update_add_htlcs,
+									prev_hop_data,
+									&logger,
+									htlc.payment_hash,
+									monitor.channel_id(),
+								);
 							},
 							HTLCSource::TrampolineForward { .. } => todo!(),
 							HTLCSource::OutboundRoute {
@@ -17368,6 +17333,60 @@ where
 
 		Ok((best_block_hash.clone(), channel_manager))
 	}
+}
+
+fn channel_monitor_recovery_internal(
+	forward_htlcs: &mut HashMap<u64, Vec<HTLCForwardInfo>>,
+	pending_events_read: &mut VecDeque<(Event, Option<EventCompletionAction>)>,
+	pending_intercepted_htlcs: &mut Option<HashMap<InterceptId, PendingAddHTLCInfo>>,
+	decode_update_add_htlcs: &mut HashMap<u64, Vec<msgs::UpdateAddHTLC>>,
+	prev_hop_data: HTLCPreviousHopData, logger: &impl Logger, payment_hash: PaymentHash,
+	channel_id: ChannelId,
+) {
+	let pending_forward_matches_htlc = |info: &PendingAddHTLCInfo| {
+		info.prev_funding_outpoint == prev_hop_data.outpoint
+			&& info.prev_htlc_id == prev_hop_data.htlc_id
+	};
+	// The ChannelMonitor is now responsible for this HTLC's
+	// failure/success and will let us know what its outcome is. If we
+	// still have an entry for this HTLC in `forward_htlcs` or
+	// `pending_intercepted_htlcs`, we were apparently not persisted after
+	// the monitor was when forwarding the payment.
+	decode_update_add_htlcs.retain(|scid, update_add_htlcs| {
+		update_add_htlcs.retain(|update_add_htlc| {
+			let matches = *scid == prev_hop_data.short_channel_id && update_add_htlc.htlc_id == prev_hop_data.htlc_id;
+			if matches {
+				log_info!(logger, "Removing pending to-decode HTLC with hash {} as it was forwarded to the closed channel {}",
+					payment_hash, channel_id);
+			}
+			!matches
+		});
+		!update_add_htlcs.is_empty()
+	});
+	forward_htlcs.retain(|_, forwards| {
+		forwards.retain(|forward| {
+			if let HTLCForwardInfo::AddHTLC(htlc_info) = forward {
+				if pending_forward_matches_htlc(&htlc_info) {
+					log_info!(logger, "Removing pending to-forward HTLC with hash {} as it was forwarded to the closed channel {}",
+						payment_hash, channel_id);
+					false
+				} else { true }
+			} else { true }
+		});
+		!forwards.is_empty()
+	});
+	pending_intercepted_htlcs.as_mut().unwrap().retain(|intercepted_id, htlc_info| {
+		if pending_forward_matches_htlc(&htlc_info) {
+			log_info!(logger, "Removing pending intercepted HTLC with hash {} as it was forwarded to the closed channel {}",
+				payment_hash, channel_id);
+			pending_events_read.retain(|(event, _)| {
+				if let Event::HTLCIntercepted { intercept_id: ev_id, .. } = event {
+					intercepted_id != ev_id
+				} else { true }
+			});
+			false
+		} else { true }
+	});
 }
 
 #[cfg(test)]

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7938,7 +7938,48 @@ where
 					htlc_failure_reason,
 				);
 			},
-			HTLCSource::TrampolineForward { .. } => todo!(),
+			// TODO: This branch should be tested when Trampoline Forwarding is implemented.
+			HTLCSource::TrampolineForward {
+				previous_hop_data,
+				incoming_trampoline_shared_secret,
+				..
+			} => {
+				// TODO: what do we want to do with this given we do not wish to propagate it directly?
+				let _decoded_onion_failure =
+					onion_error.decode_onion_failure(&self.secp_ctx, &self.logger, &source);
+				let incoming_trampoline_shared_secret = Some(*incoming_trampoline_shared_secret);
+				for current_hop_data in previous_hop_data {
+					let incoming_packet_shared_secret =
+						&current_hop_data.incoming_packet_shared_secret;
+					let channel_id = &current_hop_data.channel_id;
+					let short_channel_id = &current_hop_data.short_channel_id;
+					let htlc_id = &current_hop_data.htlc_id;
+					let blinded_failure = &current_hop_data.blinded_failure;
+					log_trace!(
+						WithContext::from(&self.logger, None, Some(*channel_id), Some(*payment_hash)),
+						"Failing {}HTLC with payment_hash {} backwards from us following Trampoline forwarding failure: {:?}",
+						if blinded_failure.is_some() { "blinded " } else { "" }, &payment_hash, onion_error
+					);
+					let onion_error = HTLCFailReason::reason(
+						LocalHTLCFailureReason::TemporaryTrampolineFailure,
+						Vec::new(),
+					);
+					let htlc_failure_reason = self.get_htlc_failure_from_blinded_failure_forward(
+						blinded_failure,
+						&onion_error,
+						incoming_packet_shared_secret,
+						&incoming_trampoline_shared_secret,
+						htlc_id,
+					);
+					self.fail_htlc_backwards_from_forward(
+						&onion_error,
+						failure_type.clone(),
+						short_channel_id,
+						channel_id,
+						htlc_failure_reason,
+					);
+				}
+			},
 		}
 	}
 

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1678,6 +1678,13 @@ pub enum LocalHTLCFailureReason {
 	HTLCMaximum,
 	/// The HTLC was failed because our remote peer is offline.
 	PeerOffline,
+	/// We have been unable to forward a payment to the next Trampoline node but may be able to
+	/// do it later.
+	TemporaryTrampolineFailure,
+	/// The amount or CLTV expiry were insufficient to route the payment to the next Trampoline.
+	TrampolineFeeOrExpiryInsufficient,
+	/// The specified next Trampoline node cannot be reached from our node.
+	UnknownNextTrampoline,
 }
 
 impl LocalHTLCFailureReason {
@@ -1718,6 +1725,9 @@ impl LocalHTLCFailureReason {
 			Self::InvalidOnionPayload | Self::InvalidTrampolinePayload => PERM | 22,
 			Self::MPPTimeout => 23,
 			Self::InvalidOnionBlinding => BADONION | PERM | 24,
+			Self::TemporaryTrampolineFailure => NODE | 25,
+			Self::TrampolineFeeOrExpiryInsufficient => NODE | 26,
+			Self::UnknownNextTrampoline => PERM | 27,
 			Self::UnknownFailureCode { code } => *code,
 		}
 	}
@@ -1852,6 +1862,9 @@ impl_writeable_tlv_based_enum!(LocalHTLCFailureReason,
 	(79, HTLCMinimum) => {},
 	(81, HTLCMaximum) => {},
 	(83, PeerOffline) => {},
+	(85, TemporaryTrampolineFailure) => {},
+	(87, TrampolineFeeOrExpiryInsufficient) => {},
+	(89, UnknownNextTrampoline) => {},
 );
 
 impl From<&HTLCFailReason> for HTLCHandlingFailureReason {
@@ -2018,6 +2031,11 @@ impl HTLCFailReason {
 					debug_assert!(false, "Unknown failure code: {}", code)
 				}
 			},
+			LocalHTLCFailureReason::TemporaryTrampolineFailure => debug_assert!(data.is_empty()),
+			LocalHTLCFailureReason::TrampolineFeeOrExpiryInsufficient => {
+				debug_assert_eq!(data.len(), 10)
+			},
+			LocalHTLCFailureReason::UnknownNextTrampoline => debug_assert!(data.is_empty()),
 		}
 
 		Self(HTLCFailReasonRepr::Reason { data, failure_reason })

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -1077,6 +1077,7 @@ impl Readable for Vec<u8> {
 
 impl_for_vec!(ecdsa::Signature);
 impl_for_vec!(crate::chain::channelmonitor::ChannelMonitorUpdate);
+impl_for_vec!(crate::ln::channelmanager::HTLCPreviousHopData);
 impl_for_vec!(crate::ln::channelmanager::MonitorUpdateCompletionAction);
 impl_for_vec!(crate::ln::channelmanager::PaymentClaimDetails);
 impl_for_vec!(crate::ln::msgs::SocketAddress);
@@ -1086,6 +1087,7 @@ impl_for_vec!(NegotiatedTxInput);
 impl_for_vec!(InteractiveTxOutput);
 impl_writeable_for_vec!(&crate::routing::router::BlindedTail);
 impl_readable_for_vec!(crate::routing::router::BlindedTail);
+impl_for_vec!(crate::routing::router::RouteHop);
 impl_for_vec!(crate::routing::router::TrampolineHop);
 impl_for_vec_with_element_length_prefix!(crate::ln::msgs::UpdateAddHTLC);
 impl_writeable_for_vec_with_element_length_prefix!(&crate::ln::msgs::UpdateAddHTLC);


### PR DESCRIPTION
This PR is on top of #3983 is part of the split-up of #3976

Main focus of this PR is to add a `TrampolineForward` variant to `HTLCSource` enum, then we extract most logic to be re-used and then implement the places where we require it.

After this PR only left is the implementation of finding path and forward the HTLCs and adding tests for all reamaining "to do" statements