### PR TITLE
Implement invalid-parameters-error for lightning-liquidity

### DIFF
--- a/lightning-liquidity/Cargo.toml
+++ b/lightning-liquidity/Cargo.toml
@@ -23,6 +23,7 @@ backtrace = ["dep:backtrace"]
 lightning = { version = "0.2.0", path = "../lightning", default-features = false }
 lightning-types = { version = "0.3.0", path = "../lightning-types", default-features = false }
 lightning-invoice = { version = "0.34.0", path = "../lightning-invoice", default-features = false, features = ["serde"] }
+lightning-macros = { version = "0.2", path = "../lightning-macros" }
 
 bitcoin = { version = "0.32.2", default-features = false, features = ["serde"] }
 

--- a/lightning-liquidity/src/lib.rs
+++ b/lightning-liquidity/src/lib.rs
@@ -56,6 +56,7 @@ extern crate alloc;
 
 mod prelude {
 	pub(crate) use lightning::util::hash_tables::*;
+	pub(crate) use lightning_macros::DeserializeWithUnknowns;
 }
 
 pub mod events;

--- a/lightning-liquidity/src/lsps0/msgs.rs
+++ b/lightning-liquidity/src/lsps0/msgs.rs
@@ -1,9 +1,12 @@
 //! Message, request, and other primitive types used to implement LSPS0.
 
+use crate::prelude::*;
+
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 
-use crate::lsps0::ser::{LSPSMessage, LSPSRequestId, LSPSResponseError};
+use crate::lsps0::ser::{DeserializeWithUnknowns, LSPSMessage, LSPSRequestId, LSPSResponseError};
 
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +17,7 @@ pub(crate) const LSPS0_LISTPROTOCOLS_METHOD_NAME: &str = "lsps0.list_protocols";
 /// Please refer to the [bLIP-50 / LSPS0
 /// specification](https://github.com/lightning/blips/blob/master/blip-0050.md#lsps-specification-support-query)
 /// for more information.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct LSPS0ListProtocolsRequest {}
 
 /// A response to a `list_protocols` request.
@@ -22,7 +25,7 @@ pub struct LSPS0ListProtocolsRequest {}
 /// Please refer to the [bLIP-50 / LSPS0
 /// specification](https://github.com/lightning/blips/blob/master/blip-0050.md#lsps-specification-support-query)
 /// for more information.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LSPS0ListProtocolsResponse {
 	/// A list of supported protocols.
 	pub protocols: Vec<u16>,

--- a/lightning-liquidity/src/lsps0/ser.rs
+++ b/lightning-liquidity/src/lsps0/ser.rs
@@ -469,6 +469,9 @@ impl Serialize for LSPSMessage {
 					LSPS5Response::ListWebhooks(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
 					},
+					LSPS5Response::ListWebhooksError(error) => {
+						jsonrpc_object.serialize_field(JSONRPC_ERROR_FIELD_KEY, error)?
+					},
 					LSPS5Response::RemoveWebhook(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
 					},

--- a/lightning-liquidity/src/lsps0/ser.rs
+++ b/lightning-liquidity/src/lsps0/ser.rs
@@ -5,6 +5,8 @@
 //! information.
 
 use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
 use core::fmt::{self, Display};
 use core::str::FromStr;
@@ -278,6 +280,15 @@ pub struct LSPSResponseError {
 	pub message: String,
 	/// A primitive or structured value that contains additional information about the error.
 	pub data: Option<String>,
+}
+
+/// A trait for deserializing from a `serde_json::Value` while capturing unknown fields.
+pub(crate) trait DeserializeWithUnknowns: Sized {
+	/// Deserializes a struct from a `serde_json::Value`, returning the struct
+	/// and a list of any unrecognized field names.
+	fn deserialize_with_unknowns(
+		value: serde_json::Value,
+	) -> Result<(Self, Vec<String>), serde_json::Error>;
 }
 
 /// A (de-)serializable LSPS message allowing to be sent over the wire.

--- a/lightning-liquidity/src/lsps1/msgs.rs
+++ b/lightning-liquidity/src/lsps1/msgs.rs
@@ -9,13 +9,15 @@
 
 //! Message, request, and other primitive types used to implement bLIP-51 / LSPS1.
 
+use crate::prelude::*;
 use alloc::string::String;
+use alloc::vec::Vec;
 
 use core::convert::TryFrom;
 
 use crate::lsps0::ser::{
 	string_amount, string_offer, u32_fee_rate, unchecked_address, unchecked_address_option,
-	LSPSDateTime, LSPSMessage, LSPSRequestId, LSPSResponseError,
+	DeserializeWithUnknowns, LSPSDateTime, LSPSMessage, LSPSRequestId, LSPSResponseError,
 };
 
 use bitcoin::{Address, FeeRate, OutPoint};
@@ -42,7 +44,7 @@ pub struct LSPS1OrderId(pub String);
 /// Please refer to the [bLIP-51 / LSPS1
 /// specification](https://github.com/lightning/blips/blob/master/blip-0051.md#1-lsps1get_info) for
 /// more information.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(default)]
 pub struct LSPS1GetInfoRequest {}
 
@@ -78,7 +80,7 @@ pub struct LSPS1Options {
 }
 
 /// A response to a [`LSPS1GetInfoRequest`].
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LSPS1GetInfoResponse {
 	/// All options supported by the LSP.
 	#[serde(flatten)]
@@ -90,7 +92,7 @@ pub struct LSPS1GetInfoResponse {
 /// Please refer to the [bLIP-51 / LSPS1
 /// specification](https://github.com/lightning/blips/blob/master/blip-0051.md#2-lsps1create_order)
 /// for more information.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LSPS1CreateOrderRequest {
 	/// The order made.
 	#[serde(flatten)]
@@ -127,7 +129,7 @@ pub struct LSPS1OrderParams {
 }
 
 /// A response to a [`LSPS1CreateOrderRequest`].
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LSPS1CreateOrderResponse {
 	/// The id of the channel order.
 	pub order_id: LSPS1OrderId,
@@ -277,7 +279,7 @@ pub struct LSPS1ChannelInfo {
 /// Please refer to the [bLIP-51 / LSPS1
 /// specification](https://github.com/lightning/blips/blob/master/blip-0051.md#21-lsps1get_order)
 /// for more information.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LSPS1GetOrderRequest {
 	/// The id of the order.
 	pub order_id: LSPS1OrderId,

--- a/lightning-liquidity/src/lsps1/service.rs
+++ b/lightning-liquidity/src/lsps1/service.rs
@@ -25,6 +25,7 @@ use crate::message_queue::MessageQueue;
 use crate::events::EventQueue;
 use crate::lsps0::ser::{
 	LSPSDateTime, LSPSProtocolMessageHandler, LSPSRequestId, LSPSResponseError,
+	LSPSResponseErrorData,
 };
 use crate::prelude::{new_hash_map, HashMap};
 use crate::sync::{Arc, Mutex, RwLock};
@@ -207,10 +208,10 @@ where
 			let response = LSPS1Response::CreateOrderError(LSPSResponseError {
 				code: LSPS1_CREATE_ORDER_REQUEST_ORDER_MISMATCH_ERROR_CODE,
 				message: format!("Order does not match options supported by LSP server"),
-				data: Some(format!(
+				data: Some(LSPSResponseErrorData::Text(format!(
 					"Supported options are {:?}",
 					&self.config.supported_options.as_ref().unwrap()
-				)),
+				))),
 			});
 			let msg = LSPS1Message::Response(request_id, response).into();
 			message_queue_notifier.enqueue(counterparty_node_id, msg);

--- a/lightning-liquidity/src/lsps2/msgs.rs
+++ b/lightning-liquidity/src/lsps2/msgs.rs
@@ -9,6 +9,8 @@
 
 //! Message, request, and other primitive types used to implement bLIP-52 / LSPS2.
 
+use crate::prelude::*;
+
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -22,8 +24,8 @@ use serde::{Deserialize, Serialize};
 use lightning::util::scid_utils;
 
 use crate::lsps0::ser::{
-	string_amount, string_amount_option, LSPSDateTime, LSPSMessage, LSPSRequestId,
-	LSPSResponseError,
+	string_amount, string_amount_option, DeserializeWithUnknowns, LSPSDateTime, LSPSMessage,
+	LSPSRequestId, LSPSResponseError,
 };
 use crate::utils;
 
@@ -36,7 +38,7 @@ pub(crate) const LSPS2_BUY_REQUEST_INVALID_OPENING_FEE_PARAMS_ERROR_CODE: i32 = 
 pub(crate) const LSPS2_BUY_REQUEST_PAYMENT_SIZE_TOO_SMALL_ERROR_CODE: i32 = 202;
 pub(crate) const LSPS2_BUY_REQUEST_PAYMENT_SIZE_TOO_LARGE_ERROR_CODE: i32 = 203;
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 /// A request made to an LSP to learn their current channel fees and parameters.
 pub struct LSPS2GetInfoRequest {
 	/// An optional token to provide to the LSP.
@@ -91,7 +93,7 @@ impl LSPS2RawOpeningFeeParams {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 /// Fees and parameters for a JIT Channel including the promise.
 ///
 /// The promise is an HMAC calculated using a secret known to the LSP and the rest of the fields as input.
@@ -120,14 +122,14 @@ pub struct LSPS2OpeningFeeParams {
 }
 
 /// A response to a [`LSPS2GetInfoRequest`]
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LSPS2GetInfoResponse {
 	/// A set of opening fee parameters.
 	pub opening_fee_params_menu: Vec<LSPS2OpeningFeeParams>,
 }
 
 /// A request to buy a JIT channel.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LSPS2BuyRequest {
 	/// The fee parameters you would like to use.
 	pub opening_fee_params: LSPS2OpeningFeeParams,
@@ -162,7 +164,7 @@ impl LSPS2InterceptScid {
 /// A response to a [`LSPS2BuyRequest`].
 ///
 /// Includes information needed to construct an invoice.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(DeserializeWithUnknowns, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LSPS2BuyResponse {
 	/// The intercept short channel id used by LSP to identify need to open channel.
 	pub jit_channel_scid: LSPS2InterceptScid,

--- a/lightning-liquidity/src/lsps5/client.rs
+++ b/lightning-liquidity/src/lsps5/client.rs
@@ -14,8 +14,8 @@ use crate::events::EventQueue;
 use crate::lsps0::ser::{LSPSMessage, LSPSProtocolMessageHandler, LSPSRequestId};
 use crate::lsps5::event::LSPS5ClientEvent;
 use crate::lsps5::msgs::{
-	LSPS5Message, LSPS5Request, LSPS5Response, ListWebhooksRequest, RemoveWebhookRequest,
-	SetWebhookRequest,
+	LSPS5ListWebhooksRequest, LSPS5Message, LSPS5RemoveWebhookRequest, LSPS5Request, LSPS5Response,
+	LSPS5SetWebhookRequest,
 };
 
 use crate::message_queue::MessageQueue;
@@ -208,8 +208,10 @@ where
 			);
 		});
 
-		let request =
-			LSPS5Request::SetWebhook(SetWebhookRequest { app_name, webhook: lsps_webhook_url });
+		let request = LSPS5Request::SetWebhook(LSPS5SetWebhookRequest {
+			app_name,
+			webhook: lsps_webhook_url,
+		});
 
 		let message = LSPS5Message::Request(request_id.clone(), request);
 		message_queue_notifier.enqueue(&counterparty_node_id, LSPSMessage::LSPS5(message));
@@ -241,7 +243,7 @@ where
 			peer_state.add_request(request_id.clone(), |s| &mut s.pending_list_webhooks_requests);
 		});
 
-		let request = LSPS5Request::ListWebhooks(ListWebhooksRequest {});
+		let request = LSPS5Request::ListWebhooks(LSPS5ListWebhooksRequest {});
 		let message = LSPS5Message::Request(request_id.clone(), request);
 		message_queue_notifier.enqueue(&counterparty_node_id, LSPSMessage::LSPS5(message));
 
@@ -281,7 +283,7 @@ where
 			});
 		});
 
-		let request = LSPS5Request::RemoveWebhook(RemoveWebhookRequest { app_name });
+		let request = LSPS5Request::RemoveWebhook(LSPS5RemoveWebhookRequest { app_name });
 		let message = LSPS5Message::Request(request_id.clone(), request);
 		message_queue_notifier.enqueue(&counterparty_node_id, LSPSMessage::LSPS5(message));
 
@@ -438,7 +440,10 @@ where
 mod tests {
 
 	use super::*;
-	use crate::{lsps0::ser::LSPSRequestId, lsps5::msgs::SetWebhookResponse};
+	use crate::{
+		lsps0::ser::LSPSRequestId, lsps5::msgs::LSPS5ListWebhooksResponse,
+		lsps5::msgs::LSPS5SetWebhookResponse,
+	};
 	use bitcoin::{key::Secp256k1, secp256k1::SecretKey};
 	use core::sync::atomic::{AtomicU64, Ordering};
 
@@ -551,7 +556,7 @@ mod tests {
 			.unwrap();
 
 		let unknown_req_id = LSPSRequestId("unknown:request:id".to_string());
-		let response = LSPS5Response::SetWebhook(SetWebhookResponse {
+		let response = LSPS5Response::SetWebhook(LSPS5SetWebhookResponse {
 			num_webhooks: 1,
 			max_webhooks: 5,
 			no_change: false,
@@ -631,7 +636,7 @@ mod tests {
 			assert!(peer_state.pending_list_webhooks_requests.contains(&list_webhooks_req_id));
 		}
 
-		let set_webhook_response = LSPS5Response::SetWebhook(SetWebhookResponse {
+		let set_webhook_response = LSPS5Response::SetWebhook(LSPS5SetWebhookResponse {
 			num_webhooks: 1,
 			max_webhooks: 5,
 			no_change: false,
@@ -652,11 +657,10 @@ mod tests {
 			assert!(peer_state.pending_list_webhooks_requests.contains(&list_webhooks_req_id));
 		}
 
-		let list_webhooks_response =
-			LSPS5Response::ListWebhooks(crate::lsps5::msgs::ListWebhooksResponse {
-				app_names: vec![],
-				max_webhooks: 5,
-			});
+		let list_webhooks_response = LSPS5Response::ListWebhooks(LSPS5ListWebhooksResponse {
+			app_names: vec![],
+			max_webhooks: 5,
+		});
 		let response_msg = LSPS5Message::Response(list_webhooks_req_id, list_webhooks_response);
 
 		// now the pending request is handled, so the peer state should be removed

--- a/lightning-liquidity/src/lsps5/msgs.rs
+++ b/lightning-liquidity/src/lsps5/msgs.rs
@@ -9,10 +9,9 @@
 
 //! LSPS5 message formats for webhook registration
 
-use crate::alloc::string::ToString;
-use crate::lsps0::ser::LSPSMessage;
-use crate::lsps0::ser::LSPSRequestId;
-use crate::lsps0::ser::LSPSResponseError;
+use crate::prelude::*;
+
+use crate::lsps0::ser::{DeserializeWithUnknowns, LSPSMessage, LSPSRequestId, LSPSResponseError};
 
 use super::url_utils::LSPSUrl;
 
@@ -25,6 +24,7 @@ use serde::Serializer;
 use serde::{Deserialize, Serialize};
 
 use alloc::string::String;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 
 use core::fmt;
@@ -418,7 +418,7 @@ impl From<LSPS5WebhookUrl> for String {
 }
 
 /// Parameters for `lsps5.set_webhook` request.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(DeserializeWithUnknowns, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LSPS5SetWebhookRequest {
 	/// Human-readable name for the webhook.
 	pub app_name: LSPS5AppName,
@@ -427,7 +427,7 @@ pub struct LSPS5SetWebhookRequest {
 }
 
 /// Response for `lsps5.set_webhook`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(DeserializeWithUnknowns, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LSPS5SetWebhookResponse {
 	/// Current number of webhooks registered for this client.
 	pub num_webhooks: u32,
@@ -438,11 +438,11 @@ pub struct LSPS5SetWebhookResponse {
 }
 
 /// Parameters for `lsps5.list_webhooks` request.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(DeserializeWithUnknowns, Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct LSPS5ListWebhooksRequest {}
 
 /// Response for `lsps5.list_webhooks`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(DeserializeWithUnknowns, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LSPS5ListWebhooksResponse {
 	/// List of app_names with registered webhooks.
 	pub app_names: Vec<LSPS5AppName>,
@@ -451,14 +451,14 @@ pub struct LSPS5ListWebhooksResponse {
 }
 
 /// Parameters for `lsps5.remove_webhook` request.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(DeserializeWithUnknowns, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LSPS5RemoveWebhookRequest {
 	/// App name identifying the webhook to remove.
 	pub app_name: LSPS5AppName,
 }
 
 /// Response for `lsps5.remove_webhook`.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(DeserializeWithUnknowns, Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct LSPS5RemoveWebhookResponse {}
 
 /// Webhook notification methods defined in LSPS5.

--- a/lightning-liquidity/src/lsps5/msgs.rs
+++ b/lightning-liquidity/src/lsps5/msgs.rs
@@ -649,6 +649,8 @@ pub enum LSPS5Response {
 	SetWebhookError(LSPSResponseError),
 	/// Response to [`ListWebhooks`](LSPS5ListWebhooksRequest) request.
 	ListWebhooks(LSPS5ListWebhooksResponse),
+	/// Error response to [`ListWebhooks`](LSPS5ListWebhooksRequest) request.
+	ListWebhooksError(LSPSResponseError),
 	/// Response to [`RemoveWebhook`](LSPS5RemoveWebhookRequest) request.
 	RemoveWebhook(LSPS5RemoveWebhookResponse),
 	/// Error response to [`RemoveWebhook`](LSPS5RemoveWebhookRequest) request.

--- a/lightning-liquidity/src/lsps5/msgs.rs
+++ b/lightning-liquidity/src/lsps5/msgs.rs
@@ -419,7 +419,7 @@ impl From<LSPS5WebhookUrl> for String {
 
 /// Parameters for `lsps5.set_webhook` request.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SetWebhookRequest {
+pub struct LSPS5SetWebhookRequest {
 	/// Human-readable name for the webhook.
 	pub app_name: LSPS5AppName,
 	/// URL of the webhook.
@@ -428,7 +428,7 @@ pub struct SetWebhookRequest {
 
 /// Response for `lsps5.set_webhook`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SetWebhookResponse {
+pub struct LSPS5SetWebhookResponse {
 	/// Current number of webhooks registered for this client.
 	pub num_webhooks: u32,
 	/// Maximum number of webhooks allowed by LSP.
@@ -439,11 +439,11 @@ pub struct SetWebhookResponse {
 
 /// Parameters for `lsps5.list_webhooks` request.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct ListWebhooksRequest {}
+pub struct LSPS5ListWebhooksRequest {}
 
 /// Response for `lsps5.list_webhooks`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ListWebhooksResponse {
+pub struct LSPS5ListWebhooksResponse {
 	/// List of app_names with registered webhooks.
 	pub app_names: Vec<LSPS5AppName>,
 	/// Maximum number of webhooks allowed by LSP.
@@ -452,14 +452,14 @@ pub struct ListWebhooksResponse {
 
 /// Parameters for `lsps5.remove_webhook` request.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RemoveWebhookRequest {
+pub struct LSPS5RemoveWebhookRequest {
 	/// App name identifying the webhook to remove.
 	pub app_name: LSPS5AppName,
 }
 
 /// Response for `lsps5.remove_webhook`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct RemoveWebhookResponse {}
+pub struct LSPS5RemoveWebhookResponse {}
 
 /// Webhook notification methods defined in LSPS5.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -633,25 +633,25 @@ impl<'de> Deserialize<'de> for WebhookNotification {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LSPS5Request {
 	/// Register or update a webhook.
-	SetWebhook(SetWebhookRequest),
+	SetWebhook(LSPS5SetWebhookRequest),
 	/// List all registered webhooks.
-	ListWebhooks(ListWebhooksRequest),
+	ListWebhooks(LSPS5ListWebhooksRequest),
 	/// Remove a webhook.
-	RemoveWebhook(RemoveWebhookRequest),
+	RemoveWebhook(LSPS5RemoveWebhookRequest),
 }
 
 /// An LSPS5 protocol response.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LSPS5Response {
-	/// Response to [`SetWebhook`](SetWebhookRequest) request.
-	SetWebhook(SetWebhookResponse),
-	/// Error response to [`SetWebhook`](SetWebhookRequest) request.
+	/// Response to [`SetWebhook`](LSPS5SetWebhookRequest) request.
+	SetWebhook(LSPS5SetWebhookResponse),
+	/// Error response to [`SetWebhook`](LSPS5SetWebhookRequest) request.
 	SetWebhookError(LSPSResponseError),
-	/// Response to [`ListWebhooks`](ListWebhooksRequest) request.
-	ListWebhooks(ListWebhooksResponse),
-	/// Response to [`RemoveWebhook`](RemoveWebhookRequest) request.
-	RemoveWebhook(RemoveWebhookResponse),
-	/// Error response to [`RemoveWebhook`](RemoveWebhookRequest) request.
+	/// Response to [`ListWebhooks`](LSPS5ListWebhooksRequest) request.
+	ListWebhooks(LSPS5ListWebhooksResponse),
+	/// Response to [`RemoveWebhook`](LSPS5RemoveWebhookRequest) request.
+	RemoveWebhook(LSPS5RemoveWebhookResponse),
+	/// Error response to [`RemoveWebhook`](LSPS5RemoveWebhookRequest) request.
 	RemoveWebhookError(LSPSResponseError),
 }
 
@@ -700,7 +700,7 @@ mod tests {
 	#[test]
 	fn parse_set_webhook_request() {
 		let json_str = r#"{"app_name":"my_app","webhook":"https://example.com/webhook"}"#;
-		let request: SetWebhookRequest = serde_json::from_str(json_str).unwrap();
+		let request: LSPS5SetWebhookRequest = serde_json::from_str(json_str).unwrap();
 		assert_eq!(request.app_name, LSPS5AppName::new("my_app".to_string()).unwrap());
 		assert_eq!(
 			request.webhook,
@@ -711,7 +711,7 @@ mod tests {
 	#[test]
 	fn parse_set_webhook_response() {
 		let json_str = r#"{"num_webhooks":1,"max_webhooks":5,"no_change":false}"#;
-		let response: SetWebhookResponse = serde_json::from_str(json_str).unwrap();
+		let response: LSPS5SetWebhookResponse = serde_json::from_str(json_str).unwrap();
 		assert_eq!(response.num_webhooks, 1);
 		assert_eq!(response.max_webhooks, 5);
 		assert_eq!(response.no_change, false);
@@ -720,7 +720,7 @@ mod tests {
 	#[test]
 	fn parse_list_webhooks_response() {
 		let json_str = r#"{"app_names":["app1","app2"],"max_webhooks":5}"#;
-		let response: ListWebhooksResponse = serde_json::from_str(json_str).unwrap();
+		let response: LSPS5ListWebhooksResponse = serde_json::from_str(json_str).unwrap();
 		let app1 = LSPS5AppName::new("app1".to_string()).unwrap();
 		let app2 = LSPS5AppName::new("app2".to_string()).unwrap();
 		assert_eq!(response.app_names, vec![app1, app2]);
@@ -730,14 +730,14 @@ mod tests {
 	#[test]
 	fn parse_empty_requests_responses() {
 		let json_str = r#"{}"#;
-		let _list_req: ListWebhooksRequest = serde_json::from_str(json_str).unwrap();
-		let _remove_resp: RemoveWebhookResponse = serde_json::from_str(json_str).unwrap();
+		let _list_req: LSPS5ListWebhooksRequest = serde_json::from_str(json_str).unwrap();
+		let _remove_resp: LSPS5RemoveWebhookResponse = serde_json::from_str(json_str).unwrap();
 	}
 
 	#[test]
 	fn spec_example_set_webhook_request() {
 		let json_str = r#"{"app_name":"My LSPS-Compliant Lightning Client","webhook":"https://www.example.org/push?l=1234567890abcdefghijklmnopqrstuv&c=best"}"#;
-		let request: SetWebhookRequest = serde_json::from_str(json_str).unwrap();
+		let request: LSPS5SetWebhookRequest = serde_json::from_str(json_str).unwrap();
 		assert_eq!(
 			request.app_name,
 			LSPS5AppName::new("My LSPS-Compliant Lightning Client".to_string()).unwrap()
@@ -755,7 +755,7 @@ mod tests {
 	#[test]
 	fn spec_example_set_webhook_response() {
 		let json_str = r#"{"num_webhooks":2,"max_webhooks":4,"no_change":false}"#;
-		let response: SetWebhookResponse = serde_json::from_str(json_str).unwrap();
+		let response: LSPS5SetWebhookResponse = serde_json::from_str(json_str).unwrap();
 		assert_eq!(response.num_webhooks, 2);
 		assert_eq!(response.max_webhooks, 4);
 		assert_eq!(response.no_change, false);
@@ -764,7 +764,7 @@ mod tests {
 	#[test]
 	fn spec_example_list_webhooks_response() {
 		let json_str = r#"{"app_names":["My LSPS-Compliant Lightning Wallet","Another Wallet With The Same Signing Device"],"max_webhooks":42}"#;
-		let response: ListWebhooksResponse = serde_json::from_str(json_str).unwrap();
+		let response: LSPS5ListWebhooksResponse = serde_json::from_str(json_str).unwrap();
 		let app1 = LSPS5AppName::new("My LSPS-Compliant Lightning Wallet".to_string()).unwrap();
 		let app2 =
 			LSPS5AppName::new("Another Wallet With The Same Signing Device".to_string()).unwrap();
@@ -775,7 +775,7 @@ mod tests {
 	#[test]
 	fn spec_example_remove_webhook_request() {
 		let json_str = r#"{"app_name":"Another Wallet With The Same Signig Device"}"#;
-		let request: RemoveWebhookRequest = serde_json::from_str(json_str).unwrap();
+		let request: LSPS5RemoveWebhookRequest = serde_json::from_str(json_str).unwrap();
 		assert_eq!(
 			request.app_name,
 			LSPS5AppName::new("Another Wallet With The Same Signig Device".to_string()).unwrap()

--- a/lightning-liquidity/src/lsps5/service.rs
+++ b/lightning-liquidity/src/lsps5/service.rs
@@ -13,8 +13,9 @@ use crate::alloc::string::ToString;
 use crate::events::EventQueue;
 use crate::lsps0::ser::{LSPSDateTime, LSPSProtocolMessageHandler, LSPSRequestId};
 use crate::lsps5::msgs::{
-	ListWebhooksRequest, ListWebhooksResponse, RemoveWebhookRequest, RemoveWebhookResponse,
-	SetWebhookRequest, SetWebhookResponse, WebhookNotification, WebhookNotificationMethod,
+	LSPS5ListWebhooksRequest, LSPS5ListWebhooksResponse, LSPS5RemoveWebhookRequest,
+	LSPS5RemoveWebhookResponse, LSPS5SetWebhookRequest, LSPS5SetWebhookResponse,
+	WebhookNotification, WebhookNotificationMethod,
 };
 use crate::message_queue::MessageQueue;
 use crate::prelude::*;
@@ -174,7 +175,7 @@ where
 
 	fn handle_set_webhook(
 		&self, counterparty_node_id: PublicKey, request_id: LSPSRequestId,
-		params: SetWebhookRequest,
+		params: LSPS5SetWebhookRequest,
 	) -> Result<(), LightningError> {
 		let mut message_queue_notifier = self.pending_messages.notifier();
 
@@ -245,7 +246,7 @@ where
 
 		let msg = LSPS5Message::Response(
 			request_id,
-			LSPS5Response::SetWebhook(SetWebhookResponse {
+			LSPS5Response::SetWebhook(LSPS5SetWebhookResponse {
 				num_webhooks: peer_state.webhooks_len() as u32,
 				max_webhooks: self.config.max_webhooks_per_client,
 				no_change,
@@ -258,7 +259,7 @@ where
 
 	fn handle_list_webhooks(
 		&self, counterparty_node_id: PublicKey, request_id: LSPSRequestId,
-		_params: ListWebhooksRequest,
+		_params: LSPS5ListWebhooksRequest,
 	) -> Result<(), LightningError> {
 		let mut message_queue_notifier = self.pending_messages.notifier();
 
@@ -268,7 +269,7 @@ where
 
 		let max_webhooks = self.config.max_webhooks_per_client;
 
-		let response = ListWebhooksResponse { app_names, max_webhooks };
+		let response = LSPS5ListWebhooksResponse { app_names, max_webhooks };
 		let msg = LSPS5Message::Response(request_id, LSPS5Response::ListWebhooks(response)).into();
 		message_queue_notifier.enqueue(&counterparty_node_id, msg);
 
@@ -277,7 +278,7 @@ where
 
 	fn handle_remove_webhook(
 		&self, counterparty_node_id: PublicKey, request_id: LSPSRequestId,
-		params: RemoveWebhookRequest,
+		params: LSPS5RemoveWebhookRequest,
 	) -> Result<(), LightningError> {
 		let mut message_queue_notifier = self.pending_messages.notifier();
 
@@ -285,7 +286,7 @@ where
 
 		if let Some(peer_state) = outer_state_lock.get_mut(&counterparty_node_id) {
 			if peer_state.remove_webhook(&params.app_name) {
-				let response = RemoveWebhookResponse {};
+				let response = LSPS5RemoveWebhookResponse {};
 				let msg =
 					LSPS5Message::Response(request_id, LSPS5Response::RemoveWebhook(response))
 						.into();

--- a/lightning-macros/Cargo.toml
+++ b/lightning-macros/Cargo.toml
@@ -21,6 +21,8 @@ proc-macro = true
 syn = { version = "2.0", default-features = false, features = ["parsing", "printing", "proc-macro", "full"] }
 proc-macro2 = { version = "1.0", default-features = false, features = ["proc-macro"] }
 quote = { version = "1.0", default-features = false, features = ["proc-macro"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 inventory = "0.3"


### PR DESCRIPTION
Closes https://github.com/lightningdevkit/rust-lightning/issues/3476

As per spec, https://github.com/BitcoinAndLightningLayerSpecs/lsp/blob/main/LSPS0/README.md#-32602-invalid-parameters-error, if an unknown param is received, error code -32602 must be returned, and the unrecognized parameter must be informed to the caller.

> Other implementors before mentioned that it's not trivial to do with serde, if it's too cumbersome we might want to bring it back to the spec group.

I tried a few things (see Notes) and I agree, it's not trivial, mainly because serde does not provide this out of the box.

I also think that this is probably too much complexity for the thing that is accomplished, but I would like others to chip in.

Notes: 

things I tried:

- import a new crate like serde-ignore or similar, or copy their approach. I don't really trust these kinds of crates
- serde's deny_unknown_fields is ok but it does not give you a structured response with the unknown fields that were unknown so we can't use it
- add an `unknown_fields` field with #[serde(flatten)] on all structs. the unknown fields would be deserialized on this new field. kind of hard to maintain and adds a lot of noise. I think it added some complexity with nested structs.
- deserialize, then serialize, and then check diff (which is what I did in a derive macro)