### PR TITLE
Commit to client's node id in bLIP-52/LSPS2 promise

### DIFF
--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -630,7 +630,10 @@ where
 							opening_fee_params_menu
 								.into_iter()
 								.map(|param| {
-									param.into_opening_fee_params(&self.config.promise_secret)
+									param.into_opening_fee_params(
+										&self.config.promise_secret,
+										counterparty_node_id,
+									)
 								})
 								.collect();
 						opening_fee_params_menu.sort_by(|a, b| {
@@ -1252,7 +1255,11 @@ where
 		}
 
 		// TODO: if payment_size_msat is specified, make sure our node has sufficient incoming liquidity from public network to receive it.
-		if !is_valid_opening_fee_params(&params.opening_fee_params, &self.config.promise_secret) {
+		if !is_valid_opening_fee_params(
+			&params.opening_fee_params,
+			&self.config.promise_secret,
+			counterparty_node_id,
+		) {
 			let response = LSPS2Response::BuyError(LSPSResponseError {
 				code: LSPS2_BUY_REQUEST_INVALID_OPENING_FEE_PARAMS_ERROR_CODE,
 				message: "valid_until is already past OR the promise did not match the provided parameters".to_string(),

--- a/lightning-liquidity/src/lsps2/utils.rs
+++ b/lightning-liquidity/src/lsps2/utils.rs
@@ -13,15 +13,17 @@ use crate::utils;
 use bitcoin::hashes::hmac::{Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::{Hash, HashEngine};
+use bitcoin::secp256k1::PublicKey;
 
 /// Determines if the given parameters are valid given the secret used to generate the promise.
 pub fn is_valid_opening_fee_params(
-	fee_params: &LSPS2OpeningFeeParams, promise_secret: &[u8; 32],
+	fee_params: &LSPS2OpeningFeeParams, promise_secret: &[u8; 32], counterparty_node_id: &PublicKey,
 ) -> bool {
 	if is_expired_opening_fee_params(fee_params) {
 		return false;
 	}
 	let mut hmac = HmacEngine::<Sha256>::new(promise_secret);
+	hmac.input(&counterparty_node_id.serialize());
 	hmac.input(&fee_params.min_fee_msat.to_be_bytes());
 	hmac.input(&fee_params.proportional.to_be_bytes());
 	hmac.input(fee_params.valid_until.to_rfc3339().as_bytes());

--- a/lightning-liquidity/tests/lsps2_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps2_integration_tests.rs
@@ -192,7 +192,11 @@ fn invoice_generation_flow() {
 			assert_eq!(request_id, get_info_request_id);
 			assert_eq!(counterparty_node_id, service_node_id);
 			let opening_fee_params = opening_fee_params_menu.first().unwrap().clone();
-			assert!(is_valid_opening_fee_params(&opening_fee_params, &promise_secret));
+			assert!(is_valid_opening_fee_params(
+				&opening_fee_params,
+				&promise_secret,
+				&client_node_id
+			));
 			opening_fee_params
 		},
 		_ => panic!("Unexpected event"),


### PR DESCRIPTION
Closes #4037.

Previously, the promise HMAC would only commit to the promise secret and the `OpeningFeeParams` fields, leaving room for other clients to reuse the same `OpeningFeeParams` in `BuyRequests` if they'd acquire it somehow out-of-bounds.

While this flexibility also has some benefits, we here have the service commit to the client's node id, making sure only the original client can redeem a specific `OpeningFeeParams`.

(cc @johncantrell97 @martinsaposnic)