### PR TITLE
Async send prefactor 

### DIFF
--- a/lightning-dns-resolver/src/lib.rs
+++ b/lightning-dns-resolver/src/lib.rs
@@ -239,8 +239,7 @@ mod test {
 				context,
 				&keys,
 				secp_ctx,
-			)
-			.unwrap()])
+			)])
 		}
 	}
 	impl Deref for DirectlyConnectedRouter {
@@ -349,8 +348,7 @@ mod test {
 			query_context,
 			&*payer_keys,
 			&secp_ctx,
-		)
-		.unwrap();
+		);
 		payer.pending_messages.lock().unwrap().push((
 			DNSResolverMessage::DNSSECQuery(msg),
 			MessageSendInstructions::WithSpecifiedReplyPath {

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -57,23 +57,19 @@ impl BlindedMessagePath {
 	pub fn one_hop<ES: Deref, T: secp256k1::Signing + secp256k1::Verification>(
 		recipient_node_id: PublicKey, local_node_receive_key: ReceiveAuthKey,
 		context: MessageContext, entropy_source: ES, secp_ctx: &Secp256k1<T>,
-	) -> Result<Self, ()>
+	) -> Self
 	where
 		ES::Target: EntropySource,
 	{
 		Self::new(&[], recipient_node_id, local_node_receive_key, context, entropy_source, secp_ctx)
 	}
 
-	/// Create a path for an onion message, to be forwarded along `node_pks`. The last node
-	/// pubkey in `node_pks` will be the destination node.
-	///
-	/// Errors if no hops are provided or if `node_pk`(s) are invalid.
-	//  TODO: make all payloads the same size with padding + add dummy hops
+	/// Create a path for an onion message, to be forwarded along `node_pks`.
 	pub fn new<ES: Deref, T: secp256k1::Signing + secp256k1::Verification>(
 		intermediate_nodes: &[MessageForwardNode], recipient_node_id: PublicKey,
 		local_node_receive_key: ReceiveAuthKey, context: MessageContext, entropy_source: ES,
 		secp_ctx: &Secp256k1<T>,
-	) -> Result<Self, ()>
+	) -> Self
 	where
 		ES::Target: EntropySource,
 	{
@@ -96,7 +92,7 @@ impl BlindedMessagePath {
 		intermediate_nodes: &[MessageForwardNode], recipient_node_id: PublicKey,
 		dummy_hop_count: usize, local_node_receive_key: ReceiveAuthKey, context: MessageContext,
 		entropy_source: ES, secp_ctx: &Secp256k1<T>,
-	) -> Result<Self, ()>
+	) -> Self
 	where
 		ES::Target: EntropySource,
 	{
@@ -107,7 +103,7 @@ impl BlindedMessagePath {
 		let blinding_secret =
 			SecretKey::from_slice(&blinding_secret_bytes[..]).expect("RNG is busted");
 
-		Ok(Self(BlindedPath {
+		Self(BlindedPath {
 			introduction_node,
 			blinding_point: PublicKey::from_secret_key(secp_ctx, &blinding_secret),
 			blinded_hops: blinded_hops(
@@ -118,9 +114,8 @@ impl BlindedMessagePath {
 				context,
 				&blinding_secret,
 				local_node_receive_key,
-			)
-			.map_err(|_| ())?,
-		}))
+			),
+		})
 	}
 
 	/// Attempts to a use a compact representation for the [`IntroductionNode`] by using a directed
@@ -669,7 +664,7 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<T>, intermediate_nodes: &[MessageForwardNode],
 	recipient_node_id: PublicKey, dummy_hop_count: usize, context: MessageContext,
 	session_priv: &SecretKey, local_node_receive_key: ReceiveAuthKey,
-) -> Result<Vec<BlindedHop>, secp256k1::Error> {
+) -> Vec<BlindedHop> {
 	let dummy_count = cmp::min(dummy_hop_count, MAX_DUMMY_HOPS_COUNT);
 	let pks = intermediate_nodes
 		.iter()

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -116,7 +116,6 @@ impl BlindedPaymentPath {
 	/// Create a blinded path for a payment, to be forwarded along `intermediate_nodes`.
 	///
 	/// Errors if:
-	/// * a provided node id is invalid
 	/// * [`BlindedPayInfo`] calculation results in an integer overflow
 	/// * any unknown features are required in the provided [`ForwardTlvs`]
 	//  TODO: make all payloads the same size with padding + add dummy hops
@@ -151,8 +150,7 @@ impl BlindedPaymentPath {
 					payee_node_id,
 					payee_tlvs,
 					&blinding_secret,
-				)
-				.map_err(|_| ())?,
+				),
 			},
 			payinfo: blinded_payinfo,
 		})
@@ -663,7 +661,7 @@ pub(crate) const PAYMENT_PADDING_ROUND_OFF: usize = 30;
 pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<T>, intermediate_nodes: &[PaymentForwardNode], payee_node_id: PublicKey,
 	payee_tlvs: ReceiveTlvs, session_priv: &SecretKey,
-) -> Result<Vec<BlindedHop>, secp256k1::Error> {
+) -> Vec<BlindedHop> {
 	let pks = intermediate_nodes
 		.iter()
 		.map(|node| (node.node_id, None))

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -1552,7 +1552,7 @@ fn route_blinding_spec_test_vector() {
 	];
 	let mut dave_eve_blinded_hops = blinded_path::utils::construct_blinded_hops(
 		&secp_ctx, path.into_iter(), &dave_eve_session_priv,
-	).unwrap();
+	);
 
 	// Concatenate an additional Bob -> Carol blinded path to the Eve -> Dave blinded path.
 	let bob_carol_session_priv = secret_from_hex("0202020202020202020202020202020202020202020202020202020202020202");
@@ -1563,7 +1563,7 @@ fn route_blinding_spec_test_vector() {
 	];
 	let bob_carol_blinded_hops = blinded_path::utils::construct_blinded_hops(
 		&secp_ctx, path.into_iter(), &bob_carol_session_priv,
-	).unwrap();
+	);
 
 	let mut blinded_hops = bob_carol_blinded_hops;
 	blinded_hops.append(&mut dave_eve_blinded_hops);
@@ -2030,7 +2030,7 @@ fn do_test_trampoline_single_hop_receive(success: bool) {
 		let path = [((carol_node_id, None), WithoutLength(&carol_unblinded_tlvs))];
 		blinded_path::utils::construct_blinded_hops(
 			&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv,
-		).unwrap()
+		)
 	} else {
 		let payee_tlvs = blinded_path::payment::TrampolineForwardTlvs {
 			next_trampoline: alice_node_id,
@@ -2051,7 +2051,7 @@ fn do_test_trampoline_single_hop_receive(success: bool) {
 		let path = [((carol_node_id, None), WithoutLength(&carol_unblinded_tlvs))];
 		blinded_path::utils::construct_blinded_hops(
 			&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv,
-		).unwrap()
+		)
 	};
 
 	let route = Route {
@@ -2255,7 +2255,7 @@ fn test_trampoline_unblinded_receive() {
 	let carol_blinding_point = PublicKey::from_secret_key(&secp_ctx, &carol_alice_trampoline_session_priv);
 	let carol_blinded_hops = blinded_path::utils::construct_blinded_hops(
 		&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv,
-	).unwrap();
+	);
 
 	let route = Route {
 		paths: vec![Path {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -8958,12 +8958,24 @@ where
 		}
 	}
 
-	#[rustfmt::skip]
-	fn get_last_revoke_and_ack<L: Deref>(&mut self, logger: &L) -> Option<msgs::RevokeAndACK> where L::Target: Logger {
-		debug_assert!(self.holder_commitment_point.next_transaction_number() <= INITIAL_COMMITMENT_NUMBER - 2);
-		self.holder_commitment_point.try_resolve_pending(&self.context.holder_signer, &self.context.secp_ctx, logger);
-		let per_commitment_secret = self.context.holder_signer.as_ref()
-			.release_commitment_secret(self.holder_commitment_point.next_transaction_number() + 2).ok();
+	fn get_last_revoke_and_ack<L: Deref>(&mut self, logger: &L) -> Option<msgs::RevokeAndACK>
+	where
+		L::Target: Logger,
+	{
+		debug_assert!(
+			self.holder_commitment_point.next_transaction_number() <= INITIAL_COMMITMENT_NUMBER - 2
+		);
+		self.holder_commitment_point.try_resolve_pending(
+			&self.context.holder_signer,
+			&self.context.secp_ctx,
+			logger,
+		);
+		let per_commitment_secret = self
+			.context
+			.holder_signer
+			.as_ref()
+			.release_commitment_secret(self.holder_commitment_point.next_transaction_number() + 2)
+			.ok();
 		if let Some(per_commitment_secret) = per_commitment_secret {
 			if self.holder_commitment_point.can_advance() {
 				self.context.signer_pending_revoke_and_ack = false;
@@ -8973,7 +8985,7 @@ where
 					next_per_commitment_point: self.holder_commitment_point.next_point(),
 					#[cfg(taproot)]
 					next_local_nonce: None,
-				})
+				});
 			}
 		}
 		if !self.holder_commitment_point.can_advance() {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -8965,14 +8965,9 @@ where
 		debug_assert!(
 			self.holder_commitment_point.next_transaction_number() <= INITIAL_COMMITMENT_NUMBER - 2
 		);
-		self.holder_commitment_point.try_resolve_pending(
-			&self.context.holder_signer,
-			&self.context.secp_ctx,
-			logger,
-		);
-		let per_commitment_secret = self
-			.context
-			.holder_signer
+		let signer = &self.context.holder_signer;
+		self.holder_commitment_point.try_resolve_pending(signer, &self.context.secp_ctx, logger);
+		let per_commitment_secret = signer
 			.as_ref()
 			.release_commitment_secret(self.holder_commitment_point.next_transaction_number() + 2)
 			.ok();

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -437,8 +437,7 @@ fn one_blinded_hop() {
 	let entropy = &*nodes[1].entropy_source;
 	let receive_key = nodes[1].messenger.node_signer.get_receive_auth_key();
 	let blinded_path =
-		BlindedMessagePath::new(&[], nodes[1].node_id, receive_key, context, entropy, &secp_ctx)
-			.unwrap();
+		BlindedMessagePath::new(&[], nodes[1].node_id, receive_key, context, entropy, &secp_ctx);
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 	nodes[0].messenger.send_onion_message(test_msg, instructions).unwrap();
@@ -463,8 +462,7 @@ fn blinded_path_with_dummy_hops() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	// Ensure that dummy hops are added to the blinded path.
 	assert_eq!(blinded_path.blinded_hops().len(), 6);
 	let destination = Destination::BlindedPath(blinded_path);
@@ -492,8 +490,7 @@ fn two_unblinded_two_blinded() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let path = OnionMessagePath {
 		intermediate_nodes: vec![nodes[1].node_id, nodes[2].node_id],
 		destination: Destination::BlindedPath(blinded_path),
@@ -525,8 +522,7 @@ fn three_blinded_hops() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -553,8 +549,7 @@ fn async_response_over_one_blinded_hop() {
 	let entropy = &*nodes[1].entropy_source;
 	let receive_key = nodes[1].messenger.node_signer.get_receive_auth_key();
 	let reply_path =
-		BlindedMessagePath::new(&[], nodes[1].node_id, receive_key, context, entropy, &secp_ctx)
-			.unwrap();
+		BlindedMessagePath::new(&[], nodes[1].node_id, receive_key, context, entropy, &secp_ctx);
 
 	// 4. Create a responder using the reply path for Alice.
 	let responder = Some(Responder::new(reply_path));
@@ -595,8 +590,7 @@ fn async_response_with_reply_path_succeeds() {
 	let entropy = &*bob.entropy_source;
 	let receive_key = bob.messenger.node_signer.get_receive_auth_key();
 	let reply_path =
-		BlindedMessagePath::new(&[], bob.node_id, receive_key, context, entropy, &secp_ctx)
-			.unwrap();
+		BlindedMessagePath::new(&[], bob.node_id, receive_key, context, entropy, &secp_ctx);
 
 	// Alice asynchronously responds to Bob, expecting a response back from him.
 	let responder = Responder::new(reply_path);
@@ -638,8 +632,7 @@ fn async_response_with_reply_path_fails() {
 	let entropy = &*bob.entropy_source;
 	let receive_key = bob.messenger.node_signer.get_receive_auth_key();
 	let reply_path =
-		BlindedMessagePath::new(&[], bob.node_id, receive_key, context, entropy, &secp_ctx)
-			.unwrap();
+		BlindedMessagePath::new(&[], bob.node_id, receive_key, context, entropy, &secp_ctx);
 
 	// Alice tries to asynchronously respond to Bob, but fails because the nodes are unannounced and
 	// disconnected. Thus, a reply path could no be created for the response.
@@ -697,8 +690,7 @@ fn test_blinded_path_padding_for_full_length_path() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 
 	assert!(is_padded(&blinded_path.blinded_hops(), MESSAGE_PADDING_ROUND_OFF));
 
@@ -734,8 +726,7 @@ fn test_blinded_path_no_padding_for_compact_path() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 
 	assert!(!is_padded(&blinded_path.blinded_hops(), MESSAGE_PADDING_ROUND_OFF));
 }
@@ -762,8 +753,7 @@ fn we_are_intro_node() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -784,8 +774,7 @@ fn we_are_intro_node() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -814,8 +803,7 @@ fn invalid_blinded_path_error() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	blinded_path.clear_blinded_hops();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
@@ -850,8 +838,7 @@ fn reply_path() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	nodes[0]
 		.messenger
 		.send_onion_message_using_path(path, test_msg.clone(), Some(reply_path))
@@ -878,8 +865,7 @@ fn reply_path() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let destination = Destination::BlindedPath(blinded_path);
 	let intermediate_nodes = [
 		MessageForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
@@ -895,8 +881,7 @@ fn reply_path() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let instructions = MessageSendInstructions::WithSpecifiedReplyPath { destination, reply_path };
 
 	nodes[0].messenger.send_onion_message(test_msg, instructions).unwrap();
@@ -1000,8 +985,7 @@ fn requests_peer_connection_for_buffered_messages() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -1049,8 +1033,7 @@ fn drops_buffered_messages_waiting_for_peer_connection() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -1114,8 +1097,7 @@ fn intercept_offline_peer_oms() {
 		context,
 		entropy,
 		&secp_ctx,
-	)
-	.unwrap();
+	);
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 


### PR DESCRIPTION
Some cleanups in preparation for implementing sending payments as an often-offline sender to an often-offline recipient. 

cc #2298 