### PR TITLE
Re-add accidentally removed `handle_channel_update` call

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -2593,6 +2593,9 @@ where
 				self.update_gossip_backlogged();
 			},
 			wire::Message::ChannelUpdate(msg) => {
+				let chan_handler = &self.message_handler.chan_handler;
+				chan_handler.handle_channel_update(their_node_id, &msg);
+
 				let route_handler = &self.message_handler.route_handler;
 				if route_handler
 					.handle_channel_update(Some(their_node_id), &msg)


### PR DESCRIPTION
In e620310e228e612e852ebedd555ac5dc0b9d389b, we made many, many small changes to prepare for running `rustfmt` on `peer_handler.rs`. Unfortunately, in the process we seem to have introduced a bug where we'd only call `handle_channel_update` on the `RoutingMessageHandler`, but not the `ChannelMessageHandler` anymore.

Here, we fix this and reinstate proper working of our channel updates.