### PR TITLE
Support multi-hop blinded paths for `ReleaseHeldHtlc` 

### DIFF
--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -302,7 +302,6 @@ fn create_static_invoice_builder<'a>(
 			payment_secret,
 			relative_expiry_secs,
 			recipient.node.list_usable_channels(),
-			recipient.node.test_get_peers_for_blinded_path(),
 		)
 		.unwrap()
 }

--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -3286,6 +3286,90 @@ fn async_payment_mpp() {
 }
 
 #[test]
+fn fallback_to_one_hop_release_htlc_path() {
+	// Check that if the sender's LSP's message router fails to find a blinded path when creating a
+	// path for the release_held_htlc message, they will fall back to manually creating a 1-hop
+	// blinded path.
+	let chanmon_cfgs = create_chanmon_cfgs(4);
+	let node_cfgs = create_node_cfgs(4, &chanmon_cfgs);
+
+	let (sender_cfg, recipient_cfg) = (often_offline_node_cfg(), often_offline_node_cfg());
+	let mut sender_lsp_cfg = test_default_channel_config();
+	sender_lsp_cfg.enable_htlc_hold = true;
+	let mut invoice_server_cfg = test_default_channel_config();
+	invoice_server_cfg.accept_forwards_to_priv_channels = true;
+
+	let node_chanmgrs = create_node_chanmgrs(
+		4,
+		&node_cfgs,
+		&[Some(sender_cfg), Some(sender_lsp_cfg), Some(invoice_server_cfg), Some(recipient_cfg)],
+	);
+	let nodes = create_network(4, &node_cfgs, &node_chanmgrs);
+	create_unannounced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0);
+	create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1_000_000, 0);
+	create_unannounced_chan_between_nodes_with_value(&nodes, 2, 3, 1_000_000, 0);
+	// Make sure all nodes are at the same block height
+	let node_max_height =
+		nodes.iter().map(|node| node.blocks.lock().unwrap().len()).max().unwrap() as u32;
+	connect_blocks(&nodes[0], node_max_height - nodes[0].best_block_info().1);
+	connect_blocks(&nodes[1], node_max_height - nodes[1].best_block_info().1);
+	connect_blocks(&nodes[2], node_max_height - nodes[2].best_block_info().1);
+	connect_blocks(&nodes[3], node_max_height - nodes[3].best_block_info().1);
+	let sender = &nodes[0];
+	let sender_lsp = &nodes[1];
+	let invoice_server = &nodes[2];
+	let recipient = &nodes[3];
+
+	let amt_msat = 5000;
+	let (static_invoice, peer_node_id, static_invoice_om) =
+		build_async_offer_and_init_payment(amt_msat, &nodes);
+
+	// Force the sender_lsp's call to MessageRouter::create_blinded_paths to fail so it has to fall
+	// back to a 1-hop blinded path when creating the paths for its revoke_and_ack message.
+	sender_lsp.message_router.create_blinded_paths_res_override.lock().unwrap().1 = Some(Err(()));
+
+	let payment_hash =
+		lock_in_htlc_for_static_invoice(&static_invoice_om, peer_node_id, sender, sender_lsp);
+
+	// Check that we actually had to fall back to a 1-hop path.
+	assert!(sender_lsp.message_router.create_blinded_paths_res_override.lock().unwrap().0 > 0);
+	sender_lsp.message_router.create_blinded_paths_res_override.lock().unwrap().1 = None;
+
+	sender_lsp.node.process_pending_htlc_forwards();
+	let (peer_id, held_htlc_om) =
+		extract_held_htlc_available_oms(sender, &[sender_lsp, invoice_server, recipient])
+			.pop()
+			.unwrap();
+	recipient.onion_messenger.handle_onion_message(peer_id, &held_htlc_om);
+
+	// The release_htlc OM should go straight to the sender's LSP since they created a 1-hop blinded
+	// path to themselves for receiving it.
+	let release_htlc_om = recipient
+		.onion_messenger
+		.next_onion_message_for_peer(sender_lsp.node.get_our_node_id())
+		.unwrap();
+	sender_lsp
+		.onion_messenger
+		.handle_onion_message(recipient.node.get_our_node_id(), &release_htlc_om);
+
+	sender_lsp.node.process_pending_htlc_forwards();
+	let mut events = sender_lsp.node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let ev = remove_first_msg_event_to_node(&invoice_server.node.get_our_node_id(), &mut events);
+	check_added_monitors!(sender_lsp, 1);
+
+	let path: &[&Node] = &[invoice_server, recipient];
+	let args = PassAlongPathArgs::new(sender_lsp, path, amt_msat, payment_hash, ev);
+	let claimable_ev = do_pass_along_path(args).unwrap();
+
+	let route: &[&[&Node]] = &[&[sender_lsp, invoice_server, recipient]];
+	let keysend_preimage = extract_payment_preimage(&claimable_ev);
+	let (res, _) =
+		claim_payment_along_route(ClaimAlongRouteArgs::new(sender, route, keysend_preimage));
+	assert_eq!(res, Some(PaidBolt12Invoice::StaticInvoice(static_invoice)));
+}
+
+#[test]
 fn fail_held_htlcs_when_cfg_unset() {
 	// Test that if we receive a held HTLC but `UserConfig::enable_htlc_hold` is unset, we will fail
 	// it backwards.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5441,12 +5441,10 @@ where
 	}
 
 	fn check_refresh_async_receive_offer_cache(&self, timer_tick_occurred: bool) {
-		let peers = self.get_peers_for_blinded_path();
 		let channels = self.list_usable_channels();
 		let entropy = &*self.entropy_source;
 		let router = &*self.router;
 		let refresh_res = self.flow.check_refresh_async_receive_offer_cache(
-			peers,
 			channels,
 			entropy,
 			router,
@@ -5534,10 +5532,7 @@ where
 					);
 				}
 			} else {
-				let reply_path = HeldHtlcReplyPath::ToUs {
-					payment_id,
-					peers: self.get_peers_for_blinded_path(),
-				};
+				let reply_path = HeldHtlcReplyPath::ToUs { payment_id };
 				let enqueue_held_htlc_available_res =
 					self.flow.enqueue_held_htlc_available(invoice, reply_path);
 				if enqueue_held_htlc_available_res.is_err() {
@@ -12264,9 +12259,7 @@ macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 	/// [`Offer`]: crate::offers::offer::Offer
 	/// [`InvoiceRequest`]: crate::offers::invoice_request::InvoiceRequest
 	pub fn create_offer_builder(&$self) -> Result<$builder, Bolt12SemanticError> {
-		let builder = $self.flow.create_offer_builder(
-			&*$self.entropy_source, $self.get_peers_for_blinded_path()
-		)?;
+		let builder = $self.flow.create_offer_builder(&*$self.entropy_source)?;
 
 		Ok(builder.into())
 	}
@@ -12289,9 +12282,7 @@ macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 	where
 		ME::Target: MessageRouter,
 	{
-		let builder = $self.flow.create_offer_builder_using_router(
-			router, &*$self.entropy_source, $self.get_peers_for_blinded_path()
-		)?;
+		let builder = $self.flow.create_offer_builder_using_router(router, &*$self.entropy_source)?;
 
 		Ok(builder.into())
 	}
@@ -12345,8 +12336,7 @@ macro_rules! create_refund_builder { ($self: ident, $builder: ty) => {
 		let entropy = &*$self.entropy_source;
 
 		let builder = $self.flow.create_refund_builder(
-			entropy, amount_msats, absolute_expiry,
-			payment_id, $self.get_peers_for_blinded_path()
+			entropy, amount_msats, absolute_expiry, payment_id
 		)?;
 
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop($self);
@@ -12389,8 +12379,7 @@ macro_rules! create_refund_builder { ($self: ident, $builder: ty) => {
 		let entropy = &*$self.entropy_source;
 
 		let builder = $self.flow.create_refund_builder_using_router(
-			router, entropy, amount_msats, absolute_expiry,
-			payment_id, $self.get_peers_for_blinded_path()
+			router, entropy, amount_msats, absolute_expiry, payment_id
 		)?;
 
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop($self);
@@ -12462,8 +12451,7 @@ where
 	pub fn set_paths_to_static_invoice_server(
 		&self, paths_to_static_invoice_server: Vec<BlindedMessagePath>,
 	) -> Result<(), ()> {
-		let peers = self.get_peers_for_blinded_path();
-		self.flow.set_paths_to_static_invoice_server(paths_to_static_invoice_server, peers)?;
+		self.flow.set_paths_to_static_invoice_server(paths_to_static_invoice_server)?;
 
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 		Ok(())
@@ -12643,10 +12631,7 @@ where
 		let invoice_request = builder.build_and_sign()?;
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 
-		self.flow.enqueue_invoice_request(
-			invoice_request.clone(), payment_id, nonce,
-			self.get_peers_for_blinded_path()
-		)?;
+		self.flow.enqueue_invoice_request(invoice_request.clone(), payment_id, nonce,)?;
 
 		let retryable_invoice_request = RetryableInvoiceRequest {
 			invoice_request: invoice_request.clone(),
@@ -12701,7 +12686,7 @@ where
 
 				let invoice = builder.allow_mpp().build_and_sign(secp_ctx)?;
 
-				self.flow.enqueue_invoice(invoice.clone(), refund, self.get_peers_for_blinded_path())?;
+				self.flow.enqueue_invoice(invoice.clone(), refund)?;
 
 				Ok(invoice)
 			},
@@ -12765,14 +12750,7 @@ where
 			optional_params.payer_note,
 		)?;
 
-		self.flow
-			.enqueue_dns_onion_message(
-				onion_message,
-				context,
-				dns_resolvers,
-				self.get_peers_for_blinded_path(),
-			)
-			.map_err(|_| ())
+		self.flow.enqueue_dns_onion_message(onion_message, context, dns_resolvers).map_err(|_| ())
 	}
 
 	/// Gets a payment secret and payment hash for use in an invoice given to a third party wishing
@@ -12913,8 +12891,7 @@ where
 	pub fn blinded_paths_for_async_recipient(
 		&self, recipient_id: Vec<u8>, relative_expiry: Option<Duration>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
-		let peers = self.get_peers_for_blinded_path();
-		self.flow.blinded_paths_for_async_recipient(recipient_id, relative_expiry, peers)
+		self.flow.blinded_paths_for_async_recipient(recipient_id, relative_expiry)
 	}
 
 	pub(super) fn duration_since_epoch(&self) -> Duration {
@@ -12946,11 +12923,6 @@ where
 					.and_then(|funded_channel| funded_channel.get_inbound_scid()),
 			})
 			.collect::<Vec<_>>()
-	}
-
-	#[cfg(test)]
-	pub(super) fn test_get_peers_for_blinded_path(&self) -> Vec<MessageForwardNode> {
-		self.get_peers_for_blinded_path()
 	}
 
 	#[cfg(test)]
@@ -14735,9 +14707,8 @@ where
 		{
 			let RetryableInvoiceRequest { invoice_request, nonce, .. } = retryable_invoice_request;
 
-			let peers = self.get_peers_for_blinded_path();
 			let enqueue_invreq_res =
-				self.flow.enqueue_invoice_request(invoice_request, payment_id, nonce, peers);
+				self.flow.enqueue_invoice_request(invoice_request, payment_id, nonce);
 			if enqueue_invreq_res.is_err() {
 				log_warn!(
 					self.logger,
@@ -14945,9 +14916,8 @@ where
 		&self, message: OfferPathsRequest, context: AsyncPaymentsContext,
 		responder: Option<Responder>,
 	) -> Option<(OfferPaths, ResponseInstruction)> {
-		let peers = self.get_peers_for_blinded_path();
 		let (message, reply_path_context) =
-			match self.flow.handle_offer_paths_request(&message, context, peers) {
+			match self.flow.handle_offer_paths_request(&message, context) {
 				Some(msg) => msg,
 				None => return None,
 			};
@@ -14965,7 +14935,6 @@ where
 			message,
 			context,
 			responder.clone(),
-			self.get_peers_for_blinded_path(),
 			self.list_usable_channels(),
 			&*self.entropy_source,
 			&*self.router,

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -100,6 +100,7 @@ where
 
 	pending_async_payments_messages: Mutex<Vec<(AsyncPaymentsMessage, MessageSendInstructions)>>,
 	async_receive_offer_cache: Mutex<AsyncReceiveOfferCache>,
+	peers_cache: Mutex<Vec<MessageForwardNode>>,
 
 	#[cfg(feature = "dnssec")]
 	pub(crate) hrn_resolver: OMNameResolver,
@@ -136,6 +137,7 @@ where
 
 			pending_offers_messages: Mutex::new(Vec::new()),
 			pending_async_payments_messages: Mutex::new(Vec::new()),
+			peers_cache: Mutex::new(Vec::new()),
 
 			#[cfg(feature = "dnssec")]
 			hrn_resolver: OMNameResolver::new(current_timestamp, best_block.height),
@@ -1738,5 +1740,16 @@ where
 	/// Get the encoded [`AsyncReceiveOfferCache`] for persistence.
 	pub fn writeable_async_receive_offer_cache(&self) -> Vec<u8> {
 		self.async_receive_offer_cache.encode()
+	}
+
+	/// Provides a set of connected peers of this node that can be used in [`BlindedMessagePath`]s
+	/// created by the [`OffersMessageFlow`].
+	///
+	/// All provided peers MUST advertise support for onion messages in their [`InitFeatures`].
+	///
+	/// [`InitFeatures`]: crate::types::features::InitFeatures
+	pub fn set_peers(&self, mut peers: Vec<MessageForwardNode>) {
+		let mut peers_cache = self.peers_cache.lock().unwrap();
+		core::mem::swap(&mut *peers_cache, &mut peers);
 	}
 }

--- a/lightning/src/offers/flow.rs
+++ b/lightning/src/offers/flow.rs
@@ -1214,9 +1214,14 @@ where
 	where
 		ES::Target: EntropySource,
 	{
-		// In the future, we should support multi-hop paths here.
 		let context =
 			MessageContext::AsyncPayments(AsyncPaymentsContext::ReleaseHeldHtlc { intercept_id });
+		if let Ok(mut paths) = self.create_blinded_paths(context.clone()) {
+			if let Some(path) = paths.pop() {
+				return path;
+			}
+		}
+
 		let num_dummy_hops = PADDED_PATH_LENGTH.saturating_sub(1);
 		BlindedMessagePath::new_with_dummy_hops(
 			&[],


### PR DESCRIPTION
In #4045, as part of supporting sending payments as an often-offline sender to an often-offline recipient, we began including blinded paths in the sender's LSP's RAA message for use as reply paths to the sender's `held_htlc_available` messages. 

Because we hold the per-peer lock corresponding to the Channel while creating this RAA, we can't use our typical approach of calling `ChannelManager::get_peers_for_blinded_path` to create these blinded paths. The `::get_peers` method takes each peer's lock in turn in order to check for usable channels/onion message feature support, and it's not permitted to hold multiple peer state locks at the same time due to the potential for deadlocks (see the `debug_sync` module).

To avoid taking other peer state locks while holding a particular `Channel`'s peer state lock, here we cache the set of peers in the `OffersMessageFlow`, which is the struct that ultimately creates the blinded paths for the RAA.

For consistency, we also stop passing in peers to every other `OffersMessageFlow` method. 

Based on ~#4045~, ~#4046~ 

