### PR TITLE
CI fix: Fix broken doc links

### DIFF
--- a/lightning-liquidity/src/lsps5/url_utils.rs
+++ b/lightning-liquidity/src/lsps5/url_utils.rs
@@ -35,22 +35,20 @@ impl LSPSUrl {
 		}
 
 		let (scheme, remainder) =
-			url_str.split_once("://").ok_or_else(|| (LSPS5ProtocolError::UrlParse))?;
+			url_str.split_once("://").ok_or_else(|| LSPS5ProtocolError::UrlParse)?;
 
 		if !scheme.eq_ignore_ascii_case("https") {
 			return Err(LSPS5ProtocolError::UnsupportedProtocol);
 		}
 
-		let host_section = remainder
-			.split(['/', '?', '#'])
-			.next()
-			.ok_or_else(|| (LSPS5ProtocolError::UrlParse))?;
+		let host_section =
+			remainder.split(['/', '?', '#']).next().ok_or_else(|| LSPS5ProtocolError::UrlParse)?;
 
 		let host_without_auth = host_section
 			.split('@')
 			.next_back()
 			.filter(|s| !s.is_empty())
-			.ok_or_else(|| (LSPS5ProtocolError::UrlParse))?;
+			.ok_or_else(|| LSPS5ProtocolError::UrlParse)?;
 
 		if host_without_auth.is_empty()
 			|| host_without_auth.chars().any(|c| !Self::is_valid_host_char(c))

--- a/lightning-types/src/features.rs
+++ b/lightning-types/src/features.rs
@@ -831,7 +831,7 @@ impl FeatureFlags {
 	/// Fetches an iterator over the bytes of this [`FeatureFlags`]
 	pub fn iter(
 		&self,
-	) -> (impl Clone + ExactSizeIterator<Item = &u8> + DoubleEndedIterator<Item = &u8>) {
+	) -> impl Clone + ExactSizeIterator<Item = &u8> + DoubleEndedIterator<Item = &u8> {
 		let slice = self.deref();
 		slice.iter()
 	}
@@ -839,7 +839,7 @@ impl FeatureFlags {
 	/// Fetches a mutable iterator over the bytes of this [`FeatureFlags`]
 	pub fn iter_mut(
 		&mut self,
-	) -> (impl ExactSizeIterator<Item = &mut u8> + DoubleEndedIterator<Item = &mut u8>) {
+	) -> impl ExactSizeIterator<Item = &mut u8> + DoubleEndedIterator<Item = &mut u8> {
 		let slice = self.deref_mut();
 		slice.iter_mut()
 	}

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -1523,7 +1523,7 @@ pub enum Event {
 	/// To accept the request (and in the case of a dual-funded channel, not contribute funds),
 	/// call [`ChannelManager::accept_inbound_channel`].
 	/// To reject the request, call [`ChannelManager::force_close_broadcasting_latest_txn`].
-	/// Note that a ['ChannelClosed`] event will _not_ be triggered if the channel is rejected.
+	/// Note that a [`ChannelClosed`] event will _not_ be triggered if the channel is rejected.
 	///
 	/// The event is only triggered when a new open channel request is received and the
 	/// [`UserConfig::manually_accept_inbound_channels`] config flag is set to true.
@@ -1533,6 +1533,7 @@ pub enum Event {
 	/// returning `Err(ReplayEvent ())`) and won't be persisted across restarts.
 	///
 	/// [`ChannelManager::accept_inbound_channel`]: crate::ln::channelmanager::ChannelManager::accept_inbound_channel
+	/// [`ChannelClosed`]: Event::ChannelClosed
 	/// [`ChannelManager::force_close_broadcasting_latest_txn`]: crate::ln::channelmanager::ChannelManager::force_close_broadcasting_latest_txn
 	/// [`UserConfig::manually_accept_inbound_channels`]: crate::util::config::UserConfig::manually_accept_inbound_channels
 	OpenChannelRequest {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2502,7 +2502,7 @@ where
 /// [`get_event_or_persistence_needed_future`]: Self::get_event_or_persistence_needed_future
 /// [`lightning-block-sync`]: https://docs.rs/lightning_block_sync/latest/lightning_block_sync
 /// [`lightning-transaction-sync`]: https://docs.rs/lightning_transaction_sync/latest/lightning_transaction_sync
-/// [`lightning-background-processor`]: https://docs.rs/lightning_background_processor/lightning_background_processor
+/// [`lightning-background-processor`]: https://docs.rs/lightning-background-processor/latest/lightning_background_processor
 /// [`list_channels`]: Self::list_channels
 /// [`list_usable_channels`]: Self::list_usable_channels
 /// [`create_channel`]: Self::create_channel
@@ -4123,7 +4123,7 @@ where
 				)
 			};
 			let chan_by_id = peer_state.channel_by_id.iter();
-			return chan_by_id.map(|(_, chan)| (chan)).map(channel_to_details).collect();
+			return chan_by_id.map(|(_, chan)| chan).map(channel_to_details).collect();
 		}
 		vec![]
 	}
@@ -4286,7 +4286,7 @@ where
 	///
 	/// The `shutdown_script` provided  will be used as the `scriptPubKey` for the closing transaction.
 	/// Will fail if a shutdown script has already been set for this channel by
-	/// ['ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]. The given shutdown script must
+	/// [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]. The given shutdown script must
 	/// also be compatible with our and the counterparty's features.
 	///
 	/// May generate a [`SendShutdown`] message event on success, which should be relayed.
@@ -4298,6 +4298,7 @@ where
 	///
 	/// [`ChannelConfig::force_close_avoidance_max_fee_satoshis`]: crate::util::config::ChannelConfig::force_close_avoidance_max_fee_satoshis
 	/// [`NonAnchorChannelFee`]: crate::chain::chaininterface::ConfirmationTarget::NonAnchorChannelFee
+	/// [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]: crate::util::config::ChannelHandshakeConfig::commit_upfront_shutdown_pubkey
 	/// [`SendShutdown`]: MessageSendEvent::SendShutdown
 	pub fn close_channel_with_feerate_and_script(
 		&self, channel_id: &ChannelId, counterparty_node_id: &PublicKey,

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1590,7 +1590,7 @@ pub enum LocalHTLCFailureReason {
 	/// The HTLC expires too far in the future, so it is rejected to avoid the worst-case outcome
 	/// of funds being held for extended periods of time.
 	///
-	/// Limit set by ['crate::ln::channelmanager::CLTV_FAR_FAR_AWAY`].
+	// Limit set by [`crate::ln::channelmanager::CLTV_FAR_FAR_AWAY`].
 	CLTVExpiryTooFar,
 	/// The HTLC payload contained in the onion packet could not be understood by our node.
 	InvalidOnionPayload,

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -2804,6 +2804,8 @@ where
 	/// [`send_payment`]: crate::ln::channelmanager::ChannelManager::send_payment
 	/// [`ChannelManager::process_pending_htlc_forwards`]: crate::ln::channelmanager::ChannelManager::process_pending_htlc_forwards
 	/// [`send_data`]: SocketDescriptor::send_data
+	/// [`lightning-net-tokio`]: https://docs.rs/lightning-net-tokio/latest/lightning_net_tokio
+	/// [`lightning-background-processor`]: https://docs.rs/lightning-background-processor/latest/lightning_background_processor
 	pub fn process_events(&self) {
 		if self.event_processing_state.fetch_add(1, Ordering::AcqRel) > 0 {
 			// If we're not the first event processor to get here, just return early, the increment


### PR DESCRIPTION
How does this sound ? ~~Could not allow useless vecs...~~ `cargo +beta doc -p lightning --document-private-items` was broken, this fixes it. The extra brackets complaints popped up on some other toolchain linter, not the stable linter.