### PR TITLE
Send `update_add_htlc` messages after HTLC removal messages

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -3053,9 +3053,6 @@ where
 									commitment_signed.len(),
 									channel_id);
 							let mut peer = get_peer_for_forwarding!(node_id)?;
-							for msg in update_add_htlcs {
-								self.enqueue_message(&mut *peer, msg);
-							}
 							for msg in update_fulfill_htlcs {
 								self.enqueue_message(&mut *peer, msg);
 							}
@@ -3063,6 +3060,9 @@ where
 								self.enqueue_message(&mut *peer, msg);
 							}
 							for msg in update_fail_malformed_htlcs {
+								self.enqueue_message(&mut *peer, msg);
+							}
+							for msg in update_add_htlcs {
 								self.enqueue_message(&mut *peer, msg);
 							}
 							if let &Some(ref msg) = update_fee {


### PR DESCRIPTION
While nodes are generally supposed to validate commitment transactions after the `commitent_signed` and not while HTLCs are being added/removed, we don't. This can make a commitment update where we use HTLC balance claimed with a fulfill to send new HTLCs, which is perfectly valid, being rejected. While we shouldn't currently generate any such commitments, we might want to in the future, and on the off-chance that we do, or where such a commitment would result in a dust threshold overrun, its always safter to add new HTLCs to a commitment only after we've removed any HTLCs we're going to remove, which we do here.