### PR TITLE
Limit outbound gossip buffer by size, rather than length

### DIFF
--- a/lightning/src/ln/peer_channel_encryptor.rs
+++ b/lightning/src/ln/peer_channel_encryptor.rs
@@ -641,6 +641,11 @@ impl PeerChannelEncryptor {
 /// padding to allow for future encryption/MACing.
 pub struct MessageBuf(Vec<u8>);
 impl MessageBuf {
+	/// The total allocated space for this message
+	pub fn capacity(&self) -> usize {
+		self.0.capacity()
+	}
+
 	/// Creates a new buffer from an encoded message (i.e. the two message-type bytes followed by
 	/// the message contents).
 	///


### PR DESCRIPTION
In 686a586c96aae6901d533646fc135379f825eb0d we stopped punishing peers for slowly draining the gossip forwarding buffer, delaying responding to our ping message. While that change was nice on its own, it also now allows us to be a bit more flexible with what enters the `gossip_broadcast_buffer`.

Because we now do not count pending messages in
`gossip_broadcast_buffer` against the peer's ping-response timer, there's no reason to continue to limit it based on `messages_sent_since_pong`. Thus, we drop that restriction here.

However, in practice, the reason for the vast majority of gossip forwarding drops on my node is the 24-message total queue limit, rather than the `messages_sent_since_pong` limit. This limit was set to bend over backwards trying to avoid counting message buffer sizes while keeping peer message buffers small.

In practice, there is really no reason to do that - summing the capacity of tens of buffers is negligible cost and allows us to be much more flexible with how many messages we queue.

Here we do so, limiting the total outbound message buffer size before gossip forwards are dropped to 128 KiB per peer, rather than 24 messages. In practice, this appears to almost entirely remove gossip forward drops on my node.