### PR TITLE
Correct gossip forwarding criteria while doing background sync

### DIFF
--- a/lightning/src/ln/peer_channel_encryptor.rs
+++ b/lightning/src/ln/peer_channel_encryptor.rs
@@ -656,6 +656,11 @@ impl MessageBuf {
 		res[16 + 2..].copy_from_slice(&encoded_msg);
 		Self(res)
 	}
+
+	#[cfg(test)]
+	pub(crate) fn fetch_encoded_msg_with_type_pfx(&self) -> Vec<u8> {
+		self.0.clone().split_off(16 + 2)
+	}
 }
 
 #[cfg(test)]

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -1355,7 +1355,7 @@ fn get_dummy_channel_announcement(short_chan_id: u64) -> msgs::ChannelAnnounceme
 	}
 }
 
-fn get_dummy_channel_update(short_chan_id: u64) -> msgs::ChannelUpdate {
+pub fn get_dummy_channel_update(short_chan_id: u64) -> msgs::ChannelUpdate {
 	use bitcoin::secp256k1::ffi::Signature as FFISignature;
 	let network = Network::Testnet;
 	msgs::ChannelUpdate {


### PR DESCRIPTION
If we're doing gossip backfill to a peer, we first forward all our `channel_announcement`s and `channel_update`s in SCID-order. While doing so, we don't forward any fresh `channel_update` messages for any channels which we haven't yet backfilled (as we'll eventually send the new update anyway, and it might get rejected without the corresponding `channel_announcement`).

Sadly, our comparison for this was the wrong way, so we actually *only* forwarded updates which were for channels we haven't yet backfilled, and dropped updates for channels we already had backfilled.