### PR TITLE
Put a 10_000vByte cap on `HolderHTLCOutput` 0FC package templates

### DIFF
--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -12,6 +12,8 @@
 use bitcoin::block::{Block, Header};
 use bitcoin::constants::genesis_block;
 use bitcoin::hash_types::{BlockHash, Txid};
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::{Hash, HashEngine};
 use bitcoin::network::Network;
 use bitcoin::script::{Script, ScriptBuf};
 use bitcoin::secp256k1::PublicKey;
@@ -21,6 +23,7 @@ use crate::chain::transaction::{OutPoint, TransactionData};
 use crate::impl_writeable_tlv_based;
 use crate::ln::types::ChannelId;
 use crate::sign::ecdsa::EcdsaChannelSigner;
+use crate::sign::HTLCDescriptor;
 
 #[allow(unused_imports)]
 use crate::prelude::*;
@@ -442,3 +445,20 @@ where
 /// This is not exported to bindings users as we just use [u8; 32] directly.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ClaimId(pub [u8; 32]);
+
+impl ClaimId {
+	pub(crate) fn from_htlcs(htlcs: &[HTLCDescriptor]) -> ClaimId {
+		let mut engine = Sha256::engine();
+		for htlc in htlcs {
+			engine.input(&htlc.commitment_txid.to_byte_array());
+			engine.input(&htlc.htlc.transaction_output_index.unwrap().to_be_bytes());
+		}
+		ClaimId(Sha256::from_engine(engine).to_byte_array())
+	}
+	pub(crate) fn step_with_bytes(&self, bytes: &[u8]) -> ClaimId {
+		let mut engine = Sha256::engine();
+		engine.input(&self.0);
+		engine.input(bytes);
+		ClaimId(Sha256::from_engine(engine).to_byte_array())
+	}
+}

--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -14,8 +14,7 @@
 
 use bitcoin::amount::Amount;
 use bitcoin::hash_types::{BlockHash, Txid};
-use bitcoin::hashes::sha256::Hash as Sha256;
-use bitcoin::hashes::{Hash, HashEngine};
+use bitcoin::hashes::Hash;
 use bitcoin::locktime::absolute::LockTime;
 use bitcoin::script::{Script, ScriptBuf};
 use bitcoin::secp256k1;
@@ -882,12 +881,7 @@ impl<ChannelSigner: EcdsaChannelSigner> OnchainTxHandler<ChannelSigner> {
 								// claim, which will always be unique per request. Once a claim ID
 								// is generated, it is assigned and remains unchanged, even if the
 								// underlying set of HTLCs changes.
-								let mut engine = Sha256::engine();
-								for htlc in htlcs {
-									engine.input(&htlc.commitment_txid.to_byte_array());
-									engine.input(&htlc.htlc.transaction_output_index.unwrap().to_be_bytes());
-								}
-								ClaimId(Sha256::from_engine(engine).to_byte_array())
+								ClaimId::from_htlcs(htlcs)
 							},
 						};
 						debug_assert!(self.pending_claim_requests.get(&claim_id).is_none());

--- a/lightning/src/events/bump_transaction/sync.rs
+++ b/lightning/src/events/bump_transaction/sync.rs
@@ -102,13 +102,14 @@ where
 {
 	fn select_confirmed_utxos(
 		&self, claim_id: ClaimId, must_spend: Vec<Input>, must_pay_to: &[TxOut],
-		target_feerate_sat_per_1000_weight: u32,
+		target_feerate_sat_per_1000_weight: u32, max_tx_weight: u64,
 	) -> Result<CoinSelection, ()> {
 		let mut fut = self.wallet.select_confirmed_utxos(
 			claim_id,
 			must_spend,
 			must_pay_to,
 			target_feerate_sat_per_1000_weight,
+			max_tx_weight,
 		);
 		let mut waker = dummy_waker();
 		let mut ctx = task::Context::from_waker(&mut waker);
@@ -140,7 +141,7 @@ pub trait CoinSelectionSourceSync {
 	/// A synchronous version of [`CoinSelectionSource::select_confirmed_utxos`].
 	fn select_confirmed_utxos(
 		&self, claim_id: ClaimId, must_spend: Vec<Input>, must_pay_to: &[TxOut],
-		target_feerate_sat_per_1000_weight: u32,
+		target_feerate_sat_per_1000_weight: u32, max_tx_weight: u64,
 	) -> Result<CoinSelection, ()>;
 
 	/// A synchronous version of [`CoinSelectionSource::sign_psbt`].
@@ -169,13 +170,14 @@ where
 {
 	fn select_confirmed_utxos<'a>(
 		&'a self, claim_id: ClaimId, must_spend: Vec<Input>, must_pay_to: &'a [TxOut],
-		target_feerate_sat_per_1000_weight: u32,
+		target_feerate_sat_per_1000_weight: u32, max_tx_weight: u64,
 	) -> AsyncResult<'a, CoinSelection> {
 		let coins = self.0.select_confirmed_utxos(
 			claim_id,
 			must_spend,
 			must_pay_to,
 			target_feerate_sat_per_1000_weight,
+			max_tx_weight,
 		);
 		Box::pin(async move { coins })
 	}

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -1604,8 +1604,10 @@ pub enum Event {
 	/// Indicates that a transaction originating from LDK needs to have its fee bumped. This event
 	/// requires confirmed external funds to be readily available to spend.
 	///
-	/// LDK does not currently generate this event unless the
-	/// [`ChannelHandshakeConfig::negotiate_anchors_zero_fee_htlc_tx`] config flag is set to true.
+	/// LDK does not currently generate this event unless either the
+	/// [`ChannelHandshakeConfig::negotiate_anchors_zero_fee_htlc_tx`] or the
+	/// [`ChannelHandshakeConfig::negotiate_anchor_zero_fee_commitments`] config flags are set to
+	/// true.
 	/// It is limited to the scope of channels with anchor outputs.
 	///
 	/// # Failure Behavior and Persistence
@@ -1613,6 +1615,7 @@ pub enum Event {
 	/// returning `Err(ReplayEvent ())`), but will only be regenerated as needed after restarts.
 	///
 	/// [`ChannelHandshakeConfig::negotiate_anchors_zero_fee_htlc_tx`]: crate::util::config::ChannelHandshakeConfig::negotiate_anchors_zero_fee_htlc_tx
+	/// [`ChannelHandshakeConfig::negotiate_anchor_zero_fee_commitments`]: crate::util::config::ChannelHandshakeConfig::negotiate_anchor_zero_fee_commitments
 	BumpTransaction(BumpTransactionEvent),
 	/// We received an onion message that is intended to be forwarded to a peer
 	/// that is currently offline. This event will only be generated if the

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -36,7 +36,6 @@ use crate::chain::channelmonitor::{
 };
 use crate::chain::transaction::{OutPoint, TransactionData};
 use crate::chain::BestBlock;
-use crate::events::bump_transaction::{BASE_INPUT_WEIGHT, EMPTY_SCRIPT_SIG_WEIGHT};
 use crate::events::{ClosureReason, FundingInfo};
 use crate::ln::chan_utils;
 use crate::ln::chan_utils::{
@@ -44,7 +43,7 @@ use crate::ln::chan_utils::{
 	selected_commitment_sat_per_1000_weight, ChannelPublicKeys, ChannelTransactionParameters,
 	ClosingTransaction, CommitmentTransaction, CounterpartyChannelTransactionParameters,
 	CounterpartyCommitmentSecrets, HTLCOutputInCommitment, HolderCommitmentTransaction,
-	FUNDING_TRANSACTION_WITNESS_WEIGHT,
+	BASE_INPUT_WEIGHT, EMPTY_SCRIPT_SIG_WEIGHT, FUNDING_TRANSACTION_WITNESS_WEIGHT,
 };
 use crate::ln::channel_state::{
 	ChannelShutdownState, CounterpartyForwardingInfo, InboundHTLCDetails, InboundHTLCStateDetails,

--- a/lightning/src/ln/funding.rs
+++ b/lightning/src/ln/funding.rs
@@ -12,7 +12,8 @@
 use bitcoin::{Amount, ScriptBuf, SignedAmount, TxOut};
 use bitcoin::{Script, Sequence, Transaction, Weight};
 
-use crate::events::bump_transaction::{Utxo, EMPTY_SCRIPT_SIG_WEIGHT};
+use crate::events::bump_transaction::Utxo;
+use crate::ln::chan_utils::EMPTY_SCRIPT_SIG_WEIGHT;
 use crate::prelude::Vec;
 use crate::sign::{P2TR_KEY_PATH_WITNESS_WEIGHT, P2WPKH_WITNESS_WEIGHT};
 

--- a/lightning/src/ln/interactivetxs.rs
+++ b/lightning/src/ln/interactivetxs.rs
@@ -26,8 +26,9 @@ use bitcoin::{
 };
 
 use crate::chain::chaininterface::fee_for_weight;
-use crate::events::bump_transaction::{BASE_INPUT_WEIGHT, EMPTY_SCRIPT_SIG_WEIGHT};
-use crate::ln::chan_utils::FUNDING_TRANSACTION_WITNESS_WEIGHT;
+use crate::ln::chan_utils::{
+	BASE_INPUT_WEIGHT, EMPTY_SCRIPT_SIG_WEIGHT, FUNDING_TRANSACTION_WITNESS_WEIGHT,
+};
 use crate::ln::channel::{FundingNegotiationContext, TOTAL_BITCOIN_SUPPLY_SATOSHIS};
 use crate::ln::funding::FundingTxInput;
 use crate::ln::msgs;

--- a/lightning/src/ln/zero_fee_commitment_tests.rs
+++ b/lightning/src/ln/zero_fee_commitment_tests.rs
@@ -1,5 +1,15 @@
-use crate::ln::chan_utils::shared_anchor_script_pubkey;
+use crate::events::{ClosureReason, Event};
+use crate::ln::chan_utils;
+use crate::ln::chan_utils::{
+	BASE_INPUT_WEIGHT, BASE_TX_SIZE, EMPTY_SCRIPT_SIG_WEIGHT, EMPTY_WITNESS_WEIGHT,
+	P2WSH_TXOUT_WEIGHT, SEGWIT_MARKER_FLAG_WEIGHT, TRUC_CHILD_MAX_WEIGHT,
+};
 use crate::ln::functional_test_utils::*;
+use crate::ln::msgs::BaseMessageHandler;
+use crate::prelude::*;
+
+use bitcoin::constants::WITNESS_SCALE_FACTOR;
+use bitcoin::Amount;
 
 #[test]
 fn test_p2a_anchor_values_under_trims_and_rounds() {
@@ -46,10 +56,10 @@ fn test_p2a_anchor_values_under_trims_and_rounds() {
 			)*
 			let txn = get_local_commitment_txn!(nodes[0], chan_id);
 			assert_eq!(txn.len(), 1);
-			assert_eq!(txn[0].output.iter().find(|output| output.script_pubkey == shared_anchor_script_pubkey()).unwrap().value.to_sat(), $expected_p2a_value_sat);
+			assert_eq!(txn[0].output.iter().find(|output| output.script_pubkey == chan_utils::shared_anchor_script_pubkey()).unwrap().value.to_sat(), $expected_p2a_value_sat);
 			let txn = get_local_commitment_txn!(nodes[1], chan_id);
 			assert_eq!(txn.len(), 1);
-			assert_eq!(txn[0].output.iter().find(|output| output.script_pubkey == shared_anchor_script_pubkey()).unwrap().value.to_sat(), $expected_p2a_value_sat);
+			assert_eq!(txn[0].output.iter().find(|output| output.script_pubkey == chan_utils::shared_anchor_script_pubkey()).unwrap().value.to_sat(), $expected_p2a_value_sat);
 			for hash in node_0_1_hashes {
 				fail_payment(&nodes[0], &[&nodes[1]], hash);
 			}
@@ -91,4 +101,339 @@ fn test_p2a_anchor_values_under_trims_and_rounds() {
 	p2a_value_test!([353_001], [353_000], 240);
 	p2a_value_test!([353_000], [353_001], 240);
 	p2a_value_test!([353_001], [353_001], 240);
+}
+
+#[test]
+fn test_htlc_claim_chunking() {
+	// Assert we split an overall HolderHTLCOutput claim into constituent
+	// HTLC claim transactions such that each transaction is under TRUC_MAX_WEIGHT.
+	// Assert we reduce the number of HTLCs in a batch transaction by 2 if the
+	// coin selection algorithm fails to meet the target weight.
+	// Assert the claim_id of the first batch transaction is the claim
+	// id assigned to the overall claim.
+	// Assert we give up bumping a HTLC transaction once the batch size is
+	// 0 or negative.
+	//
+	// Route a bunch of HTLCs, force close the channel, assert two HTLC transactions
+	// get broadcasted, confirm only one of them, assert a new one gets broadcasted
+	// to sweep the remaining HTLCs, confirm a block without that transaction while
+	// dropping all available coin selection utxos, and assert we give up creating
+	// another HTLC transaction when handling the third HTLC bump.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let mut user_cfg = test_default_channel_config();
+	user_cfg.channel_handshake_config.our_htlc_minimum_msat = 1;
+	user_cfg.channel_handshake_config.negotiate_anchor_zero_fee_commitments = true;
+	user_cfg.channel_handshake_config.our_max_accepted_htlcs = 114;
+	user_cfg.manually_accept_inbound_channels = true;
+
+	let configs = [Some(user_cfg.clone()), Some(user_cfg)];
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &configs);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let coinbase_tx = provide_anchor_utxo_reserves(&nodes, 50, Amount::from_sat(500));
+
+	const CHAN_CAPACITY: u64 = 10_000_000;
+	let (_, _, chan_id, _funding_tx) = create_announced_chan_between_nodes_with_value(
+		&nodes,
+		0,
+		1,
+		CHAN_CAPACITY,
+		(CHAN_CAPACITY / 2) * 1000,
+	);
+
+	let mut node_1_preimages = Vec::new();
+	const NONDUST_HTLC_AMT_MSAT: u64 = 1_000_000;
+	for _ in 0..75 {
+		let (preimage, payment_hash, _, _) =
+			route_payment(&nodes[0], &[&nodes[1]], NONDUST_HTLC_AMT_MSAT);
+		node_1_preimages.push((preimage, payment_hash));
+	}
+	let node_0_commit_tx = get_local_commitment_txn!(nodes[0], chan_id);
+	assert_eq!(node_0_commit_tx.len(), 1);
+	assert_eq!(node_0_commit_tx[0].output.len(), 75 + 2 + 1);
+	let node_1_commit_tx = get_local_commitment_txn!(nodes[1], chan_id);
+	assert_eq!(node_1_commit_tx.len(), 1);
+	assert_eq!(node_1_commit_tx[0].output.len(), 75 + 2 + 1);
+
+	for (preimage, payment_hash) in node_1_preimages {
+		nodes[1].node.claim_funds(preimage);
+		check_added_monitors!(nodes[1], 1);
+		expect_payment_claimed!(nodes[1], payment_hash, NONDUST_HTLC_AMT_MSAT);
+	}
+	nodes[0].node.get_and_clear_pending_msg_events();
+	nodes[1].node.get_and_clear_pending_msg_events();
+
+	mine_transaction(&nodes[0], &node_1_commit_tx[0]);
+	mine_transaction(&nodes[1], &node_1_commit_tx[0]);
+
+	let mut events = nodes[1].chain_monitor.chain_monitor.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match events.pop().unwrap() {
+		Event::BumpTransaction(bump_event) => {
+			nodes[1].bump_tx_handler.handle_event(&bump_event);
+		},
+		_ => panic!("Unexpected event"),
+	}
+
+	let htlc_claims = nodes[1].tx_broadcaster.txn_broadcast();
+	assert_eq!(htlc_claims.len(), 2);
+
+	check_spends!(htlc_claims[0], node_1_commit_tx[0], coinbase_tx);
+	check_spends!(htlc_claims[1], node_1_commit_tx[0], coinbase_tx);
+
+	assert_eq!(htlc_claims[0].input.len(), 71);
+	assert_eq!(htlc_claims[0].output.len(), 51);
+	assert_eq!(htlc_claims[1].input.len(), 34);
+	assert_eq!(htlc_claims[1].output.len(), 24);
+
+	check_closed_broadcast!(nodes[0], true);
+	check_added_monitors!(nodes[0], 1);
+	check_closed_event!(
+		nodes[0],
+		1,
+		ClosureReason::CommitmentTxConfirmed,
+		[nodes[1].node.get_our_node_id()],
+		CHAN_CAPACITY
+	);
+	assert!(nodes[0].node.list_channels().is_empty());
+	check_closed_broadcast!(nodes[1], true);
+	check_added_monitors!(nodes[1], 1);
+	check_closed_event!(
+		nodes[1],
+		1,
+		ClosureReason::CommitmentTxConfirmed,
+		[nodes[0].node.get_our_node_id()],
+		CHAN_CAPACITY
+	);
+	assert!(nodes[1].node.list_channels().is_empty());
+	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+
+	mine_transaction(&nodes[1], &htlc_claims[0]);
+
+	let mut events = nodes[1].chain_monitor.chain_monitor.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match events.pop().unwrap() {
+		Event::BumpTransaction(bump_event) => {
+			nodes[1].bump_tx_handler.handle_event(&bump_event);
+		},
+		_ => panic!("Unexpected event"),
+	}
+
+	let fresh_htlc_claims = nodes[1].tx_broadcaster.txn_broadcast();
+	assert_eq!(fresh_htlc_claims.len(), 1);
+	check_spends!(fresh_htlc_claims[0], node_1_commit_tx[0], coinbase_tx);
+	// We are targeting a higher feerate here,
+	// so we need more utxos here compared to `htlc_claims[1]` above.
+	assert_eq!(fresh_htlc_claims[0].input.len(), 37);
+	assert_eq!(fresh_htlc_claims[0].output.len(), 25);
+
+	let log_entries = nodes[1].logger.lines.lock().unwrap();
+	let batch_tx_id_assignments: Vec<_> = log_entries
+		.keys()
+		.map(|key| &key.1)
+		.filter(|log_msg| log_msg.contains("Batch transaction assigned to UTXO id"))
+		.collect();
+	assert_eq!(batch_tx_id_assignments.len(), 7);
+
+	let mut unique_claim_ids: Vec<(&str, u8)> = Vec::new();
+	for claim_id in batch_tx_id_assignments
+		.iter()
+		.map(|assignment| assignment.split_whitespace().nth(6).unwrap())
+	{
+		if let Some((_, count)) = unique_claim_ids.iter_mut().find(|(id, _count)| &claim_id == id) {
+			*count += 1;
+		} else {
+			unique_claim_ids.push((claim_id, 1));
+		}
+	}
+	unique_claim_ids.sort_unstable_by_key(|(_id, count)| *count);
+	assert_eq!(unique_claim_ids.len(), 2);
+	let (og_claim_id, og_claim_id_count) = unique_claim_ids.pop().unwrap();
+	assert_eq!(og_claim_id_count, 6);
+	assert_eq!(unique_claim_ids.pop().unwrap().1, 1);
+
+	let handling_htlc_bumps: Vec<_> = log_entries
+		.keys()
+		.map(|key| &key.1)
+		.filter(|log_msg| log_msg.contains("Handling HTLC bump"))
+		.map(|log_msg| {
+			log_msg
+				.split_whitespace()
+				.nth(5)
+				.unwrap()
+				.trim_matches(|c: char| c.is_ascii_punctuation())
+		})
+		.collect();
+	assert_eq!(handling_htlc_bumps.len(), 2);
+	assert_eq!(handling_htlc_bumps[0], og_claim_id);
+	assert_eq!(handling_htlc_bumps[1], og_claim_id);
+
+	let mut batch_sizes: Vec<u8> = batch_tx_id_assignments
+		.iter()
+		.map(|assignment| assignment.split_whitespace().nth(8).unwrap().parse().unwrap())
+		.collect();
+	batch_sizes.sort_unstable();
+	batch_sizes.reverse();
+	assert_eq!(batch_sizes.len(), 7);
+	assert_eq!(batch_sizes.pop().unwrap(), 24);
+	assert_eq!(batch_sizes.pop().unwrap(), 24);
+	for i in (51..=59).step_by(2) {
+		assert_eq!(batch_sizes.pop().unwrap(), i);
+	}
+	drop(log_entries);
+
+	nodes[1].wallet_source.clear_utxos();
+	nodes[1].chain_monitor.chain_monitor.rebroadcast_pending_claims();
+
+	let mut events = nodes[1].chain_monitor.chain_monitor.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match events.pop().unwrap() {
+		Event::BumpTransaction(bump_event) => {
+			nodes[1].bump_tx_handler.handle_event(&bump_event);
+		},
+		_ => panic!("Unexpected event"),
+	}
+
+	nodes[1].logger.assert_log(
+		"lightning::events::bump_transaction",
+		format!(
+			"Failed bumping HTLC transaction fee for commitment {}",
+			node_1_commit_tx[0].compute_txid()
+		),
+		1,
+	);
+}
+
+#[test]
+fn test_anchor_tx_too_big() {
+	// Assert all V3 anchor tx transactions are below TRUC_CHILD_MAX_WEIGHT.
+	//
+	// Provide a bunch of small utxos, fail to bump the commitment,
+	// then provide a single big-value utxo, and successfully broadcast
+	// the commitment.
+	const FEERATE: u32 = 500;
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	{
+		let mut feerate_lock = chanmon_cfgs[1].fee_estimator.sat_per_kw.lock().unwrap();
+		*feerate_lock = FEERATE;
+	}
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let mut user_cfg = test_default_channel_config();
+	user_cfg.channel_handshake_config.our_htlc_minimum_msat = 1;
+	user_cfg.channel_handshake_config.negotiate_anchor_zero_fee_commitments = true;
+	user_cfg.channel_handshake_config.our_max_accepted_htlcs = 114;
+	user_cfg.manually_accept_inbound_channels = true;
+
+	let configs = [Some(user_cfg.clone()), Some(user_cfg)];
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &configs);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let node_a_id = nodes[0].node.get_our_node_id();
+
+	let _coinbase_tx_a = provide_anchor_utxo_reserves(&nodes, 50, Amount::from_sat(500));
+
+	const CHAN_CAPACITY: u64 = 10_000_000;
+	let (_, _, chan_id, _funding_tx) = create_announced_chan_between_nodes_with_value(
+		&nodes,
+		0,
+		1,
+		CHAN_CAPACITY,
+		(CHAN_CAPACITY / 2) * 1000,
+	);
+
+	let mut node_1_preimages = Vec::new();
+	const NONDUST_HTLC_AMT_MSAT: u64 = 1_000_000;
+	for _ in 0..50 {
+		let (preimage, payment_hash, _, _) =
+			route_payment(&nodes[0], &[&nodes[1]], NONDUST_HTLC_AMT_MSAT);
+		node_1_preimages.push((preimage, payment_hash));
+	}
+	let commitment_tx = get_local_commitment_txn!(nodes[1], chan_id).pop().unwrap();
+	let commitment_txid = commitment_tx.compute_txid();
+
+	let message = "Channel force-closed".to_owned();
+	nodes[1]
+		.node
+		.force_close_broadcasting_latest_txn(&chan_id, &node_a_id, message.clone())
+		.unwrap();
+	check_added_monitors(&nodes[1], 1);
+	check_closed_broadcast!(nodes[1], true);
+
+	let reason = ClosureReason::HolderForceClosed { broadcasted_latest_txn: Some(true), message };
+	check_closed_event!(nodes[1], 1, reason, [node_a_id], CHAN_CAPACITY);
+
+	let mut events = nodes[1].chain_monitor.chain_monitor.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match events.pop().unwrap() {
+		Event::BumpTransaction(bump_event) => {
+			nodes[1].bump_tx_handler.handle_event(&bump_event);
+		},
+		_ => panic!("Unexpected event"),
+	}
+	assert!(nodes[1].tx_broadcaster.txn_broadcast().is_empty());
+	let max_coin_selection_weight = TRUC_CHILD_MAX_WEIGHT
+		- BASE_TX_SIZE * WITNESS_SCALE_FACTOR as u64
+		- SEGWIT_MARKER_FLAG_WEIGHT
+		- BASE_INPUT_WEIGHT
+		- EMPTY_SCRIPT_SIG_WEIGHT
+		- EMPTY_WITNESS_WEIGHT
+		- P2WSH_TXOUT_WEIGHT;
+	nodes[1].logger.assert_log(
+		"lightning::events::bump_transaction",
+		format!(
+			"Insufficient funds to meet target feerate {} sat/kW while remaining under {} WU",
+			FEERATE, max_coin_selection_weight
+		),
+		4,
+	);
+	nodes[1].logger.assert_log(
+		"lightning::events::bump_transaction",
+		format!("Failed bumping commitment transaction fee for {}", commitment_txid),
+		1,
+	);
+
+	let coinbase_tx_b = provide_anchor_reserves(&nodes);
+
+	nodes[1].chain_monitor.chain_monitor.rebroadcast_pending_claims();
+
+	let mut events = nodes[1].chain_monitor.chain_monitor.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match events.pop().unwrap() {
+		Event::BumpTransaction(bump_event) => {
+			nodes[1].bump_tx_handler.handle_event(&bump_event);
+		},
+		_ => panic!("Unexpected event"),
+	}
+	let txns = nodes[1].tx_broadcaster.txn_broadcast();
+	assert_eq!(txns.len(), 2);
+	check_spends!(txns[1], txns[0], coinbase_tx_b);
+	assert!(txns[1].weight().to_wu() < TRUC_CHILD_MAX_WEIGHT);
+
+	assert_eq!(txns[0].compute_txid(), commitment_txid);
+	assert_eq!(txns[1].input.len(), 2);
+	assert_eq!(txns[1].output.len(), 1);
+	nodes[1].logger.assert_log(
+		"lightning::events::bump_transaction",
+		format!(
+			"Insufficient funds to meet target feerate {} sat/kW while remaining under {} WU",
+			FEERATE, max_coin_selection_weight
+		),
+		4,
+	);
+	nodes[1].logger.assert_log(
+		"lightning::events::bump_transaction",
+		format!("Failed bumping commitment transaction fee for {}", txns[0].compute_txid()),
+		1,
+	);
+	nodes[1].logger.assert_log(
+		"lightning::events::bump_transaction",
+		format!(
+			"Broadcasting anchor transaction {} to bump channel close with txid {}",
+			txns[1].compute_txid(),
+			txns[0].compute_txid()
+		),
+		1,
+	);
 }

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -2155,6 +2155,10 @@ impl TestWalletSource {
 		self.utxos.lock().unwrap().retain(|utxo| utxo.outpoint != outpoint);
 	}
 
+	pub fn clear_utxos(&self) {
+		self.utxos.lock().unwrap().clear();
+	}
+
 	pub fn sign_tx(
 		&self, mut tx: Transaction,
 	) -> Result<Transaction, bitcoin::sighash::P2wpkhError> {


### PR DESCRIPTION
Otherwise, we could potentially hit the max 10_000vB size limit on V3 transactions (BIP 431 rule 4) if we aggregate enough HTLC-claims together.