### PR TITLE
Break up and function-ize `handle_new_monitor_update` 

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3628,8 +3628,8 @@ macro_rules! handle_monitor_update_completion {
 	} }
 }
 
-macro_rules! handle_new_monitor_update {
-	($self: ident, $update_res: expr, $peer_state_lock: expr, $peer_state: expr, $per_peer_state_lock: expr, $chan: expr, INITIAL_MONITOR) => {
+macro_rules! handle_initial_monitor {
+	($self: ident, $update_res: expr, $peer_state_lock: expr, $peer_state: expr, $per_peer_state_lock: expr, $chan: expr) => {
 		let logger = WithChannelContext::from(&$self.logger, &$chan.context, None);
 		let update_completed =
 			$self.handle_monitor_update_res($update_res, $chan.context.channel_id(), logger);
@@ -3643,6 +3643,9 @@ macro_rules! handle_new_monitor_update {
 			);
 		}
 	};
+}
+
+macro_rules! handle_new_monitor_update {
 	(
 		$self: ident, $funding_txo: expr, $update: expr, $peer_state: expr, $logger: expr,
 		$chan_id: expr, $counterparty_node_id: expr, $in_flight_updates: ident, $update_idx: ident,
@@ -10115,8 +10118,8 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					}
 
 					if let Some(funded_chan) = e.insert(Channel::from(chan)).as_funded_mut() {
-						handle_new_monitor_update!(self, persist_state, peer_state_lock, peer_state,
-							per_peer_state, funded_chan, INITIAL_MONITOR);
+						handle_initial_monitor!(self, persist_state, peer_state_lock, peer_state,
+							per_peer_state, funded_chan);
 					} else {
 						unreachable!("This must be a funded channel as we just inserted it.");
 					}
@@ -10279,7 +10282,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					})
 				{
 					Ok((funded_chan, persist_status)) => {
-						handle_new_monitor_update!(self, persist_status, peer_state_lock, peer_state, per_peer_state, funded_chan, INITIAL_MONITOR);
+						handle_initial_monitor!(self, persist_status, peer_state_lock, peer_state, per_peer_state, funded_chan);
 						Ok(())
 					},
 					Err(e) => try_channel_entry!(self, peer_state, Err(e), chan_entry),
@@ -10904,8 +10907,8 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					if let Some(monitor) = monitor_opt {
 						let monitor_res = self.chain_monitor.watch_channel(monitor.channel_id(), monitor);
 						if let Ok(persist_state) = monitor_res {
-							handle_new_monitor_update!(self, persist_state, peer_state_lock, peer_state,
-								per_peer_state, chan, INITIAL_MONITOR);
+							handle_initial_monitor!(self, persist_state, peer_state_lock, peer_state,
+								per_peer_state, chan);
 						} else {
 							let logger = WithChannelContext::from(&self.logger, &chan.context, None);
 							log_error!(logger, "Persisting initial ChannelMonitor failed, implying the channel ID was duplicated");

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3271,8 +3271,8 @@ macro_rules! locked_close_channel {
 	}};
 	($self: ident, $peer_state: expr, $funded_chan: expr, $shutdown_res_mut: expr, FUNDED) => {{
 		if let Some((_, funding_txo, _, update)) = $shutdown_res_mut.monitor_update.take() {
-			handle_new_monitor_update!($self, funding_txo, update, $peer_state,
-				$funded_chan.context, REMAIN_LOCKED_UPDATE_ACTIONS_PROCESSED_LATER);
+			handle_new_monitor_update_todo_name!($self, funding_txo, update, $peer_state,
+				$funded_chan.context);
 		}
 		// If there's a possibility that we need to generate further monitor updates for this
 		// channel, we need to store the last update_id of it. However, we don't want to insert
@@ -3666,6 +3666,7 @@ macro_rules! handle_post_close_monitor_update {
 			idx,
 			_internal_outer,
 			{
+				// If we get a monitor update for a closed channel
 				let _ = in_flight_updates.remove(idx);
 				if in_flight_updates.is_empty() {
 					let update_actions = $peer_state
@@ -3678,6 +3679,33 @@ macro_rules! handle_post_close_monitor_update {
 
 					$self.handle_monitor_update_completion_actions(update_actions);
 				}
+			}
+		)
+	}};
+}
+
+macro_rules! handle_new_monitor_update_todo_name {
+	(
+		$self: ident, $funding_txo: expr, $update: expr, $peer_state: expr, $chan_context: expr
+	) => {{
+		let logger = WithChannelContext::from(&$self.logger, &$chan_context, None);
+		let chan_id = $chan_context.channel_id();
+		let counterparty_node_id = $chan_context.get_counterparty_node_id();
+		let in_flight_updates;
+		let idx;
+		handle_new_monitor_update!(
+			$self,
+			$funding_txo,
+			$update,
+			$peer_state,
+			logger,
+			chan_id,
+			counterparty_node_id,
+			in_flight_updates,
+			idx,
+			_internal_outer,
+			{
+				let _ = in_flight_updates.remove(idx);
 			}
 		)
 	}};
@@ -3731,31 +3759,6 @@ macro_rules! handle_new_monitor_update {
 			$self.pending_background_events.lock().unwrap().push(event);
 			false
 		}
-	}};
-	(
-		$self: ident, $funding_txo: expr, $update: expr, $peer_state: expr, $chan_context: expr,
-		REMAIN_LOCKED_UPDATE_ACTIONS_PROCESSED_LATER
-	) => {{
-		let logger = WithChannelContext::from(&$self.logger, &$chan_context, None);
-		let chan_id = $chan_context.channel_id();
-		let counterparty_node_id = $chan_context.get_counterparty_node_id();
-		let in_flight_updates;
-		let idx;
-		handle_new_monitor_update!(
-			$self,
-			$funding_txo,
-			$update,
-			$peer_state,
-			logger,
-			chan_id,
-			counterparty_node_id,
-			in_flight_updates,
-			idx,
-			_internal_outer,
-			{
-				let _ = in_flight_updates.remove(idx);
-			}
-		)
 	}};
 	(
 		$self: ident, $funding_txo: expr, $update: expr, $peer_state_lock: expr, $peer_state: expr,
@@ -14039,13 +14042,12 @@ where
 											insert_short_channel_id!(short_to_chan_info, funded_channel);
 
 											if let Some(monitor_update) = monitor_update_opt {
-												handle_new_monitor_update!(
+												handle_new_monitor_update_todo_name!(
 													self,
 													funding_txo,
 													monitor_update,
 													peer_state,
-													funded_channel.context,
-													REMAIN_LOCKED_UPDATE_ACTIONS_PROCESSED_LATER
+													funded_channel.context
 												);
 												to_process_monitor_update_actions.push((
 													counterparty_node_id, channel_id

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3645,6 +3645,44 @@ macro_rules! handle_initial_monitor {
 	};
 }
 
+macro_rules! handle_post_close_monitor_update {
+	(
+		$self: ident, $funding_txo: expr, $update: expr, $peer_state_lock: expr, $peer_state: expr,
+		$per_peer_state_lock: expr, $counterparty_node_id: expr, $channel_id: expr
+	) => {{
+		let logger =
+			WithContext::from(&$self.logger, Some($counterparty_node_id), Some($channel_id), None);
+		let in_flight_updates;
+		let idx;
+		handle_new_monitor_update!(
+			$self,
+			$funding_txo,
+			$update,
+			$peer_state,
+			logger,
+			$channel_id,
+			$counterparty_node_id,
+			in_flight_updates,
+			idx,
+			_internal_outer,
+			{
+				let _ = in_flight_updates.remove(idx);
+				if in_flight_updates.is_empty() {
+					let update_actions = $peer_state
+						.monitor_update_blocked_actions
+						.remove(&$channel_id)
+						.unwrap_or(Vec::new());
+
+					mem::drop($peer_state_lock);
+					mem::drop($per_peer_state_lock);
+
+					$self.handle_monitor_update_completion_actions(update_actions);
+				}
+			}
+		)
+	}};
+}
+
 macro_rules! handle_new_monitor_update {
 	(
 		$self: ident, $funding_txo: expr, $update: expr, $peer_state: expr, $logger: expr,
@@ -3716,41 +3754,6 @@ macro_rules! handle_new_monitor_update {
 			_internal_outer,
 			{
 				let _ = in_flight_updates.remove(idx);
-			}
-		)
-	}};
-	(
-		$self: ident, $funding_txo: expr, $update: expr, $peer_state_lock: expr, $peer_state: expr,
-		$per_peer_state_lock: expr, $counterparty_node_id: expr, $channel_id: expr, POST_CHANNEL_CLOSE
-	) => {{
-		let logger =
-			WithContext::from(&$self.logger, Some($counterparty_node_id), Some($channel_id), None);
-		let in_flight_updates;
-		let idx;
-		handle_new_monitor_update!(
-			$self,
-			$funding_txo,
-			$update,
-			$peer_state,
-			logger,
-			$channel_id,
-			$counterparty_node_id,
-			in_flight_updates,
-			idx,
-			_internal_outer,
-			{
-				let _ = in_flight_updates.remove(idx);
-				if in_flight_updates.is_empty() {
-					let update_actions = $peer_state
-						.monitor_update_blocked_actions
-						.remove(&$channel_id)
-						.unwrap_or(Vec::new());
-
-					mem::drop($peer_state_lock);
-					mem::drop($per_peer_state_lock);
-
-					$self.handle_monitor_update_completion_actions(update_actions);
-				}
 			}
 		)
 	}};
@@ -4464,9 +4467,9 @@ where
 			hash_map::Entry::Vacant(_) => {},
 		}
 
-		handle_new_monitor_update!(
+		handle_post_close_monitor_update!(
 			self, funding_txo, monitor_update, peer_state_lock, peer_state, per_peer_state,
-			counterparty_node_id, channel_id, POST_CHANNEL_CLOSE
+			counterparty_node_id, channel_id
 		);
 	}
 
@@ -8925,7 +8928,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 				.push(action);
 		}
 
-		handle_new_monitor_update!(
+		handle_post_close_monitor_update!(
 			self,
 			prev_hop.funding_txo,
 			preimage_update,
@@ -8933,8 +8936,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 			peer_state,
 			per_peer_state,
 			prev_hop.counterparty_node_id,
-			chan_id,
-			POST_CHANNEL_CLOSE
+			chan_id
 		);
 	}
 
@@ -13345,7 +13347,7 @@ where
 						};
 						self.pending_background_events.lock().unwrap().push(event);
 					} else {
-						handle_new_monitor_update!(
+						handle_post_close_monitor_update!(
 							self,
 							channel_funding_outpoint,
 							update,
@@ -13353,8 +13355,7 @@ where
 							peer_state,
 							per_peer_state,
 							counterparty_node_id,
-							channel_id,
-							POST_CHANNEL_CLOSE
+							channel_id
 						);
 					}
 				},

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3654,7 +3654,7 @@ macro_rules! handle_post_close_monitor_update {
 			WithContext::from(&$self.logger, Some($counterparty_node_id), Some($channel_id), None);
 		let in_flight_updates;
 		let idx;
-		handle_new_monitor_update!(
+		handle_new_monitor_update_internal!(
 			$self,
 			$funding_txo,
 			$update,
@@ -3664,7 +3664,6 @@ macro_rules! handle_post_close_monitor_update {
 			$counterparty_node_id,
 			in_flight_updates,
 			idx,
-			_internal_outer,
 			{
 				// If we get a monitor update for a closed channel
 				let _ = in_flight_updates.remove(idx);
@@ -3693,7 +3692,7 @@ macro_rules! handle_new_monitor_update_todo_name {
 		let counterparty_node_id = $chan_context.get_counterparty_node_id();
 		let in_flight_updates;
 		let idx;
-		handle_new_monitor_update!(
+		handle_new_monitor_update_internal!(
 			$self,
 			$funding_txo,
 			$update,
@@ -3703,7 +3702,6 @@ macro_rules! handle_new_monitor_update_todo_name {
 			counterparty_node_id,
 			in_flight_updates,
 			idx,
-			_internal_outer,
 			{
 				let _ = in_flight_updates.remove(idx);
 			}
@@ -3711,11 +3709,11 @@ macro_rules! handle_new_monitor_update_todo_name {
 	}};
 }
 
-macro_rules! handle_new_monitor_update {
+macro_rules! handle_new_monitor_update_internal {
 	(
 		$self: ident, $funding_txo: expr, $update: expr, $peer_state: expr, $logger: expr,
 		$chan_id: expr, $counterparty_node_id: expr, $in_flight_updates: ident, $update_idx: ident,
-		_internal_outer, $completed: expr
+		$completed: expr
 	) => {{
 		$in_flight_updates = &mut $peer_state
 			.in_flight_monitor_updates
@@ -3760,6 +3758,9 @@ macro_rules! handle_new_monitor_update {
 			false
 		}
 	}};
+}
+
+macro_rules! handle_new_monitor_update {
 	(
 		$self: ident, $funding_txo: expr, $update: expr, $peer_state_lock: expr, $peer_state: expr,
 		$per_peer_state_lock: expr, $chan: expr
@@ -3769,7 +3770,7 @@ macro_rules! handle_new_monitor_update {
 		let counterparty_node_id = $chan.context.get_counterparty_node_id();
 		let in_flight_updates;
 		let idx;
-		handle_new_monitor_update!(
+		handle_new_monitor_update_internal!(
 			$self,
 			$funding_txo,
 			$update,
@@ -3779,7 +3780,6 @@ macro_rules! handle_new_monitor_update {
 			counterparty_node_id,
 			in_flight_updates,
 			idx,
-			_internal_outer,
 			{
 				let _ = in_flight_updates.remove(idx);
 				if in_flight_updates.is_empty() && $chan.blocked_monitor_updates_pending() == 0 {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3629,37 +3629,19 @@ macro_rules! handle_monitor_update_completion {
 }
 
 macro_rules! handle_new_monitor_update {
-	($self: ident, $update_res: expr, $logger: expr, $channel_id: expr, _internal, $completed: expr) => { {
-		debug_assert!($self.background_events_processed_since_startup.load(Ordering::Acquire));
-		match $update_res {
-			ChannelMonitorUpdateStatus::UnrecoverableError => {
-				let err_str = "ChannelMonitor[Update] persistence failed unrecoverably. This indicates we cannot continue normal operation and must shut down.";
-				log_error!($logger, "{}", err_str);
-				panic!("{}", err_str);
-			},
-			ChannelMonitorUpdateStatus::InProgress => {
-				#[cfg(not(any(test, feature = "_externalize_tests")))]
-				if $self.monitor_update_type.swap(1, Ordering::Relaxed) == 2 {
-					panic!("Cannot use both ChannelMonitorUpdateStatus modes InProgress and Completed without restart");
-				}
-				log_debug!($logger, "ChannelMonitor update for {} in flight, holding messages until the update completes.",
-					$channel_id);
-				false
-			},
-			ChannelMonitorUpdateStatus::Completed => {
-				#[cfg(not(any(test, feature = "_externalize_tests")))]
-				if $self.monitor_update_type.swap(2, Ordering::Relaxed) == 1 {
-					panic!("Cannot use both ChannelMonitorUpdateStatus modes InProgress and Completed without restart");
-				}
-				$completed;
-				true
-			},
-		}
-	} };
 	($self: ident, $update_res: expr, $peer_state_lock: expr, $peer_state: expr, $per_peer_state_lock: expr, $chan: expr, INITIAL_MONITOR) => {
 		let logger = WithChannelContext::from(&$self.logger, &$chan.context, None);
-		handle_new_monitor_update!($self, $update_res, logger, $chan.context.channel_id(), _internal,
-			handle_monitor_update_completion!($self, $peer_state_lock, $peer_state, $per_peer_state_lock, $chan))
+		let update_completed =
+			$self.handle_monitor_update_res($update_res, $chan.context.channel_id(), logger);
+		if update_completed {
+			handle_monitor_update_completion!(
+				$self,
+				$peer_state_lock,
+				$peer_state,
+				$per_peer_state_lock,
+				$chan
+			);
+		}
 	};
 	(
 		$self: ident, $funding_txo: expr, $update: expr, $peer_state: expr, $logger: expr,
@@ -3682,7 +3664,11 @@ macro_rules! handle_new_monitor_update {
 		if $self.background_events_processed_since_startup.load(Ordering::Acquire) {
 			let update_res =
 				$self.chain_monitor.update_channel($chan_id, &$in_flight_updates[$update_idx]);
-			handle_new_monitor_update!($self, update_res, $logger, $chan_id, _internal, $completed)
+			let update_completed = $self.handle_monitor_update_res(update_res, $chan_id, $logger);
+			if update_completed {
+				$completed;
+			}
+			update_completed
 		} else {
 			// We blindly assume that the ChannelMonitorUpdate will be regenerated on startup if we
 			// fail to persist it. This is a fairly safe assumption, however, since anything we do
@@ -9546,6 +9532,36 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 			mem::drop(peer_state_lock);
 			mem::drop(per_peer_state);
 			self.handle_monitor_update_completion_actions(update_actions);
+		}
+	}
+
+	/// Returns whether the monitor update is completed, `false` if the update is in-progress.
+	fn handle_monitor_update_res<LG: Logger>(
+		&self, update_res: ChannelMonitorUpdateStatus, channel_id: ChannelId, logger: LG,
+	) -> bool {
+		debug_assert!(self.background_events_processed_since_startup.load(Ordering::Acquire));
+		match update_res {
+			ChannelMonitorUpdateStatus::UnrecoverableError => {
+				let err_str = "ChannelMonitor[Update] persistence failed unrecoverably. This indicates we cannot continue normal operation and must shut down.";
+				log_error!(logger, "{}", err_str);
+				panic!("{}", err_str);
+			},
+			ChannelMonitorUpdateStatus::InProgress => {
+				#[cfg(not(any(test, feature = "_externalize_tests")))]
+				if self.monitor_update_type.swap(1, Ordering::Relaxed) == 2 {
+					panic!("Cannot use both ChannelMonitorUpdateStatus modes InProgress and Completed without restart");
+				}
+				log_debug!(logger, "ChannelMonitor update for {} in flight, holding messages until the update completes.",
+					channel_id);
+				false
+			},
+			ChannelMonitorUpdateStatus::Completed => {
+				#[cfg(not(any(test, feature = "_externalize_tests")))]
+				if self.monitor_update_type.swap(2, Ordering::Relaxed) == 1 {
+					panic!("Cannot use both ChannelMonitorUpdateStatus modes InProgress and Completed without restart");
+				}
+				true
+			},
 		}
 	}
 


### PR DESCRIPTION
Prefactor to some of @joostjager's experimental work including serialized channels in `ChannelMonitorUpdate`s as part of getting rid of `ChannelManager` persistence. 