### PR TITLE
Add support for `Testnet4`

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ lightning-liquidity = { path = "../lightning-liquidity" }
 lightning-rapid-gossip-sync = { path = "../lightning-rapid-gossip-sync" }
 lightning-persister = { path = "../lightning-persister", features = ["tokio"]}
 bech32 = "0.11.0"
-bitcoin = { version = "0.32.2", features = ["secp-lowmemory"] }
+bitcoin = { version = "0.32.4", features = ["secp-lowmemory"] }
 tokio = { version = "~1.35", default-features = false, features = ["rt-multi-thread"] }
 
 afl = { version = "0.12", optional = true }

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -22,7 +22,7 @@ std = []
 bech32 = { version = "0.11.0", default-features = false }
 lightning-types = { version = "0.3.0", path = "../lightning-types", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
-bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
+bitcoin = { version = "0.32.4", default-features = false, features = ["secp-recovery"] }
 
 [dev-dependencies]
 serde_json = { version = "1"}

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -438,6 +438,8 @@ pub enum Currency {
 	Bitcoin,
 
 	/// Bitcoin testnet
+	///
+	/// Note this will also be used for invoices on [`Network::Testnet4`].
 	BitcoinTestnet,
 
 	/// Bitcoin regtest
@@ -455,12 +457,9 @@ impl From<Network> for Currency {
 		match network {
 			Network::Bitcoin => Currency::Bitcoin,
 			Network::Testnet => Currency::BitcoinTestnet,
+			Network::Testnet4 => Currency::BitcoinTestnet,
 			Network::Regtest => Currency::Regtest,
 			Network::Signet => Currency::Signet,
-			_ => {
-				debug_assert!(false, "Need to handle new rust-bitcoin network type");
-				Currency::Regtest
-			},
 		}
 	}
 }
@@ -1624,6 +1623,9 @@ impl Bolt11Invoice {
 	}
 
 	/// Returns the network for which the invoice was issued
+	///
+	/// **Caution**: On Testnet4, this method will return [`Network::Testnet`]` rather than
+	/// [`Network::Testnet4`].
 	///
 	/// This is not exported to bindings users, see [`Self::currency`] instead.
 	pub fn network(&self) -> Network {

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -39,7 +39,7 @@ lightning-invoice = { version = "0.34.0", path = "../lightning-invoice", default
 lightning-macros = { version = "0.2", path = "../lightning-macros" }
 
 bech32 = { version = "0.11.0", default-features = false }
-bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
+bitcoin = { version = "0.32.4", default-features = false, features = ["secp-recovery"] }
 
 dnssec-prover = { version = "0.6", default-features = false }
 hashbrown = { version = "0.13", default-features = false }
@@ -58,7 +58,7 @@ lightning-macros = { path = "../lightning-macros" }
 parking_lot = { version = "0.12", default-features = false }
 
 [dev-dependencies.bitcoin]
-version = "0.32.2"
+version = "0.32.4"
 default-features = false
 features = ["bitcoinconsensus", "secp-recovery"]
 


### PR DESCRIPTION
We simply add support for `bitcoin::Network::Testnet4`, which was added with release v0.32.4, which we hence deem the new minimal requirement for `lightning` and `lightning-invoice`.