### PR TITLE
[0.2] Move V2 channel opens behind a cfg flag again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,4 +67,5 @@ check-cfg = [
     "cfg(require_route_graph_test)",
     "cfg(simple_close)",
     "cfg(peer_storage)",
+    "cfg(dual_funding)",
 ]

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -163,3 +163,5 @@ RUSTFLAGS="--cfg=simple_close" cargo test --verbose --color always -p lightning
 RUSTFLAGS="--cfg=lsps1_service" cargo test --verbose --color always -p lightning-liquidity
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=peer_storage" cargo test --verbose --color always -p lightning
+[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
+RUSTFLAGS="--cfg=dual_funding" cargo test --verbose --color always -p lightning

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -15603,6 +15603,7 @@ pub fn provided_init_features(config: &UserConfig) -> InitFeatures {
 	if config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx {
 		features.set_anchors_zero_fee_htlc_tx_optional();
 	}
+	#[cfg(dual_funding)]
 	if config.enable_dual_funded_channels {
 		features.set_dual_fund_optional();
 	}

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -927,6 +927,7 @@ pub struct UserConfig {
 	/// [`ChannelManager::send_payment_for_bolt12_invoice`]: crate::ln::channelmanager::ChannelManager::send_payment_for_bolt12_invoice
 	/// [`ChannelManager::abandon_payment`]: crate::ln::channelmanager::ChannelManager::abandon_payment
 	pub manually_handle_bolt12_invoices: bool,
+	#[cfg(dual_funding)]
 	/// If this is set to `true`, dual-funded channels will be enabled.
 	///
 	/// Default value: `false`
@@ -981,6 +982,7 @@ impl Default for UserConfig {
 			manually_accept_inbound_channels: false,
 			accept_intercept_htlcs: false,
 			manually_handle_bolt12_invoices: false,
+			#[cfg(dual_funding)]
 			enable_dual_funded_channels: false,
 			enable_htlc_hold: false,
 			hold_outbound_htlcs_at_next_hop: false,
@@ -995,19 +997,32 @@ impl Default for UserConfig {
 #[cfg(fuzzing)]
 impl Readable for UserConfig {
 	fn read<R: crate::io::Read>(reader: &mut R) -> Result<Self, crate::ln::msgs::DecodeError> {
+		let channel_handshake_config = Readable::read(reader)?;
+		let channel_handshake_limits = Readable::read(reader)?;
+		let channel_config = Readable::read(reader)?;
+		let accept_forwards_to_priv_channels = Readable::read(reader)?;
+		let accept_inbound_channels = Readable::read(reader)?;
+		let manually_accept_inbound_channels = Readable::read(reader)?;
+		let accept_intercept_htlcs = Readable::read(reader)?;
+		let manually_handle_bolt12_invoices = Readable::read(reader)?;
+		let _enable_dual_funded_channels: bool = Readable::read(reader)?;
+		let hold_outbound_htlcs_at_next_hop = Readable::read(reader)?;
+		let enable_htlc_hold = Readable::read(reader)?;
+		let reject_inbound_splices = Readable::read(reader)?;
 		Ok(Self {
-			channel_handshake_config: Readable::read(reader)?,
-			channel_handshake_limits: Readable::read(reader)?,
-			channel_config: Readable::read(reader)?,
-			accept_forwards_to_priv_channels: Readable::read(reader)?,
-			accept_inbound_channels: Readable::read(reader)?,
-			manually_accept_inbound_channels: Readable::read(reader)?,
-			accept_intercept_htlcs: Readable::read(reader)?,
-			manually_handle_bolt12_invoices: Readable::read(reader)?,
-			enable_dual_funded_channels: Readable::read(reader)?,
-			hold_outbound_htlcs_at_next_hop: Readable::read(reader)?,
-			enable_htlc_hold: Readable::read(reader)?,
-			reject_inbound_splices: Readable::read(reader)?,
+			channel_handshake_config,
+			channel_handshake_limits,
+			channel_config,
+			accept_forwards_to_priv_channels,
+			accept_inbound_channels,
+			manually_accept_inbound_channels,
+			accept_intercept_htlcs,
+			manually_handle_bolt12_invoices,
+			#[cfg(dual_funding)]
+			enable_dual_funded_channels: _enable_dual_funded_channels,
+			hold_outbound_htlcs_at_next_hop,
+			enable_htlc_hold,
+			reject_inbound_splices,
 		})
 	}
 }


### PR DESCRIPTION
While its somewhat sad to do, we didn't really make the progress we wanted on dual funded channels in 0.2, and thus aren't super confident in them. Further, because we still don't support actually contributing inputs to an inbound channel nor outbound v2 channel opens there's not really any reason to support them.

Thus, we simply re-cfg-gate them here for 0.2.