### PR TITLE
Return an error when the intercept SCID is unknown to the LSPS2 service

### DIFF
--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -981,7 +981,7 @@ where
 	/// Will generate a [`LSPS2ServiceEvent::OpenChannel`] event if the intercept scid matches a payment we are expected
 	/// and the payment amount is correct and the offer has not expired.
 	///
-	/// Will do nothing if the intercept scid does not match any of the ones we gave out.
+	/// Will return an error if the intercept scid does not match any of the ones we gave out.
 	///
 	/// [`Event::HTLCIntercepted`]: lightning::events::Event::HTLCIntercepted
 	/// [`LSPS2ServiceEvent::OpenChannel`]: crate::lsps2::event::LSPS2ServiceEvent::OpenChannel
@@ -1067,6 +1067,10 @@ where
 					});
 				},
 			}
+		} else {
+			return Err(APIError::APIMisuseError {
+				err: format!("Unknown scid provided: {}", intercept_scid),
+			});
 		}
 
 		if let Some(counterparty_node_id) = should_persist {


### PR DESCRIPTION
HTLCs can be intercepted for multiple reasons unrelated to this handler:
- Other HTLC interceptors might have generated intercept SCIDs.
- The SCID of a closed channel might have fallen into the fake SCID namespace.

The LSPS2 handler needs to indicate whether the specific SCID was known to it, so other handlers can be called or the HTLC can be failed back.

Returning a boolean is an option as well.

This is a continuation of https://github.com/lightningdevkit/lightning-liquidity/pull/138.