### PR TITLE
Pin rustfmt to 1.63

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.63.0"
+components = [ "rustfmt" ]
+profile = "minimal"


### PR DESCRIPTION
To ensure that cargo fmt effects remain equal to what the rustfmt CI job expects.