### PR TITLE
Drop `cfg(async_payments)` from tests

### DIFF
--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -141,8 +141,6 @@ fi
 echo -e "\n\nTest cfg-flag builds"
 RUSTFLAGS="--cfg=taproot" cargo test --verbose --color always -p lightning
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
-RUSTFLAGS="--cfg=async_payments" cargo test --verbose --color always -p lightning
-[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=simple_close" cargo test --verbose --color always -p lightning
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 RUSTFLAGS="--cfg=lsps1_service" cargo test --verbose --color always -p lightning-liquidity


### PR DESCRIPTION
We previously dropped `cfg(async_payments)` but didn't drop the actual `cargo test` call from our CI. Here we do that.