### PR TITLE
Doc and comment fixes from #4167

### DIFF
--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -1018,11 +1018,11 @@ pub struct ChannelTransactionParameters {
 	/// If a channel was funded with transaction A, and later spliced with transaction B, this field
 	/// tracks the txid of transaction A.
 	///
-	/// See [`compute_funding_key_tweak`] and [`ChannelSigner::pubkeys`] for more context on how
-	/// this may be used.
+	/// See [`compute_funding_key_tweak`] and [`ChannelSigner::new_funding_pubkey`] for more context
+	/// on how this may be used.
 	///
 	/// [`compute_funding_key_tweak`]: crate::sign::compute_funding_key_tweak
-	/// [`ChannelSigner::pubkeys`]: crate::sign::ChannelSigner::pubkeys
+	/// [`ChannelSigner::new_funding_pubkey`]: crate::sign::ChannelSigner::new_funding_pubkey
 	pub splice_parent_funding_txid: Option<Txid>,
 	/// This channel's type, as negotiated during channel open. For old objects where this field
 	/// wasn't serialized, it will default to static_remote_key at deserialization.

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -83,15 +83,15 @@ impl Clone for TestChannelSigner {
 	fn clone(&self) -> Self {
 		// Generally, a signer should only ever be cloned when a ChannelMonitor is cloned (which
 		// doesn't fetch the pubkeys at all). This isn't really a critical test, but if it
-		// it ever does fail we should make sure the clone is hapening in a sensible place.
+		// ever does fail we should make sure the clone is happening in a sensible place.
 		assert!(!self.have_fetched_pubkeys.load(Ordering::Acquire));
 		Self {
 			inner: self.inner.clone(),
 			state: Arc::clone(&self.state),
 			disable_revocation_policy_check: self.disable_revocation_policy_check,
 			disable_all_state_policy_checks: self.disable_all_state_policy_checks,
-			// In some tests we clone a `ChannelMonitor` multiple times, so have to initialize with
-			// `!have_fetched_pubkeys` to ensure the above assertion passes.
+			// In some tests we clone a `ChannelMonitor` multiple times, so we have to initialize
+			// with `!have_fetched_pubkeys` to ensure the above assertion passes.
 			have_fetched_pubkeys: AtomicBool::new(false),
 		}
 	}


### PR DESCRIPTION
This fixes incorrect docs and comments introduced by e95ebf8b9a3d43108176e21c8b4c6bd82f3aaabf and
491b6949fec743e34c74c3a472cf0a2cb83d7ab3