### PR TITLE
symlink the root README in crates so that crates.io shows it

### DIFF
--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0+git"
 authors = ["Valentine Wallace <vwallace@protonmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
+readme = "../README.md"
 description = """
 Utilities to perform required background tasks for Rust Lightning.
 """

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0+git"
 authors = ["Jeffrey Czyz", "Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
+readme = "../README.md"
 description = """
 Utilities to fetch the chain data from a block source and feed them into Rust Lightning.
 """

--- a/lightning-custom-message/Cargo.toml
+++ b/lightning-custom-message/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0+git"
 authors = ["Jeffrey Czyz"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
+readme = "../README.md"
 description = """
 Utilities for supporting custom peer-to-peer messages in LDK.
 """

--- a/lightning-dns-resolver/Cargo.toml
+++ b/lightning-dns-resolver/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0+git"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning/"
+readme = "../README.md"
 description = "A crate which implements DNSSEC resolution for lightning clients over bLIP 32 using `tokio` and the `dnssec-prover` crate."
 edition = "2021"
 rust-version = "1.75"

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0+git"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning/"
+readme = "../README.md"
 description = """
 Implementation of the rust-lightning network stack using Tokio.
 For Rust-Lightning clients which wish to make direct connections to Lightning P2P nodes, this is a simple alternative to implementing the required network stack, especially for those already using Tokio.

--- a/lightning-persister/Cargo.toml
+++ b/lightning-persister/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0+git"
 authors = ["Valentine Wallace", "Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
+readme = "../README.md"
 description = """
 Utilities for LDK data persistence and retrieval.
 """

--- a/lightning-transaction-sync/Cargo.toml
+++ b/lightning-transaction-sync/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0+git"
 authors = ["Elias Rohrer"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"
+readme = "../README.md"
 description = """
 Utilities for syncing LDK via the transaction-based `Confirm` interface.
 """

--- a/lightning-types/Cargo.toml
+++ b/lightning-types/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0+git"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning/"
+readme = "../README.md"
 description = """
 Basic types which are used in the lightning network
 """

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0+git"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning/"
+readme = "../README.md"
 description = """
 A Complete Bitcoin Lightning Library in Rust.
 Handles the core functionality of the Lightning Network, allowing clients to implement custom wallet, chain interactions, storage and network logic without enforcing a specific runtime.


### PR DESCRIPTION
`crates.io` will show any README/README.md which apears in the crate which is uploaded, but it doesn't consider the README from the workspace, only if its in the crate itself. Thus, we symlink the top-level README in all our crates in the hopes that it works.