### PR TITLE
Include monitor name in error when failing to load a monitor

### DIFF
--- a/lightning/src/util/persist.rs
+++ b/lightning/src/util/persist.rs
@@ -955,9 +955,12 @@ where
 			Some(res) => Ok(res),
 			None => Err(io::Error::new(
 				io::ErrorKind::InvalidData,
-				"ChannelMonitor was stale, with no updates since LDK 0.0.118. \
+				format!(
+					"ChannelMonitor {} was stale, with no updates since LDK 0.0.118. \
 						It cannot be read by modern versions of LDK, though also does not contain any funds left to sweep. \
 						You should manually delete it instead",
+					monitor_key,
+				),
 			)),
 		}
 	}


### PR DESCRIPTION
If we fail to load a `ChannelMonitor` due to the new limits in LDK 0.2, its useful to communicate which monitor failed, which we do here.

Requested at
https://github.com/lightningdevkit/rust-lightning/pull/4146#discussion_r2418136988