### PR TITLE
Remove `get_revoke_commit_msgs` macro

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -1597,11 +1597,11 @@ mod tests {
 	use crate::chain::channelmonitor::ANTI_REORG_DELAY;
 	use crate::chain::{ChannelMonitorUpdateStatus, Watch};
 	use crate::events::{ClosureReason, Event};
+	use crate::get_htlc_update_msgs;
 	use crate::ln::functional_test_utils::*;
 	use crate::ln::msgs::{BaseMessageHandler, ChannelMessageHandler, MessageSendEvent};
 	use crate::{check_added_monitors, check_closed_event};
 	use crate::{expect_payment_path_successful, get_event_msg};
-	use crate::{get_htlc_update_msgs, get_revoke_commit_msgs};
 
 	const CHAINSYNC_MONITOR_PARTITION_FACTOR: u32 = 5;
 
@@ -1696,7 +1696,7 @@ mod tests {
 		expect_payment_sent(&nodes[0], payment_preimage_1, None, false, false);
 		nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &updates.commitment_signed);
 		check_added_monitors!(nodes[0], 1);
-		let (as_first_raa, as_first_update) = get_revoke_commit_msgs!(nodes[0], node_b_id);
+		let (as_first_raa, as_first_update) = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 
 		nodes[1].node.handle_revoke_and_ack(node_a_id, &as_first_raa);
 		check_added_monitors!(nodes[1], 1);
@@ -1716,7 +1716,7 @@ mod tests {
 		nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_first_raa);
 		expect_payment_path_successful!(nodes[0]);
 		check_added_monitors!(nodes[0], 1);
-		let (as_second_raa, as_second_update) = get_revoke_commit_msgs!(nodes[0], node_b_id);
+		let (as_second_raa, as_second_update) = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 
 		nodes[1].node.handle_revoke_and_ack(node_a_id, &as_second_raa);
 		check_added_monitors!(nodes[1], 1);

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -941,7 +941,7 @@ fn test_monitor_update_raa_while_paused() {
 	nodes[0].chain_monitor.chain_monitor.force_channel_monitor_updated(channel_id, latest_update);
 	check_added_monitors!(nodes[0], 0);
 
-	let as_update_raa = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let as_update_raa = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &as_update_raa.0);
 	check_added_monitors!(nodes[1], 1);
 	let bs_cs = get_htlc_update_msgs!(nodes[1], node_a_id);
@@ -1412,7 +1412,7 @@ fn raa_no_response_awaiting_raa_state() {
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &payment_event.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
 
-	let bs_responses = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let bs_responses = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_responses.0);
 	check_added_monitors!(nodes[0], 1);
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
@@ -1442,7 +1442,7 @@ fn raa_no_response_awaiting_raa_state() {
 	nodes[1].chain_monitor.chain_monitor.force_channel_monitor_updated(channel_id, latest_update);
 	// nodes[1] should be AwaitingRAA here!
 	check_added_monitors!(nodes[1], 0);
-	let bs_responses = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let bs_responses = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	expect_and_process_pending_htlcs(&nodes[1], false);
 	expect_payment_claimable!(nodes[1], payment_hash_1, payment_secret_1, 1000000);
 
@@ -1699,7 +1699,7 @@ fn monitor_failed_no_reestablish_response() {
 	let (latest_update, _) = get_latest_mon_update_id(&nodes[1], channel_id);
 	nodes[1].chain_monitor.chain_monitor.force_channel_monitor_updated(channel_id, latest_update);
 	check_added_monitors!(nodes[1], 0);
-	let bs_responses = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let bs_responses = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_responses.0);
 	check_added_monitors!(nodes[0], 1);
@@ -1754,7 +1754,7 @@ fn first_message_on_recv_ordering() {
 	nodes[1].node.handle_update_add_htlc(node_a_id, &payment_event.msgs[0]);
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &payment_event.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
-	let bs_responses = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let bs_responses = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_responses.0);
 	check_added_monitors!(nodes[0], 1);
@@ -1802,7 +1802,7 @@ fn first_message_on_recv_ordering() {
 	expect_and_process_pending_htlcs(&nodes[1], false);
 	expect_payment_claimable!(nodes[1], payment_hash_1, payment_secret_1, 1000000);
 
-	let bs_responses = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let bs_responses = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_responses.0);
 	check_added_monitors!(nodes[0], 1);
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &bs_responses.1);
@@ -2601,7 +2601,7 @@ fn do_update_fee_resend_test(deliver_update: bool, parallel_updates: bool) {
 			.node
 			.handle_commitment_signed_batch_test(node_a_id, &update_msgs.commitment_signed);
 		check_added_monitors!(nodes[1], 1);
-		let (bs_first_raa, bs_first_cs) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+		let (bs_first_raa, bs_first_cs) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 		nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_first_raa);
 		check_added_monitors!(nodes[0], 1);
 		let as_second_update = get_htlc_update_msgs!(nodes[0], node_b_id);
@@ -2713,7 +2713,7 @@ fn do_channel_holding_cell_serialize(disconnect: bool, reload_a: bool) {
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &send.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
 
-	let (raa, cs) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (raa, cs) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &raa);
 	check_added_monitors!(nodes[0], 1);
@@ -2891,7 +2891,7 @@ fn do_test_reconnect_dup_htlc_claims(htlc_status: HTLCStatusAtDupClaim, second_f
 		nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &send_event.commitment_msg);
 		check_added_monitors!(nodes[1], 1);
 
-		let (bs_raa, bs_cs) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+		let (bs_raa, bs_cs) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 		nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_raa);
 		check_added_monitors!(nodes[0], 1);
 		nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &bs_cs);
@@ -3171,7 +3171,7 @@ fn double_temp_error() {
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &commitment_signed_b1);
 	check_added_monitors!(nodes[0], 1);
 	nodes[0].node.process_pending_htlc_forwards();
-	let (raa_a1, commitment_signed_a1) = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let (raa_a1, commitment_signed_a1) = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 	check_added_monitors!(nodes[1], 0);
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &raa_a1);
@@ -3644,7 +3644,7 @@ fn do_test_inverted_mon_completion_order(
 	check_added_monitors(&nodes[1], 1);
 	if complete_bc_commitment_dance {
 		let (bs_revoke_and_ack, bs_commitment_signed) =
-			get_revoke_commit_msgs!(nodes[1], node_c_id);
+			get_revoke_commit_msgs(&nodes[1], &node_c_id);
 		nodes[2].node.handle_revoke_and_ack(node_b_id, &bs_revoke_and_ack);
 		check_added_monitors(&nodes[2], 1);
 		nodes[2].node.handle_commitment_signed_batch_test(node_b_id, &bs_commitment_signed);
@@ -3830,7 +3830,7 @@ fn do_test_durable_preimages_on_closed_channel(
 	// ChannelMonitor.
 	nodes[1].node.handle_commitment_signed_batch_test(node_c_id, &cs_updates.commitment_signed);
 	check_added_monitors(&nodes[1], 1);
-	let _ = get_revoke_commit_msgs!(nodes[1], node_c_id);
+	let _ = get_revoke_commit_msgs(&nodes[1], &node_c_id);
 
 	let mon_bc = get_monitor!(nodes[1], chan_id_bc).encode();
 
@@ -4023,7 +4023,7 @@ fn do_test_reload_mon_update_completion_actions(close_during_reload: bool) {
 	// doesn't let the preimage-removing monitor update fly.
 	nodes[1].node.handle_commitment_signed_batch_test(node_c_id, &cs_updates.commitment_signed);
 	check_added_monitors(&nodes[1], 1);
-	let (bs_raa, bs_cs) = get_revoke_commit_msgs!(nodes[1], node_c_id);
+	let (bs_raa, bs_cs) = get_revoke_commit_msgs(&nodes[1], &node_c_id);
 
 	nodes[2].node.handle_revoke_and_ack(node_b_id, &bs_raa);
 	check_added_monitors(&nodes[2], 1);

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -18590,7 +18590,7 @@ mod tests {
 		expect_payment_sent(&nodes[0], payment_preimage, None, false, false);
 		nodes[0].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &bs_1st_updates.commitment_signed);
 		check_added_monitors!(nodes[0], 1);
-		let (as_first_raa, as_first_cs) = get_revoke_commit_msgs!(nodes[0], nodes[1].node.get_our_node_id());
+		let (as_first_raa, as_first_cs) = get_revoke_commit_msgs(&nodes[0], &nodes[1].node.get_our_node_id());
 		nodes[1].node.handle_revoke_and_ack(nodes[0].node.get_our_node_id(), &as_first_raa);
 		check_added_monitors!(nodes[1], 1);
 		let mut bs_2nd_updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1014,16 +1014,6 @@ pub fn get_updates_and_revoke<CM: AChannelManager, H: NodeHolder<CM = CM>>(
 	)
 }
 
-#[macro_export]
-/// Gets an RAA and CS which were sent in response to a commitment update
-///
-/// Don't use this, use the identically-named function instead.
-macro_rules! get_revoke_commit_msgs {
-	($node: expr, $node_id: expr) => {
-		$crate::ln::functional_test_utils::get_revoke_commit_msgs(&$node, &$node_id)
-	};
-}
-
 /// Get an specific event message from the pending events queue.
 #[macro_export]
 macro_rules! get_event_msg {
@@ -2728,7 +2718,7 @@ pub fn do_main_commitment_signed_dance(
 	let node_a_id = node_a.node.get_our_node_id();
 	let node_b_id = node_b.node.get_our_node_id();
 
-	let (as_revoke_and_ack, as_commitment_signed) = get_revoke_commit_msgs!(node_a, node_b_id);
+	let (as_revoke_and_ack, as_commitment_signed) = get_revoke_commit_msgs(node_a, &node_b_id);
 	check_added_monitors!(node_b, 0);
 	assert!(node_b.node.get_and_clear_pending_msg_events().is_empty());
 	node_b.node.handle_revoke_and_ack(node_a_id, &as_revoke_and_ack);

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -2392,7 +2392,7 @@ pub fn test_force_close_fail_back() {
 	nodes[2].node.handle_update_add_htlc(node_b_id, &payment_event.msgs[0]);
 	nodes[2].node.handle_commitment_signed_batch_test(node_b_id, &payment_event.commitment_msg);
 	check_added_monitors(&nodes[2], 1);
-	let (_, _) = get_revoke_commit_msgs!(nodes[2], node_b_id);
+	let _ = get_revoke_commit_msgs(&nodes[2], &node_b_id);
 
 	// nodes[2] now has the latest commitment transaction, but hasn't revoked its previous
 	// state or updated nodes[1]' state. Now force-close and broadcast that commitment/HTLC
@@ -2673,7 +2673,7 @@ fn do_test_drop_messages_peer_disconnect(messages_delivered: u8, simulate_broken
 				.handle_commitment_signed_batch_test(node_a_id, &payment_event.commitment_msg);
 			check_added_monitors(&nodes[1], 1);
 			let (bs_revoke_and_ack, bs_commitment_signed) =
-				get_revoke_commit_msgs!(nodes[1], node_a_id);
+				get_revoke_commit_msgs(&nodes[1], &node_a_id);
 
 			if messages_delivered >= 4 {
 				nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_revoke_and_ack);
@@ -2837,7 +2837,7 @@ fn do_test_drop_messages_peer_disconnect(messages_delivered: u8, simulate_broken
 			nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &commitment_signed);
 			check_added_monitors(&nodes[0], 1);
 			let (as_revoke_and_ack, as_commitment_signed) =
-				get_revoke_commit_msgs!(nodes[0], node_b_id);
+				get_revoke_commit_msgs(&nodes[0], &node_b_id);
 
 			if messages_delivered >= 3 {
 				nodes[1].node.handle_revoke_and_ack(node_a_id, &as_revoke_and_ack);
@@ -4930,7 +4930,7 @@ fn do_htlc_claim_local_commitment_only(use_dust: bool) {
 
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &bs_updates.commitment_signed);
 	check_added_monitors(&nodes[0], 1);
-	let as_updates = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let as_updates = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &as_updates.0);
 	check_added_monitors(&nodes[1], 1);
 
@@ -5015,7 +5015,7 @@ fn do_htlc_claim_previous_remote_commitment_only(use_dust: bool, check_revoke_no
 	nodes[0].node.handle_update_fail_htlc(node_b_id, &bs_updates.update_fail_htlcs[0]);
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &bs_updates.commitment_signed);
 	check_added_monitors(&nodes[0], 1);
-	let as_updates = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let as_updates = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &as_updates.0);
 	check_added_monitors(&nodes[1], 1);
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &as_updates.1);
@@ -5131,7 +5131,7 @@ pub fn test_fail_holding_cell_htlc_upon_free() {
 
 	// Flush the pending fee update.
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, commitment_signed);
-	let (as_revoke_and_ack, _) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (as_revoke_and_ack, _) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	check_added_monitors(&nodes[1], 1);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &as_revoke_and_ack);
 	check_added_monitors(&nodes[0], 1);
@@ -5241,7 +5241,7 @@ pub fn test_free_and_fail_holding_cell_htlcs() {
 
 	// Flush the pending fee update.
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, commitment_signed);
-	let (revoke_and_ack, commitment_signed) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (revoke_and_ack, commitment_signed) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	check_added_monitors(&nodes[1], 1);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &revoke_and_ack);
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &commitment_signed);
@@ -5393,7 +5393,7 @@ pub fn test_fail_holding_cell_htlc_upon_free_multihop() {
 
 	// Flush the pending fee update.
 	nodes[2].node.handle_commitment_signed_batch_test(node_b_id, commitment_signed);
-	let (raa, commitment_signed) = get_revoke_commit_msgs!(nodes[2], node_b_id);
+	let (raa, commitment_signed) = get_revoke_commit_msgs(&nodes[2], &node_b_id);
 	check_added_monitors(&nodes[2], 1);
 	nodes[1].node.handle_revoke_and_ack(node_c_id, &raa);
 	nodes[1].node.handle_commitment_signed_batch_test(node_c_id, &commitment_signed);
@@ -5437,7 +5437,7 @@ pub fn test_fail_holding_cell_htlc_upon_free_multihop() {
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &commitment_signed);
 
 	// Complete the HTLC failure+removal process.
-	let (raa, commitment_signed) = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let (raa, commitment_signed) = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 	check_added_monitors(&nodes[0], 1);
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &raa);
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &commitment_signed);
@@ -9420,7 +9420,7 @@ pub fn test_disconnects_peer_awaiting_response_ticks() {
 	check_added_monitors(&&nodes[1], 1);
 
 	// This will prompt Bob (nodes[1]) to respond with his `CommitmentSigned` and `RevokeAndACK`.
-	let (bob_revoke_and_ack, bob_commitment_signed) = get_revoke_commit_msgs!(&nodes[1], node_a_id);
+	let (bob_revoke_and_ack, bob_commitment_signed) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bob_revoke_and_ack);
 	check_added_monitors(&&nodes[0], 1);
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &bob_commitment_signed);

--- a/lightning/src/ln/htlc_reserve_unit_tests.rs
+++ b/lightning/src/ln/htlc_reserve_unit_tests.rs
@@ -326,7 +326,7 @@ pub fn test_channel_reserve_holding_cell_htlcs() {
 
 	// flush the pending htlc
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &payment_event_1.commitment_msg);
-	let (as_revoke_and_ack, as_commitment_signed) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (as_revoke_and_ack, as_commitment_signed) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	check_added_monitors(&nodes[1], 1);
 
 	// the pending htlc should be promoted to committed
@@ -695,7 +695,7 @@ pub fn holding_cell_htlc_counting() {
 		.handle_commitment_signed_batch_test(node_b_id, &initial_payment_event.commitment_msg);
 	check_added_monitors(&nodes[2], 1);
 
-	let (bs_revoke_and_ack, bs_commitment_signed) = get_revoke_commit_msgs!(nodes[2], node_b_id);
+	let (bs_revoke_and_ack, bs_commitment_signed) = get_revoke_commit_msgs(&nodes[2], &node_b_id);
 	nodes[1].node.handle_revoke_and_ack(node_c_id, &bs_revoke_and_ack);
 	check_added_monitors(&nodes[1], 1);
 	let as_updates = get_htlc_update_msgs!(nodes[1], node_c_id);
@@ -711,7 +711,7 @@ pub fn holding_cell_htlc_counting() {
 	check_added_monitors(&nodes[2], 1);
 	nodes[2].node.handle_revoke_and_ack(node_b_id, &as_raa);
 	check_added_monitors(&nodes[2], 1);
-	let (bs_revoke_and_ack, bs_commitment_signed) = get_revoke_commit_msgs!(nodes[2], node_b_id);
+	let (bs_revoke_and_ack, bs_commitment_signed) = get_revoke_commit_msgs(&nodes[2], &node_b_id);
 
 	nodes[1].node.handle_revoke_and_ack(node_c_id, &bs_revoke_and_ack);
 	check_added_monitors(&nodes[1], 1);
@@ -1778,7 +1778,7 @@ pub fn test_update_add_htlc_bolt2_receiver_check_repeated_id_ignore() {
 	assert_eq!(updates.commitment_signed[0].htlc_signatures.len(), 1);
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &updates.commitment_signed);
 	check_added_monitors(&nodes[1], 1);
-	let _bs_responses = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let _bs_responses = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 
 	nodes[1].node.handle_update_add_htlc(node_a_id, &updates.update_add_htlcs[0]);
 

--- a/lightning/src/ln/monitor_tests.rs
+++ b/lightning/src/ln/monitor_tests.rs
@@ -16,7 +16,7 @@ use crate::chain::Watch;
 use crate::chain::channelmonitor::{Balance, BalanceSource, ChannelMonitorUpdateStep, HolderCommitmentTransactionBalance, ANTI_REORG_DELAY, ARCHIVAL_DELAY_BLOCKS, COUNTERPARTY_CLAIMABLE_WITHIN_BLOCKS_PINNABLE, LATENCY_GRACE_PERIOD_BLOCKS};
 use crate::chain::transaction::OutPoint;
 use crate::chain::chaininterface::{ConfirmationTarget, LowerBoundedFeeEstimator, compute_feerate_sat_per_1000_weight};
-use crate::events::bump_transaction::{BumpTransactionEvent};
+use crate::events::bump_transaction::BumpTransactionEvent;
 use crate::events::{Event, ClosureReason, HTLCHandlingFailureType};
 use crate::ln::channel;
 use crate::ln::types::ChannelId;
@@ -586,7 +586,7 @@ fn do_test_claim_value_force_close(keyed_anchors: bool, p2a_anchor: bool, prev_c
 		expect_payment_sent(&nodes[0], payment_preimage, None, false, false);
 		nodes[0].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &b_htlc_msgs.commitment_signed);
 		check_added_monitors!(nodes[0], 1);
-		let (as_raa, as_cs) = get_revoke_commit_msgs!(nodes[0], nodes[1].node.get_our_node_id());
+		let (as_raa, as_cs) = get_revoke_commit_msgs(&nodes[0], &nodes[1].node.get_our_node_id());
 		nodes[1].node.handle_revoke_and_ack(nodes[0].node.get_our_node_id(), &as_raa);
 		let _htlc_updates = get_htlc_update_msgs!(&nodes[1], nodes[0].node.get_our_node_id());
 		check_added_monitors!(nodes[1], 1);
@@ -3655,7 +3655,7 @@ fn do_test_lost_timeout_monitor_events(confirm_tx: CommitmentType, dust_htlcs: b
 	nodes[2].node.handle_commitment_signed_batch_test(node_b_id, &updates.commitment_signed);
 	check_added_monitors(&nodes[2], 1);
 
-	let (cs_raa, cs_cs) = get_revoke_commit_msgs!(nodes[2], node_b_id);
+	let (cs_raa, cs_cs) = get_revoke_commit_msgs(&nodes[2], &node_b_id);
 	if confirm_tx == CommitmentType::LocalWithLastHTLC {
 		// Only deliver the last RAA + CS if we need to update the local commitment with the third
 		// HTLC.

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -3006,7 +3006,7 @@ fn auto_retry_partial_failure() {
 	nodes[1].node.handle_update_add_htlc(node_a_id, &payment_event.msgs[0]);
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &payment_event.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
-	let (bs_first_raa, bs_first_cs) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (bs_first_raa, bs_first_cs) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_first_raa);
 	check_added_monitors!(nodes[0], 1);
@@ -3023,7 +3023,7 @@ fn auto_retry_partial_failure() {
 	nodes[1].node.handle_update_add_htlc(node_a_id, &as_2nd_htlcs.msgs[1]);
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &as_2nd_htlcs.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
-	let (bs_second_raa, bs_second_cs) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (bs_second_raa, bs_second_cs) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_second_raa);
 	check_added_monitors!(nodes[0], 1);
@@ -3047,7 +3047,7 @@ fn auto_retry_partial_failure() {
 	expect_payment_sent(&nodes[0], payment_preimage, None, false, false);
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &bs_claim.commitment_signed);
 	check_added_monitors!(nodes[0], 1);
-	let (as_third_raa, as_third_cs) = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let (as_third_raa, as_third_cs) = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &as_third_raa);
 	check_added_monitors!(nodes[1], 4);
@@ -3067,7 +3067,7 @@ fn auto_retry_partial_failure() {
 	nodes[0].node.handle_update_fulfill_htlc(node_b_id, bs_second_fulfill_b);
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &bs_2nd_claim.commitment_signed);
 	check_added_monitors!(nodes[0], 1);
-	let (as_fourth_raa, as_fourth_cs) = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let (as_fourth_raa, as_fourth_cs) = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &as_fourth_raa);
 	check_added_monitors!(nodes[1], 1);
@@ -3536,7 +3536,7 @@ fn no_extra_retries_on_back_to_back_fail() {
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &first_htlc.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
 
-	let (bs_first_raa, bs_first_cs) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (bs_first_raa, bs_first_cs) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_first_raa);
 	check_added_monitors!(nodes[0], 1);
 
@@ -3554,7 +3554,7 @@ fn no_extra_retries_on_back_to_back_fail() {
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &second_htlc.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
 
-	let (bs_second_raa, bs_second_cs) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (bs_second_raa, bs_second_cs) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_second_raa);
 	check_added_monitors!(nodes[0], 1);
 	nodes[0].node.handle_commitment_signed_batch_test(node_b_id, &bs_second_cs);
@@ -3777,7 +3777,7 @@ fn test_simple_partial_retry() {
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &first_htlc.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
 
-	let (bs_first_raa, bs_first_cs) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (bs_first_raa, bs_first_cs) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_first_raa);
 	check_added_monitors!(nodes[0], 1);
 

--- a/lightning/src/ln/priv_short_conf_tests.rs
+++ b/lightning/src/ln/priv_short_conf_tests.rs
@@ -943,7 +943,7 @@ fn test_0conf_channel_with_async_monitor() {
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, &as_send.commitment_msg);
 	check_added_monitors!(nodes[1], 1);
 
-	let (bs_raa, bs_commitment_signed) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (bs_raa, bs_commitment_signed) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_raa);
 	check_added_monitors!(nodes[0], 1);
 

--- a/lightning/src/ln/quiescence_tests.rs
+++ b/lightning/src/ln/quiescence_tests.rs
@@ -109,7 +109,7 @@ fn allow_shutdown_while_awaiting_quiescence(local_shutdown: bool) {
 	remote_node
 		.node
 		.handle_commitment_signed_batch_test(local_node_id, &update_add.commitment_signed);
-	let (revoke_and_ack, commit_sig) = get_revoke_commit_msgs!(remote_node, local_node_id);
+	let (revoke_and_ack, commit_sig) = get_revoke_commit_msgs(remote_node, &local_node_id);
 	local_node.node.handle_revoke_and_ack(remote_node_id, &revoke_and_ack);
 	check_added_monitors(local_node, 1);
 
@@ -155,7 +155,7 @@ fn allow_shutdown_while_awaiting_quiescence(local_shutdown: bool) {
 		.node
 		.handle_commitment_signed_batch_test(remote_node_id, &update_fail.commitment_signed);
 
-	let (revoke_and_ack, commit_sig) = get_revoke_commit_msgs!(local_node, remote_node_id);
+	let (revoke_and_ack, commit_sig) = get_revoke_commit_msgs(local_node, &remote_node_id);
 	remote_node.node.handle_revoke_and_ack(local_node_id, &revoke_and_ack);
 	check_added_monitors(remote_node, 1);
 	remote_node.node.handle_commitment_signed_batch_test(local_node_id, &commit_sig);
@@ -214,7 +214,7 @@ fn test_quiescence_waits_for_async_signer_and_monitor_update() {
 	// `revoke_and_ack` goes out, and drive the state machine forward.
 	nodes[1].disable_channel_signer_op(&node_id_0, &chan_id, SignerOp::ReleaseCommitmentSecret);
 
-	let (revoke_and_ack, commit_sig) = get_revoke_commit_msgs!(&nodes[0], node_id_1);
+	let (revoke_and_ack, commit_sig) = get_revoke_commit_msgs(&nodes[0], &node_id_1);
 	nodes[1].node.handle_revoke_and_ack(node_id_0, &revoke_and_ack);
 	check_added_monitors(&nodes[1], 1);
 	nodes[1].node.handle_commitment_signed_batch_test(node_id_0, &commit_sig);
@@ -318,7 +318,7 @@ fn test_quiescence_on_final_revoke_and_ack_pending_monitor_update() {
 	nodes[1].node.handle_commitment_signed_batch_test(node_id_0, &update_add.commitment_signed);
 	check_added_monitors(&nodes[1], 1);
 
-	let (revoke_and_ack, commit_sig) = get_revoke_commit_msgs!(&nodes[1], node_id_0);
+	let (revoke_and_ack, commit_sig) = get_revoke_commit_msgs(&nodes[1], &node_id_0);
 	nodes[0].node.handle_revoke_and_ack(node_id_1, &revoke_and_ack);
 	check_added_monitors(&nodes[0], 1);
 	nodes[0].node.handle_commitment_signed_batch_test(node_id_1, &commit_sig);

--- a/lightning/src/ln/update_fee_tests.rs
+++ b/lightning/src/ln/update_fee_tests.rs
@@ -262,7 +262,7 @@ pub fn test_multi_flight_update_fee() {
 	// Deliver first update_fee/commitment_signed pair, generating (1) and (2):
 	nodes[1].node.handle_update_fee(node_a_id, update_msg_1);
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, commitment_signed_1);
-	let (bs_revoke_msg, bs_commitment_signed) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (bs_revoke_msg, bs_commitment_signed) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	check_added_monitors(&nodes[1], 1);
 
 	// nodes[0] is awaiting a revoke from nodes[1] before it will create a new commitment
@@ -316,7 +316,7 @@ pub fn test_multi_flight_update_fee() {
 	nodes[1]
 		.node
 		.handle_commitment_signed_batch_test(node_a_id, &as_second_update.commitment_signed);
-	let (bs_second_revoke, bs_second_commitment) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (bs_second_revoke, bs_second_commitment) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	check_added_monitors(&nodes[1], 1);
 
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &bs_second_revoke);
@@ -364,7 +364,7 @@ pub fn test_update_fee_vanilla() {
 	nodes[1].node.handle_update_fee(node_a_id, update_msg.unwrap());
 
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, commitment_signed);
-	let (revoke_msg, commitment_signed) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (revoke_msg, commitment_signed) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	check_added_monitors(&nodes[1], 1);
 
 	nodes[0].node.handle_revoke_and_ack(node_b_id, &revoke_msg);
@@ -665,7 +665,7 @@ pub fn test_update_fee_with_fundee_update_add_htlc() {
 	};
 	nodes[1].node.handle_update_fee(node_a_id, update_msg.unwrap());
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, commitment_signed);
-	let (revoke_msg, commitment_signed) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (revoke_msg, commitment_signed) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	check_added_monitors(&nodes[1], 1);
 
 	let (route, our_payment_hash, our_payment_preimage, our_payment_secret) =
@@ -704,7 +704,7 @@ pub fn test_update_fee_with_fundee_update_add_htlc() {
 		.node
 		.handle_commitment_signed_batch_test(node_b_id, &commitment_update.commitment_signed);
 	check_added_monitors(&nodes[0], 1);
-	let (revoke, commitment_signed) = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let (revoke, commitment_signed) = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &revoke);
 	check_added_monitors(&nodes[1], 1);
@@ -789,7 +789,7 @@ pub fn test_update_fee() {
 
 	// Generate (2) and (3):
 	nodes[1].node.handle_commitment_signed_batch_test(node_a_id, commitment_signed);
-	let (revoke_msg, commitment_signed_0) = get_revoke_commit_msgs!(nodes[1], node_a_id);
+	let (revoke_msg, commitment_signed_0) = get_revoke_commit_msgs(&nodes[1], &node_a_id);
 	check_added_monitors(&nodes[1], 1);
 
 	// Deliver (2):
@@ -1111,7 +1111,7 @@ pub fn do_cannot_afford_on_holding_cell_release(
 	nodes[0].node.handle_commitment_signed(node_b_id, &payment_event.commitment_msg[0]);
 	check_added_monitors(&nodes[0], 1);
 
-	let (revoke_ack, commitment_signed) = get_revoke_commit_msgs!(nodes[0], node_b_id);
+	let (revoke_ack, commitment_signed) = get_revoke_commit_msgs(&nodes[0], &node_b_id);
 
 	nodes[1].node.handle_revoke_and_ack(node_a_id, &revoke_ack);
 	check_added_monitors(&nodes[1], 1);


### PR DESCRIPTION
Replaces the last remaining calls to `get_revoke_commit_msgs` macro to the identically-named function.