### PR TITLE
Avoid force-closing 0-conf channels when funding is reorg'd

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -11344,9 +11344,13 @@ where
 		}
 
 		// Check if the funding transaction was unconfirmed
+		let original_scid = self.funding.short_channel_id;
+		let was_confirmed = self.funding.funding_tx_confirmed_in.is_some();
 		let funding_tx_confirmations = self.funding.get_funding_tx_confirmations(height);
 		if funding_tx_confirmations == 0 {
 			self.funding.funding_tx_confirmation_height = 0;
+			self.funding.short_channel_id = None;
+			self.funding.funding_tx_confirmed_in = None;
 		}
 
 		if let Some(channel_ready) = self.check_get_channel_ready(height, logger) {
@@ -11361,18 +11365,33 @@ where
 			self.context.channel_state.is_our_channel_ready() {
 
 			// If we've sent channel_ready (or have both sent and received channel_ready), and
-			// the funding transaction has become unconfirmed,
-			// close the channel and hope we can get the latest state on chain (because presumably
-			// the funding transaction is at least still in the mempool of most nodes).
+			// the funding transaction has become unconfirmed, we'll probably get a new SCID when
+			// it re-confirms.
 			//
-			// Note that ideally we wouldn't force-close if we see *any* reorg on a 1-conf or
-			// 0-conf channel, but not doing so may lead to the
-			// `ChannelManager::short_to_chan_info` map  being inconsistent, so we currently have
-			// to.
-			if funding_tx_confirmations == 0 && self.funding.funding_tx_confirmed_in.is_some() {
-				let err_reason = format!("Funding transaction was un-confirmed. Locked at {} confs, now have {} confs.",
-					self.context.minimum_depth.unwrap(), funding_tx_confirmations);
-				return Err(ClosureReason::ProcessingError { err: err_reason });
+			// Worse, if the funding has un-confirmed we could have accepted some HTLC(s) over it
+			// and are now at risk of double-spend. While its possible, even likely, that this is
+			// just a trivial reorg and we should wait to see the new block connected in the next
+			// call, its also possible we've been double-spent. To avoid further loss of funds, we
+			// need some kind of method to freeze the channel and avoid accepting further HTLCs,
+			// but absent such a method, we just force-close.
+			//
+			// The one exception we make is for 0-conf channels, which we decided to trust anyway,
+			// in which case we simply track the previous SCID as a `historical_scids` the same as
+			// after a channel is spliced.
+			if funding_tx_confirmations == 0 && was_confirmed {
+				if let Some(scid) = original_scid {
+					self.context.historical_scids.push(scid);
+				} else {
+					debug_assert!(false);
+				}
+				if self.context.minimum_depth(&self.funding).expect("set for a ready channel") > 0 {
+					// Reset the original short_channel_id so that we'll generate a closure
+					// `channel_update` broadcast event.
+					self.funding.short_channel_id = original_scid;
+					let err_reason = format!("Funding transaction was un-confirmed, originally locked at {} confs.",
+						self.context.minimum_depth.unwrap());
+					return Err(ClosureReason::ProcessingError { err: err_reason });
+				}
 			}
 		} else if !self.funding.is_outbound() && self.funding.funding_tx_confirmed_in.is_none() &&
 				height >= self.context.channel_creation_height + FUNDING_CONF_DEADLINE_BLOCKS {

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -386,9 +386,9 @@ fn do_test_unconf_chan(reload_node: bool, reorg_after_reload: bool, use_funding_
 		assert_eq!(txn.len(), 1);
 	}
 
-	let expected_err = "Funding transaction was un-confirmed. Locked at 6 confs, now have 0 confs.";
+	let expected_err = "Funding transaction was un-confirmed, originally locked at 6 confs.";
 	if reorg_after_reload || !reload_node {
-		handle_announce_close_broadcast_events(&nodes, 0, 1, true, "Channel closed because of an exception: Funding transaction was un-confirmed. Locked at 6 confs, now have 0 confs.");
+		handle_announce_close_broadcast_events(&nodes, 0, 1, true, "Channel closed because of an exception: Funding transaction was un-confirmed, originally locked at 6 confs.");
 		check_added_monitors!(nodes[1], 1);
 		let reason = ClosureReason::CounterpartyForceClosed { peer_msg: UntrustedString(format!("Channel closed because of an exception: {}", expected_err)) };
 		check_closed_event(&nodes[1], 1, reason, &[nodes[0].node.get_our_node_id()], 100000);


### PR DESCRIPTION
When we see a funding transaction for one of our chanels reorg'd out, we worry that its possible we've been double-spent and immediately force-close the channel to avoid accepting any more HTLCs on it. This isn't ideal, but is mostly fine as most nodes require 6 confirmations and 6 block reorgs are exceedingly rare.

However, this isn't so okay for 0-conf channels - in that case we elected to trust the funder anyway, so reorgs shouldn't worry us. Still, to handle this correctly we needed to track the old SCID and ensure our logic is safe across an SCID change. Luckily, we did that work for splices, and can now take advantage of it here.

Fixes #3836.