### PR TITLE
Expose `process_pending_update_add_htlcs` in tests

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -6794,7 +6794,15 @@ where
 		Ok(())
 	}
 
-	pub(crate) fn process_pending_update_add_htlcs(&self) -> bool {
+	#[cfg(any(test, feature = "_test_utils"))]
+	/// Process any pending inbound [`msgs::UpdateAddHTLC`] messages, decoding the onion and placing
+	/// the pending HTLC in `ChannelManager::forward_htlcs` or
+	/// `ChannelManager::pending_intercepted_htlcs` as well as generating relevant [`Event`]s.
+	pub fn test_process_pending_update_add_htlcs(&self) -> bool {
+		self.process_pending_update_add_htlcs()
+	}
+
+	fn process_pending_update_add_htlcs(&self) -> bool {
 		let mut should_persist = false;
 		let mut decode_update_add_htlcs = new_hash_map();
 		mem::swap(&mut decode_update_add_htlcs, &mut self.decode_update_add_htlcs.lock().unwrap());

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -1172,7 +1172,7 @@ fn test_onion_failure() {
 		&payment_secret,
 		|_| {},
 		|| {
-			nodes[1].node.process_pending_update_add_htlcs();
+			nodes[1].node.test_process_pending_update_add_htlcs();
 			for (_, pending_forwards) in nodes[1].node.forward_htlcs.lock().unwrap().iter_mut() {
 				for f in pending_forwards.iter_mut() {
 					match f {
@@ -1201,7 +1201,7 @@ fn test_onion_failure() {
 		&payment_secret,
 		|_| {},
 		|| {
-			nodes[1].node.process_pending_update_add_htlcs();
+			nodes[1].node.test_process_pending_update_add_htlcs();
 			// violate amt_to_forward > msg.amount_msat
 			for (_, pending_forwards) in nodes[1].node.forward_htlcs.lock().unwrap().iter_mut() {
 				for f in pending_forwards.iter_mut() {
@@ -2440,7 +2440,7 @@ fn test_phantom_onion_hmac_failure() {
 	nodes[1].node.handle_update_add_htlc(nodes[0].node.get_our_node_id(), &update_add);
 	commitment_signed_dance!(nodes[1], nodes[0], &update_0.commitment_signed, false, true);
 	expect_htlc_failure_conditions(nodes[1].node.get_and_clear_pending_events(), &[]);
-	nodes[1].node.process_pending_update_add_htlcs();
+	nodes[1].node.test_process_pending_update_add_htlcs();
 
 	// Modify the payload so the phantom hop's HMAC is bogus.
 	let sha256_of_onion = {
@@ -2513,7 +2513,7 @@ fn test_phantom_invalid_onion_payload() {
 	nodes[1].node.handle_update_add_htlc(nodes[0].node.get_our_node_id(), &update_add);
 	commitment_signed_dance!(nodes[1], nodes[0], &update_0.commitment_signed, false, true);
 	expect_htlc_failure_conditions(nodes[1].node.get_and_clear_pending_events(), &[]);
-	nodes[1].node.process_pending_update_add_htlcs();
+	nodes[1].node.test_process_pending_update_add_htlcs();
 
 	// Modify the onion packet to have an invalid payment amount.
 	for (_, pending_forwards) in nodes[1].node.forward_htlcs.lock().unwrap().iter_mut() {
@@ -2612,7 +2612,7 @@ fn test_phantom_final_incorrect_cltv_expiry() {
 	nodes[1].node.handle_update_add_htlc(nodes[0].node.get_our_node_id(), &update_add);
 	commitment_signed_dance!(nodes[1], nodes[0], &update_0.commitment_signed, false, true);
 	expect_htlc_failure_conditions(nodes[1].node.get_and_clear_pending_events(), &[]);
-	nodes[1].node.process_pending_update_add_htlcs();
+	nodes[1].node.test_process_pending_update_add_htlcs();
 
 	// Modify the payload so the phantom hop's HMAC is bogus.
 	for (_, pending_forwards) in nodes[1].node.forward_htlcs.lock().unwrap().iter_mut() {

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -633,7 +633,7 @@ fn test_reject_mpp_keysend_htlc_mismatching_secret() {
 	nodes[3].node.handle_update_add_htlc(node_b_id, &update_add_1);
 	commitment_signed_dance!(nodes[3], nodes[1], update_1.commitment_signed, false, true);
 	expect_htlc_failure_conditions(nodes[3].node.get_and_clear_pending_events(), &[]);
-	nodes[3].node.process_pending_update_add_htlcs();
+	nodes[3].node.test_process_pending_update_add_htlcs();
 
 	assert!(nodes[3].node.get_and_clear_pending_msg_events().is_empty());
 	for (_, pending_forwards) in nodes[3].node.forward_htlcs.lock().unwrap().iter_mut() {
@@ -682,7 +682,7 @@ fn test_reject_mpp_keysend_htlc_mismatching_secret() {
 	nodes[3].node.handle_update_add_htlc(node_c_id, &update_add_3);
 	commitment_signed_dance!(nodes[3], nodes[2], update_3.commitment_signed, false, true);
 	expect_htlc_failure_conditions(nodes[3].node.get_and_clear_pending_events(), &[]);
-	nodes[3].node.process_pending_update_add_htlcs();
+	nodes[3].node.test_process_pending_update_add_htlcs();
 
 	assert!(nodes[3].node.get_and_clear_pending_msg_events().is_empty());
 	for (_, pending_forwards) in nodes[3].node.forward_htlcs.lock().unwrap().iter_mut() {

--- a/lightning/src/ln/reload_tests.rs
+++ b/lightning/src/ln/reload_tests.rs
@@ -966,7 +966,7 @@ fn do_forwarded_payment_no_manager_persistence(use_cs_commitment: bool, claim_ht
 	let mut intercept_id = None;
 	let mut expected_outbound_amount_msat = None;
 	if use_intercept {
-		nodes[1].node.process_pending_update_add_htlcs();
+		nodes[1].node.test_process_pending_update_add_htlcs();
 		let events = nodes[1].node.get_and_clear_pending_events();
 		assert_eq!(events.len(), 1);
 		match events[0] {


### PR DESCRIPTION
Useful for upgrade/downgrade testing in the `lightning-tests` module, which cannot access `lightning`-internal methods.

Backported to 0.2 for testing on 0.3 