### PR TITLE
Only log if we actually persisted `LiquidityManager` data

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -1228,12 +1228,20 @@ where
 		}
 
 		if let Some(liquidity_manager) = liquidity_manager.as_ref() {
-			log_trace!(logger, "Persisting LiquidityManager...");
 			let fut = async {
-				liquidity_manager.get_lm().persist().await.map_err(|e| {
-					log_error!(logger, "Persisting LiquidityManager failed: {}", e);
-					e
-				})
+				liquidity_manager
+					.get_lm()
+					.persist()
+					.await
+					.map(|did_persist| {
+						if did_persist {
+							log_trace!(logger, "Persisted LiquidityManager.");
+						}
+					})
+					.map_err(|e| {
+						log_error!(logger, "Persisting LiquidityManager failed: {}", e);
+						e
+					})
 			};
 			futures.set_e(Box::pin(fut));
 		}

--- a/lightning-liquidity/src/events/event_queue.rs
+++ b/lightning-liquidity/src/events/event_queue.rs
@@ -129,12 +129,12 @@ where
 		EventQueueNotifierGuard(self)
 	}
 
-	pub async fn persist(&self) -> Result<(), lightning::io::Error> {
+	pub async fn persist(&self) -> Result<bool, lightning::io::Error> {
 		let fut = {
 			let mut state_lock = self.state.lock().unwrap();
 
 			if !state_lock.needs_persist {
-				return Ok(());
+				return Ok(false);
 			}
 
 			state_lock.needs_persist = false;
@@ -153,7 +153,7 @@ where
 			e
 		})?;
 
-		Ok(())
+		Ok(true)
 	}
 }
 


### PR DESCRIPTION
Previously, we logged "Persisting LiquidityManager..." on each background processor wakeup, which can be very spammy, even on TRACE level.

Here, we opt to only log if something actually needed to be repersisted and we did so (in case of failure we're logging that anyways, too).