### PR TITLE
Note `SocketDescriptor::send_data` semantics changes in renotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,9 @@
    `ListProtocols` message (#3785).
  * A rare race which might lead `PeerManager` (and `lightning-net-tokio`) to
    stop reading from a peer until a new message is sent to that peer has been
-   fixed (#4168).
+   fixed. Note that this changed the semantics of the
+   `SocketDescriptor::send_data` method without changing its signature, check
+   that your implementation matches the new documentation (#4168).
  * The fields in `SocketAddress::OnionV3` are now correctly parsed, and the
    `Display` for such addresses is now lowercase (#4090).
  * `PeerManager` is now more conservative about disconnecting peers which aren't


### PR DESCRIPTION
`SocketDescriptor::send_data` semantics were changed in 0.2, without changing the method signature. As such the release notes really should be explicit about this.