### PR TITLE
Expose our "offchain balance" in `Balance`s

### DIFF
--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1,4 +1,4 @@
-// This file is Copyright its original authors, visible in version controlXXX
+// This file is Copyright its original authors, visible in version control
 // history.
 //
 // This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1015,10 +1015,10 @@ impl Balance {
 	/// The "offchain balance", in satoshis.
 	///
 	/// When the channel has yet to close, this returns the balance we are owed, ignoring fees,
-	/// reserve values, anchors, and dust limits. This more closely corresponds with the sum of our
-	/// inbound and outbound payments and may be more useful as the balance displayed in an
-	/// end-user wallet. Still, it is somewhat misleading from an on-chain-funds-available
-	/// perspective.
+	/// reserve values, anchors, and dust limits. This is the sum of our inbound and outbound
+	/// payments, initial channel contribution, and splices and may be more useful as the balance
+	/// displayed in an end-user wallet. Still, it is somewhat misleading from an
+	/// on-chain-funds-available perspective.
 	///
 	/// For pending payments, splice behavior, or behavior after a channel has been closed, this
 	/// behaves the same as [`Self::claimable_amount_satoshis`].

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1,4 +1,4 @@
-// This file is Copyright its original authors, visible in version control
+// This file is Copyright its original authors, visible in version controlXXX
 // history.
 //
 // This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
@@ -802,6 +802,18 @@ pub struct HolderCommitmentTransactionBalance {
 	/// The amount available to claim, in satoshis, excluding the on-chain fees which will be
 	/// required to do so.
 	pub amount_satoshis: u64,
+	/// The amount which is owed to us, excluding HTLCs, before dust limits, fees, anchor outputs,
+	/// and reserve values.
+	///
+	/// If the channel is (eventually) cooperatively closed, and this value is above the channel's
+	/// dust limit, then we will be paid this on-chain less any fees required for the closure.
+	///
+	/// This is generally roughly equal to [`Self::amount_satoshis`] +
+	/// [`Self::transaction_fee_satoshis`] + any anchor outputs in the current commitment
+	/// transaction. It might differ slightly due to differences in rounding and HTLC calculation.
+	///
+	/// This will be `None` for channels last updated on LDK 0.2 or prior.
+	pub amount_offchain_satoshis: Option<u64>,
 	/// The transaction fee we pay for the closing commitment transaction. This amount is not
 	/// included in the [`HolderCommitmentTransactionBalance::amount_satoshis`] value.
 	/// This amount includes the sum of dust HTLCs on the commitment transaction, any elided anchors,
@@ -3117,6 +3129,8 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 				.chain(us.pending_funding.iter())
 				.map(|funding| {
 					let to_self_value_sat = funding.current_holder_commitment_tx.to_broadcaster_value_sat();
+					let to_self_offchain_msat =
+						funding.current_holder_commitment_tx.to_broadcaster_value_offchain_msat();
 					// In addition to `commit_tx_fee_sat`, this can also include dust HTLCs, any
 					// elided anchors, and the total msat amount rounded down from non-dust HTLCs.
 					let transaction_fee_satoshis = if us.holder_pays_commitment_tx_fee.unwrap_or(true) {
@@ -3128,6 +3142,8 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 					};
 					HolderCommitmentTransactionBalance {
 						amount_satoshis: to_self_value_sat + claimable_inbound_htlc_value_sat,
+						amount_offchain_satoshis:
+							to_self_offchain_msat.map(|v| v / 1_000 + claimable_inbound_htlc_value_sat),
 						transaction_fee_satoshis,
 					}
 				})
@@ -4556,16 +4572,23 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 		})
 	}
 
-	#[rustfmt::skip]
 	fn build_counterparty_commitment_tx(
 		&self, channel_parameters: &ChannelTransactionParameters, commitment_number: u64,
 		their_per_commitment_point: &PublicKey, to_broadcaster_value: u64,
 		to_countersignatory_value: u64, feerate_per_kw: u32,
-		nondust_htlcs: Vec<HTLCOutputInCommitment>
+		nondust_htlcs: Vec<HTLCOutputInCommitment>,
 	) -> CommitmentTransaction {
 		let channel_parameters = &channel_parameters.as_counterparty_broadcastable();
-		CommitmentTransaction::new(commitment_number, their_per_commitment_point,
-			to_broadcaster_value, to_countersignatory_value, feerate_per_kw, nondust_htlcs, channel_parameters, &self.onchain_tx_handler.secp_ctx)
+		CommitmentTransaction::new_without_broadcaster_value(
+			commitment_number,
+			their_per_commitment_point,
+			to_broadcaster_value,
+			to_countersignatory_value,
+			feerate_per_kw,
+			nondust_htlcs,
+			channel_parameters,
+			&self.onchain_tx_handler.secp_ctx,
+		)
 	}
 
 	#[rustfmt::skip]

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -4579,7 +4579,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 		nondust_htlcs: Vec<HTLCOutputInCommitment>,
 	) -> CommitmentTransaction {
 		let channel_parameters = &channel_parameters.as_counterparty_broadcastable();
-		CommitmentTransaction::new_without_broadcaster_value(
+		CommitmentTransaction::new_without_broadcaster_offchain_value(
 			commitment_number,
 			their_per_commitment_point,
 			to_broadcaster_value,

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -990,11 +990,12 @@ impl Balance {
 	/// [`Balance::MaybePreimageClaimableHTLC`].
 	///
 	/// On-chain fees required to claim the balance are not included in this amount.
-	#[rustfmt::skip]
 	pub fn claimable_amount_satoshis(&self) -> u64 {
 		match self {
 			Balance::ClaimableOnChannelClose {
-				balance_candidates, confirmed_balance_candidate_index, ..
+				balance_candidates,
+				confirmed_balance_candidate_index,
+				..
 			} => {
 				if *confirmed_balance_candidate_index != 0 {
 					balance_candidates[*confirmed_balance_candidate_index].amount_satoshis
@@ -1002,12 +1003,16 @@ impl Balance {
 					balance_candidates.last().map(|balance| balance.amount_satoshis).unwrap_or(0)
 				}
 			},
-			Balance::ClaimableAwaitingConfirmations { amount_satoshis, .. }|
-			Balance::ContentiousClaimable { amount_satoshis, .. }|
-			Balance::CounterpartyRevokedOutputClaimable { amount_satoshis, .. }
-				=> *amount_satoshis,
-			Balance::MaybeTimeoutClaimableHTLC { amount_satoshis, outbound_payment, .. }
-				=> if *outbound_payment { 0 } else { *amount_satoshis },
+			Balance::ClaimableAwaitingConfirmations { amount_satoshis, .. }
+			| Balance::ContentiousClaimable { amount_satoshis, .. }
+			| Balance::CounterpartyRevokedOutputClaimable { amount_satoshis, .. } => *amount_satoshis,
+			Balance::MaybeTimeoutClaimableHTLC { amount_satoshis, outbound_payment, .. } => {
+				if *outbound_payment {
+					0
+				} else {
+					*amount_satoshis
+				}
+			},
 			Balance::MaybePreimageClaimableHTLC { .. } => 0,
 		}
 	}
@@ -1022,25 +1027,35 @@ impl Balance {
 	///
 	/// For pending payments, splice behavior, or behavior after a channel has been closed, this
 	/// behaves the same as [`Self::claimable_amount_satoshis`].
-	#[rustfmt::skip]
 	pub fn offchain_amount_satoshis(&self) -> u64 {
 		match self {
 			Balance::ClaimableOnChannelClose {
-				balance_candidates, confirmed_balance_candidate_index, ..
+				balance_candidates,
+				confirmed_balance_candidate_index,
+				..
 			} => {
 				if *confirmed_balance_candidate_index != 0 {
 					let candidate = &balance_candidates[*confirmed_balance_candidate_index];
 					candidate.amount_offchain_satoshis.unwrap_or(candidate.amount_satoshis)
 				} else {
-					balance_candidates.last().map(|balance| balance.amount_offchain_satoshis.unwrap_or(balance.amount_satoshis)).unwrap_or(0)
+					balance_candidates
+						.last()
+						.map(|balance| {
+							balance.amount_offchain_satoshis.unwrap_or(balance.amount_satoshis)
+						})
+						.unwrap_or(0)
 				}
 			},
-			Balance::ClaimableAwaitingConfirmations { amount_satoshis, .. }|
-			Balance::ContentiousClaimable { amount_satoshis, .. }|
-			Balance::CounterpartyRevokedOutputClaimable { amount_satoshis, .. }
-				=> *amount_satoshis,
-			Balance::MaybeTimeoutClaimableHTLC { amount_satoshis, outbound_payment, .. }
-				=> if *outbound_payment { 0 } else { *amount_satoshis },
+			Balance::ClaimableAwaitingConfirmations { amount_satoshis, .. }
+			| Balance::ContentiousClaimable { amount_satoshis, .. }
+			| Balance::CounterpartyRevokedOutputClaimable { amount_satoshis, .. } => *amount_satoshis,
+			Balance::MaybeTimeoutClaimableHTLC { amount_satoshis, outbound_payment, .. } => {
+				if *outbound_payment {
+					0
+				} else {
+					*amount_satoshis
+				}
+			},
 			Balance::MaybePreimageClaimableHTLC { .. } => 0,
 		}
 	}

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -1375,7 +1375,7 @@ impl HolderCommitmentTransaction {
 		for _ in 0..nondust_htlcs.len() {
 			counterparty_htlc_sigs.push(dummy_sig);
 		}
-		let inner = CommitmentTransaction::new_without_broadcaster_value(
+		let inner = CommitmentTransaction::new_without_broadcaster_offchain_value(
 			0, &dummy_key, 0, 0, 0, nondust_htlcs, &channel_parameters.as_counterparty_broadcastable(), &secp_ctx
 		);
 		HolderCommitmentTransaction {
@@ -1728,7 +1728,7 @@ impl CommitmentTransaction {
 		)
 	}
 
-	pub(crate) fn new_without_broadcaster_value(
+	pub(crate) fn new_without_broadcaster_offchain_value(
 		commitment_number: u64, per_commitment_point: &PublicKey, to_broadcaster_value_sat: u64,
 		to_countersignatory_value_sat: u64, feerate_per_kw: u32,
 		nondust_htlcs: Vec<HTLCOutputInCommitment>,
@@ -2385,7 +2385,7 @@ mod tests {
 
 		#[rustfmt::skip]
 		fn build(&self, to_broadcaster_sats: u64, to_countersignatory_sats: u64, nondust_htlcs: Vec<HTLCOutputInCommitment>) -> CommitmentTransaction {
-			CommitmentTransaction::new_without_broadcaster_value(
+			CommitmentTransaction::new_without_broadcaster_offchain_value(
 				self.commitment_number, &self.per_commitment_point, to_broadcaster_sats, to_countersignatory_sats, self.feerate_per_kw,
 				nondust_htlcs, &self.channel_parameters.as_holder_broadcastable(), &self.secp_ctx
 			)

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -1748,7 +1748,6 @@ impl CommitmentTransaction {
 		)
 	}
 
-	#[rustfmt::skip]
 	fn build(
 		commitment_number: u64, per_commitment_point: &PublicKey, to_broadcaster_value_sat: u64,
 		to_broadcaster_value_offchain_msat: Option<u64>, to_countersignatory_value_sat: u64,
@@ -1758,15 +1757,32 @@ impl CommitmentTransaction {
 	) -> CommitmentTransaction {
 		let to_broadcaster_value_sat = Amount::from_sat(to_broadcaster_value_sat);
 		let to_countersignatory_value_sat = Amount::from_sat(to_countersignatory_value_sat);
-		let keys = TxCreationKeys::from_channel_static_keys(per_commitment_point, channel_parameters.broadcaster_pubkeys(), channel_parameters.countersignatory_pubkeys(), secp_ctx);
+		let keys = TxCreationKeys::from_channel_static_keys(
+			per_commitment_point,
+			channel_parameters.broadcaster_pubkeys(),
+			channel_parameters.countersignatory_pubkeys(),
+			secp_ctx,
+		);
 
 		// Build and sort the outputs of the transaction.
 		// Also sort the HTLC output data in `nondust_htlcs` in the same order, and populate the
 		// transaction output indices therein.
-		let outputs = Self::build_outputs_and_htlcs(&keys, to_broadcaster_value_sat, to_countersignatory_value_sat, &mut nondust_htlcs, channel_parameters);
+		let outputs = Self::build_outputs_and_htlcs(
+			&keys,
+			to_broadcaster_value_sat,
+			to_countersignatory_value_sat,
+			&mut nondust_htlcs,
+			channel_parameters,
+		);
 
-		let (obscured_commitment_transaction_number, txins) = Self::build_inputs(commitment_number, channel_parameters);
-		let transaction = Self::make_transaction(obscured_commitment_transaction_number, txins, outputs, channel_parameters);
+		let (obscured_commitment_transaction_number, txins) =
+			Self::build_inputs(commitment_number, channel_parameters);
+		let transaction = Self::make_transaction(
+			obscured_commitment_transaction_number,
+			txins,
+			outputs,
+			channel_parameters,
+		);
 		let txid = transaction.compute_txid();
 		CommitmentTransaction {
 			commitment_number,
@@ -1778,10 +1794,7 @@ impl CommitmentTransaction {
 			nondust_htlcs,
 			channel_type_features: channel_parameters.channel_type_features().clone(),
 			keys,
-			built: BuiltCommitmentTransaction {
-				transaction,
-				txid
-			},
+			built: BuiltCommitmentTransaction { transaction, txid },
 		}
 	}
 

--- a/lightning/src/ln/htlc_reserve_unit_tests.rs
+++ b/lightning/src/ln/htlc_reserve_unit_tests.rs
@@ -2346,7 +2346,7 @@ pub fn do_test_dust_limit_fee_accounting(can_afford: bool) {
 				get_channel_ref!(nodes[0], nodes[1], per_peer_lock, peer_state_lock, chan_id);
 			let chan_signer = channel.as_funded().unwrap().get_signer();
 
-			let commitment_tx = CommitmentTransaction::new_without_broadcaster_value(
+			let commitment_tx = CommitmentTransaction::new_without_broadcaster_offchain_value(
 				commitment_number,
 				&remote_point,
 				node_1_balance_sat,

--- a/lightning/src/ln/htlc_reserve_unit_tests.rs
+++ b/lightning/src/ln/htlc_reserve_unit_tests.rs
@@ -2346,7 +2346,7 @@ pub fn do_test_dust_limit_fee_accounting(can_afford: bool) {
 				get_channel_ref!(nodes[0], nodes[1], per_peer_lock, peer_state_lock, chan_id);
 			let chan_signer = channel.as_funded().unwrap().get_signer();
 
-			let commitment_tx = CommitmentTransaction::new(
+			let commitment_tx = CommitmentTransaction::new_without_broadcaster_value(
 				commitment_number,
 				&remote_point,
 				node_1_balance_sat,

--- a/lightning/src/ln/update_fee_tests.rs
+++ b/lightning/src/ln/update_fee_tests.rs
@@ -489,7 +489,7 @@ pub fn do_test_update_fee_that_funder_cannot_afford(channel_type_features: Chann
 		let local_chan_signer = local_chan.as_funded().unwrap().get_signer();
 
 		let nondust_htlcs: Vec<HTLCOutputInCommitment> = vec![];
-		let commitment_tx = CommitmentTransaction::new(
+		let commitment_tx = CommitmentTransaction::new_without_broadcaster_value(
 			INITIAL_COMMITMENT_NUMBER - 1,
 			&remote_point,
 			push_sats,
@@ -590,7 +590,7 @@ pub fn test_update_fee_that_saturates_subs() {
 			get_channel_ref!(nodes[0], nodes[1], per_peer_lock, peer_state_lock, chan_id);
 		let local_chan_signer = local_chan.as_funded().unwrap().get_signer();
 		let nondust_htlcs: Vec<HTLCOutputInCommitment> = vec![];
-		let commitment_tx = CommitmentTransaction::new(
+		let commitment_tx = CommitmentTransaction::new_without_broadcaster_value(
 			INITIAL_COMMITMENT_NUMBER,
 			&remote_point,
 			8500,

--- a/lightning/src/ln/update_fee_tests.rs
+++ b/lightning/src/ln/update_fee_tests.rs
@@ -489,7 +489,7 @@ pub fn do_test_update_fee_that_funder_cannot_afford(channel_type_features: Chann
 		let local_chan_signer = local_chan.as_funded().unwrap().get_signer();
 
 		let nondust_htlcs: Vec<HTLCOutputInCommitment> = vec![];
-		let commitment_tx = CommitmentTransaction::new_without_broadcaster_value(
+		let commitment_tx = CommitmentTransaction::new_without_broadcaster_offchain_value(
 			INITIAL_COMMITMENT_NUMBER - 1,
 			&remote_point,
 			push_sats,
@@ -590,7 +590,7 @@ pub fn test_update_fee_that_saturates_subs() {
 			get_channel_ref!(nodes[0], nodes[1], per_peer_lock, peer_state_lock, chan_id);
 		let local_chan_signer = local_chan.as_funded().unwrap().get_signer();
 		let nondust_htlcs: Vec<HTLCOutputInCommitment> = vec![];
-		let commitment_tx = CommitmentTransaction::new_without_broadcaster_value(
+		let commitment_tx = CommitmentTransaction::new_without_broadcaster_offchain_value(
 			INITIAL_COMMITMENT_NUMBER,
 			&remote_point,
 			8500,

--- a/lightning/src/sign/tx_builder.rs
+++ b/lightning/src/sign/tx_builder.rs
@@ -417,7 +417,11 @@ impl TxBuilder for SpecTxBuilder {
 			)
 		};
 
-		let mut to_broadcaster_value_sat = if local { value_to_self } else { value_to_remote };
+		let (mut to_broadcaster_value_sat, to_broadcaster_value_offchain_msat) = if local {
+			(value_to_self, value_to_self_after_htlcs_msat)
+		} else {
+			(value_to_remote, value_to_remote_after_htlcs_msat)
+		};
 		let mut to_countersignatory_value_sat = if local { value_to_remote } else { value_to_self };
 
 		if to_broadcaster_value_sat >= broadcaster_dust_limit_satoshis {
@@ -451,6 +455,7 @@ impl TxBuilder for SpecTxBuilder {
 			commitment_number,
 			per_commitment_point,
 			to_broadcaster_value_sat,
+			to_broadcaster_value_offchain_msat,
 			to_countersignatory_value_sat,
 			feerate_per_kw,
 			htlcs_in_tx,


### PR DESCRIPTION
    `Balance` seeks to expose our balance accurate based on what we
    would get, less fees, if we were to force-close right now. This is
    great, but for an end-user wallet its not really what you want to
    display as the "balance" of the wallet.

    Instead, you want to give a balance which matches the sum of HTLCs
    received over time, which is only possible when balance information
    is avilable which ignores things like dust, anchors, fees, and
    reserve values.

    Here we provide such a balance - a new "offchain balance" in
    `HolderCommitmentTransactionBalance`.

Fixes #4241.