### PR TITLE
Bump `lightning-block-sync` version number to fix SemVer CI

### DIFF
--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-block-sync"
-version = "0.2.0+git"
+version = "0.3.0+git"
 authors = ["Jeffrey Czyz", "Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning"


### PR DESCRIPTION
PR #4175 made the first breaking API change in `lightning-block-sync` since v0.2 without bumping the version number. Here we bump the version number, allowing our SemVer CI check to be happy again.