### PR TITLE
Expose onion decoding types for differential fuzzing

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7282,7 +7282,7 @@ where
 								&onion_packet.public_key.unwrap(),
 								&onion_packet.hop_data,
 								onion_packet.hmac,
-								payment_hash,
+								Some(payment_hash),
 								None,
 								&*self.node_signer,
 							);

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -596,7 +596,7 @@ where
 
 	let next_hop = match onion_utils::decode_next_payment_hop(
 		Recipient::Node, &msg.onion_routing_packet.public_key.unwrap(), &msg.onion_routing_packet.hop_data[..], msg.onion_routing_packet.hmac,
-		msg.payment_hash, msg.blinding_point, node_signer
+		Some(msg.payment_hash), msg.blinding_point, node_signer
 	) {
 		Ok(res) => res,
 		Err(onion_utils::OnionDecodeErr::Malformed { err_msg, reason }) => {

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1199,7 +1199,7 @@ mod fuzzy_onion_utils {
 
 	pub fn decode_next_payment_hop<NS: Deref>(
 		recipient: Recipient, hop_pubkey: &PublicKey, hop_data: &[u8], hmac_bytes: [u8; 32],
-		payment_hash: PaymentHash, blinding_point: Option<PublicKey>, node_signer: NS,
+		payment_hash: Option<PaymentHash>, blinding_point: Option<PublicKey>, node_signer: NS,
 	) -> Result<Hop, OnionDecodeErr>
 	where
 		NS::Target: NodeSigner,
@@ -1217,7 +1217,7 @@ mod fuzzy_onion_utils {
 			shared_secret.secret_bytes(),
 			hop_data,
 			hmac_bytes,
-			Some(payment_hash),
+			payment_hash,
 			(blinding_point, &(*node_signer)),
 		);
 		match decoded_hop {
@@ -1286,7 +1286,7 @@ mod fuzzy_onion_utils {
 						trampoline_shared_secret,
 						&hop_data.trampoline_packet.hop_data,
 						hop_data.trampoline_packet.hmac,
-						Some(payment_hash),
+						payment_hash,
 						(blinding_point, node_signer),
 					);
 					match decoded_trampoline_hop {


### PR DESCRIPTION
This PR exposes internal onion decoding types and functions behind the `fuzzing` cfg flag to enable differential fuzzing against other Lightning implementations.

**Changes**

- Move `Hop`, `OnionDecodeErr`, `NextPacketBytes`, and `decode_next_payment_hop` into `fuzzy_onion_utils` module (exposed only with `#[cfg(fuzzing)]`)
- Make `payment_hash` parameter optional in `decode_next_payment_hop` to support fuzzing scenarios where onion decoding needs to be tested independently

Closes #4247