### PR TITLE
Allow clippy's new assertions-on-constants lint

### DIFF
--- a/ci/check-lint.sh
+++ b/ci/check-lint.sh
@@ -13,6 +13,7 @@ CLIPPY() {
 		-A clippy::unwrap-or-default \
 		-A clippy::upper_case_acronyms \
 		-A clippy::swap-with-temporary \
+		-A clippy::assertions-on-constants \
 		`# Things where we do odd stuff on purpose ` \
 		-A clippy::unusual_byte_groupings \
 		-A clippy::unit_arg \


### PR DESCRIPTION
This is really dumb, `assert!(cfg!(fuzzing))` is a perfectly reasonable thing to write!