### PR TITLE
LDK Node Integration CI: Also patch LDK dependencies if `git`

### DIFF
--- a/.github/workflows/ldk-node-integration.yml
+++ b/.github/workflows/ldk-node-integration.yml
@@ -39,6 +39,19 @@ jobs:
             lightning-transaction-sync = { path = "../rust-lightning/lightning-transaction-sync" }
             lightning-liquidity = { path = "../rust-lightning/lightning-liquidity" }
             lightning-macros = { path = "../rust-lightning/lightning-macros" }
+
+            [patch."https://github.com/lightningdevkit/rust-lightning"]
+            lightning = { path = "../rust-lightning/lightning" }
+            lightning-types = { path = "../rust-lightning/lightning-types" }
+            lightning-invoice = { path = "../rust-lightning/lightning-invoice" }
+            lightning-net-tokio = { path = "../rust-lightning/lightning-net-tokio" }
+            lightning-persister = { path = "../rust-lightning/lightning-persister" }
+            lightning-background-processor = { path = "../rust-lightning/lightning-background-processor" }
+            lightning-rapid-gossip-sync = { path = "../rust-lightning/lightning-rapid-gossip-sync" }
+            lightning-block-sync = { path = "../rust-lightning/lightning-block-sync" }
+            lightning-transaction-sync = { path = "../rust-lightning/lightning-transaction-sync" }
+            lightning-liquidity = { path = "../rust-lightning/lightning-liquidity" }
+            lightning-macros = { path = "../rust-lightning/lightning-macros" }
           EOF
           cargo check
           cargo check --features uniffi


### PR DESCRIPTION
By now, we switched our LDK Node `main` to a specific commit on LDK's `main`. Since we don't have the `crates.io` dependencies in the `Cargo.toml`, the patch command won't actually do anything but silently fail, i.e., *not* check the PR changes against the LDK Node main branch.

Here we fix this by also patching the git repository path.