### PR TITLE
Add a trivial helper to LSPS5's `WebhookNotification`

### DIFF
--- a/lightning-liquidity/src/lsps5/event.rs
+++ b/lightning-liquidity/src/lsps5/event.rs
@@ -30,9 +30,9 @@ pub enum LSPS5ServiceEvent {
 	/// via their registered webhook.
 	///
 	/// The LSP should send an HTTP POST to the [`url`], using the
-	/// JSON-serialized [`notification`] as the body and including the `headers`.
-	/// If the HTTP request fails, the LSP may implement a retry policy according to its
-	/// implementation preferences.
+	/// JSON-serialized [`notification`] (via [`WebhookNotification::to_request_body`]) as the body
+	/// and including the `headers`.  If the HTTP request fails, the LSP may implement a retry
+	/// policy according to its implementation preferences.
 	///
 	/// The notification is signed using the LSP's node ID to ensure authenticity
 	/// when received by the client. The client verifies this signature using

--- a/lightning-liquidity/src/lsps5/msgs.rs
+++ b/lightning-liquidity/src/lsps5/msgs.rs
@@ -565,6 +565,12 @@ impl WebhookNotification {
 	pub fn onion_message_incoming() -> Self {
 		Self { method: WebhookNotificationMethod::LSPS5OnionMessageIncoming }
 	}
+
+	/// Encodes this notification into JSON which can be sent as the body of an HTTP request to
+	/// deliver the notification.
+	pub fn to_request_body(&self) -> String {
+		serde_json::to_string(self).unwrap()
+	}
 }
 
 impl Serialize for WebhookNotification {


### PR DESCRIPTION
`LSPS5ServiceEvent::SendWebhookNotification`'s docs say to send the `WebhookNotification` as the HTTP request body "as JSON", which is great, but it leaves the dev to figure out how to do that. Its nice to have a helper to do that, which is trivial so we provide it here.