### PR TITLE
BOLT12 Recurrence: Proof-of-Concept Implementation

### DIFF
--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -8,8 +8,11 @@
 // licenses.
 
 use crate::utils::test_logger;
+use bitcoin::blockdata::constants::genesis_block;
+use bitcoin::Network;
 use bitcoin::secp256k1::{self, Keypair, Parity, PublicKey, Secp256k1, SecretKey};
 use core::convert::TryFrom;
+use core::time::Duration;
 use lightning::blinded_path::payment::{
 	BlindedPaymentPath, Bolt12OfferContext, ForwardTlvs, PaymentConstraints, PaymentContext,
 	PaymentForwardNode, PaymentRelay, ReceiveTlvs,
@@ -81,6 +84,9 @@ fn privkey(byte: u8) -> SecretKey {
 fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
 	invoice_request: &InvoiceRequest, secp_ctx: &Secp256k1<T>,
 ) -> Result<UnsignedBolt12Invoice, Bolt12SemanticError> {
+	let network = Network::Bitcoin;
+	let genesis_block = genesis_block(network);
+
 	let expanded_key = ExpandedKey::new([42; 32]);
 	let entropy_source = Randomness {};
 	let receive_auth_key = ReceiveAuthKey([41; 32]);
@@ -145,7 +151,8 @@ fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
 	.unwrap();
 
 	let payment_hash = PaymentHash([42; 32]);
-	invoice_request.respond_with(vec![payment_path], payment_hash)?.build()
+	let now = Duration::from_secs(genesis_block.header.time as u64);
+	invoice_request.respond_with(vec![payment_path], payment_hash, now)?.build()
 }
 
 pub fn invoice_request_deser_test<Out: test_logger::Output>(data: &[u8], out: Out) {

--- a/fuzz/src/invoice_request_deser.rs
+++ b/fuzz/src/invoice_request_deser.rs
@@ -98,6 +98,7 @@ fn build_response<T: secp256k1::Signing + secp256k1::Verification>(
 					.payer_note()
 					.map(|s| UntrustedString(s.to_string())),
 				human_readable_name: None,
+				recurrence_counter: None,
 			}
 		};
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -15403,7 +15403,7 @@ where
 					None => return None,
 				};
 
-				let invoice_request = match self.flow.verify_invoice_request(invoice_request, context) {
+				let verified_invoice_request = match self.flow.verify_invoice_request(invoice_request, context) {
 					Ok(InvreqResponseInstructions::SendInvoice(invoice_request)) => invoice_request,
 					Ok(InvreqResponseInstructions::SendStaticInvoice { recipient_id, invoice_slot, invoice_request }) => {
 						self.pending_events.lock().unwrap().push_back((Event::StaticInvoiceRequested {
@@ -15414,6 +15414,7 @@ where
 					},
 					Err(_) => return None,
 				};
+				let invoice_request = verified_invoice_request.inner();
 
 				#[cfg(not(feature = "std"))]
 				let created_at = Duration::from_secs(self.highest_seen_timestamp.load(Ordering::Acquire) as u64);
@@ -15421,6 +15422,86 @@ where
 				let created_at = std::time::SystemTime::now()
 					.duration_since(std::time::SystemTime::UNIX_EPOCH)
 					.expect("SystemTime::now() should come after SystemTime::UNIX_EPOCH");
+
+				// Recurrence checks
+				let recurrence_basetime = if let Some(recurrence_fields) = invoice_request.recurrence_fields() {
+					let payer_id = invoice_request.payer_signing_pubkey();
+					let mut sessions = self.active_inbound_recurrence_sessions.lock().unwrap();
+
+					// We first categorise the invoice request based on it's type.
+					let recurrence_counter = invoice_request.recurrence_counter();
+					let recurrence_cancel = invoice_request.recurrence_cancel();
+					let existing_session = sessions.get(&payer_id);
+
+					match (existing_session, recurrence_counter, recurrence_cancel) {
+						// This represents case where the payer, didn't support recurrence
+						// but we set recurrence optional so we allow payer to pay one-off
+						(None, None, None) => { None },
+						// It's the first invoice request in recurrence series
+						(None, Some(0), None) => {
+							let recurrence_basetime = recurrence_fields
+								.recurrence_base
+								.map(|base| base.basetime)
+								.unwrap_or(created_at.as_secs());
+
+							// Calculate the next_invoice_request_paywindow
+							let seconds_before = recurrence_fields
+								.recurrence_paywindow.map(|window| window.seconds_before as u64)
+								.unwrap_or(recurrence_fields.recurrence.period_length_secs());
+
+							let seconds_after = recurrence_fields
+								.recurrence_paywindow.map(|window| window.seconds_after as u64)
+								.unwrap_or(recurrence_fields.recurrence.period_length_secs());
+
+							// Next we prepare inbound recurrence_data to be stored in our recurrence session
+							let recurrence_data = InboundRecurrenceSessionData {
+								recurrence_fields,
+								invoice_request_start: invoice_request.recurrence_start(),
+								next_payable_counter: 0,
+								recurrence_basetime,
+								next_invoice_request_window: (recurrence_basetime.saturating_sub(seconds_before), recurrence_basetime.saturating_add(seconds_after)),
+							};
+							// Now we store it in our active_inbound_recurrence_sessions
+							sessions.insert(payer_id, recurrence_data);
+
+							Some(recurrence_basetime)
+
+						},
+						// it's a successive invoice request in recurrence series
+						(Some(data), Some(counter), None) if counter > 0 => {
+							// We confirm all the data to ensure this is an expected successive invoice request
+							if data.invoice_request_start != invoice_request.recurrence_start()
+								|| data.next_payable_counter != counter
+							{
+								return None
+							}
+
+							// Next we ensure that the successive invoice_request is received between the period's paywindow
+							if created_at.as_secs() < data.next_invoice_request_window.0
+								|| created_at.as_secs() >= data.next_invoice_request_window.1
+							{
+								return None
+							}
+
+							Some(data.recurrence_basetime)
+						},
+						// it's a cancel recurrence invoice request
+						(Some(_data), Some(counter), Some(())) if counter > 0 => {
+							// Here we simply remove the data from our sessions
+							sessions.remove(&payer_id);
+
+							// And since cancellation invoice request are stub invoice request,
+							// we don't respond to this invoice request
+							return None
+						},
+						_ => {
+							debug_assert!(false, "Should be unreachable, as all the invalid cases are handled during parsing");
+							return None
+						}
+					}
+				} else {
+					None
+				};
 
 				let get_payment_info = |amount_msats, relative_expiry| {
 					self.create_inbound_payment(
@@ -15430,7 +15511,7 @@ where
 					).map_err(|_| Bolt12SemanticError::InvalidAmount)
 				};
 
-				let (result, context) = match invoice_request {
+				let (result, context) = match verified_invoice_request {
 					InvoiceRequestVerifiedFromOffer::DerivedKeys(request) => {
 						let result = self.flow.create_invoice_builder_from_invoice_request_with_keys(
 							&self.router,
@@ -15441,7 +15522,11 @@ where
 						);
 
 						match result {
-							Ok((builder, context)) => {
+							Ok((mut builder, context)) => {
+								recurrence_basetime.map(|basetime|
+									builder.set_invoice_recurrence_basetime(basetime)
+								);
+
 								let res = builder
 									.build_and_sign(&self.secp_ctx)
 									.map_err(InvoiceError::from);
@@ -15466,7 +15551,10 @@ where
 						);
 
 						match result {
-							Ok((builder, context)) => {
+							Ok((mut builder, context)) => {
+								recurrence_basetime.map(|basetime|
+									builder.set_invoice_recurrence_basetime(basetime)
+								);
 								let res = builder
 									.build()
 									.map_err(InvoiceError::from)

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -20,6 +20,7 @@
 use bitcoin::block::Header;
 use bitcoin::constants::ChainHash;
 use bitcoin::key::constants::SECRET_KEY_SIZE;
+use bitcoin::key::Keypair;
 use bitcoin::network::Network;
 use bitcoin::transaction::Transaction;
 
@@ -94,7 +95,7 @@ use crate::offers::flow::{HeldHtlcReplyPath, InvreqResponseInstructions, OffersM
 use crate::offers::invoice::{Bolt12Invoice, UnsignedBolt12Invoice};
 use crate::offers::invoice_error::InvoiceError;
 use crate::offers::invoice_request::{
-	InvoiceRequest, InvoiceRequestFields, InvoiceRequestVerifiedFromOffer,
+	InvoiceRequest, InvoiceRequestFields, InvoiceRequestVerifiedFromOffer, UnsignedInvoiceRequest,
 };
 use crate::offers::nonce::Nonce;
 use crate::offers::offer::{
@@ -13141,6 +13142,14 @@ where
 		&self, offer: &Offer, amount_msats: Option<u64>, payment_id: PaymentId,
 		optional_params: OptionalOfferPaymentParams,
 	) -> Result<(), Bolt12SemanticError> {
+		if offer.recurrence_fields().is_some() {
+			debug_assert!(
+				false,
+				"Offer contains recurrence. Use pay_for_offer_with_recurrence instead"
+			);
+			return Err(Bolt12SemanticError::InvalidRecurrence);
+		}
+
 		let create_pending_payment_fn = |retryable_invoice_request: RetryableInvoiceRequest| {
 			self.pending_outbound_payments
 				.add_new_awaiting_invoice(
@@ -13160,6 +13169,64 @@ where
 			optional_params.payer_note,
 			payment_id,
 			None,
+			None,
+			None,
+			create_pending_payment_fn,
+		)
+	}
+
+	/// Initiates a BOLT12 recurrence by sending the primary invoice request.
+	///
+	/// This method starts a new outbound recurrence session for the given
+	/// `Offer`. It sends the first (counter = 0) `InvoiceRequest` and records
+	/// the necessary recurrence context so that subsequent payments can be
+	/// continued via [`pay_for_recurrence`].
+	///
+	/// Unlike [`pay_for_offer`], this call establishes long-lived payer-side
+	/// state. The provided `recurrence_id` uniquely identifies the recurrence
+	/// session and is later used to continue or cancel it.
+	///
+	/// The optional `recurrence_start` specifies the starting period index
+	/// for the recurrence and must satisfy the constraints imposed by the
+	/// Offer’s recurrence fields:
+	/// - If the Offer defines a recurrence base time, `recurrence_start`
+	///   must be provided.
+	/// - If the Offer does not define a recurrence base, `recurrence_start`
+	///   must be omitted.
+	///
+	/// Returns an error if the Offer is not recurrence-enabled, the supplied
+	/// recurrence parameters are invalid, or the primary invoice request
+	/// cannot be constructed or enqueued.
+	///
+	/// On success, an outbound recurrence session is created and persisted,
+	/// and the recurrence may be continued using `pay_for_recurrence` or
+	/// explicitly terminated using `cancel_recurrence`.
+	pub fn pay_for_offer_with_recurrence(
+		&self, offer: &Offer, amount_msats: Option<u64>, payment_id: PaymentId,
+		recurrence_id: RecurrenceId, optional_params: OptionalOfferPaymentParams,
+		recurrence_start: Option<u32>,
+	) -> Result<(), Bolt12SemanticError> {
+		let create_pending_payment_fn = |retryable_invoice_request: RetryableInvoiceRequest| {
+			self.pending_outbound_payments
+				.add_new_awaiting_invoice(
+					payment_id,
+					StaleExpiration::TimerTicks(1),
+					optional_params.retry_strategy,
+					optional_params.route_params_config,
+					Some(retryable_invoice_request),
+				)
+				.map_err(|_| Bolt12SemanticError::DuplicatePaymentId)
+		};
+
+		self.pay_for_offer_intern(
+			offer,
+			if offer.expects_quantity() { Some(1) } else { None },
+			amount_msats,
+			optional_params.payer_note,
+			payment_id,
+			Some(recurrence_id),
+			None,
+			recurrence_start,
 			create_pending_payment_fn,
 		)
 	}
@@ -13170,6 +13237,14 @@ where
 		&self, offer: &OfferFromHrn, amount_msats: u64, payment_id: PaymentId,
 		optional_params: OptionalOfferPaymentParams,
 	) -> Result<(), Bolt12SemanticError> {
+		if offer.offer.recurrence_fields().is_some() {
+			debug_assert!(
+				false,
+				"Offer contains recurrence. Use pay_for_offer_with_recurrence instead"
+			);
+			return Err(Bolt12SemanticError::InvalidRecurrence);
+		}
+
 		let create_pending_payment_fn = |retryable_invoice_request: RetryableInvoiceRequest| {
 			self.pending_outbound_payments
 				.add_new_awaiting_invoice(
@@ -13188,7 +13263,9 @@ where
 			Some(amount_msats),
 			optional_params.payer_note,
 			payment_id,
+			None,
 			Some(offer.hrn),
+			None,
 			create_pending_payment_fn,
 		)
 	}
@@ -13212,6 +13289,14 @@ where
 		&self, offer: &Offer, amount_msats: Option<u64>, payment_id: PaymentId,
 		optional_params: OptionalOfferPaymentParams, quantity: u64,
 	) -> Result<(), Bolt12SemanticError> {
+		if offer.recurrence_fields().is_some() {
+			debug_assert!(
+				false,
+				"Offer contains recurrence. Use pay_for_offer_with_recurrence instead"
+			);
+			return Err(Bolt12SemanticError::InvalidRecurrence);
+		}
+
 		let create_pending_payment_fn = |retryable_invoice_request: RetryableInvoiceRequest| {
 			self.pending_outbound_payments
 				.add_new_awaiting_invoice(
@@ -13231,6 +13316,8 @@ where
 			optional_params.payer_note,
 			payment_id,
 			None,
+			None,
+			None,
 			create_pending_payment_fn,
 		)
 	}
@@ -13238,15 +13325,127 @@ where
 	#[rustfmt::skip]
 	fn pay_for_offer_intern<CPP: FnOnce(RetryableInvoiceRequest) -> Result<(), Bolt12SemanticError>>(
 		&self, offer: &Offer, quantity: Option<u64>, amount_msats: Option<u64>,
-		payer_note: Option<String>, payment_id: PaymentId,
-		human_readable_name: Option<HumanReadableName>, create_pending_payment: CPP,
+		payer_note: Option<String>, payment_id: PaymentId, recurrence_id: Option<RecurrenceId>,
+		human_readable_name: Option<HumanReadableName>,
+		recurrence_start: Option<u32>, create_pending_payment: CPP,
 	) -> Result<(), Bolt12SemanticError> {
 		let entropy = &*self.entropy_source;
 		let nonce = Nonce::from_entropy_source(entropy);
 
-		let builder = self.flow.create_invoice_request_builder(
-			offer, nonce, payment_id,
-		)?;
+		let expanded_key = &self.inbound_payment_key;
+		let secp_ctx = &self.secp_ctx;
+
+		let (keys_opt, builder) = match (recurrence_id, offer.recurrence_fields()) {
+			(Some(id), Some(fields)) => {
+				let recurrence_basetime = fields.recurrence_base;
+
+				// Validate user-supplied recurrence_start against the offer's recurrence requirements.
+				match (recurrence_basetime, recurrence_start) {
+					// Offer defines a recurrence_base → caller must provide a recurrence_start.
+					(Some(_), None) => {
+						return Err(Bolt12SemanticError::InvalidRecurrence)
+					}
+					// Offer is not recurrent → caller must *not* provide recurrence_start.
+					(None, Some(_)) => {
+						return Err(Bolt12SemanticError::InvalidRecurrence)
+					}
+					_ => {}
+				}
+
+				// Compute the base timestamp and the next trigger time for the recurrence session.
+				//
+				// If the offer defines a recurrence_base, we have enough information to compute
+				// the invoice recurrence basetime and the next trigger time immediately.
+				//
+				// If the offer does not define a recurrence_base, we must wait until the first
+				// invoice corresponding to this recurrence is received, as the
+				// invoice_recurrence_basetime is derived from that invoice.
+				//
+				// Note:
+				// We choose to create the OutboundRecurrenceSessionData at this point even if
+				// some recurrence fields might not be yet known. This is necessary because we must
+				// persist the original offer in the session data in order to create successive
+				// invoice requests.
+				//
+				// In the payer flow, this is the only point at which we have access to the
+				// complete original offer.
+				let (invoice_recurrence_basetime, next_trigger_time) =
+					if let Some(base) = recurrence_basetime {
+						let basetime = base.basetime;
+						let start = recurrence_start.expect("Checked presence earlier");
+						let period = fields.recurrence.period_length_secs();
+
+						let next_trigger =
+							basetime + (start as u64).saturating_mul(period);
+
+						(Some(basetime), Some(next_trigger))
+					} else {
+						(None, None)
+					};
+
+				// The keypair used to sign the primary invoice request of the recurrence.
+				//
+				// WARNING:
+				// This key derivation provides minimal security. It relies solely on the
+				// user-provided recurrence_id as its entropy source and exists only to ensure
+				// that the payer_signing_pubkey remains stable across all invoice requests
+				// belonging to the same recurrence.
+				//
+				// This approach is only for a proof of concept, but MUST NOT be used in
+				// a production-ready design.
+				//
+				// In later phases, this may be replaced by:
+				// 1. A stateful approach where recurrence keys are managed by the NodeSigner
+				//    implementation, or
+				// 2. A stateless derivation scheme where the original signing keys can be
+				//    deterministically rebuilt from stable but secret recurrence inputs.
+				let keys = {
+					let mut seed = expanded_key.hmac_for_offer();
+					seed.input(&id.0);
+
+					let hmac = Hmac::from_engine(seed);
+					let privkey = SecretKey::from_slice(hmac.as_byte_array()).unwrap();
+					Keypair::from_secret_key(secp_ctx, &privkey)
+				};
+
+				{
+					let data = OutboundRecurrenceSessionData {
+						offer: offer.clone(),
+						payer_signing_pubkey: keys.public_key(),
+						recurrence_start,
+						// Primary invoice request. Hence counter -> 0.
+						next_recurrence_counter: 0,
+						invoice_recurrence_basetime,
+						next_trigger_time,
+					};
+
+					let mut sessions = self.active_outbound_recurrence_sessions.lock().unwrap();
+					sessions.insert(id, data);
+				}
+
+				let builder = offer.
+					request_invoice_with_explicit_signing_pubkey(keys.public_key(), expanded_key, nonce, secp_ctx, payment_id)?;
+
+				let builder = builder.chain_hash(self.chain_hash)?;
+				let builder = builder.recurrence_counter(0);
+
+				let builder = match recurrence_start {
+					None => builder,
+					Some(start) => builder.recurrence_start(start)
+				};
+
+				(Some(keys), builder)
+			},
+
+			(None, None) => {
+				(None, self.flow.create_invoice_request_builder(
+					offer, nonce, payment_id,
+				)?)
+			},
+
+			// All other combinations are invalid.
+			_ => return Err(Bolt12SemanticError::InvalidRecurrence)
+		};
 
 		let builder = match quantity {
 			None => builder,
@@ -13265,7 +13464,16 @@ where
 			Some(hrn) => builder.sourced_from_human_readable_name(hrn),
 		};
 
-		let invoice_request = builder.build_and_sign()?;
+		let invoice_request = match keys_opt {
+			Some(keys) => {
+				builder.build()?
+				.sign(|message: &UnsignedInvoiceRequest|
+					Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+				).expect("failed verifying signature")
+			},
+			None => builder.build_and_sign()?
+		};
+
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 
 		self.flow.enqueue_invoice_request(
@@ -15971,7 +16179,8 @@ where
 				}
 				if let Ok((amt_msats, payer_note)) = self.pending_outbound_payments.params_for_payment_awaiting_offer(payment_id) {
 					let offer_pay_res =
-						self.pay_for_offer_intern(&offer, None, Some(amt_msats), payer_note, payment_id, Some(name),
+						self.pay_for_offer_intern(&offer, None, Some(amt_msats), payer_note, payment_id,
+							None, Some(name), None,
 							|retryable_invoice_request| {
 								self.pending_outbound_payments
 									.received_offer(payment_id, Some(retryable_invoice_request))

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -50,7 +50,7 @@ use crate::chain::transaction::{OutPoint, TransactionData};
 use crate::chain::{BestBlock, ChannelMonitorUpdateStatus, Confirm, Watch};
 use crate::events::{
 	self, ClosureReason, Event, EventHandler, EventsProvider, HTLCHandlingFailureType,
-	InboundChannelFunds, PaymentFailureReason, ReplayEvent,
+	InboundChannelFunds, PaymentFailureReason, PaymentPurpose, ReplayEvent,
 };
 use crate::events::{FundingInfo, PaidBolt12Invoice};
 use crate::ln::chan_utils::selected_commitment_sat_per_1000_weight;
@@ -93,7 +93,9 @@ use crate::offers::async_receive_offer_cache::AsyncReceiveOfferCache;
 use crate::offers::flow::{HeldHtlcReplyPath, InvreqResponseInstructions, OffersMessageFlow};
 use crate::offers::invoice::{Bolt12Invoice, UnsignedBolt12Invoice};
 use crate::offers::invoice_error::InvoiceError;
-use crate::offers::invoice_request::{InvoiceRequest, InvoiceRequestVerifiedFromOffer};
+use crate::offers::invoice_request::{
+	InvoiceRequest, InvoiceRequestFields, InvoiceRequestVerifiedFromOffer,
+};
 use crate::offers::nonce::Nonce;
 use crate::offers::offer::{InboundRecurrenceSessionData, Offer, OfferFromHrn, RecurrenceFields};
 use crate::offers::parse::Bolt12SemanticError;
@@ -9514,6 +9516,44 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 						payment_id,
 						durable_preimage_channel,
 					}) = payment {
+						// At this point, the payment has been successfully claimed. If it belongs
+						// to a recurring offer, we can safely advance the recurrence state.
+
+						match &purpose {
+							PaymentPurpose::Bolt12OfferPayment {
+								payment_context: Bolt12OfferContext {
+									invoice_request: InvoiceRequestFields {
+										payer_signing_pubkey,
+										recurrence_counter: Some(paid_counter),
+										..
+									},
+									..
+								},
+								..
+							} => {
+								let mut sessions = self.active_inbound_recurrence_sessions.lock().unwrap();
+
+								if let Some(data) = sessions.get_mut(payer_signing_pubkey) {
+									if data.next_payable_counter == *paid_counter {
+										data.next_payable_counter += 1;
+
+										// Update the next_invoice_request_paywindow
+										let seconds_before = data.recurrence_fields
+											.recurrence_paywindow.map(|window| window.seconds_before as u64)
+											.unwrap_or(data.recurrence_fields.recurrence.period_length_secs());
+
+										let seconds_after = data.recurrence_fields
+											.recurrence_paywindow.map(|window| window.seconds_after as u64)
+											.unwrap_or(data.recurrence_fields.recurrence.period_length_secs());
+
+										let new_start_time = data.recurrence_fields.recurrence.start_time(data.recurrence_basetime, data.next_payable_counter);
+										data.next_invoice_request_window = (new_start_time.saturating_sub(seconds_before), new_start_time.saturating_add(seconds_after));
+									}
+								}
+							},
+							_ => {}
+						}
+
 						let event = events::Event::PaymentClaimed {
 							payment_hash,
 							purpose,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -95,7 +95,7 @@ use crate::offers::invoice::{Bolt12Invoice, UnsignedBolt12Invoice};
 use crate::offers::invoice_error::InvoiceError;
 use crate::offers::invoice_request::{InvoiceRequest, InvoiceRequestVerifiedFromOffer};
 use crate::offers::nonce::Nonce;
-use crate::offers::offer::{Offer, OfferFromHrn};
+use crate::offers::offer::{Offer, OfferFromHrn, RecurrenceFields};
 use crate::offers::parse::Bolt12SemanticError;
 use crate::offers::refund::Refund;
 use crate::offers::static_invoice::StaticInvoice;
@@ -12772,6 +12772,32 @@ macro_rules! create_offer_builder { ($self: ident, $builder: ty) => {
 	pub fn create_offer_builder(&$self) -> Result<$builder, Bolt12SemanticError> {
 		let builder = $self.flow.create_offer_builder(
 			&*$self.entropy_source, $self.get_peers_for_blinded_path()
+		)?;
+
+		Ok(builder.into())
+	}
+
+	/// Creates an [`OfferBuilder`] for a recurring offer.
+	///
+	/// This behaves like [`Self::create_offer_builder`] but additionally embeds
+	/// the recurrence TLVs defined in `recurrence_fields`.
+	///
+	/// Use this when constructing subscription-style offers where each invoice
+	/// request must correspond to a specific recurrence period. The provided
+	/// [`RecurrenceFields`] specify:
+	/// - how often invoices may be requested,
+	/// - when the first period begins,
+	/// - optional paywindows, and
+	/// - optional period limits.
+	///
+	/// Refer to [`Self::create_offer_builder`] for notes on privacy,
+	/// requirements, and potential failure cases.
+	pub fn create_offer_builder_with_recurrence(
+		&$self,
+		recurrence_fields: RecurrenceFields
+	) -> Result<$builder, Bolt12SemanticError> {
+		let builder = $self.flow.create_offer_builder_with_recurrence(
+			&*$self.entropy_source, recurrence_fields, $self.get_peers_for_blinded_path()
 		)?;
 
 		Ok(builder.into())

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -13290,7 +13290,7 @@ where
 
 		let data = match sessions.get(&recurrence_id) {
 			None => return Err(Bolt12SemanticError::InvalidRecurrence),
-			Some(data) => data
+			Some(data) => data,
 		};
 
 		let create_pending_payment_fn = |retryable_invoice_request: RetryableInvoiceRequest| {
@@ -13328,15 +13328,20 @@ where
 			"Derived KeyPair does not match the payer signing public key"
 		);
 
-		let builder = offer.
-			request_invoice_with_explicit_signing_pubkey(keys.public_key(), expanded_key, nonce, secp_ctx, payment_id)?;
+		let builder = offer.request_invoice_with_explicit_signing_pubkey(
+			keys.public_key(),
+			expanded_key,
+			nonce,
+			secp_ctx,
+			payment_id,
+		)?;
 
 		let builder = builder.chain_hash(self.chain_hash)?;
 		let builder = builder.recurrence_counter(data.next_recurrence_counter);
 
 		let builder = match data.recurrence_start {
 			None => builder,
-			Some(start) => builder.recurrence_start(start)
+			Some(start) => builder.recurrence_start(start),
 		};
 
 		let builder = match quantity {
@@ -13352,16 +13357,20 @@ where
 			Some(payer_note) => builder.payer_note(payer_note),
 		};
 
-		let invoice_request = builder.build()?
-			.sign(|message: &UnsignedInvoiceRequest|
+		let invoice_request = builder
+			.build()?
+			.sign(|message: &UnsignedInvoiceRequest| {
 				Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
-			).expect("failed verifying signature");
+			})
+			.expect("failed verifying signature");
 
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
 
 		self.flow.enqueue_invoice_request(
-			invoice_request.clone(), payment_id, nonce,
-			self.get_peers_for_blinded_path()
+			invoice_request.clone(),
+			payment_id,
+			nonce,
+			self.get_peers_for_blinded_path(),
 		)?;
 
 		let retryable_invoice_request = RetryableInvoiceRequest {
@@ -13371,6 +13380,95 @@ where
 		};
 
 		create_pending_payment_fn(retryable_invoice_request)
+	}
+
+	/// Explicitly cancels an active BOLT12 recurrence session.
+	///
+	/// If payer wish to stop a recurrence, they must actively signal
+	/// cancellation to the payee so that no further recurrence-enabled
+	/// invoices are issued or accepted.
+	///
+	/// This method constructs and sends a final `InvoiceRequest` carrying a
+	/// recurrence cancellation signal, derived from the existing outbound
+	/// recurrence session identified by `recurrence_id`.
+	///
+	/// Cancellation is treated as an explicit protocol action rather than a
+	/// local state change. Once the cancellation request is enqueued, the
+	/// corresponding outbound recurrence session is removed, ensuring that no
+	/// further payments can be initiated for that recurrence.
+	///
+	/// Returns an error if the recurrence does not exist or the cancellation
+	/// request cannot be constructed or enqueued.
+	pub fn cancel_recurrence(
+		&self, recurrence_id: RecurrenceId,
+	) -> Result<(), Bolt12SemanticError> {
+		let mut sessions = self.active_outbound_recurrence_sessions.lock().unwrap();
+
+		let data = match sessions.get(&recurrence_id) {
+			None => return Err(Bolt12SemanticError::InvalidRecurrence),
+			Some(data) => data,
+		};
+
+		let entropy = &*self.entropy_source;
+		let nonce = Nonce::from_entropy_source(entropy);
+		let expanded_key = &self.inbound_payment_key;
+		let secp_ctx = &self.secp_ctx;
+
+		let offer = &data.offer;
+
+		let keys = {
+			let mut seed = expanded_key.hmac_for_offer();
+			seed.input(&recurrence_id.0);
+
+			let hmac = Hmac::from_engine(seed);
+			let privkey = SecretKey::from_slice(hmac.as_byte_array()).unwrap();
+			Keypair::from_secret_key(secp_ctx, &privkey)
+		};
+
+		debug_assert_eq!(
+			keys.public_key(),
+			data.payer_signing_pubkey,
+			"Derived KeyPair does not match the payer signing public key"
+		);
+
+		// Create a Dummy Payment ID, we don't accept a response back
+		let payment_id = PaymentId([1; 32]);
+
+		let builder = offer.request_invoice_with_explicit_signing_pubkey(
+			keys.public_key(),
+			expanded_key,
+			nonce,
+			secp_ctx,
+			payment_id,
+		)?;
+		let builder = builder.chain_hash(self.chain_hash)?;
+
+		// Spec commentary: Spec is not clear about when sending cancel invoice request
+		// do we need to set the appropriate recurrence_counter, and recurrence_start.
+		// We decide to be conservative here, by still setting them appropriately.
+		let builder = builder.recurrence_counter(data.next_recurrence_counter);
+
+		let builder = match data.recurrence_start {
+			None => builder,
+			Some(start) => builder.recurrence_start(start),
+		};
+
+		let builder = builder.recurrence_cancel();
+
+		let invoice_request = builder.build_and_sign()?;
+		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
+
+		self.flow.enqueue_invoice_request(
+			invoice_request.clone(),
+			payment_id,
+			nonce,
+			self.get_peers_for_blinded_path(),
+		)?;
+
+		// Ones we enqueue the invoice request, we remove the data from sessions
+		sessions.remove(&recurrence_id);
+
+		Ok(())
 	}
 
 	/// Pays for an [`Offer`] which was built by resolving a human readable name. It is otherwise

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8412,6 +8412,149 @@ where
 
 			let now = duration_since_epoch.as_secs();
 
+			// -----------------------------------------------------------------------------
+			// Outbound Recurrence session cleanup
+			//
+			// We prune active outbound recurrence sessions that are no longer payable.
+			// A session becomes invalid if:
+			// 1. Its recurrence limit has been reached, OR
+			// 2. The payer has missed the allowed payment window for the current period.
+			//
+			// Sessions that have not yet received their first invoice are kept alive.
+			// -----------------------------------------------------------------------------
+			{
+				let mut sessions = self.active_outbound_recurrence_sessions.lock().unwrap();
+
+				// `retain` keeps entries for which the closure returns `true`
+				sessions.retain(|_, data| {
+					match (data.invoice_recurrence_basetime, data.next_trigger_time) {
+						// -----------------------------------------------------------------
+						// Case A: Waiting for the first invoice
+						//
+						// No invoice basetime and no trigger time implies that the recurrence
+						// session has been created but no invoice has been received yet.
+						// We cannot invalidate the session at this stage.
+						// -----------------------------------------------------------------
+						(None, None) => true,
+
+						// -----------------------------------------------------------------
+						// Case B: Active recurrence with known basetime and trigger
+						// -----------------------------------------------------------------
+						(Some(recurrence_basetime), Some(trigger_time)) => {
+							// Active recurrence sessions must always correspond to offers
+							// that actually define recurrence fields. If this invariant is
+							// violated, the session is considered invalid.
+							let fields = match data.offer.recurrence_fields() {
+								Some(fields) => fields,
+								None => {
+									debug_assert!(
+										false,
+										"Active recurrence session without recurrence fields, shouldn't be possible."
+									);
+									return false;
+								},
+							};
+
+							// -------------------------------------------------------------
+							// 1. Recurrence limit check
+							//
+							// If the next recurrence counter has reached the offer-defined
+							// recurrence limit, the recurrence sequence is complete and
+							// the session must be removed.
+							// -------------------------------------------------------------
+							if let Some(limit) = fields.recurrence_limit {
+								if data.next_recurrence_counter >= limit.0 {
+									return false;
+								}
+							}
+
+							// -------------------------------------------------------------
+							// 2. Paywindow expiry check
+							//
+							// Each recurrence period defines a payable window starting from
+							// the period's start time. If the next trigger occurs after the
+							// end of this window, the period went unpaid and the recurrence
+							// session becomes void.
+							//
+							// If no explicit paywindow is defined, the full recurrence
+							// period length is treated as the payable window.
+							// -------------------------------------------------------------
+							let paywindow_secs = fields
+								.recurrence_paywindow
+								.map(|window| window.seconds_after as u64)
+								.unwrap_or(fields.recurrence.period_length_secs());
+
+							let window_end = fields
+								.recurrence
+								.start_time(recurrence_basetime, data.next_recurrence_counter)
+								+ paywindow_secs;
+
+							// Keep the session only if the trigger is still within
+							// the payable window.
+							trigger_time <= window_end
+						},
+
+						// -----------------------------------------------------------------
+						// Any other combination of basetime/trigger is invalid by design
+						// -----------------------------------------------------------------
+						_ => {
+							debug_assert!(
+								false,
+								"Invalid recurrence session state: inconsistent basetime/trigger"
+							);
+							false
+						},
+					}
+				});
+			}
+
+			{
+				let mut inbound_sessions = self.active_inbound_recurrence_sessions.lock().unwrap();
+
+				// -----------------------------------------------------------------------------
+				// Inbound Recurrence session cleanup
+				//
+				// We prune active inbound recurrence sessions that can no longer accept
+				// valid recurrence-enabled `invoice_request`s.
+				//
+				// A session becomes invalid if:
+				// 1. Its recurrence limit has been reached, OR
+				// 2. The valid time window for receiving the next `invoice_request`
+				//    has elapsed without a valid request being received.
+				// -----------------------------------------------------------------------------
+				inbound_sessions.retain(|_, data| {
+					// -------------------------------------------------------------
+					// 1. Recurrence limit check
+					//
+					// If the next expected recurrence counter has reached the
+					// offer-defined recurrence limit, the recurrence sequence is
+					// complete and the session must be removed.
+					// -------------------------------------------------------------
+					if let Some(limit) = data.recurrence_fields.recurrence_limit {
+						if data.next_payable_counter >= limit.0 {
+							return false;
+						}
+					}
+
+					// -------------------------------------------------------------
+					// 2. Invoice request window expiry check
+					//
+					// Each recurrence period defines a valid time window during which
+					// the next recurrence-enabled `invoice_request` may be received.
+					//
+					// If the current time has passed the end of this window without
+					// receiving a valid request, the period is considered missed and
+					// the recurrence session becomes void.
+					// -------------------------------------------------------------
+					if now >= data.next_invoice_request_window.1 {
+						return false;
+					}
+
+					true
+				});
+			}
+
+
 			// Periodically scan active outbound recurrence sessions and trigger payments
 			// whose scheduled execution time has arrived.
 			//

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -8410,6 +8410,40 @@ where
 				should_persist = NotifyOption::DoPersist;
 			}
 
+			let now = duration_since_epoch.as_secs();
+
+			// Periodically scan active outbound recurrence sessions and trigger payments
+			// whose scheduled execution time has arrived.
+			//
+			// If a session's `next_trigger_time` has passed, we attempt the payment for the
+			// current recurrence cycle using `pay_for_recurrence`. A fresh `PaymentId` is
+			// generated so the attempt can be tracked independently.
+			//
+			// After triggering the payment we temporarily push the `next_trigger_time`
+			// forward by 30 seconds. This acts as a simple retry interval, allowing us to
+			// reattempt the same recurrence cycle if the payment fails or does not complete.
+			// The actual recurrence schedule will be updated once the cycle successfully
+			// completes.
+			{
+				let mut sessions = self.active_outbound_recurrence_sessions.lock().unwrap();
+
+				for (recurrence_id, data) in sessions.iter_mut() {
+					let payment_id = PaymentId(self.entropy_source.get_secure_random_bytes());
+
+					if data.next_trigger_time <= Some(now) {
+						let _ = self.pay_for_recurrence(
+							*recurrence_id,
+							None,
+							payment_id,
+							OptionalOfferPaymentParams::default(),
+						);
+
+						// Retry again in 30 seconds if the current cycle has not completed.
+						data.next_trigger_time = Some(now.saturating_add(30));
+					}
+				}
+			}
+
 			should_persist
 		});
 	}
@@ -13229,6 +13263,114 @@ where
 			recurrence_start,
 			create_pending_payment_fn,
 		)
+	}
+
+	/// Continues an active BOLT12 recurrence by sending the next invoice request.
+	///
+	/// Unlike [`pay_for_offer_with_recurrence`], which initiates a one-off payment
+	/// (or the primary request of a recurrence), this method operates on an existing
+	/// outbound recurrence session identified by `recurrence_id`.
+	///
+	/// The payer reuses the stored recurrence context to:
+	/// - derive a stable payer signing key,
+	/// - populate the next expected recurrence counter,
+	/// - and construct a correctly-linked `InvoiceRequest` for the next period.
+	///
+	/// This API enforces recurrence continuity by requiring an existing
+	/// recurrence session and rejecting attempts to pay unknown or expired
+	/// recurrences.
+	///
+	/// Returns an error if the recurrence does not exist, the payment ID is
+	/// duplicated, or the invoice request cannot be constructed or enqueued.
+	pub fn pay_for_recurrence(
+		&self, recurrence_id: RecurrenceId, amount_msats: Option<u64>, payment_id: PaymentId,
+		optional_params: OptionalOfferPaymentParams,
+	) -> Result<(), Bolt12SemanticError> {
+		let sessions = self.active_outbound_recurrence_sessions.lock().unwrap();
+
+		let data = match sessions.get(&recurrence_id) {
+			None => return Err(Bolt12SemanticError::InvalidRecurrence),
+			Some(data) => data
+		};
+
+		let create_pending_payment_fn = |retryable_invoice_request: RetryableInvoiceRequest| {
+			self.pending_outbound_payments
+				.add_new_awaiting_invoice(
+					payment_id,
+					StaleExpiration::TimerTicks(1),
+					optional_params.retry_strategy,
+					optional_params.route_params_config,
+					Some(retryable_invoice_request),
+				)
+				.map_err(|_| Bolt12SemanticError::DuplicatePaymentId)
+		};
+
+		let entropy = &*self.entropy_source;
+		let nonce = Nonce::from_entropy_source(entropy);
+		let expanded_key = &self.inbound_payment_key;
+		let secp_ctx = &self.secp_ctx;
+
+		let offer = &data.offer;
+		let quantity = if offer.expects_quantity() { Some(1) } else { None };
+
+		let keys = {
+			let mut seed = expanded_key.hmac_for_offer();
+			seed.input(&recurrence_id.0);
+
+			let hmac = Hmac::from_engine(seed);
+			let privkey = SecretKey::from_slice(hmac.as_byte_array()).unwrap();
+			Keypair::from_secret_key(secp_ctx, &privkey)
+		};
+
+		debug_assert_eq!(
+			keys.public_key(),
+			data.payer_signing_pubkey,
+			"Derived KeyPair does not match the payer signing public key"
+		);
+
+		let builder = offer.
+			request_invoice_with_explicit_signing_pubkey(keys.public_key(), expanded_key, nonce, secp_ctx, payment_id)?;
+
+		let builder = builder.chain_hash(self.chain_hash)?;
+		let builder = builder.recurrence_counter(data.next_recurrence_counter);
+
+		let builder = match data.recurrence_start {
+			None => builder,
+			Some(start) => builder.recurrence_start(start)
+		};
+
+		let builder = match quantity {
+			None => builder,
+			Some(quantity) => builder.quantity(quantity)?,
+		};
+		let builder = match amount_msats {
+			None => builder,
+			Some(amount_msats) => builder.amount_msats(amount_msats)?,
+		};
+		let builder = match optional_params.payer_note {
+			None => builder,
+			Some(payer_note) => builder.payer_note(payer_note),
+		};
+
+		let invoice_request = builder.build()?
+			.sign(|message: &UnsignedInvoiceRequest|
+				Ok(secp_ctx.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+			).expect("failed verifying signature");
+
+		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(self);
+
+		self.flow.enqueue_invoice_request(
+			invoice_request.clone(), payment_id, nonce,
+			self.get_peers_for_blinded_path()
+		)?;
+
+		let retryable_invoice_request = RetryableInvoiceRequest {
+			invoice_request: invoice_request.clone(),
+			nonce,
+			needs_retry: true,
+		};
+
+		create_pending_payment_fn(retryable_invoice_request)
 	}
 
 	/// Pays for an [`Offer`] which was built by resolving a human readable name. It is otherwise

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -683,6 +683,7 @@ fn creates_and_pays_for_offer_using_two_hop_blinded_path() {
 			quantity: None,
 			payer_note_truncated: None,
 			human_readable_name: None,
+			recurrence_counter: None,
 		},
 	});
 	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
@@ -841,6 +842,7 @@ fn creates_and_pays_for_offer_using_one_hop_blinded_path() {
 			quantity: None,
 			payer_note_truncated: None,
 			human_readable_name: None,
+			recurrence_counter: None,
 		},
 	});
 	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
@@ -962,6 +964,7 @@ fn pays_for_offer_without_blinded_paths() {
 			quantity: None,
 			payer_note_truncated: None,
 			human_readable_name: None,
+			recurrence_counter: None,
 		},
 	});
 
@@ -1229,6 +1232,7 @@ fn creates_and_pays_for_offer_with_retry() {
 			quantity: None,
 			payer_note_truncated: None,
 			human_readable_name: None,
+			recurrence_counter: None,
 		},
 	});
 	assert_eq!(invoice_request.amount_msats(), Some(10_000_000));
@@ -1294,6 +1298,7 @@ fn pays_bolt12_invoice_asynchronously() {
 			quantity: None,
 			payer_note_truncated: None,
 			human_readable_name: None,
+			recurrence_counter: None,
 		},
 	});
 
@@ -1391,6 +1396,7 @@ fn creates_offer_with_blinded_path_using_unannounced_introduction_node() {
 			quantity: None,
 			payer_note_truncated: None,
 			human_readable_name: None,
+			recurrence_counter: None,
 		},
 	});
 	assert_ne!(invoice_request.payer_signing_pubkey(), bob_id);

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -2337,7 +2337,7 @@ fn fails_paying_invoice_with_unknown_required_features() {
 
 	let invoice = match verified_invoice_request {
 		InvoiceRequestVerifiedFromOffer::DerivedKeys(request) => {
-			request.respond_using_derived_keys_no_std(payment_paths, payment_hash, created_at).unwrap()
+			request.respond_using_derived_keys(payment_paths, payment_hash, created_at).unwrap()
 				.features_unchecked(Bolt12InvoiceFeatures::unknown())
 				.build_and_sign(&secp_ctx).unwrap()
 		},

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -3206,7 +3206,7 @@ mod tests {
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
 			.build_and_sign().unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), created_at).unwrap()
+			.respond_with(payment_paths(), payment_hash(), created_at).unwrap()
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 
@@ -3253,7 +3253,7 @@ mod tests {
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
 			.build_and_sign().unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now()).unwrap()
+			.respond_with(payment_paths(), payment_hash(), now()).unwrap()
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 
@@ -3316,7 +3316,7 @@ mod tests {
 			.build().unwrap()
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id).unwrap()
 			.build_and_sign().unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now()).unwrap()
+			.respond_with(payment_paths(), payment_hash(), now()).unwrap()
 			.build().unwrap()
 			.sign(recipient_sign).unwrap();
 

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -1987,6 +1987,11 @@ mod tests {
 					issuer: None,
 					quantity_max: None,
 					issuer_id: Some(&recipient_pubkey()),
+					recurrence_compulsory: None,
+					recurrence_optional: None,
+					recurrence_base: None,
+					recurrence_paywindow: None,
+					recurrence_limit: None,
 				},
 				InvoiceRequestTlvStreamRef {
 					chain: None,
@@ -2090,6 +2095,11 @@ mod tests {
 					issuer: None,
 					quantity_max: None,
 					issuer_id: None,
+					recurrence_compulsory: None,
+					recurrence_optional: None,
+					recurrence_base: None,
+					recurrence_paywindow: None,
+					recurrence_limit: None,
 				},
 				InvoiceRequestTlvStreamRef {
 					chain: None,

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -2002,6 +2002,9 @@ mod tests {
 					payer_note: None,
 					paths: None,
 					offer_from_hrn: None,
+					recurrence_counter: None,
+					recurrence_start: None,
+					recurrence_cancel: None,
 				},
 				InvoiceTlvStreamRef {
 					paths: Some(Iterable(
@@ -2110,6 +2113,9 @@ mod tests {
 					payer_note: None,
 					paths: None,
 					offer_from_hrn: None,
+					recurrence_counter: None,
+					recurrence_start: None,
+					recurrence_cancel: None,
 				},
 				InvoiceTlvStreamRef {
 					paths: Some(Iterable(

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -422,6 +422,7 @@ macro_rules! invoice_builder_methods {
 				fallbacks: None,
 				features: Bolt12InvoiceFeatures::empty(),
 				signing_pubkey,
+				invoice_recurrence_basetime: None,
 				#[cfg(test)]
 				experimental_baz: None,
 			}
@@ -437,6 +438,29 @@ macro_rules! invoice_builder_methods {
 			}
 
 			Ok(Self { invreq_bytes, invoice: contents, signing_pubkey_strategy })
+		}
+
+		/// Sets the `invoice_recurrence_basetime` inside the invoice contents.
+		///
+		/// This anchors the recurrence schedule for invoices produced in a
+		/// recurring-offer flow. Must be identical across all invoices in the
+		/// same recurrence session.
+		#[allow(dead_code)]
+		pub(crate) fn set_invoice_recurrence_basetime(
+			&mut $self,
+			basetime: u64
+		) {
+			match &mut $self.invoice {
+				InvoiceContents::ForOffer { fields, .. } => {
+					fields.invoice_recurrence_basetime = Some(basetime);
+				},
+				InvoiceContents::ForRefund { .. } => {
+					debug_assert!(
+						false,
+						"set_invoice_recurrence_basetime called on refund invoice"
+					);
+				}
+			}
 		}
 	};
 }
@@ -773,6 +797,36 @@ struct InvoiceFields {
 	fallbacks: Option<Vec<FallbackAddress>>,
 	features: Bolt12InvoiceFeatures,
 	signing_pubkey: PublicKey,
+	/// The recurrence anchor time (UNIX timestamp) for this invoice.
+	///
+	/// Semantics:
+	/// - If the offer specifies an explicit `recurrence_base`, this MUST equal it.
+	/// - If the offer does not specify a base, this MUST be the creation time
+	///   of the *first* invoice in the recurrence sequence.
+	///
+	/// Requirements:
+	/// - The payee must remember the basetime from the first invoice and reuse it
+	///   for all subsequent invoices in the recurrence.
+	/// - The payer must verify that the basetime in each invoice matches the
+	///   basetime of previously paid periods, ensuring a stable schedule.
+	///
+	/// Practical effect:
+	/// This timestamp anchors the recurrence period calculation for the entire
+	/// recurring-payment flow.
+	///
+	/// Spec Commentary:
+	/// The spec currently requires this field even when the offer already includes
+	/// its own `recurrence_base`. Since invoices are always prsent alongside their
+	/// offer, the basetime is already known. Duplicating it across offer → invoice
+	/// adds redundant equivalence checks without providing new information.
+	///
+	/// Possible simplification:
+	/// - Include `invoice_recurrence_basetime` **only when** the offer did *not* define one.
+	/// - Omit it otherwise and treat the offer as the single source of truth.
+	///
+	/// This avoids redundant duplication and simplifies validation while preserving
+	/// all necessary semantics.
+	invoice_recurrence_basetime: Option<u64>,
 	#[cfg(test)]
 	experimental_baz: Option<u64>,
 }
@@ -1402,6 +1456,7 @@ impl InvoiceFields {
 				features,
 				node_id: Some(&self.signing_pubkey),
 				message_paths: None,
+				invoice_recurrence_basetime: self.invoice_recurrence_basetime,
 			},
 			ExperimentalInvoiceTlvStreamRef {
 				#[cfg(test)]
@@ -1483,6 +1538,7 @@ tlv_stream!(InvoiceTlvStream, InvoiceTlvStreamRef<'a>, INVOICE_TYPES, {
 	(172, fallbacks: (Vec<FallbackAddress>, WithoutLength)),
 	(174, features: (Bolt12InvoiceFeatures, WithoutLength)),
 	(176, node_id: PublicKey),
+	(177, invoice_recurrence_basetime: (u64, HighZeroBytesDroppedBigSize)),
 	// Only present in `StaticInvoice`s.
 	(236, message_paths: (Vec<BlindedMessagePath>, WithoutLength)),
 });
@@ -1674,6 +1730,7 @@ impl TryFrom<PartialInvoiceTlvStream> for InvoiceContents {
 				features,
 				node_id,
 				message_paths,
+				invoice_recurrence_basetime,
 			},
 			experimental_offer_tlv_stream,
 			experimental_invoice_request_tlv_stream,
@@ -1713,6 +1770,7 @@ impl TryFrom<PartialInvoiceTlvStream> for InvoiceContents {
 			fallbacks,
 			features,
 			signing_pubkey,
+			invoice_recurrence_basetime,
 			#[cfg(test)]
 			experimental_baz,
 		};
@@ -1720,6 +1778,11 @@ impl TryFrom<PartialInvoiceTlvStream> for InvoiceContents {
 		check_invoice_signing_pubkey(&fields.signing_pubkey, &offer_tlv_stream)?;
 
 		if offer_tlv_stream.issuer_id.is_none() && offer_tlv_stream.paths.is_none() {
+			// Recurrence should not be present in Refund.
+			if fields.invoice_recurrence_basetime.is_some() {
+				return Err(Bolt12SemanticError::InvalidAmount);
+			}
+
 			let refund = RefundContents::try_from((
 				payer_tlv_stream,
 				offer_tlv_stream,
@@ -1741,6 +1804,61 @@ impl TryFrom<PartialInvoiceTlvStream> for InvoiceContents {
 				experimental_offer_tlv_stream,
 				experimental_invoice_request_tlv_stream,
 			))?;
+
+			// Recurrence checks
+			if let Some(offer_recurrence) = invoice_request.inner.offer.recurrence_fields() {
+				// 1. MUST have basetime whenever offer has recurrence (optional or compulsory).
+				let invoice_basetime = match fields.invoice_recurrence_basetime {
+					Some(ts) => ts,
+					None => {
+						return Err(Bolt12SemanticError::InvalidMetadata);
+					},
+				};
+
+				let offer_base = offer_recurrence.recurrence_base;
+				let counter = invoice_request.recurrence_counter();
+
+				match counter {
+					// ----------------------------------------------------------------------
+					// Case A: No counter (payer does NOT support recurrence)
+					// Treat as single-payment invoice.
+					// Basetime MUST still match presence rules (spec), but nothing else here.
+					// ----------------------------------------------------------------------
+					None => {
+						// Nothing else to validate.
+						// This invoice is not part of a recurrence sequence.
+					},
+					// ------------------------------------------------------------------
+					// Case B: First recurrence invoice (counter = 0)
+					// ------------------------------------------------------------------
+					Some(0) => {
+						match offer_base {
+							// Offer defines explicit basetime → MUST match exactly
+							Some(base) => {
+								if invoice_basetime != base.basetime {
+									return Err(Bolt12SemanticError::InvalidMetadata);
+								}
+							},
+
+							// Offer has no basetime → MUST match invoice.created_at
+							None => {
+								if invoice_basetime != fields.created_at.as_secs() {
+									return Err(Bolt12SemanticError::InvalidMetadata);
+								}
+							},
+						}
+					},
+					// ------------------------------------------------------------------
+					// Case C: Successive recurrence invoices (counter > 0)
+					// ------------------------------------------------------------------
+					Some(_counter_gt_0) => {
+						// Spec says SHOULD check equality with previous invoice basetime.
+						// We cannot enforce that here. MUST be done upstream.
+						//
+						// TODO: Enforce SHOULD: invoice_basetime == previous_invoice_basetime
+					},
+				}
+			}
 
 			if let Some(requested_amount_msats) = invoice_request.amount_msats() {
 				if amount_msats != requested_amount_msats {
@@ -2019,6 +2137,7 @@ mod tests {
 					features: None,
 					node_id: Some(&recipient_pubkey()),
 					message_paths: None,
+					invoice_recurrence_basetime: None,
 				},
 				SignatureTlvStreamRef { signature: Some(&invoice.signature()) },
 				ExperimentalOfferTlvStreamRef { experimental_foo: None },
@@ -2130,6 +2249,7 @@ mod tests {
 					features: None,
 					node_id: Some(&recipient_pubkey()),
 					message_paths: None,
+					invoice_recurrence_basetime: None,
 				},
 				SignatureTlvStreamRef { signature: Some(&invoice.signature()) },
 				ExperimentalOfferTlvStreamRef { experimental_foo: None },

--- a/lightning/src/offers/invoice.rs
+++ b/lightning/src/offers/invoice.rs
@@ -47,18 +47,7 @@
 //! // Invoice for the "offer to be paid" flow.
 //! # <InvoiceBuilder<ExplicitSigningPubkey>>::from(
 //! InvoiceRequest::try_from(bytes)?
-#![cfg_attr(
-	feature = "std",
-	doc = "
-    .respond_with(payment_paths, payment_hash)?
-"
-)]
-#![cfg_attr(
-	not(feature = "std"),
-	doc = "
-    .respond_with_no_std(payment_paths, payment_hash, core::time::Duration::from_secs(0))?
-"
-)]
+//! 	.respond_with(payment_paths, payment_hash, core::time::Duration::from_secs(0))?
 //! # )
 //!     .relative_expiry(3600)
 //!     .allow_mpp()
@@ -86,18 +75,7 @@
 //! # <InvoiceBuilder<ExplicitSigningPubkey>>::from(
 //! "lnr1qcp4256ypq"
 //!     .parse::<Refund>()?
-#![cfg_attr(
-	feature = "std",
-	doc = "
-    .respond_with(payment_paths, payment_hash, pubkey)?
-"
-)]
-#![cfg_attr(
-	not(feature = "std"),
-	doc = "
-    .respond_with_no_std(payment_paths, payment_hash, pubkey, core::time::Duration::from_secs(0))?
-"
-)]
+//! 	.respond_with(payment_paths, payment_hash, pubkey, core::time::Duration::from_secs(0))?
 //! # )
 //!     .relative_expiry(3600)
 //!     .allow_mpp()
@@ -1995,7 +1973,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths.clone(), payment_hash, now)
+			.respond_with(payment_paths.clone(), payment_hash, now)
 			.unwrap()
 			.build()
 			.unwrap();
@@ -2160,7 +2138,7 @@ mod tests {
 			.unwrap()
 			.build()
 			.unwrap()
-			.respond_with_no_std(payment_paths.clone(), payment_hash, recipient_pubkey(), now)
+			.respond_with(payment_paths.clone(), payment_hash, recipient_pubkey(), now)
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2263,7 +2241,6 @@ mod tests {
 		}
 	}
 
-	#[cfg(feature = "std")]
 	#[test]
 	fn builds_invoice_from_offer_with_expiration() {
 		let expanded_key = ExpandedKey::new([42; 32]);
@@ -2284,7 +2261,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with(payment_paths(), payment_hash())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 		{
@@ -2299,7 +2276,7 @@ mod tests {
 			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
 			.unwrap()
 			.build_unchecked_and_sign()
-			.respond_with(payment_paths(), payment_hash())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 		{
@@ -2308,7 +2285,6 @@ mod tests {
 		}
 	}
 
-	#[cfg(feature = "std")]
 	#[test]
 	fn builds_invoice_from_refund_with_expiration() {
 		let future_expiry = Duration::from_secs(u64::max_value());
@@ -2319,7 +2295,7 @@ mod tests {
 			.absolute_expiry(future_expiry)
 			.build()
 			.unwrap()
-			.respond_with(payment_paths(), payment_hash(), recipient_pubkey())
+			.respond_with(payment_paths(), payment_hash(), recipient_pubkey(), now())
 			.unwrap()
 			.build()
 		{
@@ -2331,7 +2307,7 @@ mod tests {
 			.absolute_expiry(past_expiry)
 			.build()
 			.unwrap()
-			.respond_with(payment_paths(), payment_hash(), recipient_pubkey())
+			.respond_with(payment_paths(), payment_hash(), recipient_pubkey(), now())
 			.unwrap()
 			.build()
 		{
@@ -2380,7 +2356,7 @@ mod tests {
 		match verified_request {
 			InvoiceRequestVerifiedFromOffer::DerivedKeys(req) => {
 				let invoice = req
-					.respond_using_derived_keys_no_std(payment_paths(), payment_hash(), now())
+					.respond_using_derived_keys(payment_paths(), payment_hash(), now())
 					.unwrap()
 					.build_and_sign(&secp_ctx);
 
@@ -2412,7 +2388,7 @@ mod tests {
 			.unwrap();
 
 		if let Err(e) = refund
-			.respond_using_derived_keys_no_std(
+			.respond_using_derived_keys(
 				payment_paths(),
 				payment_hash(),
 				now(),
@@ -2449,7 +2425,7 @@ mod tests {
 			.unwrap();
 
 		let invoice = refund
-			.respond_using_derived_keys_no_std(
+			.respond_using_derived_keys(
 				payment_paths(),
 				payment_hash(),
 				now(),
@@ -2482,7 +2458,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now)
+			.respond_with(payment_paths(), payment_hash(), now)
 			.unwrap()
 			.relative_expiry(one_hour.as_secs() as u32)
 			.build()
@@ -2503,7 +2479,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now - one_hour)
+			.respond_with(payment_paths(), payment_hash(), now - one_hour)
 			.unwrap()
 			.relative_expiry(one_hour.as_secs() as u32 - 1)
 			.build()
@@ -2535,7 +2511,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2565,7 +2541,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2585,7 +2561,7 @@ mod tests {
 			.quantity(u64::max_value())
 			.unwrap()
 			.build_unchecked_and_sign()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 		{
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
@@ -2613,7 +2589,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.fallback_v0_p2wsh(&script.wscript_hash())
 			.fallback_v0_p2wpkh(&pubkey.wpubkey_hash().unwrap())
@@ -2669,7 +2645,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.allow_mpp()
 			.build()
@@ -2697,7 +2673,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2715,7 +2691,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2742,7 +2718,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2819,7 +2795,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2863,7 +2839,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.relative_expiry(3600)
 			.build()
@@ -2896,7 +2872,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2940,7 +2916,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -2982,7 +2958,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.allow_mpp()
 			.build()
@@ -3025,11 +3001,10 @@ mod tests {
 			.build_and_sign()
 			.unwrap();
 		#[cfg(not(c_bindings))]
-		let invoice_builder =
-			invoice_request.respond_with_no_std(payment_paths(), payment_hash(), now()).unwrap();
+		let invoice_builder = invoice_request.respond_with(payment_paths(), payment_hash(), now()).unwrap();
 		#[cfg(c_bindings)]
 		let mut invoice_builder =
-			invoice_request.respond_with_no_std(payment_paths(), payment_hash(), now()).unwrap();
+			invoice_request.respond_with(payment_paths(), payment_hash(), now()).unwrap();
 		let invoice_builder = invoice_builder
 			.fallback_v0_p2wsh(&script.wscript_hash())
 			.fallback_v0_p2wpkh(&pubkey.wpubkey_hash().unwrap())
@@ -3088,7 +3063,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3175,12 +3150,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std_using_signing_pubkey(
-				payment_paths(),
-				payment_hash(),
-				now(),
-				pubkey(46),
-			)
+			.respond_with_using_signing_pubkey(payment_paths(), payment_hash(), now(), pubkey(46))
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3205,7 +3175,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std_using_signing_pubkey(
+			.respond_with_using_signing_pubkey(
 				payment_paths(),
 				payment_hash(),
 				now(),
@@ -3247,7 +3217,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.amount_msats_unchecked(2000)
 			.build()
@@ -3276,7 +3246,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.amount_msats_unchecked(2000)
 			.build()
@@ -3299,7 +3269,7 @@ mod tests {
 			.unwrap()
 			.build()
 			.unwrap()
-			.respond_using_derived_keys_no_std(
+			.respond_using_derived_keys(
 				payment_paths(),
 				payment_hash(),
 				now(),
@@ -3340,7 +3310,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3373,7 +3343,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3416,7 +3386,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap();
@@ -3455,7 +3425,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap();
@@ -3501,7 +3471,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.experimental_baz(42)
 			.build()
@@ -3527,7 +3497,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap();
@@ -3568,7 +3538,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap();
@@ -3606,7 +3576,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3647,7 +3617,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3682,7 +3652,7 @@ mod tests {
 			.unwrap()
 			.build_and_sign()
 			.unwrap()
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3730,7 +3700,7 @@ mod tests {
 			.unwrap();
 
 		let invoice = invoice_request
-			.respond_with_no_std(payment_paths(), payment_hash(), now())
+			.respond_with(payment_paths(), payment_hash(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3746,7 +3716,7 @@ mod tests {
 			RefundBuilder::new(vec![1; 32], payer_pubkey(), 1000).unwrap().build().unwrap();
 
 		let invoice = refund
-			.respond_with_no_std(payment_paths(), payment_hash(), recipient_pubkey(), now())
+			.respond_with(payment_paths(), payment_hash(), recipient_pubkey(), now())
 			.unwrap()
 			.build()
 			.unwrap()
@@ -3776,7 +3746,7 @@ mod tests {
 			.unwrap();
 
 		let invoice = invoice_request
-			.respond_with_no_std(payment_paths, payment_hash(), now)
+			.respond_with(payment_paths, payment_hash(), now)
 			.unwrap()
 			.build()
 			.unwrap()

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -1647,6 +1647,11 @@ mod tests {
 					issuer: None,
 					quantity_max: None,
 					issuer_id: Some(&recipient_pubkey()),
+					recurrence_compulsory: None,
+					recurrence_optional: None,
+					recurrence_base: None,
+					recurrence_paywindow: None,
+					recurrence_limit: None,
 				},
 				InvoiceRequestTlvStreamRef {
 					chain: None,

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -186,7 +186,8 @@ macro_rules! invoice_request_builder_methods { (
 		InvoiceRequestContentsWithoutPayerSigningPubkey {
 			payer: PayerContents(metadata), offer, chain: None, amount_msats: None,
 			features: InvoiceRequestFeatures::empty(), quantity: None, payer_note: None,
-			offer_from_hrn: None,
+			offer_from_hrn: None, recurrence_counter: None, recurrence_start: None,
+			recurrence_cancel: None,
 			#[cfg(test)]
 			experimental_bar: None,
 		}
@@ -252,6 +253,31 @@ macro_rules! invoice_request_builder_methods { (
 	/// Successive calls to this method will override the previous setting.
 	pub fn sourced_from_human_readable_name($($self_mut)* $self: $self_type, hrn: HumanReadableName) -> $return_type {
 		$self.invoice_request.offer_from_hrn = Some(hrn);
+		$return_value
+	}
+
+	/// Sets the [`InvoiceRequest::recurrence_counter`].
+	///
+	/// Successive calls to this method override the previous setting.
+	pub fn recurrence_counter($($self_mut)* $self: $self_type, counter: u32) -> $return_type {
+		$self.invoice_request.recurrence_counter = Some(counter);
+		$return_value
+	}
+
+	/// Sets the [`InvoiceRequest::recurrence_start`].
+	///
+	/// Successive calls to this method override the previous setting.
+	pub fn recurrence_start($($self_mut)* $self: $self_type, start: u32) -> $return_type {
+		$self.invoice_request.recurrence_start = Some(start);
+		$return_value
+	}
+
+	/// Marks this invoice request as a recurrence cancellation.
+	///
+	/// MUST NOT be used on the first invoice request (`recurrence_counter = 0`).
+	/// Successive calls override the previous setting.
+	pub fn recurrence_cancel($($self_mut)* $self: $self_type) -> $return_type {
+		$self.invoice_request.recurrence_cancel = Some(());
 		$return_value
 	}
 
@@ -686,6 +712,36 @@ pub(super) struct InvoiceRequestContentsWithoutPayerSigningPubkey {
 	quantity: Option<u64>,
 	payer_note: Option<String>,
 	offer_from_hrn: Option<HumanReadableName>,
+	/// Recurrence counter for this invoice request.
+	///
+	/// This is the Nth invoice request the payer is making for this offer.
+	/// Important: this does *not* necessarily equal the Nth period of the recurrence.
+	///
+	/// The actual period index is:
+	///     period_index = recurrence_start + recurrence_counter
+	///
+	/// The counter implicitly assumes that all earlier payments
+	/// (0 .. recurrence_counter-1) were successfully completed.
+	/// The payee does not track past payments; it simply verifies
+	/// that the incoming counter is the next expected one.
+	recurrence_counter: Option<u32>,
+	/// Starting offset into the recurrence schedule.
+	///
+	/// Example: If the offer has a basetime of Jan 1st and recurrence period
+	/// is monthly, and the payer wants to begin on April 1st, then:
+	///     recurrence_start = 3
+	///
+	/// This field is only meaningful for offers that define a `recurrence_base`,
+	/// since offset is defined relative to a fixed basetime.
+	recurrence_start: Option<u32>,
+	/// Indicates that the payer wishes to *cancel* the recurrence.
+	///
+	/// MUST NOT be set on the first invoice request (counter = 0).
+	///
+	/// When this field is present, the request is effectively a cancellation
+	/// message; the payee should send invoice corresponding to this stub
+	/// invoice_request.
+	recurrence_cancel: Option<()>,
 	#[cfg(test)]
 	experimental_bar: Option<u64>,
 }
@@ -734,6 +790,30 @@ macro_rules! invoice_request_accessors { ($self: ident, $contents: expr) => {
 	/// A possibly transient pubkey used to sign the invoice request.
 	pub fn payer_signing_pubkey(&$self) -> PublicKey {
 		$contents.payer_signing_pubkey()
+	}
+
+	/// Returns the recurrence counter for this invoice request, if present.
+	///
+	/// This indicates which request in the recurrence sequence this is.
+	/// `None` means the invoice request is not part of a recurrence flow.
+	pub fn recurrence_counter(&$self) -> Option<u32> {
+		$contents.recurrence_counter()
+	}
+
+	/// Returns the recurrence start offset, if present.
+	///
+	/// This is only set when the offer defines an absolute recurrence basetime.
+	/// It indicates from which period the payer wishes to begin.
+	pub fn recurrence_start(&$self) -> Option<u32> {
+		$contents.recurrence_start()
+	}
+
+	/// Returns whether this invoice request is cancelling an ongoing recurrence.
+	///
+	/// `Some(())` means the payer wishes to cancel.
+	/// This MUST NOT be set on the initial request in a recurrence sequence.
+	pub fn recurrence_cancel(&$self) -> Option<()> {
+		$contents.recurrence_cancel()
 	}
 
 	/// A payer-provided note which will be seen by the recipient and reflected back in the invoice
@@ -1050,6 +1130,7 @@ macro_rules! fields_accessor {
 				inner: InvoiceRequestContentsWithoutPayerSigningPubkey {
 					quantity,
 					payer_note,
+					recurrence_counter,
 					..
 				},
 			} = &$inner;
@@ -1063,6 +1144,7 @@ macro_rules! fields_accessor {
 					// down to the nearest valid UTF-8 code point boundary.
 					.map(|s| UntrustedString(string_truncate_safe(s, PAYER_NOTE_LIMIT))),
 				human_readable_name: $self.offer_from_hrn().clone(),
+				recurrence_counter: *recurrence_counter,
 			}
 		}
 	};
@@ -1167,6 +1249,18 @@ impl InvoiceRequestContents {
 		self.inner.quantity
 	}
 
+	pub(super) fn recurrence_counter(&self) -> Option<u32> {
+		self.inner.recurrence_counter
+	}
+
+	pub(super) fn recurrence_start(&self) -> Option<u32> {
+		self.inner.recurrence_start
+	}
+
+	pub(super) fn recurrence_cancel(&self) -> Option<()> {
+		self.inner.recurrence_cancel
+	}
+
 	pub(super) fn payer_signing_pubkey(&self) -> PublicKey {
 		self.payer_signing_pubkey
 	}
@@ -1222,6 +1316,9 @@ impl InvoiceRequestContentsWithoutPayerSigningPubkey {
 			payer_note: self.payer_note.as_ref(),
 			offer_from_hrn: self.offer_from_hrn.as_ref(),
 			paths: None,
+			recurrence_counter: self.recurrence_counter,
+			recurrence_start: self.recurrence_start,
+			recurrence_cancel: self.recurrence_cancel.as_ref(),
 		};
 
 		let experimental_invoice_request = ExperimentalInvoiceRequestTlvStreamRef {
@@ -1282,6 +1379,9 @@ tlv_stream!(InvoiceRequestTlvStream, InvoiceRequestTlvStreamRef<'a>, INVOICE_REQ
 	// Only used for Refund since the onion message of an InvoiceRequest has a reply path.
 	(90, paths: (Vec<BlindedMessagePath>, WithoutLength)),
 	(91, offer_from_hrn: HumanReadableName),
+	(92, recurrence_counter: (u32, HighZeroBytesDroppedBigSize)),
+	(93, recurrence_start: (u32, HighZeroBytesDroppedBigSize)),
+	(94, recurrence_cancel: ()),
 });
 
 /// Valid type range for experimental invoice_request TLV records.
@@ -1434,6 +1534,9 @@ impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 				payer_note,
 				paths,
 				offer_from_hrn,
+				recurrence_counter,
+				recurrence_start,
+				recurrence_cancel,
 			},
 			experimental_offer_tlv_stream,
 			ExperimentalInvoiceRequestTlvStream {
@@ -1470,6 +1573,102 @@ impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 			return Err(Bolt12SemanticError::UnexpectedPaths);
 		}
 
+		let offer_recurrence = offer.recurrence_fields();
+		let offer_base = offer_recurrence.and_then(|f| f.recurrence_base);
+
+		match (
+			offer_recurrence,
+			offer_base,
+			recurrence_counter,
+			recurrence_start,
+			recurrence_cancel,
+		) {
+			// Offer without recurrence → No recurrence fields should be in IR
+			(None, None, None, None, None) => { /* OK */ },
+			// ------------------------------------------------------------
+			// Recurrence OPTIONAL (no basetime)
+			// ------------------------------------------------------------
+			// 1. No fields → treat as normal single payment. Supports backward compatibility.
+			// Spec Suggestion:
+			//
+			// Currently the reader MUST reject any invoice_request that omits
+			// `invreq_recurrence_counter` when the offer contains recurrence_optional
+			// or recurrence_compulsory.
+			// However, recurrence_optional is explicitly intended to preserve
+			// compatibility with payers that do not implement recurrence. Such payers
+			// should be able to make a single, non-recurring payment without setting
+			// any recurrence fields.
+			// Therefore, for recurrence_optional, it should be valid to omit all
+			// recurrence-related fields (counter, start, cancel), and the invoice
+			// request should be treated as a normal single payment.
+			(Some(_), None, None, None, None) => { /* OK */ },
+			// 2. Only counter → payer supports recurrence; starting at counter
+			(Some(_), None, Some(_), None, None) => { /* OK */ },
+			// 3. counter > 0 → allowed cancellation
+			(Some(_), None, Some(c), None, Some(())) if c > 0 => { /* OK */ },
+			// INVALID optional cases:
+			(Some(_), None, _, Some(_), _) => {
+				// recurrence_start MUST NOT appear without basetime
+				return Err(Bolt12SemanticError::InvalidMetadata);
+			},
+			(Some(_), None, Some(c), None, Some(())) if c == 0 => {
+				// cannot cancel first request
+				return Err(Bolt12SemanticError::InvalidMetadata);
+			},
+			(Some(_), None, _, _, _) => {
+				// All other recurrence optional combinations invalid
+				return Err(Bolt12SemanticError::InvalidMetadata);
+			},
+			// ------------------------------------------------------------
+			// Recurrence COMPULSORY (with basetime)
+			// ------------------------------------------------------------
+
+			// 1. First request: counter=0, start present, cancel absent
+			(Some(_), Some(_), Some(0), Some(_), None) => { /* OK */ },
+			// 2. Later periods: counter>0, start present, cancel MAY be present
+			(Some(_), Some(_), Some(c), Some(_), _cancel) if c > 0 => { /* OK */ },
+
+			// INVALID compulsory cases ------------------------------------
+			// Missing counter or start
+			(Some(_), Some(_), None, _, _) | (Some(_), Some(_), _, None, _) => {
+				return Err(Bolt12SemanticError::InvalidMetadata);
+			},
+			// Cancel on first request (counter=0)
+			(Some(_), Some(_), Some(c), Some(_), Some(())) if c == 0 => {
+				return Err(Bolt12SemanticError::InvalidMetadata);
+			},
+			// Any other recurrence compulsory combination is invalid
+			(Some(_), Some(_), _, _, _) => {
+				return Err(Bolt12SemanticError::InvalidMetadata);
+			},
+			// Any other combination is invalid
+			(_, _, _, _, _) => {
+				return Err(Bolt12SemanticError::InvalidMetadata);
+			},
+		}
+
+		// Limit, and Paywindow checks.
+		if let Some(fields) = &offer_recurrence {
+			if let Some(limit) = fields.recurrence_limit {
+				// Only enforce limit when recurrence is actually in use.
+				if let Some(counter) = recurrence_counter {
+					let offset = recurrence_start.unwrap_or(0);
+					let period_index = counter.saturating_add(offset);
+
+					if period_index > limit.0 {
+						return Err(Bolt12SemanticError::InvalidMetadata);
+					}
+				}
+			}
+			if let Some(_paywindow) = fields.recurrence_paywindow {
+				// TODO: implement once we compute:
+				// let period_start_time = ...
+				//
+				// if now < period_start_time - paywindow.seconds_before { ... }
+				// if now >= period_start_time + paywindow.seconds_after { ... }
+			}
+		}
+
 		Ok(InvoiceRequestContents {
 			inner: InvoiceRequestContentsWithoutPayerSigningPubkey {
 				payer,
@@ -1480,6 +1679,9 @@ impl TryFrom<PartialInvoiceRequestTlvStream> for InvoiceRequestContents {
 				quantity,
 				payer_note,
 				offer_from_hrn,
+				recurrence_counter,
+				recurrence_start,
+				recurrence_cancel,
 				#[cfg(test)]
 				experimental_bar,
 			},
@@ -1505,6 +1707,19 @@ pub struct InvoiceRequestFields {
 
 	/// The Human Readable Name which the sender indicated they were paying to.
 	pub human_readable_name: Option<HumanReadableName>,
+
+	/// If the invoice request belonged to a recurring offer, this field
+	/// contains the *recurrence counter* (zero-based).
+	///
+	/// Semantics:
+	/// - `None` means this payment is not part of a recurrence (either a
+	///   one-off request, or the payer does not understand recurrence).
+	/// - `Some(n)` means this payment corresponds to period `n`, where
+	///   `n` matches the invoice request's `invreq_recurrence_counter`.
+	///
+	/// This is consumed by the payee when the payment is actually claimed,
+	/// allowing the recurrence state to advance (`next_payable_counter += 1`).
+	pub recurrence_counter: Option<u32>,
 }
 
 /// The maximum number of characters included in [`InvoiceRequestFields::payer_note_truncated`].
@@ -1522,6 +1737,7 @@ impl Writeable for InvoiceRequestFields {
 			(1, self.human_readable_name, option),
 			(2, self.quantity.map(|v| HighZeroBytesDroppedBigSize(v)), option),
 			(4, self.payer_note_truncated.as_ref().map(|s| WithoutLength(&s.0)), option),
+			(6, self.recurrence_counter.map(|v| HighZeroBytesDroppedBigSize(v)), option),
 		});
 		Ok(())
 	}
@@ -1534,6 +1750,7 @@ impl Readable for InvoiceRequestFields {
 			(1, human_readable_name, option),
 			(2, quantity, (option, encoding: (u64, HighZeroBytesDroppedBigSize))),
 			(4, payer_note_truncated, (option, encoding: (String, WithoutLength))),
+			(6, recurrence_counter, (option, encoding: (u32, HighZeroBytesDroppedBigSize))),
 		});
 
 		Ok(InvoiceRequestFields {
@@ -1541,6 +1758,7 @@ impl Readable for InvoiceRequestFields {
 			quantity,
 			payer_note_truncated: payer_note_truncated.map(|s| UntrustedString(s)),
 			human_readable_name,
+			recurrence_counter,
 		})
 	}
 }
@@ -1662,6 +1880,9 @@ mod tests {
 					payer_note: None,
 					paths: None,
 					offer_from_hrn: None,
+					recurrence_counter: None,
+					recurrence_start: None,
+					recurrence_cancel: None,
 				},
 				SignatureTlvStreamRef { signature: Some(&invoice_request.signature()) },
 				ExperimentalOfferTlvStreamRef { experimental_foo: None },
@@ -3117,6 +3338,7 @@ mod tests {
 						quantity: Some(1),
 						payer_note_truncated: Some(UntrustedString(expected_payer_note)),
 						human_readable_name: None,
+						recurrence_counter: None,
 					}
 				);
 

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -138,7 +138,7 @@ pub struct InvoiceRequestWithDerivedPayerSigningPubkeyBuilder<'a, 'b> {
 	secp_ctx: Option<&'b Secp256k1<secp256k1::All>>,
 }
 
-macro_rules! invoice_request_derived_payer_signing_pubkey_builder_methods {
+macro_rules! invoice_request_building_methods {
 	(
 	$self: ident, $self_type: ty, $secp_context: ty
 ) => {
@@ -158,6 +158,22 @@ macro_rules! invoice_request_derived_payer_signing_pubkey_builder_methods {
 			}
 		}
 
+		#[cfg_attr(c_bindings, allow(dead_code))]
+		pub(super) fn explicit_signing_pubkey(
+			offer: &'a Offer, payer_signing_pubkey: PublicKey, expanded_key: &ExpandedKey,
+			nonce: Nonce, secp_ctx: &'b Secp256k1<$secp_context>, payment_id: PaymentId,
+		) -> Self {
+			let payment_id = Some(payment_id);
+			let derivation_material = MetadataMaterial::new(nonce, expanded_key, payment_id);
+			let metadata = Metadata::Derived(derivation_material);
+			Self {
+				offer,
+				invoice_request: Self::create_contents(offer, metadata),
+				payer_signing_pubkey: Some(payer_signing_pubkey),
+				secp_ctx: Some(secp_ctx),
+			}
+		}
+
 		/// Builds a signed [`InvoiceRequest`] after checking for valid semantics.
 		pub fn build_and_sign($self: $self_type) -> Result<InvoiceRequest, Bolt12SemanticError> {
 			let (unsigned_invoice_request, keys, secp_ctx) = $self.build_with_checks()?;
@@ -173,6 +189,16 @@ macro_rules! invoice_request_derived_payer_signing_pubkey_builder_methods {
 				})
 				.unwrap();
 			Ok(invoice_request)
+		}
+
+		/// Builds an unsigned [`InvoiceRequest`] after checking for valid semantics. It can be signed
+		/// by [`UnsignedInvoiceRequest::sign`].
+		pub(crate) fn build(
+			$self: $self_type,
+		) -> Result<UnsignedInvoiceRequest, Bolt12SemanticError> {
+			let (unsigned_invoice_request, keys, _) = $self.build_with_checks()?;
+			debug_assert!(keys.is_none());
+			Ok(unsigned_invoice_request)
 		}
 	};
 }
@@ -427,7 +453,7 @@ macro_rules! invoice_request_builder_test_methods { (
 } }
 
 impl<'a, 'b, T: secp256k1::Signing> InvoiceRequestBuilder<'a, 'b, T> {
-	invoice_request_derived_payer_signing_pubkey_builder_methods!(self, Self, T);
+	invoice_request_building_methods!(self, Self, T);
 	invoice_request_builder_methods!(self, Self, Self, self, T, mut);
 
 	#[cfg(test)]
@@ -436,13 +462,13 @@ impl<'a, 'b, T: secp256k1::Signing> InvoiceRequestBuilder<'a, 'b, T> {
 
 #[cfg(all(c_bindings, not(test)))]
 impl<'a, 'b> InvoiceRequestWithDerivedPayerSigningPubkeyBuilder<'a, 'b> {
-	invoice_request_derived_payer_signing_pubkey_builder_methods!(self, &mut Self, secp256k1::All);
+	invoice_request_building_methods!(self, &mut Self, secp256k1::All);
 	invoice_request_builder_methods!(self, &mut Self, (), (), secp256k1::All);
 }
 
 #[cfg(all(c_bindings, test))]
 impl<'a, 'b> InvoiceRequestWithDerivedPayerSigningPubkeyBuilder<'a, 'b> {
-	invoice_request_derived_payer_signing_pubkey_builder_methods!(self, &mut Self, secp256k1::All);
+	invoice_request_building_methods!(self, &mut Self, secp256k1::All);
 	invoice_request_builder_methods!(self, &mut Self, &mut Self, self, secp256k1::All);
 	invoice_request_builder_test_methods!(self, &mut Self, &mut Self, self);
 }

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -391,6 +391,16 @@ macro_rules! offer_builder_methods { (
 		$return_value
 	}
 
+	/// Set the [Offer::recurrence_fields] for the offer.
+	///
+	/// Successive calls to this method will override the previous setting.
+	pub fn recurrence(
+		$($self_mut)* $self: $self_type, recurrence: RecurrenceFields,
+	) -> $return_type {
+		$self.offer.recurrence_fields = Some(recurrence);
+		$return_value
+	}
+
 	/// Sets the quantity of items for [`Offer::supported_quantity`]. If not called, defaults to
 	/// [`Quantity::One`].
 	///

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -701,7 +701,9 @@ impl Recurrence {
 			TimeUnit::Months => 2_592_000,
 		};
 
-		(self.period as u64).checked_mul(factor).expect("recurrence period length should not overflow.")
+		(self.period as u64)
+			.checked_mul(factor)
+			.expect("recurrence period length should not overflow.")
 	}
 
 	/// For a give period number, gives it start time in UNIX
@@ -924,6 +926,49 @@ impl_writeable_tlv_based!(InboundRecurrenceSessionData, {
 	(4, next_payable_counter, required),
 	(6, recurrence_basetime, required),
 	(8, next_invoice_request_window, required),
+});
+
+/// Contains all the information and state required to maintain an outbound
+/// recurrence sesssion flow.
+pub struct OutboundRecurrenceSessionData {
+	/// The offer corresponding to which this recurrence is.
+	///
+	/// We need to store the entire offer, because we need it for the creation
+	/// of successive invoice request (for reference, invoice request contains
+	/// it's own offer.)
+	///
+	/// Since we are storing the entire offer, here I opt for not storing the
+	/// Offer' recurrence fields separately, since we can access them directly
+	/// from offer's callers.
+	pub offer: Offer,
+	/// The payer signing public key used to sign the initial (primary)
+	/// invoice request, and consequently all successive invoice requests
+	/// in this recurrence session.
+	///
+	/// This is stored to:
+	/// - Keep the signing key readily available for future requests, and
+	/// - Ensure that any derived [`KeyPair`] continues to resolve to the same
+	///   payer signing public key.
+	pub payer_signing_pubkey: PublicKey,
+	/// The recurrence start we set with the primary invoice request we sent.
+	pub recurrence_start: Option<u32>,
+	/// The next payable counter of period for the payer.
+	pub next_recurrence_counter: u32,
+	/// The basetime of the first invoice of the recurrence.
+	/// If the offer doesn't define an offer_basetime, this will be set equal
+	/// to first invoice's invoice_recurrence_basetime, ones we receive it.
+	pub invoice_recurrence_basetime: Option<u64>,
+	/// Tracker that keeps track of when's the recurrence should be triggered (in UNIX).
+	pub next_trigger_time: Option<u64>,
+}
+
+impl_writeable_tlv_based!(OutboundRecurrenceSessionData, {
+	(0, offer, required),
+	(2, payer_signing_pubkey, required),
+	(4, recurrence_start, option),
+	(6, next_recurrence_counter, required),
+	(8, invoice_recurrence_basetime, required),
+	(10, next_trigger_time, required)
 });
 
 /// Represents the recurrence-related fields in an Offer.

--- a/lightning/src/offers/parse.rs
+++ b/lightning/src/offers/parse.rs
@@ -224,6 +224,10 @@ pub enum Bolt12SemanticError {
 	///
 	/// [`Refund`]: super::refund::Refund
 	UnexpectedHumanReadableName,
+	/// Recurrence was not expected but present.
+	UnexpectedRecurrence,
+	/// Recurrence was present but contains invalid values.
+	InvalidRecurrence,
 }
 
 impl From<CheckedHrpstringError> for Bolt12ParseError {

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -813,6 +813,9 @@ impl RefundContents {
 			payer_note: self.payer_note.as_ref(),
 			paths: self.paths.as_ref(),
 			offer_from_hrn: None,
+			recurrence_counter: None,
+			recurrence_start: None,
+			recurrence_cancel: None,
 		};
 
 		let experimental_offer = ExperimentalOfferTlvStreamRef {
@@ -938,6 +941,9 @@ impl TryFrom<RefundTlvStream> for RefundContents {
 				payer_note,
 				paths,
 				offer_from_hrn,
+				recurrence_counter,
+				recurrence_start,
+				recurrence_cancel,
 			},
 			ExperimentalOfferTlvStream {
 				#[cfg(test)]
@@ -1001,6 +1007,11 @@ impl TryFrom<RefundTlvStream> for RefundContents {
 		if offer_from_hrn.is_some() {
 			// Only offers can be resolved using Human Readable Names
 			return Err(Bolt12SemanticError::UnexpectedHumanReadableName);
+		}
+
+		if recurrence_counter.is_some() || recurrence_start.is_some() || recurrence_cancel.is_some()
+		{
+			return Err(Bolt12SemanticError::UnexpectedRecurrence);
 		}
 
 		let amount_msats = match amount {
@@ -1142,6 +1153,9 @@ mod tests {
 					payer_note: None,
 					paths: None,
 					offer_from_hrn: None,
+					recurrence_counter: None,
+					recurrence_start: None,
+					recurrence_cancel: None,
 				},
 				ExperimentalOfferTlvStreamRef { experimental_foo: None },
 				ExperimentalInvoiceRequestTlvStreamRef { experimental_bar: None },

--- a/lightning/src/offers/refund.rs
+++ b/lightning/src/offers/refund.rs
@@ -789,6 +789,11 @@ impl RefundContents {
 			issuer: self.issuer.as_ref(),
 			quantity_max: None,
 			issuer_id: None,
+			recurrence_compulsory: None,
+			recurrence_optional: None,
+			recurrence_base: None,
+			recurrence_paywindow: None,
+			recurrence_limit: None,
 		};
 
 		let features = {
@@ -918,6 +923,11 @@ impl TryFrom<RefundTlvStream> for RefundContents {
 				issuer,
 				quantity_max,
 				issuer_id,
+				recurrence_compulsory,
+				recurrence_optional,
+				recurrence_base,
+				recurrence_paywindow,
+				recurrence_limit,
 			},
 			InvoiceRequestTlvStream {
 				chain,
@@ -977,6 +987,15 @@ impl TryFrom<RefundTlvStream> for RefundContents {
 
 		if issuer_id.is_some() {
 			return Err(Bolt12SemanticError::UnexpectedIssuerSigningPubkey);
+		}
+
+		if recurrence_compulsory.is_some()
+			|| recurrence_optional.is_some()
+			|| recurrence_base.is_some()
+			|| recurrence_paywindow.is_some()
+			|| recurrence_limit.is_some()
+		{
+			return Err(Bolt12SemanticError::UnexpectedRecurrence);
 		}
 
 		if offer_from_hrn.is_some() {
@@ -1108,6 +1127,11 @@ mod tests {
 					issuer: None,
 					quantity_max: None,
 					issuer_id: None,
+					recurrence_compulsory: None,
+					recurrence_optional: None,
+					recurrence_base: None,
+					recurrence_paywindow: None,
+					recurrence_limit: None,
 				},
 				InvoiceRequestTlvStreamRef {
 					chain: None,

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -908,6 +908,11 @@ mod tests {
 					issuer: None,
 					quantity_max: None,
 					issuer_id: Some(&signing_pubkey),
+					recurrence_compulsory: None,
+					recurrence_optional: None,
+					recurrence_base: None,
+					recurrence_paywindow: None,
+					recurrence_limit: None,
 				},
 				InvoiceTlvStreamRef {
 					paths: Some(Iterable(

--- a/lightning/src/offers/static_invoice.rs
+++ b/lightning/src/offers/static_invoice.rs
@@ -474,6 +474,7 @@ impl InvoiceContents {
 			node_id: Some(&self.signing_pubkey),
 			amount: None,
 			payment_hash: None,
+			invoice_recurrence_basetime: None,
 		};
 
 		let experimental_invoice = ExperimentalInvoiceTlvStreamRef {
@@ -673,6 +674,7 @@ impl TryFrom<PartialInvoiceTlvStream> for InvoiceContents {
 				message_paths,
 				payment_hash,
 				amount,
+				invoice_recurrence_basetime,
 			},
 			experimental_offer_tlv_stream,
 			ExperimentalInvoiceTlvStream {
@@ -708,6 +710,11 @@ impl TryFrom<PartialInvoiceTlvStream> for InvoiceContents {
 		}
 		if offer_tlv_stream.chains.as_ref().map_or(0, |chains| chains.len()) > 1 {
 			return Err(Bolt12SemanticError::UnexpectedChain);
+		}
+
+		// Static invoices MUST NOT set recurrence.
+		if invoice_recurrence_basetime.is_some() {
+			return Err(Bolt12SemanticError::UnexpectedRecurrence);
 		}
 
 		Ok(InvoiceContents {
@@ -927,6 +934,7 @@ mod tests {
 					features: None,
 					node_id: Some(&signing_pubkey),
 					message_paths: Some(&paths),
+					invoice_recurrence_basetime: None,
 				},
 				SignatureTlvStreamRef { signature: Some(&invoice.signature()) },
 				ExperimentalOfferTlvStreamRef { experimental_foo: None },


### PR DESCRIPTION
Builds on #4245

# BOLT12 Recurrence: Proof-of-Concept Implementation (Payer Flow)

This PR extends the existing BOLT12 Recurrence Proof-of-Concept by implementing the payer-side recurrence flow in LDK. It builds on the payee-side recurrence draft, completing the end-to-end protocol loop by allowing a payer to initiate, continue, validate, cancel, and expire recurring payments against a recurrence-enabled Offer.

---

## What This PR Adds

### 1. Outbound Recurrence State (Payer Side)

Adds a minimal in-memory state tracker in `ChannelManager` to maintain outbound recurrence sessions. Each session records the original `Offer`, the payer signing public key, and the recurrence progress required to validate invoices and advance payments safely. This mirrors the inbound recurrence tracker introduced on the payee side and provides a single source of truth for payer-side recurrence flow.

---

### 2. Recurrence Initiation and Continuation APIs

Introduces explicit payer-side APIs for managing recurrence lifecycles:
- `pay_for_offer_with_recurrence` to initiate a recurrence by sending the primary invoice request and creating recurrence state.
- `pay_for_recurrence` to continue an active recurrence using stored session context.

This separation makes recurrence boundaries explicit and avoids overloading the existing one-off payment APIs.

---

### 3. Payer-Side Recurrence Invoice Handling

Adds payer-side validation for recurrence-enabled invoices. Incoming invoices are checked against outbound recurrence state to enforce counter continuity, basetime consistency, and period alignment. Recurrence state is advanced only after successful payment, preventing incorrect progression if invoices are produced but not settled.

---

### 4. Explicit Cancellation and Expiry

Adds support for explicit payer-side recurrence cancellation via a final invoice request carrying a cancellation signal. Also introduces time-based expiry logic for both outbound and inbound recurrence sessions, ensuring that sessions are removed once they are no longer payable or valid.

---

## Design Notes

### Intentional PoC Scope

As with the payee-side implementation, this PR makes deliberate simplifications to keep the logic auditable and reviewable. Recurrence state is not persisted across restarts, key handling is minimal, and period calculations are simplified. All such choices are documented inline.

---

## What This PR Does Not Implement Yet

- Production-grade recurrence key management  
- Persistent recurrence state  
- Full spec-accurate period calculations  

These are intentionally deferred to keep the payer flow focused.
