### PR TITLE
`NetworkGraph`: Update chan/node estimation numbers, determine pre-allocation dynamically on read

### DIFF
--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -1802,12 +1802,18 @@ where
 {
 	/// Creates a new, empty, network graph.
 	pub fn new(network: Network, logger: L) -> NetworkGraph<L> {
+		let (node_map_cap, chan_map_cap) = if matches!(network, Network::Bitcoin) {
+			(NODE_COUNT_ESTIMATE, CHAN_COUNT_ESTIMATE)
+		} else {
+			(0, 0)
+		};
+
 		Self {
 			secp_ctx: Secp256k1::verification_only(),
 			chain_hash: ChainHash::using_genesis_block(network),
 			logger,
-			channels: RwLock::new(IndexedMap::with_capacity(CHAN_COUNT_ESTIMATE)),
-			nodes: RwLock::new(IndexedMap::with_capacity(NODE_COUNT_ESTIMATE)),
+			channels: RwLock::new(IndexedMap::with_capacity(chan_map_cap)),
+			nodes: RwLock::new(IndexedMap::with_capacity(node_map_cap)),
 			next_node_counter: AtomicUsize::new(0),
 			removed_node_counters: Mutex::new(Vec::new()),
 			last_rapid_gossip_sync_timestamp: Mutex::new(None),


### PR DESCRIPTION
```
NetworkGraph: Update node and channel count estimates for Jan 2026
```

```
NetworkGraph: Determine pre-allocations using actual numbers when reading

When reading a persisted network graph, we previously pre-allocated our
default node/channels estimate count for the respective `IndexedMap`
capacities. However, this might unnecessarily allocate memory on
reading, for example if we have an (almost) empty network graph for one
reason or another. As we have the actual counts of persisted nodes and
channels available, we here simply opt to allocate these numbers (plus
15%). This will also ensure that our pre-allocations will keep
up-to-date over time as the network grows or shrinks.
```

```
NetworkGraph: One pre-allocate memory on mainnet

Previously, we'd always pre-allocate memory for the node and channel
maps based on mainnet numbers, even if we're on another network like
`Regest`. Here, we only apply the estimates if we're actually on
`Network::Bitcoin`, which should reduce the `NetworkGraph`'s memory
footprint considerably in tests.
```