### PR TITLE
Remove spurious debug assertion added in 0.2

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -8981,7 +8981,6 @@ where
 							update_fail_htlcs.len() + update_fail_malformed_htlcs.len(),
 							&self.context.channel_id);
 					} else {
-						debug_assert!(htlcs_to_fail.is_empty());
 						let reason = if self.context.channel_state.is_local_stfu_sent() {
 							"exits quiescence"
 						} else if self.context.channel_state.is_monitor_update_in_progress() {

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -971,7 +971,7 @@ pub fn get_revoke_commit_msgs<CM: AChannelManager, H: NodeHolder<CM = CM>>(
 				assert_eq!(node_id, recipient);
 				(*msg).clone()
 			},
-			_ => panic!("Unexpected event"),
+			_ => panic!("Unexpected event: {events:?}"),
 		},
 		match events[1] {
 			MessageSendEvent::UpdateHTLCs { ref node_id, ref channel_id, ref updates } => {
@@ -984,7 +984,7 @@ pub fn get_revoke_commit_msgs<CM: AChannelManager, H: NodeHolder<CM = CM>>(
 				assert!(updates.commitment_signed.iter().all(|cs| cs.channel_id == *channel_id));
 				updates.commitment_signed.clone()
 			},
-			_ => panic!("Unexpected event"),
+			_ => panic!("Unexpected event: {events:?}"),
 		},
 	)
 }


### PR DESCRIPTION
In 20877b3e229ffedee9483e2b021fdcb98c7a378a we added a `debug_assert`ion to validate that if we call
`maybe_free_holding_cell_htlcs` and it doesn't manage to generate a new commitment (implying `!can_generate_new_commitment()`) that we don't have any HTLCs to fail, but there was no reason for that, and its reachable.

Here we simply remove the spurious debug assertion and add a test that exercises it.