### PR TITLE
Defer MonitorUpdatingPersister writes to flush()

### DIFF
--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -824,6 +824,10 @@ impl<Signer: sign::ecdsa::EcdsaChannelSigner> Persist<Signer> for WatchtowerPers
 			monitor_name,
 		);
 	}
+
+	fn flush(&self, _count: usize) -> Result<Vec<(ChannelId, u64)>, io::Error> {
+		Ok(Vec::new())
+	}
 }
 
 pub struct TestPersister {
@@ -886,6 +890,10 @@ impl<Signer: sign::ecdsa::EcdsaChannelSigner> Persist<Signer> for TestPersister 
 		// remove the channel from the offchain_monitor_updates and chain_sync_monitor_persistences.
 		self.offchain_monitor_updates.lock().unwrap().remove(&monitor_name);
 		self.chain_sync_monitor_persistences.lock().unwrap().retain(|x| x != &monitor_name);
+	}
+
+	fn flush(&self, _count: usize) -> Result<Vec<(ChannelId, u64)>, io::Error> {
+		Ok(Vec::new())
 	}
 }
 


### PR DESCRIPTION
Update MonitorUpdatingPersister and MonitorUpdatingPersisterAsync to queue persist operations in memory instead of writing immediately to disk. The Persist trait methods now return ChannelMonitorUpdateStatus:: InProgress and the actual writes happen when flush() is called.

This fixes a race condition that could cause channel force closures: previously, if the node crashed after writing channel monitors but before writing the channel manager, the monitors would be ahead of the manager on restart. By deferring monitor writes until after the channel manager is persisted (via flush()), we ensure the manager is always at least as up-to-date as the monitors.

Key changes:
- Add PendingWrite enum to represent queued write/remove operations
- Add pending_writes queue to MonitorUpdatingPersisterAsyncInner
- Add flush() to Persist trait and ChainMonitor
- Update Persist impl to queue writes and return InProgress
- Call flush() in background processor after channel manager persistence
- Remove unused event_notifier from AsyncPersister