### PR TITLE
Treat offer_amount of 0 as equivalent to None

### DIFF
--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -2040,6 +2040,12 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::MissingAmount),
 		}
 
+		// An offer with amount_msats(0) must be rejected by the builder per BOLT 12.
+		match OfferBuilder::new(recipient_pubkey()).amount_msats(0).build() {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
+		}
+
 		match OfferBuilder::new(recipient_pubkey())
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -402,7 +402,7 @@ macro_rules! offer_builder_methods { (
 	pub fn build($($self_mut)* $self: $self_type) -> Result<Offer, Bolt12SemanticError> {
 		match $self.offer.amount {
 			Some(Amount::Bitcoin { amount_msats }) => {
-				if amount_msats > MAX_VALUE_MSAT {
+				if amount_msats == 0 || amount_msats > MAX_VALUE_MSAT {
 					return Err(Bolt12SemanticError::InvalidAmount);
 				}
 			},
@@ -1306,11 +1306,12 @@ impl TryFrom<FullOfferTlvStream> for OfferContents {
 
 		let amount = match (currency, amount) {
 			(None, None) => None,
-			(None, Some(amount_msats)) if amount_msats > MAX_VALUE_MSAT => {
+			(None, Some(amount_msats)) if amount_msats == 0 || amount_msats > MAX_VALUE_MSAT => {
 				return Err(Bolt12SemanticError::InvalidAmount);
 			},
 			(None, Some(amount_msats)) => Some(Amount::Bitcoin { amount_msats }),
 			(Some(_), None) => return Err(Bolt12SemanticError::MissingAmount),
+			(Some(_), Some(0)) => return Err(Bolt12SemanticError::InvalidAmount),
 			(Some(currency_bytes), Some(amount)) => {
 				let iso4217_code = CurrencyCode::new(currency_bytes)
 					.map_err(|_| Bolt12SemanticError::InvalidCurrencyCode)?;
@@ -1702,6 +1703,12 @@ mod tests {
 			Ok(_) => panic!("expected error"),
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
 		}
+
+		// An amount of 0 must be rejected per BOLT 12.
+		match OfferBuilder::new(pubkey(42)).amount_msats(0).build() {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidAmount),
+		}
 	}
 
 	#[test]
@@ -1972,6 +1979,59 @@ mod tests {
 			Err(e) => assert_eq!(
 				e,
 				Bolt12ParseError::InvalidSemantics(Bolt12SemanticError::InvalidCurrencyCode)
+			),
+		}
+
+		// An offer with amount=0 must be rejected per BOLT 12.
+		let mut tlv_stream = offer.as_tlv_stream();
+		tlv_stream.0.amount = Some(0);
+		tlv_stream.0.currency = None;
+
+		let mut encoded_offer = Vec::new();
+		tlv_stream.write(&mut encoded_offer).unwrap();
+
+		match Offer::try_from(encoded_offer) {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(
+				e,
+				Bolt12ParseError::InvalidSemantics(Bolt12SemanticError::InvalidAmount)
+			),
+		}
+
+		// An offer with amount=0 and a currency must also be rejected.
+		let mut tlv_stream = offer.as_tlv_stream();
+		tlv_stream.0.amount = Some(0);
+		tlv_stream.0.currency = Some(b"USD");
+
+		let mut encoded_offer = Vec::new();
+		tlv_stream.write(&mut encoded_offer).unwrap();
+
+		match Offer::try_from(encoded_offer) {
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(
+				e,
+				Bolt12ParseError::InvalidSemantics(Bolt12SemanticError::InvalidAmount)
+			),
+		}
+
+		// BOLT 12 test vectors: verify rejection of offers with amount=0 from their
+		// bech32 encoding (see bolt12/offers-test.json).
+		match "lno1pqqq5qqkyyp4he0fg7pqje62jmnq78cr0ashv4q06qql58tyd9rhp3t2wuyugtq".parse::<Offer>()
+		{
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(
+				e,
+				Bolt12ParseError::InvalidSemantics(Bolt12SemanticError::InvalidAmount)
+			),
+		}
+
+		match "lno1qcp4256ypqqq5qqkyyp4he0fg7pqje62jmnq78cr0ashv4q06qql58tyd9rhp3t2wuyugtq"
+			.parse::<Offer>()
+		{
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(
+				e,
+				Bolt12ParseError::InvalidSemantics(Bolt12SemanticError::InvalidAmount)
 			),
 		}
 	}


### PR DESCRIPTION
## Summary

- Normalize `offer_amount=0` to `None` in both the builder and parser for consistent internal representation
- An amount of zero has no practical meaning (you cannot pay zero), so treating it as "no amount specified" simplifies handling
- When parsing offers with `amount=0` (with or without currency), the amount is normalized to `None`

## Motivation

Per BOLT12, if no specific minimum amount is required, the `offer_amount` field should be omitted rather than set to zero. This change ensures offers with `amount=0` are handled gracefully rather than causing unexpected behavior downstream.

Spec clarification pending: https://github.com/lightning/bolts/issues/1314

## Test plan

- [x] Builder test: `amount_msats(0)` results in `amount() == None` and `as_tlv_stream().0.amount == None`
- [x] Roundtrip test: serialize and re-parse maintains `None` state
- [x] Parser tests: TLV with `amount=0` (with and without currency) results in `amount() == None`
- [x] Invoice request tests: offer with `amount=0` requires invoice request to provide amount