### PR TITLE
BOLT 12: Validate bech32 padding per BIP-173

### DIFF
--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -2528,5 +2528,12 @@ mod bolt12_tests {
 			"lno1pgx9getnwss8vetrw3hhyucsespjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq".parse::<Offer>(),
 			Err(Bolt12ParseError::Decode(DecodeError::InvalidValue)),
 		);
+
+		// Bech32 padding exceeds 4-bit limit (BOLT 12 test vector)
+		// See: https://github.com/lightning/bolts/pull/1312
+		assert!(matches!(
+			"lno1zcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pkseseq".parse::<Offer>(),
+			Err(Bolt12ParseError::InvalidPadding(_))
+		));
 	}
 }


### PR DESCRIPTION
## Summary

Add validation for bech32 padding in BOLT 12 offer parsing per BIP-173 which states:

> "Any incomplete group at the end MUST be 4 bits or less, MUST be all zeroes, and is discarded."

Previously, LDK would accept offers with invalid bech32 padding, while other implementations (Lightning-kmp, Eclair) correctly reject them. This was identified through differential fuzzing across Lightning implementations.

## Changes

- Call `validate_segwit_padding()` from the bech32 crate during offer parsing
- Add new `InvalidPadding` error variant to `Bolt12ParseError`
- Add test vector from the BOLT specification for invalid padding

## References

- Spec PR: https://github.com/lightning/bolts/pull/1312