### PR TITLE
Support async signing of interactive-tx initial commitment signatures

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -10216,7 +10216,6 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 				},
 			}
 
-			// TODO(dual_funding): For async signing support we need to hold back `tx_signatures` until the `commitment_signed` is ready.
 			if let Some(msg) = tx_signatures {
 				pending_msg_events.push(MessageSendEvent::SendTxSignatures {
 					node_id: counterparty_node_id,
@@ -12908,6 +12907,24 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					if let Some(msg) = msgs.funding_signed {
 						pending_msg_events
 							.push(MessageSendEvent::SendFundingSigned { node_id, msg });
+					}
+					if let Some(msg) = msgs.funding_commit_sig {
+						pending_msg_events.push(MessageSendEvent::UpdateHTLCs {
+							node_id,
+							channel_id,
+							updates: CommitmentUpdate {
+								update_add_htlcs: vec![],
+								update_fulfill_htlcs: vec![],
+								update_fail_htlcs: vec![],
+								update_fail_malformed_htlcs: vec![],
+								update_fee: None,
+								commitment_signed: vec![msg],
+							},
+						});
+					}
+					if let Some(msg) = msgs.tx_signatures {
+						pending_msg_events
+							.push(MessageSendEvent::SendTxSignatures { node_id, msg });
 					}
 					if let Some(msg) = msgs.closing_signed {
 						pending_msg_events


### PR DESCRIPTION
```
This commit allows for an async signer to immediately return upon a call
to `EcdsaChannelSigner::sign_counterparty_commitment` for the initial
commitment signatures of an interactively funded transaction, such that
they can call back in via `ChannelManager::signer_unblocked` once the
signatures are ready. This is done for both splices and dual-funded
channels, though note that the latter still require more work to be
integrated. Since `tx_signatures` must be sent only after exchanging
`commitment_signed`, we make sure to hold them back if they're ready to
be sent until our `commitment_signed` is also ready.
```

Depends on #4336.