### PR TITLE
(0.5) Deprecate legacy pending HTLC `ChannelManager` persistence

### DIFF
--- a/lightning-tests/Cargo.toml
+++ b/lightning-tests/Cargo.toml
@@ -15,6 +15,7 @@ lightning-types = { path = "../lightning-types", features = ["_test_utils"] }
 lightning-invoice = { path = "../lightning-invoice", default-features = false }
 lightning-macros = { path = "../lightning-macros" }
 lightning = { path = "../lightning", features = ["_test_utils"] }
+lightning_0_3 = { package = "lightning", git = "https://github.com/valentinewallace/rust-lightning", branch = "2026-02-dedup-htlc-fwd-data", features = ["_test_utils"] }
 lightning_0_2 = { package = "lightning", version = "0.2.0", features = ["_test_utils"] }
 lightning_0_1 = { package = "lightning", version = "0.1.7", features = ["_test_utils"] }
 lightning_0_0_125 = { package = "lightning", version = "0.0.125", features = ["_test_utils"] }

--- a/lightning-tests/src/lib.rs
+++ b/lightning-tests/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg_attr(test, macro_use)]
 extern crate lightning;
 
 #[cfg(all(test, not(taproot)))]

--- a/lightning-tests/src/upgrade_downgrade_tests.rs
+++ b/lightning-tests/src/upgrade_downgrade_tests.rs
@@ -51,6 +51,8 @@ use lightning_0_3::events::{
 };
 use lightning_0_3::expect_payment_claimable as expect_payment_claimable_0_3;
 use lightning_0_3::get_event_msg as get_event_msg_0_3;
+use lightning_0_3::get_monitor as get_monitor_0_3;
+use lightning_0_3::ln::channelmanager::PaymentId as PaymentId_0_3;
 use lightning_0_3::ln::functional_test_utils as lightning_0_3_utils;
 use lightning_0_3::ln::functional_test_utils::{
 	PaymentFailedConditions as PaymentFailedConditions_0_3, ReconnectArgs as ReconnectArgs_0_3,
@@ -60,21 +62,29 @@ use lightning_0_3::ln::funding::SpliceContribution as SpliceContribution_0_3;
 use lightning_0_3::ln::msgs::BaseMessageHandler as _;
 use lightning_0_3::ln::msgs::ChannelMessageHandler as _;
 use lightning_0_3::ln::msgs::MessageSendEvent as MessageSendEvent_0_3;
+use lightning_0_3::ln::outbound_payment::RecipientOnionFields as RecipientOnionFields_0_3;
 use lightning_0_3::ln::splicing_tests::lock_splice as lock_splice_0_3;
 use lightning_0_3::ln::splicing_tests::splice_channel as splice_channel_0_3;
 use lightning_0_3::ln::types::ChannelId as ChannelId_0_3;
 use lightning_0_3::reload_node as reload_node_0_3;
+use lightning_0_3::routing::router as router_0_3;
 use lightning_0_3::types::payment::{
 	PaymentHash as PaymentHash_0_3, PaymentPreimage as PaymentPreimage_0_3,
 	PaymentSecret as PaymentSecret_0_3,
 };
+use lightning_0_3::util::ser::Writeable as _;
 
 use lightning::chain::channelmonitor::{ANTI_REORG_DELAY, HTLC_FAIL_BACK_BUFFER};
 use lightning::check_spends;
 use lightning::events::{ClosureReason, Event};
+use lightning::expect_payment_claimable;
 use lightning::ln::functional_test_utils as lightning_local_utils;
+use lightning::ln::functional_test_utils::{ReconnectArgs, SendEvent};
+use lightning::ln::msgs::ChannelMessageHandler as _;
 use lightning::reload_node;
 use lightning::sign::OutputSpender;
+use lightning::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
+use lightning::util::ser::Writeable as _;
 
 use bitcoin::script::Builder;
 use bitcoin::secp256k1::Secp256k1;
@@ -768,6 +778,636 @@ fn do_upgrade_mid_htlc_forward(test: MidHtlcForwardCase) {
 			.unwrap();
 		nodes[1].node.process_pending_htlc_forwards();
 	}
+
+	let pay_secret = PaymentSecret_0_3(payment_secret_bytes);
+	let pay_hash = PaymentHash_0_3(payment_hash_bytes);
+	let pay_preimage = PaymentPreimage_0_3(payment_preimage_bytes);
+
+	lightning_0_3_utils::check_added_monitors(&nodes[1], 1);
+	let forward_event = SendEvent_0_3::from_node(&nodes[1]);
+	nodes[2].node.handle_update_add_htlc(node_b_id, &forward_event.msgs[0]);
+	let commitment = &forward_event.commitment_msg;
+	lightning_0_3_utils::do_commitment_signed_dance(&nodes[2], &nodes[1], commitment, false, false);
+
+	lightning_0_3_utils::expect_and_process_pending_htlcs(&nodes[2], false);
+	expect_payment_claimable_0_3!(nodes[2], pay_hash, pay_secret, 1_000_000);
+	lightning_0_3_utils::claim_payment(&nodes[0], &[&nodes[1], &nodes[2]], pay_preimage);
+}
+
+#[test]
+fn test_0_3_pending_forward_upgrade() {
+	// Tests upgrading from 0.3 with a pending HTLC forward.
+	// Phase 1: Create state in 0.3 with a pending forward (HTLC locked on inbound edge of node B)
+	// Phase 2: Reload with local lightning and complete the payment
+	let (node_a_ser, node_b_ser, node_c_ser, mon_a_1_ser, mon_b_1_ser, mon_b_2_ser, mon_c_1_ser);
+	let (node_a_id, node_b_id, _node_c_id);
+	let (payment_secret_bytes, payment_hash_bytes, payment_preimage_bytes);
+
+	{
+		let chanmon_cfgs = lightning_0_3_utils::create_chanmon_cfgs(3);
+		let node_cfgs = lightning_0_3_utils::create_node_cfgs(3, &chanmon_cfgs);
+		let node_chanmgrs =
+			lightning_0_3_utils::create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+		let nodes = lightning_0_3_utils::create_network(3, &node_cfgs, &node_chanmgrs);
+
+		node_a_id = nodes[0].node.get_our_node_id();
+		node_b_id = nodes[1].node.get_our_node_id();
+		_node_c_id = nodes[2].node.get_our_node_id();
+		let chan_id_a = lightning_0_3_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 0, 1, 10_000_000, 0,
+		)
+		.2;
+
+		let chan_id_b = lightning_0_3_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 1, 2, 50_000, 0,
+		)
+		.2;
+
+		// Ensure all nodes are at the same initial height.
+		let node_max_height = nodes.iter().map(|node| node.best_block_info().1).max().unwrap();
+		for node in &nodes {
+			let blocks_to_mine = node_max_height - node.best_block_info().1;
+			if blocks_to_mine > 0 {
+				lightning_0_3_utils::connect_blocks(node, blocks_to_mine);
+			}
+		}
+
+		// Initiate an HTLC to be sent over node_a -> node_b -> node_c
+		let (preimage, hash, secret) =
+			lightning_0_3_utils::get_payment_preimage_hash(&nodes[2], Some(1_000_000), None);
+		payment_preimage_bytes = preimage.0;
+		payment_hash_bytes = hash.0;
+		payment_secret_bytes = secret.0;
+
+		let pay_params = router_0_3::PaymentParameters::from_node_id(
+			_node_c_id,
+			lightning_0_3_utils::TEST_FINAL_CLTV,
+		)
+		.with_bolt11_features(nodes[2].node.bolt11_invoice_features())
+		.unwrap();
+
+		let route_params =
+			router_0_3::RouteParameters::from_payment_params_and_value(pay_params, 1_000_000);
+		let route = lightning_0_3_utils::get_route(&nodes[0], &route_params).unwrap();
+
+		let onion = RecipientOnionFields_0_3::secret_only(secret);
+		let id = PaymentId_0_3(hash.0);
+		nodes[0].node.send_payment_with_route(route, hash, onion, id).unwrap();
+
+		lightning_0_3_utils::check_added_monitors(&nodes[0], 1);
+		let send_event = SendEvent_0_3::from_node(&nodes[0]);
+
+		// Lock in the HTLC on the inbound edge of node_b without initiating the outbound edge.
+		nodes[1].node.handle_update_add_htlc(node_a_id, &send_event.msgs[0]);
+		lightning_0_3_utils::do_commitment_signed_dance(
+			&nodes[1],
+			&nodes[0],
+			&send_event.commitment_msg,
+			false,
+			false,
+		);
+		// Process the pending update_add_htlcs but don't forward yet
+		nodes[1].node.test_process_pending_update_add_htlcs();
+		let events = nodes[1].node.get_and_clear_pending_events();
+		assert!(events.is_empty());
+
+		node_a_ser = nodes[0].node.encode();
+		node_b_ser = nodes[1].node.encode();
+		node_c_ser = nodes[2].node.encode();
+		mon_a_1_ser = get_monitor_0_3!(nodes[0], chan_id_a).encode();
+		mon_b_1_ser = get_monitor_0_3!(nodes[1], chan_id_a).encode();
+		mon_b_2_ser = get_monitor_0_3!(nodes[1], chan_id_b).encode();
+		mon_c_1_ser = get_monitor_0_3!(nodes[2], chan_id_b).encode();
+	}
+
+	// Create a dummy node to reload over with the 0.3 state
+	let mut chanmon_cfgs = lightning_local_utils::create_chanmon_cfgs(3);
+
+	// Our TestChannelSigner will fail as we're jumping ahead, so disable its state-based checks
+	chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[2].keys_manager.disable_all_state_policy_checks = true;
+
+	let node_cfgs = lightning_local_utils::create_node_cfgs(3, &chanmon_cfgs);
+	let (persister_a, persister_b, persister_c, chain_mon_a, chain_mon_b, chain_mon_c);
+	let node_chanmgrs =
+		lightning_local_utils::create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let (node_a, node_b, node_c);
+	let mut nodes = lightning_local_utils::create_network(3, &node_cfgs, &node_chanmgrs);
+
+	let config = lightning_local_utils::test_default_channel_config();
+	let a_mons = &[&mon_a_1_ser[..]];
+	reload_node!(nodes[0], config.clone(), &node_a_ser, a_mons, persister_a, chain_mon_a, node_a);
+	let b_mons = &[&mon_b_1_ser[..], &mon_b_2_ser[..]];
+	reload_node!(nodes[1], config.clone(), &node_b_ser, b_mons, persister_b, chain_mon_b, node_b);
+	let c_mons = &[&mon_c_1_ser[..]];
+	reload_node!(nodes[2], config, &node_c_ser, c_mons, persister_c, chain_mon_c, node_c);
+
+	lightning_local_utils::reconnect_nodes(ReconnectArgs::new(&nodes[0], &nodes[1]));
+	let mut reconnect_b_c_args = ReconnectArgs::new(&nodes[1], &nodes[2]);
+	reconnect_b_c_args.send_channel_ready = (true, true);
+	reconnect_b_c_args.send_announcement_sigs = (true, true);
+	lightning_local_utils::reconnect_nodes(reconnect_b_c_args);
+
+	// Now release the HTLC from node_b to node_c, to be claimed back to node_a
+	nodes[1].node.process_pending_htlc_forwards();
+
+	let pay_secret = PaymentSecret(payment_secret_bytes);
+	let pay_hash = PaymentHash(payment_hash_bytes);
+	let pay_preimage = PaymentPreimage(payment_preimage_bytes);
+
+	lightning_local_utils::check_added_monitors(&nodes[1], 1);
+	let forward_event = SendEvent::from_node(&nodes[1]);
+	nodes[2].node.handle_update_add_htlc(node_b_id, &forward_event.msgs[0]);
+	let commitment = &forward_event.commitment_msg;
+	lightning_local_utils::do_commitment_signed_dance(
+		&nodes[2], &nodes[1], commitment, false, false,
+	);
+
+	lightning_local_utils::expect_and_process_pending_htlcs(&nodes[2], false);
+	expect_payment_claimable!(nodes[2], pay_hash, pay_secret, 1_000_000);
+	lightning_local_utils::claim_payment(&nodes[0], &[&nodes[1], &nodes[2]], pay_preimage);
+}
+
+#[test]
+fn test_0_2_pending_forward_upgrade_fails() {
+	// Tests that upgrading directly from 0.2 to local lightning fails with DecodeError::InvalidValue
+	// when there's a pending HTLC forward, because in 0.5 we started requiring new pending_htlc
+	// fields that started being written in 0.3.
+	// XXX update this
+	use lightning::ln::channelmanager::ChannelManagerReadArgs;
+	use lightning::ln::msgs::DecodeError;
+	use lightning::util::ser::ReadableArgs;
+
+	let (node_b_ser, mon_b_1_ser, mon_b_2_ser);
+
+	{
+		let chanmon_cfgs = lightning_0_2_utils::create_chanmon_cfgs(3);
+		let node_cfgs = lightning_0_2_utils::create_node_cfgs(3, &chanmon_cfgs);
+		let node_chanmgrs =
+			lightning_0_2_utils::create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+		let nodes = lightning_0_2_utils::create_network(3, &node_cfgs, &node_chanmgrs);
+
+		let chan_id_a = lightning_0_2_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 0, 1, 10_000_000, 0,
+		)
+		.2;
+
+		let chan_id_b = lightning_0_2_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 1, 2, 50_000, 0,
+		)
+		.2;
+
+		// Send HTLC from node_a to node_c, hold at node_b (don't call process_pending_htlc_forwards)
+		let node_a_id = nodes[0].node.get_our_node_id();
+		let node_c_id = nodes[2].node.get_our_node_id();
+		let (_preimage, hash, secret) =
+			lightning_0_2_utils::get_payment_preimage_hash(&nodes[2], Some(1_000_000), None);
+
+		let pay_params = router_0_2::PaymentParameters::from_node_id(
+			node_c_id,
+			lightning_0_2_utils::TEST_FINAL_CLTV,
+		)
+		.with_bolt11_features(nodes[2].node.bolt11_invoice_features())
+		.unwrap();
+
+		let route_params =
+			router_0_2::RouteParameters::from_payment_params_and_value(pay_params, 1_000_000);
+		let route = lightning_0_2_utils::get_route(&nodes[0], &route_params).unwrap();
+
+		let onion = RecipientOnionFields_0_2::secret_only(secret);
+		let id = PaymentId_0_2(hash.0);
+		nodes[0].node.send_payment_with_route(route, hash, onion, id).unwrap();
+
+		lightning_0_2_utils::check_added_monitors(&nodes[0], 1);
+		let send_event = lightning_0_2_utils::SendEvent::from_node(&nodes[0]);
+
+		// Lock in the HTLC on the inbound edge of node_b without initiating the outbound edge.
+		nodes[1].node.handle_update_add_htlc(node_a_id, &send_event.msgs[0]);
+		commitment_signed_dance_0_2!(nodes[1], nodes[0], send_event.commitment_msg, false);
+
+		// Process the pending HTLC to create a pending forward (but don't actually forward it)
+		nodes[1].node.test_process_pending_update_add_htlcs();
+
+		// Serialize node_b with the pending forward
+		node_b_ser = nodes[1].node.encode();
+		mon_b_1_ser = get_monitor_0_2!(nodes[1], chan_id_a).encode();
+		mon_b_2_ser = get_monitor_0_2!(nodes[1], chan_id_b).encode();
+	}
+
+	// Try to reload using local lightning - this should fail with DecodeError::InvalidValue
+	let mut chanmon_cfgs = lightning_local_utils::create_chanmon_cfgs(1);
+	chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+
+	let node_cfgs = lightning_local_utils::create_node_cfgs(1, &chanmon_cfgs);
+	let node_chanmgrs = lightning_local_utils::create_node_chanmgrs(1, &node_cfgs, &[None]);
+	let nodes = lightning_local_utils::create_network(1, &node_cfgs, &node_chanmgrs);
+
+	// Read the monitors first
+	use lightning::util::test_channel_signer::TestChannelSigner;
+	let mut monitor_read_1 = &mon_b_1_ser[..];
+	let (_, monitor_1) = <(
+		bitcoin::BlockHash,
+		lightning::chain::channelmonitor::ChannelMonitor<TestChannelSigner>,
+	)>::read(
+		&mut monitor_read_1, (nodes[0].keys_manager, nodes[0].keys_manager)
+	)
+	.unwrap();
+
+	let mut monitor_read_2 = &mon_b_2_ser[..];
+	let (_, monitor_2) = <(
+		bitcoin::BlockHash,
+		lightning::chain::channelmonitor::ChannelMonitor<TestChannelSigner>,
+	)>::read(
+		&mut monitor_read_2, (nodes[0].keys_manager, nodes[0].keys_manager)
+	)
+	.unwrap();
+
+	// Try to read the ChannelManager - this should fail
+	use lightning::util::hash_tables::new_hash_map;
+	let mut channel_monitors = new_hash_map();
+	channel_monitors.insert(monitor_1.channel_id(), &monitor_1);
+	channel_monitors.insert(monitor_2.channel_id(), &monitor_2);
+
+	let config = lightning_local_utils::test_default_channel_config();
+	let mut node_read = &node_b_ser[..];
+	let read_args = ChannelManagerReadArgs {
+		config,
+		entropy_source: nodes[0].keys_manager,
+		node_signer: nodes[0].keys_manager,
+		signer_provider: nodes[0].keys_manager,
+		fee_estimator: nodes[0].fee_estimator,
+		router: nodes[0].router,
+		message_router: nodes[0].message_router,
+		chain_monitor: nodes[0].chain_monitor,
+		tx_broadcaster: nodes[0].tx_broadcaster,
+		logger: nodes[0].logger,
+		channel_monitors,
+	};
+
+	let result =
+		<(bitcoin::BlockHash, lightning::ln::functional_test_utils::TestChannelManager)>::read(
+			&mut node_read,
+			read_args,
+		);
+
+	assert!(matches!(result, Err(DecodeError::InvalidValue)));
+}
+
+#[test]
+fn test_0_2_to_0_3_to_local_pending_forward_upgrade() {
+	// Tests that upgrading from 0.2 to 0.3 to local with a pending HTLC forward works.
+	// The key is that 0.3 can read 0.2's format and re-serialize it in the new format
+	// that local can then read.
+	let (node_a_ser_0_3, node_b_ser_0_3, node_c_ser_0_3);
+	let (mon_a_1_ser_0_3, mon_b_1_ser_0_3, mon_b_2_ser_0_3, mon_c_1_ser_0_3);
+	let (node_a_id, node_b_id);
+	let (payment_secret_bytes, payment_hash_bytes, payment_preimage_bytes);
+	let (chan_id_a_bytes, chan_id_b_bytes);
+
+	// Phase 1: Create network on 0.2 with pending HTLC forward
+	let (node_a_ser_0_2, node_b_ser_0_2, node_c_ser_0_2);
+	let (mon_a_1_ser_0_2, mon_b_1_ser_0_2, mon_b_2_ser_0_2, mon_c_1_ser_0_2);
+	{
+		let chanmon_cfgs = lightning_0_2_utils::create_chanmon_cfgs(3);
+		let node_cfgs = lightning_0_2_utils::create_node_cfgs(3, &chanmon_cfgs);
+		let node_chanmgrs =
+			lightning_0_2_utils::create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+		let nodes = lightning_0_2_utils::create_network(3, &node_cfgs, &node_chanmgrs);
+
+		node_a_id = nodes[0].node.get_our_node_id();
+		node_b_id = nodes[1].node.get_our_node_id();
+		let node_c_id = nodes[2].node.get_our_node_id();
+
+		let chan_id_a = lightning_0_2_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 0, 1, 10_000_000, 0,
+		)
+		.2;
+		chan_id_a_bytes = chan_id_a.0;
+
+		let chan_id_b = lightning_0_2_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 1, 2, 50_000, 0,
+		)
+		.2;
+		chan_id_b_bytes = chan_id_b.0;
+
+		// Ensure all nodes are at the same initial height.
+		let node_max_height = nodes.iter().map(|node| node.best_block_info().1).max().unwrap();
+		for node in &nodes {
+			let blocks_to_mine = node_max_height - node.best_block_info().1;
+			if blocks_to_mine > 0 {
+				lightning_0_2_utils::connect_blocks(node, blocks_to_mine);
+			}
+		}
+
+		// Initiate an HTLC to be sent over node_a -> node_b -> node_c
+		let (preimage, hash, secret) =
+			lightning_0_2_utils::get_payment_preimage_hash(&nodes[2], Some(1_000_000), None);
+		payment_preimage_bytes = preimage.0;
+		payment_hash_bytes = hash.0;
+		payment_secret_bytes = secret.0;
+
+		let pay_params = router_0_2::PaymentParameters::from_node_id(
+			node_c_id,
+			lightning_0_2_utils::TEST_FINAL_CLTV,
+		)
+		.with_bolt11_features(nodes[2].node.bolt11_invoice_features())
+		.unwrap();
+
+		let route_params =
+			router_0_2::RouteParameters::from_payment_params_and_value(pay_params, 1_000_000);
+		let route = lightning_0_2_utils::get_route(&nodes[0], &route_params).unwrap();
+
+		let onion = RecipientOnionFields_0_2::secret_only(secret);
+		let id = PaymentId_0_2(hash.0);
+		nodes[0].node.send_payment_with_route(route, hash, onion, id).unwrap();
+
+		lightning_0_2_utils::check_added_monitors(&nodes[0], 1);
+		let send_event = lightning_0_2_utils::SendEvent::from_node(&nodes[0]);
+
+		// Lock in the HTLC on the inbound edge of node_b without initiating the outbound edge.
+		nodes[1].node.handle_update_add_htlc(node_a_id, &send_event.msgs[0]);
+		commitment_signed_dance_0_2!(nodes[1], nodes[0], send_event.commitment_msg, false);
+		// Process the pending update_add_htlcs to create pending forward state
+		nodes[1].node.test_process_pending_update_add_htlcs();
+		let events = nodes[1].node.get_and_clear_pending_events();
+		assert!(events.is_empty());
+
+		node_a_ser_0_2 = nodes[0].node.encode();
+		node_b_ser_0_2 = nodes[1].node.encode();
+		node_c_ser_0_2 = nodes[2].node.encode();
+		mon_a_1_ser_0_2 = get_monitor_0_2!(nodes[0], chan_id_a).encode();
+		mon_b_1_ser_0_2 = get_monitor_0_2!(nodes[1], chan_id_a).encode();
+		mon_b_2_ser_0_2 = get_monitor_0_2!(nodes[1], chan_id_b).encode();
+		mon_c_1_ser_0_2 = get_monitor_0_2!(nodes[2], chan_id_b).encode();
+	}
+
+	// Phase 2: Reload on 0.3, forward the HTLC (but don't claim), and re-serialize
+	{
+		let mut chanmon_cfgs = lightning_0_3_utils::create_chanmon_cfgs(3);
+		chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+		chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+		chanmon_cfgs[2].keys_manager.disable_all_state_policy_checks = true;
+
+		let node_cfgs = lightning_0_3_utils::create_node_cfgs(3, &chanmon_cfgs);
+		let (persister_a, persister_b, persister_c, chain_mon_a, chain_mon_b, chain_mon_c);
+		let node_chanmgrs =
+			lightning_0_3_utils::create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+		let (node_a, node_b, node_c);
+		let mut nodes = lightning_0_3_utils::create_network(3, &node_cfgs, &node_chanmgrs);
+
+		let config = lightning_0_3_utils::test_default_channel_config();
+		let a_mons = &[&mon_a_1_ser_0_2[..]];
+		reload_node_0_3!(
+			nodes[0],
+			config.clone(),
+			&node_a_ser_0_2,
+			a_mons,
+			persister_a,
+			chain_mon_a,
+			node_a
+		);
+		let b_mons = &[&mon_b_1_ser_0_2[..], &mon_b_2_ser_0_2[..]];
+		reload_node_0_3!(
+			nodes[1],
+			config.clone(),
+			&node_b_ser_0_2,
+			b_mons,
+			persister_b,
+			chain_mon_b,
+			node_b
+		);
+		let c_mons = &[&mon_c_1_ser_0_2[..]];
+		reload_node_0_3!(
+			nodes[2],
+			config,
+			&node_c_ser_0_2,
+			c_mons,
+			persister_c,
+			chain_mon_c,
+			node_c
+		);
+
+		// Reconnect nodes after reload
+		lightning_0_3_utils::reconnect_nodes(ReconnectArgs_0_3::new(&nodes[0], &nodes[1]));
+		let mut reconnect_b_c_args = ReconnectArgs_0_3::new(&nodes[1], &nodes[2]);
+		reconnect_b_c_args.send_channel_ready = (true, true);
+		reconnect_b_c_args.send_announcement_sigs = (true, true);
+		lightning_0_3_utils::reconnect_nodes(reconnect_b_c_args);
+
+		// Forward the HTLC from node_b to node_c (but don't claim yet)
+		nodes[1].node.process_pending_htlc_forwards();
+
+		let pay_hash = PaymentHash_0_3(payment_hash_bytes);
+		let pay_secret = PaymentSecret_0_3(payment_secret_bytes);
+
+		lightning_0_3_utils::check_added_monitors(&nodes[1], 1);
+		let forward_event = SendEvent_0_3::from_node(&nodes[1]);
+		nodes[2].node.handle_update_add_htlc(node_b_id, &forward_event.msgs[0]);
+		let commitment = &forward_event.commitment_msg;
+		lightning_0_3_utils::do_commitment_signed_dance(
+			&nodes[2], &nodes[1], commitment, false, false,
+		);
+
+		lightning_0_3_utils::expect_and_process_pending_htlcs(&nodes[2], false);
+		expect_payment_claimable_0_3!(nodes[2], pay_hash, pay_secret, 1_000_000);
+
+		// Re-serialize in 0.3 format - now the HTLC has been forwarded (not just pending)
+		node_a_ser_0_3 = nodes[0].node.encode();
+		node_b_ser_0_3 = nodes[1].node.encode();
+		node_c_ser_0_3 = nodes[2].node.encode();
+
+		let chan_id_a = ChannelId_0_3(chan_id_a_bytes);
+		let chan_id_b = ChannelId_0_3(chan_id_b_bytes);
+
+		mon_a_1_ser_0_3 = get_monitor_0_3!(nodes[0], chan_id_a).encode();
+		mon_b_1_ser_0_3 = get_monitor_0_3!(nodes[1], chan_id_a).encode();
+		mon_b_2_ser_0_3 = get_monitor_0_3!(nodes[1], chan_id_b).encode();
+		mon_c_1_ser_0_3 = get_monitor_0_3!(nodes[2], chan_id_b).encode();
+	}
+
+	// Phase 3: Reload on local and claim the payment (HTLC already forwarded in Phase 2)
+	let mut chanmon_cfgs = lightning_local_utils::create_chanmon_cfgs(3);
+	chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[2].keys_manager.disable_all_state_policy_checks = true;
+
+	let node_cfgs = lightning_local_utils::create_node_cfgs(3, &chanmon_cfgs);
+	let (persister_a, persister_b, persister_c, chain_mon_a, chain_mon_b, chain_mon_c);
+	let node_chanmgrs =
+		lightning_local_utils::create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let (node_a, node_b, node_c);
+	let mut nodes = lightning_local_utils::create_network(3, &node_cfgs, &node_chanmgrs);
+
+	let config = lightning_local_utils::test_default_channel_config();
+	let a_mons = &[&mon_a_1_ser_0_3[..]];
+	reload_node!(
+		nodes[0],
+		config.clone(),
+		&node_a_ser_0_3,
+		a_mons,
+		persister_a,
+		chain_mon_a,
+		node_a
+	);
+	let b_mons = &[&mon_b_1_ser_0_3[..], &mon_b_2_ser_0_3[..]];
+	reload_node!(
+		nodes[1],
+		config.clone(),
+		&node_b_ser_0_3,
+		b_mons,
+		persister_b,
+		chain_mon_b,
+		node_b
+	);
+	let c_mons = &[&mon_c_1_ser_0_3[..]];
+	reload_node!(nodes[2], config, &node_c_ser_0_3, c_mons, persister_c, chain_mon_c, node_c);
+
+	lightning_local_utils::reconnect_nodes(ReconnectArgs::new(&nodes[0], &nodes[1]));
+	lightning_local_utils::reconnect_nodes(ReconnectArgs::new(&nodes[1], &nodes[2]));
+
+	// The HTLC was already forwarded and claimable event generated in Phase 2.
+	// After reload, just claim the payment - the HTLC is already locked on node C.
+	let pay_preimage = PaymentPreimage(payment_preimage_bytes);
+	lightning_local_utils::claim_payment(&nodes[0], &[&nodes[1], &nodes[2]], pay_preimage);
+}
+
+#[test]
+fn test_local_to_0_3_pending_forward_downgrade() {
+	// Tests downgrading from local lightning to 0.3 with a pending HTLC forward works.
+	// Phase 1: Create state in local lightning with a pending forward
+	// Phase 2: Reload with 0.3 and complete the payment
+	use lightning::ln::types::ChannelId;
+
+	let (node_a_ser, node_b_ser, node_c_ser, mon_a_1_ser, mon_b_1_ser, mon_b_2_ser, mon_c_1_ser);
+	let (node_a_id, node_b_id);
+	let (payment_secret_bytes, payment_hash_bytes, payment_preimage_bytes);
+	let (chan_id_a_bytes, chan_id_b_bytes);
+
+	// Phase 1: Create network on local lightning with pending HTLC forward
+	{
+		let chanmon_cfgs = lightning_local_utils::create_chanmon_cfgs(3);
+		let node_cfgs = lightning_local_utils::create_node_cfgs(3, &chanmon_cfgs);
+		let node_chanmgrs =
+			lightning_local_utils::create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+		let nodes = lightning_local_utils::create_network(3, &node_cfgs, &node_chanmgrs);
+
+		node_a_id = nodes[0].node.get_our_node_id();
+		node_b_id = nodes[1].node.get_our_node_id();
+		let node_c_id = nodes[2].node.get_our_node_id();
+
+		let chan_id_a = lightning_local_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 0, 1, 10_000_000, 0,
+		)
+		.2;
+		chan_id_a_bytes = chan_id_a.0;
+
+		let chan_id_b = lightning_local_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 1, 2, 50_000, 0,
+		)
+		.2;
+		chan_id_b_bytes = chan_id_b.0;
+
+		// Ensure all nodes are at the same initial height.
+		let node_max_height = nodes.iter().map(|node| node.best_block_info().1).max().unwrap();
+		for node in &nodes {
+			let blocks_to_mine = node_max_height - node.best_block_info().1;
+			if blocks_to_mine > 0 {
+				lightning_local_utils::connect_blocks(node, blocks_to_mine);
+			}
+		}
+
+		// Initiate an HTLC to be sent over node_a -> node_b -> node_c
+		let (preimage, hash, secret) =
+			lightning_local_utils::get_payment_preimage_hash(&nodes[2], Some(1_000_000), None);
+		payment_preimage_bytes = preimage.0;
+		payment_hash_bytes = hash.0;
+		payment_secret_bytes = secret.0;
+
+		use lightning::routing::router as local_router;
+		let pay_params = local_router::PaymentParameters::from_node_id(
+			node_c_id,
+			lightning_local_utils::TEST_FINAL_CLTV,
+		)
+		.with_bolt11_features(nodes[2].node.bolt11_invoice_features())
+		.unwrap();
+
+		let route_params =
+			local_router::RouteParameters::from_payment_params_and_value(pay_params, 1_000_000);
+		let route = lightning_local_utils::get_route(&nodes[0], &route_params).unwrap();
+
+		use lightning::ln::channelmanager::PaymentId as LocalPaymentId;
+		use lightning::ln::outbound_payment::RecipientOnionFields as LocalRecipientOnionFields;
+		let onion = LocalRecipientOnionFields::secret_only(secret);
+		let id = LocalPaymentId(hash.0);
+		nodes[0].node.send_payment_with_route(route, hash, onion, id).unwrap();
+
+		lightning_local_utils::check_added_monitors(&nodes[0], 1);
+		let send_event = SendEvent::from_node(&nodes[0]);
+
+		// Lock in the HTLC on the inbound edge of node_b without initiating the outbound edge.
+		nodes[1].node.handle_update_add_htlc(node_a_id, &send_event.msgs[0]);
+		lightning_local_utils::do_commitment_signed_dance(
+			&nodes[1],
+			&nodes[0],
+			&send_event.commitment_msg,
+			false,
+			false,
+		);
+		node_a_ser = nodes[0].node.encode();
+		node_b_ser = nodes[1].node.encode();
+		node_c_ser = nodes[2].node.encode();
+		mon_a_1_ser = lightning::get_monitor!(nodes[0], ChannelId(chan_id_a_bytes)).encode();
+		mon_b_1_ser = lightning::get_monitor!(nodes[1], ChannelId(chan_id_a_bytes)).encode();
+		mon_b_2_ser = lightning::get_monitor!(nodes[1], ChannelId(chan_id_b_bytes)).encode();
+		mon_c_1_ser = lightning::get_monitor!(nodes[2], ChannelId(chan_id_b_bytes)).encode();
+	}
+
+	// Phase 2: Reload on 0.3 and complete the payment
+	let mut chanmon_cfgs = lightning_0_3_utils::create_chanmon_cfgs(3);
+	chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[2].keys_manager.disable_all_state_policy_checks = true;
+
+	let node_cfgs = lightning_0_3_utils::create_node_cfgs(3, &chanmon_cfgs);
+	let (persister_a, persister_b, persister_c, chain_mon_a, chain_mon_b, chain_mon_c);
+	let node_chanmgrs =
+		lightning_0_3_utils::create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let (node_a, node_b, node_c);
+	let mut nodes = lightning_0_3_utils::create_network(3, &node_cfgs, &node_chanmgrs);
+
+	let config = lightning_0_3_utils::test_default_channel_config();
+	let a_mons = &[&mon_a_1_ser[..]];
+	reload_node_0_3!(
+		nodes[0],
+		config.clone(),
+		&node_a_ser,
+		a_mons,
+		persister_a,
+		chain_mon_a,
+		node_a
+	);
+	let b_mons = &[&mon_b_1_ser[..], &mon_b_2_ser[..]];
+	reload_node_0_3!(
+		nodes[1],
+		config.clone(),
+		&node_b_ser,
+		b_mons,
+		persister_b,
+		chain_mon_b,
+		node_b
+	);
+	let c_mons = &[&mon_c_1_ser[..]];
+	reload_node_0_3!(nodes[2], config, &node_c_ser, c_mons, persister_c, chain_mon_c, node_c);
+
+	lightning_0_3_utils::reconnect_nodes(ReconnectArgs_0_3::new(&nodes[0], &nodes[1]));
+	let mut reconnect_b_c_args = ReconnectArgs_0_3::new(&nodes[1], &nodes[2]);
+	reconnect_b_c_args.send_channel_ready = (true, true);
+	reconnect_b_c_args.send_announcement_sigs = (true, true);
+	lightning_0_3_utils::reconnect_nodes(reconnect_b_c_args);
+
+	// Now release the HTLC from node_b to node_c, to be claimed back to node_a
+	nodes[1].node.process_pending_htlc_forwards();
 
 	let pay_secret = PaymentSecret_0_3(payment_secret_bytes);
 	let pay_hash = PaymentHash_0_3(payment_hash_bytes);

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -51,8 +51,8 @@ use crate::ln::channel_state::{
 };
 use crate::ln::channelmanager::{
 	self, BlindedFailure, ChannelReadyOrder, FundingConfirmedMessage, HTLCPreviousHopData,
-	HTLCSource, OpenChannelMessage, PaymentClaimDetails, PendingHTLCInfo, RAACommitmentOrder,
-	SentHTLCId, BREAKDOWN_TIMEOUT, MAX_LOCAL_BREAKDOWN_TIMEOUT, MIN_CLTV_EXPIRY_DELTA,
+	HTLCSource, OpenChannelMessage, PaymentClaimDetails, RAACommitmentOrder, SentHTLCId,
+	BREAKDOWN_TIMEOUT, MAX_LOCAL_BREAKDOWN_TIMEOUT, MIN_CLTV_EXPIRY_DELTA,
 };
 use crate::ln::funding::{FundingTxInput, SpliceContribution};
 use crate::ln::interactivetxs::{
@@ -1179,8 +1179,6 @@ pub(super) struct MonitorRestoreUpdates {
 	/// A `CommitmentUpdate` to be sent to our channel peer.
 	pub commitment_update: Option<msgs::CommitmentUpdate>,
 	pub commitment_order: RAACommitmentOrder,
-	// TODO: get rid of this
-	pub accepted_htlcs: Vec<(PendingHTLCInfo, u64)>,
 	pub failed_htlcs: Vec<(HTLCSource, PaymentHash, HTLCFailReason)>,
 	pub finalized_claimed_htlcs: Vec<(HTLCSource, Option<AttributionData>)>,
 	/// Inbound update_adds that are now irrevocably committed to this channel and are ready for the
@@ -9563,9 +9561,9 @@ where
 			self.context.monitor_pending_commitment_signed = false;
 			return MonitorRestoreUpdates {
 				raa: None, commitment_update: None, commitment_order: RAACommitmentOrder::RevokeAndACKFirst,
-				accepted_htlcs: Vec::new(), failed_htlcs, finalized_claimed_htlcs, pending_update_adds,
-				funding_broadcastable, channel_ready, announcement_sigs, tx_signatures: None,
-				channel_ready_order, committed_outbound_htlc_sources
+				failed_htlcs, finalized_claimed_htlcs, pending_update_adds, funding_broadcastable,
+				channel_ready, announcement_sigs, tx_signatures: None, channel_ready_order,
+				committed_outbound_htlc_sources
 			};
 		}
 
@@ -9594,7 +9592,7 @@ where
 			if commitment_update.is_some() { "a" } else { "no" }, if raa.is_some() { "an" } else { "no" },
 			match commitment_order { RAACommitmentOrder::CommitmentFirst => "commitment", RAACommitmentOrder::RevokeAndACKFirst => "RAA"});
 		MonitorRestoreUpdates {
-			raa, commitment_update, commitment_order, accepted_htlcs: Vec::new(), failed_htlcs, finalized_claimed_htlcs,
+			raa, commitment_update, commitment_order, failed_htlcs, finalized_claimed_htlcs,
 			pending_update_adds, funding_broadcastable, channel_ready, announcement_sigs, tx_signatures,
 			channel_ready_order, committed_outbound_htlc_sources
 		}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -7608,7 +7608,6 @@ where
 					false,
 					Vec::new(),
 					Vec::new(),
-					Vec::new(),
 					logger,
 				);
 				UpdateFulfillCommitFetch::NewClaim { monitor_update, htlc_value_msat }
@@ -8146,15 +8145,7 @@ where
 			&self.context.channel_id()
 		);
 
-		self.monitor_updating_paused(
-			false,
-			false,
-			false,
-			Vec::new(),
-			Vec::new(),
-			Vec::new(),
-			logger,
-		);
+		self.monitor_updating_paused(false, false, false, Vec::new(), Vec::new(), logger);
 		self.context
 			.interactive_tx_signing_session
 			.as_mut()
@@ -8258,15 +8249,7 @@ where
 			.as_mut()
 			.expect("Signing session must exist for negotiated pending splice")
 			.received_commitment_signed();
-		self.monitor_updating_paused(
-			false,
-			false,
-			false,
-			Vec::new(),
-			Vec::new(),
-			Vec::new(),
-			logger,
-		);
+		self.monitor_updating_paused(false, false, false, Vec::new(), Vec::new(), logger);
 		self.context.monitor_pending_tx_signatures = true;
 
 		Ok(self.push_ret_blockable_mon_update(monitor_update))
@@ -8566,7 +8549,6 @@ where
 			false,
 			Vec::new(),
 			Vec::new(),
-			Vec::new(),
 			logger,
 		);
 		return Ok(self.push_ret_blockable_mon_update(monitor_update));
@@ -8766,15 +8748,7 @@ where
 				if update_fee.is_some() { "a fee update, " } else { "" },
 				update_add_count, update_fulfill_count, update_fail_count);
 
-			self.monitor_updating_paused(
-				false,
-				true,
-				false,
-				Vec::new(),
-				Vec::new(),
-				Vec::new(),
-				logger,
-			);
+			self.monitor_updating_paused(false, true, false, Vec::new(), Vec::new(), logger);
 			(self.push_ret_blockable_mon_update(monitor_update), htlcs_to_fail)
 		} else {
 			(None, Vec::new())
@@ -9109,7 +9083,6 @@ where
 					false,
 					true,
 					false,
-					Vec::new(),
 					revoked_htlcs,
 					finalized_claimed_htlcs,
 					logger,
@@ -9156,7 +9129,6 @@ where
 						false,
 						true,
 						false,
-						Vec::new(),
 						revoked_htlcs,
 						finalized_claimed_htlcs,
 						logger,
@@ -9170,7 +9142,6 @@ where
 						false,
 						false,
 						false,
-						Vec::new(),
 						revoked_htlcs,
 						finalized_claimed_htlcs,
 						logger,
@@ -9480,7 +9451,6 @@ where
 	/// [`ChannelMonitorUpdateStatus::InProgress`]: crate::chain::ChannelMonitorUpdateStatus::InProgress
 	fn monitor_updating_paused<L: Logger>(
 		&mut self, resend_raa: bool, resend_commitment: bool, resend_channel_ready: bool,
-		pending_forwards: Vec<(PendingHTLCInfo, u64)>,
 		pending_fails: Vec<(HTLCSource, PaymentHash, HTLCFailReason)>,
 		pending_finalized_claimed_htlcs: Vec<(HTLCSource, Option<AttributionData>)>, logger: &L,
 	) {
@@ -9489,7 +9459,6 @@ where
 		self.context.monitor_pending_revoke_and_ack |= resend_raa;
 		self.context.monitor_pending_commitment_signed |= resend_commitment;
 		self.context.monitor_pending_channel_ready |= resend_channel_ready;
-		self.context.monitor_pending_forwards.extend(pending_forwards);
 		self.context.monitor_pending_failures.extend(pending_fails);
 		self.context.monitor_pending_finalized_fulfills.extend(pending_finalized_claimed_htlcs);
 		self.context.channel_state.set_monitor_update_in_progress();
@@ -10705,15 +10674,7 @@ where
 				}],
 				channel_id: Some(self.context.channel_id()),
 			};
-			self.monitor_updating_paused(
-				false,
-				false,
-				false,
-				Vec::new(),
-				Vec::new(),
-				Vec::new(),
-				logger,
-			);
+			self.monitor_updating_paused(false, false, false, Vec::new(), Vec::new(), logger);
 			self.push_ret_blockable_mon_update(monitor_update)
 		} else {
 			None
@@ -11454,15 +11415,7 @@ where
 			}],
 			channel_id: Some(self.context.channel_id()),
 		};
-		self.monitor_updating_paused(
-			false,
-			false,
-			false,
-			Vec::new(),
-			Vec::new(),
-			Vec::new(),
-			logger,
-		);
+		self.monitor_updating_paused(false, false, false, Vec::new(), Vec::new(), logger);
 		let monitor_update = self.push_ret_blockable_mon_update(monitor_update);
 
 		let announcement_sigs =
@@ -13131,15 +13084,7 @@ where
 		let can_add_htlc = send_res.map_err(|(_, msg)| ChannelError::Ignore(msg))?;
 		if can_add_htlc {
 			let monitor_update = self.build_commitment_no_status_check(logger);
-			self.monitor_updating_paused(
-				false,
-				true,
-				false,
-				Vec::new(),
-				Vec::new(),
-				Vec::new(),
-				logger,
-			);
+			self.monitor_updating_paused(false, true, false, Vec::new(), Vec::new(), logger);
 			Ok(self.push_ret_blockable_mon_update(monitor_update))
 		} else {
 			Ok(None)
@@ -13259,15 +13204,7 @@ where
 				}],
 				channel_id: Some(self.context.channel_id()),
 			};
-			self.monitor_updating_paused(
-				false,
-				false,
-				false,
-				Vec::new(),
-				Vec::new(),
-				Vec::new(),
-				&&logger,
-			);
+			self.monitor_updating_paused(false, false, false, Vec::new(), Vec::new(), &&logger);
 			self.push_ret_blockable_mon_update(monitor_update)
 		} else {
 			None
@@ -13876,7 +13813,6 @@ impl<SP: SignerProvider> OutboundV1Channel<SP> {
 			need_channel_ready,
 			Vec::new(),
 			Vec::new(),
-			Vec::new(),
 			logger,
 		);
 		Ok((channel, channel_monitor))
@@ -14173,7 +14109,6 @@ impl<SP: SignerProvider> InboundV1Channel<SP> {
 			false,
 			false,
 			need_channel_ready,
-			Vec::new(),
 			Vec::new(),
 			Vec::new(),
 			logger,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -17928,15 +17928,6 @@ pub struct ChannelManagerReadArgs<
 	///
 	/// This is not exported to bindings users because we have no HashMap bindings
 	pub channel_monitors: HashMap<ChannelId, &'a ChannelMonitor<SP::EcdsaSigner>>,
-
-	/// Whether the `ChannelManager` should attempt to reconstruct its set of pending HTLCs from
-	/// `Channel{Monitor}` data rather than its own persisted maps, which is planned to become
-	/// the default behavior in upcoming versions.
-	///
-	/// If `None`, whether we reconstruct or use the legacy maps will be decided randomly during
-	/// `ChannelManager::from_channel_manager_data`.
-	#[cfg(test)]
-	pub reconstruct_manager_from_monitors: Option<bool>,
 }
 
 impl<
@@ -17974,8 +17965,6 @@ impl<
 			channel_monitors: hash_map_from_iter(
 				channel_monitors.drain(..).map(|monitor| (monitor.channel_id(), monitor)),
 			),
-			#[cfg(test)]
-			reconstruct_manager_from_monitors: None,
 		}
 	}
 }

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -17514,6 +17514,7 @@ impl<'a, ES: EntropySource, NS: NodeSigner, SP: SignerProvider, L: Logger>
 				(
 					args.entropy_source,
 					args.signer_provider,
+					args.logger,
 					&provided_channel_type_features(&args.config),
 				),
 			)?;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -18702,10 +18702,6 @@ impl<
 					is_channel_closed = !peer_state.channel_by_id.contains_key(channel_id);
 					if let Some(chan) = peer_state.channel_by_id.get(channel_id) {
 						if let Some(funded_chan) = chan.as_funded() {
-							// Legacy HTLCs are from pre-LDK 0.3 and cannot be reconstructed.
-							if funded_chan.has_legacy_inbound_htlcs() {
-								return Err(DecodeError::InvalidValue);
-							}
 							// Reconstruct `ChannelManager::decode_update_add_htlcs` from the serialized
 							// `Channel` as part of removing the requirement to regularly persist the
 							// `ChannelManager`.

--- a/lightning/src/ln/reload_tests.rs
+++ b/lightning/src/ln/reload_tests.rs
@@ -439,7 +439,6 @@ fn test_manager_serialize_deserialize_inconsistent_monitor() {
 		tx_broadcaster: nodes[0].tx_broadcaster,
 		logger: &logger,
 		channel_monitors: node_0_stale_monitors.iter().map(|monitor| { (monitor.channel_id(), monitor) }).collect(),
-		reconstruct_manager_from_monitors: None,
 	}) { } else {
 		panic!("If the monitor(s) are stale, this indicates a bug and we should get an Err return");
 	};
@@ -458,7 +457,6 @@ fn test_manager_serialize_deserialize_inconsistent_monitor() {
 		tx_broadcaster: nodes[0].tx_broadcaster,
 		logger: &logger,
 		channel_monitors: node_0_monitors.iter().map(|monitor| { (monitor.channel_id(), monitor) }).collect(),
-		reconstruct_manager_from_monitors: None,
 	}).unwrap();
 	nodes_0_deserialized = nodes_0_deserialized_tmp;
 	assert!(nodes_0_read.is_empty());
@@ -1961,8 +1959,7 @@ fn test_reload_node_with_preimage_in_monitor_claims_htlc() {
 		&[&mon_0_1_serialized, &mon_1_2_serialized],
 		persister,
 		new_chain_monitor,
-		nodes_1_deserialized,
-		Some(true)
+		nodes_1_deserialized
 	);
 
 	// When the claim is reconstructed during reload, a PaymentForwarded event is generated.
@@ -2064,8 +2061,7 @@ fn test_reload_node_without_preimage_fails_htlc() {
 		&[&mon_0_1_serialized, &mon_1_2_serialized],
 		persister,
 		new_chain_monitor,
-		nodes_1_deserialized,
-		Some(true)
+		nodes_1_deserialized
 	);
 
 	// After reload, nodes[1] should have generated an HTLCHandlingFailed event.

--- a/lightning/src/ln/reload_tests.rs
+++ b/lightning/src/ln/reload_tests.rs
@@ -2208,8 +2208,7 @@ fn test_reload_with_mpp_claims_on_same_channel() {
 		&[&mon_0_1_serialized, &mon_1_2_a_serialized, &mon_1_2_b_serialized],
 		persister,
 		new_chain_monitor,
-		nodes_1_deserialized,
-		Some(true)
+		nodes_1_deserialized
 	);
 
 	// When the claims are reconstructed during reload, PaymentForwarded events are regenerated.

--- a/pending_changelog/upgrade-0.2-pending-htlc.txt
+++ b/pending_changelog/upgrade-0.2-pending-htlc.txt
@@ -1,0 +1,9 @@
+Backwards Compatibility
+=======================
+
+ * Upgrading directly from 0.2 to 0.5 with pending HTLC forwards is not supported.
+   If you have pending HTLC forwards when upgrading from 0.2, you must first upgrade
+   to 0.3, forward the HTLCs (completing at least the outbound commitment), then
+   upgrade to 0.5. Attempting to upgrade directly from 0.2 to 0.5 with pending HTLC
+   forwards will result in a `DecodeError::InvalidValue` when reading the
+   `ChannelManager`.


### PR DESCRIPTION
In LDK 0.3 we're adding support for reconstructing the `ChannelManager`'s pending
forward HTLCs maps from channel data as part of removing the requirement to
regularly persist the manager, but til 0.5 we still would write/read those maps
within the manager to maintain compat with 0.2-. Also 0.3 adds a new field to
`Channel` that allowed the map reconstruction.

Once a few versions have passed, we have more confidence that the new field
is being written, so here we deprecate persistence of the old legacy maps and only
attempt to read them if the manager serialized version indicates that they were
written. We can also deprecate some other old codepaths, see commit messages. 

Partially addresses #4286 

Based on #4303 

- [x] Test upgrading 0.2 -> 0.3/0.4 -> 0.5
- [x] Test downgrading 0.5 -> 0.3/4 -> 0.2 
- [x] Update `upgrade_downgrade_tests` that currently upgrade from 0.2- to `main`, to upgrade to 0.3/0.4 instead (since 0.2- to 0.5 is unsupported) 
- [ ] Clean up clauded'd upgrade/downgrade tests
- [ ] Update `upgrade_downgrade_tests` to not point to my branch once 0.3 is released 