### PR TITLE
invoice: Use PaymentHash in raw invoice types

### DIFF
--- a/lightning-invoice/src/ser.rs
+++ b/lightning-invoice/src/ser.rs
@@ -7,9 +7,9 @@ use bech32::{ByteIterExt, Fe32, Fe32IterExt};
 
 use super::{
 	constants, Bolt11Invoice, Bolt11InvoiceFeatures, Bolt11InvoiceSignature, Currency, Description,
-	ExpiryTime, Fallback, MinFinalCltvExpiryDelta, PayeePubKey, PaymentSecret, PositiveTimestamp,
-	PrivateRoute, RawDataPart, RawHrp, RawTaggedField, RouteHintHop, Sha256, SiPrefix,
-	SignedRawBolt11Invoice, TaggedField,
+	ExpiryTime, Fallback, MinFinalCltvExpiryDelta, PayeePubKey, PaymentHash, PaymentSecret,
+	PositiveTimestamp, PrivateRoute, RawDataPart, RawHrp, RawTaggedField, RouteHintHop, Sha256,
+	SiPrefix, SignedRawBolt11Invoice, TaggedField,
 };
 
 macro_rules! define_iterator_enum {
@@ -90,6 +90,18 @@ impl Base32Iterable for PaymentSecret {
 }
 
 impl Base32Len for PaymentSecret {
+	fn base32_len(&self) -> usize {
+		52
+	}
+}
+
+impl Base32Iterable for PaymentHash {
+	fn fe_iter<'s>(&'s self) -> impl Iterator<Item = Fe32> + 's {
+		self.0[..].fe_iter()
+	}
+}
+
+impl Base32Len for PaymentHash {
 	fn base32_len(&self) -> usize {
 		52
 	}

--- a/lightning-invoice/tests/ser_de.rs
+++ b/lightning-invoice/tests/ser_de.rs
@@ -18,9 +18,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-						"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+					<[u8; 32]>::try_from(
+						Vec::from_hex(
+							"0001020304050607080900010203040506070809000102030405060708090102",
+						)
+						.unwrap(),
+					)
+					.unwrap(),
+				))
 				.description("Please consider supporting this project".to_owned())
 				.build_raw()
 				.unwrap()
@@ -39,9 +45,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.amount_milli_satoshis(250_000_000)
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.description("1 cup coffee".to_owned())
 				.expiry_time(Duration::from_secs(60))
 				.build_raw()
@@ -61,9 +73,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.amount_milli_satoshis(250_000_000)
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.description("ナンセンス 1杯".to_owned())
 				.expiry_time(Duration::from_secs(60))
 				.build_raw()
@@ -84,9 +102,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.build_raw()
 				.unwrap()
 				.sign(|_| {
@@ -105,9 +129,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.fallback(Fallback::PubKeyHash(PubkeyHash::from_slice(&[49, 114, 181, 101, 79, 102, 131, 200, 251, 20, 105, 89, 211, 71, 206, 48, 60, 174, 76, 167]).unwrap()))
 				.build_raw()
 				.unwrap()
@@ -127,9 +157,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.fallback(Fallback::PubKeyHash(PubkeyHash::from_slice(&[4, 182, 31, 125, 193, 234, 13, 201, 148, 36, 70, 76, 196, 6, 77, 197, 100, 217, 30, 137]).unwrap()))
 				.private_route(RouteHint(vec![RouteHintHop {
 					src_node_id: PublicKey::from_slice(&<Vec<u8>>::from_hex(
@@ -166,9 +202,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.fallback(Fallback::ScriptHash(ScriptHash::from_slice(&[143, 85, 86, 59, 154, 25, 243, 33, 194, 17, 233, 185, 243, 140, 223, 104, 110, 160, 120, 69]).unwrap()))
 				.build_raw()
 				.unwrap()
@@ -188,9 +230,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.fallback(Fallback::SegWitProgram { version: WitnessVersion::V0,
 					program: vec![117, 30, 118, 232, 25, 145, 150, 212, 84, 148, 28, 69, 209, 179, 163, 35, 241, 67, 59, 214]
 				})
@@ -212,9 +260,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.description_hash(sha256::Hash::hash(b"One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon"))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.fallback(Fallback::SegWitProgram { version: WitnessVersion::V0,
 					program: vec![24, 99, 20, 60, 20, 197, 22, 104, 4, 189, 25, 32, 51, 86, 218, 19, 108, 152, 86, 120, 205, 77, 39, 161, 184, 198, 50, 150, 4, 144, 50, 98]
 				})
@@ -235,9 +289,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.amount_milli_satoshis(967878534)
 				.duration_since_epoch(Duration::from_secs(1572468703))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"462264ede7e14047e9b249da94fefc47f41f7d02ee9b091815a5506bc8abf75f"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+					<[u8; 32]>::try_from(
+						Vec::from_hex(
+							"462264ede7e14047e9b249da94fefc47f41f7d02ee9b091815a5506bc8abf75f",
+						)
+						.unwrap(),
+					)
+					.unwrap(),
+				))
 				.expiry_time(Duration::from_secs(604800))
 				.min_final_cltv_expiry_delta(10)
 				.description("Blockstream Store: 88.85 USD for Blockstream Ledger Nano S x 1, \"Back In My Day\" Sticker x 2, \"I Got Lightning Working\" Sticker x 2 and 1 more items".to_owned())
@@ -267,9 +327,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.amount_milli_satoshis(2_500_000_000)
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.description("coffee beans".to_owned())
 				.build_raw()
 				.unwrap()
@@ -288,9 +354,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.amount_milli_satoshis(2_500_000_000)
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.description("coffee beans".to_owned())
 				.build_raw()
 				.unwrap()
@@ -309,9 +381,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 				.amount_milli_satoshis(2_500_000_000)
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.description("coffee beans".to_owned())
 				.build_raw()
 				.unwrap()
@@ -329,9 +407,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(1_000_000_000)
 				.duration_since_epoch(Duration::from_secs(1496314658))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.description("payment metadata inside".to_owned())
 				.payment_metadata(<Vec<u8>>::from_hex("01fafaf0").unwrap())
 				.require_payment_metadata()
@@ -355,9 +439,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.amount_milli_satoshis(1_000_000_000)
 				.duration_since_epoch(Duration::from_secs(1496314658))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.description("payment metadata inside".to_owned())
 				.payment_metadata(<Vec<u8>>::from_hex("01fafaf0").unwrap())
 				.require_payment_metadata()
@@ -378,9 +468,15 @@ fn get_test_tuples() -> Vec<(String, SignedRawBolt11Invoice, bool, bool)> {
 			InvoiceBuilder::new(Currency::Bitcoin)
 				.duration_since_epoch(Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([0x11; 32]))
-				.payment_hash(sha256::Hash::from_str(
-					"0001020304050607080900010203040506070809000102030405060708090102"
-				).unwrap())
+				.payment_hash(lightning_invoice::PaymentHash(
+				<[u8; 32]>::try_from(
+					Vec::from_hex(
+						"0001020304050607080900010203040506070809000102030405060708090102",
+					)
+					.unwrap(),
+				)
+				.unwrap(),
+			))
 				.description("Please consider supporting this project".to_owned())
 				.build_raw()
 				.unwrap()

--- a/lightning-liquidity/tests/lsps2_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps2_integration_tests.rs
@@ -47,7 +47,6 @@ use lightning_invoice::{Bolt11Invoice, InvoiceBuilder, RoutingFees};
 
 use lightning_types::payment::PaymentHash;
 
-use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::Network;
 use lightning_types::payment::PaymentPreimage;
@@ -137,10 +136,6 @@ fn create_jit_invoice(
 		htlc_minimum_msat: None,
 		htlc_maximum_msat: None,
 	}]);
-
-	let payment_hash = sha256::Hash::from_slice(&payment_hash.0).map_err(|e| {
-		log_error!(node.logger, "Invalid payment hash: {:?}", e);
-	})?;
 
 	let currency = Network::Bitcoin.into();
 	let mut invoice_builder = InvoiceBuilder::new(currency)

--- a/lightning/src/ln/bolt11_payment_tests.rs
+++ b/lightning/src/ln/bolt11_payment_tests.rs
@@ -16,8 +16,6 @@ use crate::ln::msgs::ChannelMessageHandler;
 use crate::ln::outbound_payment::Bolt11PaymentError;
 use crate::routing::router::RouteParametersConfig;
 use crate::sign::{NodeSigner, Recipient};
-use bitcoin::hashes::sha256::Hash as Sha256;
-use bitcoin::hashes::Hash;
 use lightning_invoice::{Bolt11Invoice, Currency, InvoiceBuilder};
 use std::time::SystemTime;
 
@@ -39,7 +37,7 @@ fn payment_metadata_end_to_end_for_invoice_with_amount() {
 	let timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
 	let invoice = InvoiceBuilder::new(Currency::Bitcoin)
 		.description("test".into())
-		.payment_hash(Sha256::from_slice(&payment_hash.0).unwrap())
+		.payment_hash(payment_hash)
 		.payment_secret(payment_secret)
 		.duration_since_epoch(timestamp)
 		.min_final_cltv_expiry_delta(144)
@@ -108,7 +106,7 @@ fn payment_metadata_end_to_end_for_invoice_with_no_amount() {
 	let timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
 	let invoice = InvoiceBuilder::new(Currency::Bitcoin)
 		.description("test".into())
-		.payment_hash(Sha256::from_slice(&payment_hash.0).unwrap())
+		.payment_hash(payment_hash)
 		.payment_secret(payment_secret)
 		.duration_since_epoch(timestamp)
 		.min_final_cltv_expiry_delta(144)

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -13309,7 +13309,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 		let mut invoice = invoice
 			.duration_since_epoch(duration_since_epoch)
 			.payee_pub_key(self.get_our_node_id())
-			.payment_hash(Hash::from_slice(&payment_hash.0).unwrap())
+			.payment_hash(payment_hash)
 			.payment_secret(payment_secret)
 			.basic_mpp()
 			.min_final_cltv_expiry_delta(

--- a/lightning/src/ln/invoice_utils.rs
+++ b/lightning/src/ln/invoice_utils.rs
@@ -18,7 +18,6 @@ use crate::sign::{EntropySource, NodeSigner, Recipient};
 use crate::types::payment::PaymentHash;
 use crate::util::logger::{Logger, Record};
 use alloc::collections::{btree_map, BTreeMap};
-use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::PublicKey;
 #[cfg(not(feature = "std"))]
 use core::iter::Iterator;
@@ -228,7 +227,7 @@ where
 
 	let mut invoice = invoice
 		.duration_since_epoch(duration_since_epoch)
-		.payment_hash(Hash::from_slice(&payment_hash.0).unwrap())
+		.payment_hash(payment_hash)
 		.payment_secret(payment_secret)
 		.min_final_cltv_expiry_delta(
 			// Add a buffer of 3 to the delta if present, otherwise use LDK's minimum.
@@ -1257,7 +1256,8 @@ mod test {
 			Duration::from_secs(genesis_timestamp),
 		)
 		.unwrap();
-		let (payment_hash, payment_secret) = (invoice.payment_hash(), *invoice.payment_secret());
+		let payment_hash = invoice.payment_hash();
+		let payment_secret = *invoice.payment_secret();
 		let payment_preimage = if user_generated_pmt_hash {
 			user_payment_preimage
 		} else {


### PR DESCRIPTION
Closes #4292

**Note: This is a breaking change for InvoiceBuilder. Downstream consumers (like ldk-node) will need to update their builder calls to pass PaymentHash directly.**

Refactors `RawBolt11Invoice`, `RawDataPart`, and `TaggedField` to use
`lightning_types::payment::PaymentHash` instead of `bitcoin::hashes::sha256::Hash`.
This improves type safety and aligns the raw invoice types with the high-level
`Bolt11Invoice`.

This is a follow-up to #4293 to complete the migration of invoice types to PaymentHash. 

Specific changes:
- `TaggedField::PaymentHash` now holds a `PaymentHash`.
- `InvoiceBuilder::payment_hash` now accepts a `PaymentHash` directly.
- Implemented Base32 traits for PaymentHash in lightning-invoice to support
  serialization.
- Updated tests to resolve name collisions between the PaymentHash type and
  the TaggedField variant.
- Updated downstream usage in the `lightning` crate (channelmanager and
  invoice_utils) to remove redundant hash conversions now that the builder
  accepts the strong type.