### PR TITLE
feat: track in-flight amount for pending payments

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3522,7 +3522,7 @@ impl<
 		F: FeeEstimator,
 		R: Router,
 		MR: MessageRouter,
-		L: Logger + std::ops::Deref,
+		L: Logger + core::ops::Deref,
 	> ChannelManager<M, T, ES, NS, SP, F, R, MR, L>
 {
 	/// Constructs a new `ChannelManager` to hold several channels and route between them.
@@ -3962,8 +3962,6 @@ impl<
 	///
 	/// [`ChainMonitor::get_claimable_balances`]: crate::chain::chainmonitor::ChainMonitor::get_claimable_balances
 	pub fn get_balance_details(&self, balances: &[Balance]) -> BalanceDetails {
-		use crate::chain::channelmonitor::Balance;
-
 		let recent_payments = self.list_recent_payments();
 
 		let mut claimable_on_channel_close_msat: u64 = 0;

--- a/lightning/src/ln/payment_tests.rs
+++ b/lightning/src/ln/payment_tests.rs
@@ -2415,11 +2415,9 @@ fn test_get_balance_details_catches_orphaned_htlcs() {
 	create_announced_chan_between_nodes(&nodes, 0, 1);
 	create_announced_chan_between_nodes(&nodes, 1, 2);
 
-	// Send a payment without having ChannelManager track it yet, simulating an orphaned HTLC
 	use crate::chain::channelmonitor::Balance;
 	use crate::ln::channelmanager::collect_pending_payment_state;
 	use crate::ln::channelmanager::PaymentId;
-	use crate::routing::router::{PaymentParameters, RouteParameters};
 	use crate::util::test_utils;
 
 	let payment_id = PaymentId([42; 32]);
@@ -2458,7 +2456,7 @@ fn test_get_balance_details_catches_orphaned_htlcs() {
 	// After abandonment, the payment shouldn't be in pending payments
 	let recent_payments = nodes[0].node.list_recent_payments();
 	let abandoned = recent_payments.iter().any(|p| {
-		matches!(p, crate::ln::channelmanager::RecentPaymentDetails::Abandoned { 
+		matches!(p, crate::ln::channelmanager::RecentPaymentDetails::Abandoned {
 			payment_id: pid, .. 
 		} if *pid == payment_id)
 	});

--- a/pending_changelog/3374-pending-retry-amount.txt
+++ b/pending_changelog/3374-pending-retry-amount.txt
@@ -1,0 +1,8 @@
+## API Updates
+
+* `RecentPaymentDetails::Pending` now includes `inflight_msat` and `is_retryable`
+  to track payment retry state (#3374).
+* Added `ChannelManager::get_spendable_balance_msat()` and `get_balance_details()`
+  to calculate available balance without double-counting stuck payments (#3374).
+* Added `BalanceDetails` struct for detailed balance breakdown (#3374).
+* `Balance::MaybeTimeoutClaimableHTLC` now includes `payment_id` (#3374).


### PR DESCRIPTION
fix #3374 

adds `inflight_msat` to `RecentPaymentDetails::Pending` to expose the amount currently locked in HTLCs. this allows wallets to avoid balance flicker during payment retries by distinguishing between inflight funds and funds waiting to retry