### PR TITLE
Fuzz multi-part payments

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -2548,6 +2548,16 @@ pub fn do_test<Out: Output>(data: &[u8], underlying_out: Out, anchors: bool) {
 
 				process_all_events!();
 
+				// Verify no payments are stuck - all should have resolved
+				for (idx, pending) in pending_payments.borrow().iter().enumerate() {
+					assert!(
+						pending.is_empty(),
+						"Node {} has {} stuck pending payments after settling all state",
+						idx,
+						pending.len()
+					);
+				}
+
 				// Finally, make sure that at least one end of each channel can make a substantial payment
 				for &scid in &chan_ab_scids {
 					assert!(


### PR DESCRIPTION
Increases fuzz coverage for multi-path payments in `chanmon_consistency`. Helpful for increasing confidence that #4345 (which makes use of async persistence) is stable to use.

## Changes
- Expand `chanmon_consistency` from 2 to 6 channels (3 per peer pair)
- Add MPP payment fuzzing commands (`0x70`-`0x74`) that split payments across multiple channels, with variants for direct, single-hop, and multi-hop paths
- Assert no stuck payments after settling all state
