### PR TITLE
Revert "Check semver of all workspace crates rather than an explicit …

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -13,13 +13,40 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
-      - name: Install Rust stable toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain stable
-          rustup override set stable
-      - name: Install SemVer Checker
-        run: cargo install cargo-semver-checks --locked
-      - name: Check SemVer with all features
-        run: cargo semver-checks
-      - name: Check SemVer without any non-default features
-        run: cargo semver-checks --only-explicit-features
+      - name: Check SemVer with default features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            feature-group: default-features
+      - name: Check SemVer *without* default features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            feature-group: only-explicit-features
+      - name: Check lightning-background-processor SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            package: lightning-background-processor
+            feature-group: only-explicit-features
+      - name: Check lightning-block-sync SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            package: lightning-block-sync
+            feature-group: only-explicit-features
+            features: rpc-client,rest-client
+      - name: Check lightning-transaction-sync electrum SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            manifest-path: lightning-transaction-sync/Cargo.toml
+            feature-group: only-explicit-features
+            features: electrum
+      - name: Check lightning-transaction-sync esplora-blocking SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            manifest-path: lightning-transaction-sync/Cargo.toml
+            feature-group: only-explicit-features
+            features: esplora-blocking
+      - name: Check lightning-transaction-sync esplora-async SemVer
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+            manifest-path: lightning-transaction-sync/Cargo.toml
+            feature-group: only-explicit-features
+            features: esplora-async


### PR DESCRIPTION
…list"

This reverts commit a123cfa0d4a2c83b329bfea554b8aa920a2e7929.

In this commit we made a bunch of changes to our SemVer CI that switched away from the default CI action, but also stopped testing particular features for sub-crates. Here we revert these changes as we still want to test explicit features individually *and* should just use the CI action.