### PR TITLE
Add non-atomic ordered batch write method to KVStore traits

### DIFF
--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -825,7 +825,7 @@ impl<Signer: sign::ecdsa::EcdsaChannelSigner> Persist<Signer> for WatchtowerPers
 		);
 	}
 
-	fn flush(&self, _count: usize) -> Result<Vec<(ChannelId, u64)>, io::Error> {
+	fn flush(&self, _count: usize, _channel_manager_bytes: Vec<u8>) -> Result<Vec<(ChannelId, u64)>, io::Error> {
 		Ok(Vec::new())
 	}
 }
@@ -892,7 +892,7 @@ impl<Signer: sign::ecdsa::EcdsaChannelSigner> Persist<Signer> for TestPersister 
 		self.chain_sync_monitor_persistences.lock().unwrap().retain(|x| x != &monitor_name);
 	}
 
-	fn flush(&self, _count: usize) -> Result<Vec<(ChannelId, u64)>, io::Error> {
+	fn flush(&self, _count: usize, _channel_manager_bytes: Vec<u8>) -> Result<Vec<(ChannelId, u64)>, io::Error> {
 		Ok(Vec::new())
 	}
 }


### PR DESCRIPTION
Adds `write_batch` method to both `KVStoreSync` and `KVStore` traits with default implementations that delegate to the single `write` method.

- `BatchWriteEntry`: struct containing namespace, key, and data
- `BatchWriteResult`: returns successful write count and optional error
- Writes execute sequentially in order; stops on first error
- Existing implementations automatically inherit the default behavior

And show how it can be used in the background processor to write a complete batch.

Based on #4317