### PR TITLE
Use `SignedAmount::unsigned_abs` to avoid overflow

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2664,8 +2664,8 @@ impl FundingScope {
 		their_funding_contribution: SignedAmount, counterparty_funding_pubkey: PublicKey,
 		our_new_holder_keys: ChannelPublicKeys,
 	) -> Self {
-		debug_assert!(our_funding_contribution.abs() <= SignedAmount::MAX_MONEY);
-		debug_assert!(their_funding_contribution.abs() <= SignedAmount::MAX_MONEY);
+		debug_assert!(our_funding_contribution.unsigned_abs() <= Amount::MAX_MONEY);
+		debug_assert!(their_funding_contribution.unsigned_abs() <= Amount::MAX_MONEY);
 
 		let post_channel_value = prev_funding.compute_post_splice_value(
 			our_funding_contribution.to_sat(),
@@ -12155,7 +12155,7 @@ where
 	fn validate_splice_contributions(
 		&self, our_funding_contribution: SignedAmount, their_funding_contribution: SignedAmount,
 	) -> Result<(), String> {
-		if our_funding_contribution.abs() > SignedAmount::MAX_MONEY {
+		if our_funding_contribution.unsigned_abs() > Amount::MAX_MONEY {
 			return Err(format!(
 				"Channel {} cannot be spliced; our {} contribution exceeds the total bitcoin supply",
 				self.context.channel_id(),
@@ -12163,7 +12163,7 @@ where
 			));
 		}
 
-		if their_funding_contribution.abs() > SignedAmount::MAX_MONEY {
+		if their_funding_contribution.unsigned_abs() > Amount::MAX_MONEY {
 			return Err(format!(
 				"Channel {} cannot be spliced; their {} contribution exceeds the total bitcoin supply",
 				self.context.channel_id(),


### PR DESCRIPTION
In debug mode, using `SignedAmount::abs` can lead to an integer overflow when used with `SignedAmount::MIN`. Use `SignedAmount::unsigned_abs` to avoid this.