### PR TITLE
fuzz: fix ChaCha20 encrypt_single_block to preserve data

### DIFF
--- a/lightning/src/crypto/chacha20.rs
+++ b/lightning/src/crypto/chacha20.rs
@@ -321,6 +321,7 @@ mod fuzzy_chacha {
 		) {
 			debug_assert_eq!(dest.len(), src.len());
 			debug_assert!(dest.len() <= 32);
+			dest.copy_from_slice(src);
 		}
 
 		pub fn encrypt_single_block_in_place(


### PR DESCRIPTION
The fuzzing ChaCha20's encrypt_single_block wasn't copying src to dest, leaving dest as zeros. This caused payment metadata in payment_secret to be lost, making the receiver detect LdkPaymentHash (method 0) instead of UserPaymentHash (method 1), which then failed preimage verification. 

This means we were never actually fuzzing successful payment completions - all payments failed with "mismatching preimage". The fix makes encrypt_single_block copy src to dest (identity encryption), matching the behavior of process().

Verified by adding a panic in the PaymentSent handler: before the fix it never triggered, after the fix it does.