### PR TITLE
Let Claude run per-crate/feature tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,11 @@ See [README.md](README.md) for the workspace layout and [ARCH.md](ARCH.md) for s
 
 ## Development Rules
 
-- Always ensure tests pass before committing. To this end, you should run the test suite via `./ci/ci-tests.sh`.
+- Always ensure tests pass before committing. To this end, you should run
+  `cargo +1.75.0 test` for all affected crates and/or features. Upon completion
+  of the full task you might prompt the user whether they want you to run the
+  full CI tests via `./ci/ci-tests.sh`. Note however that this script will run
+  for a very long time, so please don't timeout when you do.
 - Run `cargo +1.75.0 fmt --all` after every code change
 - Never add new dependencies unless explicitly requested
 - Please always disclose the use of any AI tools in commit messages and PR descriptions using a `Co-Authored-By:` line.


### PR DESCRIPTION
Previously, we instructed Claude to always run `./ci/ci-tests.sh` which doesn't seem to work well in practice, as he seems to also employ some kind of timeout, potentially leading to him getting stuck.

Here we update `CLAUDE.md` accordingly, having him only run `cargo test`

(Yes, @joostjager, you were right on the original PR, my bad).