### PR TITLE
Fix thread starvation in `test_single_channel_multiple_mpp`

### DIFF
--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -4715,6 +4715,9 @@ fn test_single_channel_multiple_mpp() {
 				}
 				have_event = true;
 			}
+			if !have_event {
+				std::thread::yield_now();
+			}
 		}
 	});
 


### PR DESCRIPTION
The busy-wait loop polling for `PaymentClaimed` events had no yield, causing it to continuously acquire `ChannelManager` locks via `get_and_clear_pending_events()`. This could starve the `claim_funds` thread of lock access, preventing it from ever queuing the event. Add a `yield_now()` call matching the pattern used by the other two spin loops in this test.