### PR TITLE
Use `DirEntry::file_type` rather than `metadata...` in `list`

### DIFF
--- a/lightning-persister/src/fs_store.rs
+++ b/lightning-persister/src/fs_store.rs
@@ -560,15 +560,15 @@ fn dir_entry_is_key(dir_entry: &fs::DirEntry) -> Result<bool, lightning::io::Err
 		}
 	}
 
-	let metadata = dir_entry.metadata()?;
+	let file_type = dir_entry.file_type()?;
 
 	// We allow the presence of directories in the empty primary namespace and just skip them.
-	if metadata.is_dir() {
+	if file_type.is_dir() {
 		return Ok(false);
 	}
 
 	// If we otherwise don't find a file at the given path something went wrong.
-	if !metadata.is_file() {
+	if !file_type.is_file() {
 		debug_assert!(
 			false,
 			"Failed to list keys at path {}: file couldn't be accessed.",


### PR DESCRIPTION
In the discussions at #3799 it was noted that `DirEntry::file_type` will often use cached information rather than making a fresh syscall, fixing the `list` race condition where we lose files while iterating the directory for some filesystems on some Unix platforms.

For some reason, that fix didn't make it into the merged PR, and we rather stuck with `DirEntry::metadata()` which *always* does a fresh syscall and always exhibits the problematic behavior. Here we simply swap for `DirEntry::file_type` which at least fixes the issue for "some filesome filesystems (among them: Btrfs, ext2, ext3, and ext4)" (per `readdir(3)`).