### PR TITLE
Add CI job to report main branch build failures via GitHub issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,3 +342,50 @@ jobs:
       - name: Test tor connections using lightning-net-tokio
         run: |
           TOR_PROXY="127.0.0.1:9050" RUSTFLAGS="--cfg=tor" cargo test --verbose --color always -p lightning-net-tokio
+
+  notify-failure:
+    needs: [build, fuzz, linting, rustfmt, check_release, check_docs, benchmark, ext-test, tor-connect, coverage]
+    if: failure() && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create or update failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          LABEL="build failed"
+          TITLE="Failed build: ${{ github.workflow }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          REPO_URL="https://github.com/${{ github.repository }}"
+          COMMITTER="${{ github.event.head_commit.author.username }}"
+          BODY="GitHub Actions workflow [${{ github.workflow }} #${{ github.run_number }}](${RUN_URL}) failed."
+          BODY="${BODY}"$'\n\n'"Event: ${{ github.event_name }}"
+          BRANCH="${{ github.ref_name }}"
+          BODY="${BODY}"$'\n'"Branch: [${BRANCH}](${REPO_URL}/tree/${BRANCH})"
+          BODY="${BODY}"$'\n'"Commit: [${{ github.sha }}](${REPO_URL}/commit/${{ github.sha }})"
+          if [ -n "$COMMITTER" ]; then
+            BODY="${BODY}"$'\n'"Committer: @${COMMITTER}"
+          fi
+
+          # Ensure label exists
+          if ! gh label list --search "$LABEL" --json name --jq '.[].name' | grep -qxF "$LABEL"; then
+            gh label create "$LABEL"
+          fi
+
+          # Find existing open issue with this label
+          ISSUE_NUMBER=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+          else
+            ISSUE_URL=$(gh issue create --title "$TITLE" --label "$LABEL" --body "$BODY")
+            ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
+          fi
+
+          # Assign issue to committer if no one is assigned yet
+          ASSIGNEE_COUNT=$(gh issue view "$ISSUE_NUMBER" --json assignees --jq '.assignees | length')
+          if [ "$ASSIGNEE_COUNT" = "0" ] && [ -n "$COMMITTER" ]; then
+            gh issue edit "$ISSUE_NUMBER" --add-assignee "$COMMITTER" || true
+          fi


### PR DESCRIPTION
Adds a `notify-failure` job to the main CI workflow (`build.yml`) that automatically creates a GitHub issue when the main branch build fails. The job uses inline `gh` CLI commands (no third-party action dependency) to create or comment on an issue labeled "build failed". It triggers on `main` branch pushes when at least one job in `build.yml` has failed.

The job depends on all existing jobs in `build.yml` and runs after they complete. If any job fails, it either creates a new issue with the "build failed" label or adds a comment to an existing open issue with that label. Each comment includes the workflow run link, event, branch, commit, and committer (as an @-mention). Closing the issue signals the problem is resolved; subsequent failures will create a fresh issue. The first committer whose push triggers a failure is assigned to the issue; subsequent failures that add comments do not reassign.

Note that this only covers jobs in `build.yml`. Other workflows that run on main pushes (`semver.yml`, `ldk-node-integration.yml`) are not covered yet, as GitHub Actions `needs` cannot cross workflow boundaries. Expanding coverage would require some restructuring (e.g., converting them to reusable workflows or duplicating the notification job).

Permissions are scoped to `issues: write` only, so the token cannot be used to push code, modify workflows, or access secrets.

Tested on the main branch of my fork by deliberately breaking the build. The action successfully created an issue: https://github.com/joostjager/rust-lightning/issues/7
