### PR TITLE
Fuzz stdin support

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -39,6 +39,7 @@ cc = "1.0"
 members = ["."]
 
 [profile.release]
+panic = "abort"
 lto = true
 codegen-units = 1
 debug-assertions = true
@@ -46,12 +47,13 @@ overflow-checks = true
 
 # When testing a large fuzz corpus, -O1 offers a nice speedup
 [profile.dev]
+panic = "abort"
 opt-level = 1
 
 [lib]
 name = "lightning_fuzz"
 path = "src/lib.rs"
-crate-type = ["rlib", "dylib", "staticlib"]
+crate-type = ["rlib", "staticlib"]
 
 [lints.rust.unexpected_cfgs]
 level = "forbid"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -148,6 +148,16 @@ mv hfuzz_workspace/fuzz_target/SIGABRT.PC.7ffff7e21ce1.STACK.[…].fuzz ./test_c
 
 This will reproduce the failing fuzz input and yield a usable stack trace.
 
+Alternatively, you can use the `stdin_fuzz` feature to pipe the crash input directly without
+creating test case files on disk:
+
+```shell
+echo -ne '\x2d\x31\x36\x38\x37\x34\x09\x01...' | RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz" cargo run --features stdin_fuzz --bin full_stack_target
+```
+
+Panics will abort the process directly (the crate uses `panic = "abort"`), resulting in a
+non-zero exit code. Piping via stdin is useful for reproducing crashes during `git bisect` or
+when working with AI agents that can construct and pipe byte sequences directly.
 
 ## How do I add a new fuzz test?
 

--- a/fuzz/src/bin/base32_target.rs
+++ b/fuzz/src/bin/base32_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::base32::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		base32_run(data.as_ptr(), data.len());
+		base32_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			base32_run(data.as_ptr(), data.len());
+			base32_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	base32_run(data.as_ptr(), data.len());
+	base32_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	base32_run(data.as_ptr(), data.len());
+	base32_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		base32_run(data.as_ptr(), data.len());
+		base32_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/bech32_parse_target.rs
+++ b/fuzz/src/bin/bech32_parse_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::bech32_parse::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		bech32_parse_run(data.as_ptr(), data.len());
+		bech32_parse_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			bech32_parse_run(data.as_ptr(), data.len());
+			bech32_parse_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	bech32_parse_run(data.as_ptr(), data.len());
+	bech32_parse_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	bech32_parse_run(data.as_ptr(), data.len());
+	bech32_parse_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		bech32_parse_run(data.as_ptr(), data.len());
+		bech32_parse_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/bolt11_deser_target.rs
+++ b/fuzz/src/bin/bolt11_deser_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::bolt11_deser::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		bolt11_deser_run(data.as_ptr(), data.len());
+		bolt11_deser_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			bolt11_deser_run(data.as_ptr(), data.len());
+			bolt11_deser_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	bolt11_deser_run(data.as_ptr(), data.len());
+	bolt11_deser_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	bolt11_deser_run(data.as_ptr(), data.len());
+	bolt11_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		bolt11_deser_run(data.as_ptr(), data.len());
+		bolt11_deser_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/chanmon_consistency_target.rs
+++ b/fuzz/src/bin/chanmon_consistency_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::chanmon_consistency::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		chanmon_consistency_run(data.as_ptr(), data.len());
+		chanmon_consistency_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			chanmon_consistency_run(data.as_ptr(), data.len());
+			chanmon_consistency_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	chanmon_consistency_run(data.as_ptr(), data.len());
+	chanmon_consistency_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	chanmon_consistency_run(data.as_ptr(), data.len());
+	chanmon_consistency_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		chanmon_consistency_run(data.as_ptr(), data.len());
+		chanmon_consistency_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/chanmon_deser_target.rs
+++ b/fuzz/src/bin/chanmon_deser_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::chanmon_deser::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		chanmon_deser_run(data.as_ptr(), data.len());
+		chanmon_deser_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			chanmon_deser_run(data.as_ptr(), data.len());
+			chanmon_deser_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	chanmon_deser_run(data.as_ptr(), data.len());
+	chanmon_deser_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	chanmon_deser_run(data.as_ptr(), data.len());
+	chanmon_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		chanmon_deser_run(data.as_ptr(), data.len());
+		chanmon_deser_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/feature_flags_target.rs
+++ b/fuzz/src/bin/feature_flags_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::feature_flags::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		feature_flags_run(data.as_ptr(), data.len());
+		feature_flags_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			feature_flags_run(data.as_ptr(), data.len());
+			feature_flags_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	feature_flags_run(data.as_ptr(), data.len());
+	feature_flags_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	feature_flags_run(data.as_ptr(), data.len());
+	feature_flags_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		feature_flags_run(data.as_ptr(), data.len());
+		feature_flags_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/fromstr_to_netaddress_target.rs
+++ b/fuzz/src/bin/fromstr_to_netaddress_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::fromstr_to_netaddress::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		fromstr_to_netaddress_run(data.as_ptr(), data.len());
+		fromstr_to_netaddress_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			fromstr_to_netaddress_run(data.as_ptr(), data.len());
+			fromstr_to_netaddress_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	fromstr_to_netaddress_run(data.as_ptr(), data.len());
+	fromstr_to_netaddress_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	fromstr_to_netaddress_run(data.as_ptr(), data.len());
+	fromstr_to_netaddress_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		fromstr_to_netaddress_run(data.as_ptr(), data.len());
+		fromstr_to_netaddress_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/fs_store_target.rs
+++ b/fuzz/src/bin/fs_store_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::fs_store::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		fs_store_run(data.as_ptr(), data.len());
+		fs_store_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			fs_store_run(data.as_ptr(), data.len());
+			fs_store_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	fs_store_run(data.as_ptr(), data.len());
+	fs_store_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	fs_store_run(data.as_ptr(), data.len());
+	fs_store_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		fs_store_run(data.as_ptr(), data.len());
+		fs_store_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/full_stack_target.rs
+++ b/fuzz/src/bin/full_stack_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::full_stack::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		full_stack_run(data.as_ptr(), data.len());
+		full_stack_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			full_stack_run(data.as_ptr(), data.len());
+			full_stack_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	full_stack_run(data.as_ptr(), data.len());
+	full_stack_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	full_stack_run(data.as_ptr(), data.len());
+	full_stack_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		full_stack_run(data.as_ptr(), data.len());
+		full_stack_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/indexedmap_target.rs
+++ b/fuzz/src/bin/indexedmap_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::indexedmap::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		indexedmap_run(data.as_ptr(), data.len());
+		indexedmap_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			indexedmap_run(data.as_ptr(), data.len());
+			indexedmap_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	indexedmap_run(data.as_ptr(), data.len());
+	indexedmap_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	indexedmap_run(data.as_ptr(), data.len());
+	indexedmap_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		indexedmap_run(data.as_ptr(), data.len());
+		indexedmap_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/invoice_deser_target.rs
+++ b/fuzz/src/bin/invoice_deser_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::invoice_deser::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		invoice_deser_run(data.as_ptr(), data.len());
+		invoice_deser_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			invoice_deser_run(data.as_ptr(), data.len());
+			invoice_deser_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	invoice_deser_run(data.as_ptr(), data.len());
+	invoice_deser_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	invoice_deser_run(data.as_ptr(), data.len());
+	invoice_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		invoice_deser_run(data.as_ptr(), data.len());
+		invoice_deser_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/invoice_request_deser_target.rs
+++ b/fuzz/src/bin/invoice_request_deser_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::invoice_request_deser::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		invoice_request_deser_run(data.as_ptr(), data.len());
+		invoice_request_deser_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			invoice_request_deser_run(data.as_ptr(), data.len());
+			invoice_request_deser_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	invoice_request_deser_run(data.as_ptr(), data.len());
+	invoice_request_deser_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	invoice_request_deser_run(data.as_ptr(), data.len());
+	invoice_request_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		invoice_request_deser_run(data.as_ptr(), data.len());
+		invoice_request_deser_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/lsps_message_target.rs
+++ b/fuzz/src/bin/lsps_message_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::lsps_message::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		lsps_message_run(data.as_ptr(), data.len());
+		lsps_message_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			lsps_message_run(data.as_ptr(), data.len());
+			lsps_message_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	lsps_message_run(data.as_ptr(), data.len());
+	lsps_message_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	lsps_message_run(data.as_ptr(), data.len());
+	lsps_message_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		lsps_message_run(data.as_ptr(), data.len());
+		lsps_message_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_accept_channel_target.rs
+++ b/fuzz/src/bin/msg_accept_channel_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_accept_channel::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_accept_channel_run(data.as_ptr(), data.len());
+		msg_accept_channel_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_accept_channel_run(data.as_ptr(), data.len());
+			msg_accept_channel_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_accept_channel_run(data.as_ptr(), data.len());
+	msg_accept_channel_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_accept_channel_run(data.as_ptr(), data.len());
+	msg_accept_channel_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_accept_channel_run(data.as_ptr(), data.len());
+		msg_accept_channel_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_accept_channel_v2_target.rs
+++ b/fuzz/src/bin/msg_accept_channel_v2_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_accept_channel_v2::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_accept_channel_v2_run(data.as_ptr(), data.len());
+		msg_accept_channel_v2_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_accept_channel_v2_run(data.as_ptr(), data.len());
+			msg_accept_channel_v2_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_accept_channel_v2_run(data.as_ptr(), data.len());
+	msg_accept_channel_v2_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_accept_channel_v2_run(data.as_ptr(), data.len());
+	msg_accept_channel_v2_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_accept_channel_v2_run(data.as_ptr(), data.len());
+		msg_accept_channel_v2_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_announcement_signatures_target.rs
+++ b/fuzz/src/bin/msg_announcement_signatures_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_announcement_signatures::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_announcement_signatures_run(data.as_ptr(), data.len());
+		msg_announcement_signatures_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_announcement_signatures_run(data.as_ptr(), data.len());
+			msg_announcement_signatures_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_announcement_signatures_run(data.as_ptr(), data.len());
+	msg_announcement_signatures_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_announcement_signatures_run(data.as_ptr(), data.len());
+	msg_announcement_signatures_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_announcement_signatures_run(data.as_ptr(), data.len());
+		msg_announcement_signatures_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_blinded_message_path_target.rs
+++ b/fuzz/src/bin/msg_blinded_message_path_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_blinded_message_path::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_blinded_message_path_run(data.as_ptr(), data.len());
+		msg_blinded_message_path_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_blinded_message_path_run(data.as_ptr(), data.len());
+			msg_blinded_message_path_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_blinded_message_path_run(data.as_ptr(), data.len());
+	msg_blinded_message_path_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_blinded_message_path_run(data.as_ptr(), data.len());
+	msg_blinded_message_path_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_blinded_message_path_run(data.as_ptr(), data.len());
+		msg_blinded_message_path_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_channel_announcement_target.rs
+++ b/fuzz/src/bin/msg_channel_announcement_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_channel_announcement::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_channel_announcement_run(data.as_ptr(), data.len());
+		msg_channel_announcement_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_channel_announcement_run(data.as_ptr(), data.len());
+			msg_channel_announcement_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_channel_announcement_run(data.as_ptr(), data.len());
+	msg_channel_announcement_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_announcement_run(data.as_ptr(), data.len());
+	msg_channel_announcement_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_channel_announcement_run(data.as_ptr(), data.len());
+		msg_channel_announcement_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_channel_details_target.rs
+++ b/fuzz/src/bin/msg_channel_details_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_channel_details::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_channel_details_run(data.as_ptr(), data.len());
+		msg_channel_details_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_channel_details_run(data.as_ptr(), data.len());
+			msg_channel_details_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_channel_details_run(data.as_ptr(), data.len());
+	msg_channel_details_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_details_run(data.as_ptr(), data.len());
+	msg_channel_details_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_channel_details_run(data.as_ptr(), data.len());
+		msg_channel_details_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_channel_ready_target.rs
+++ b/fuzz/src/bin/msg_channel_ready_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_channel_ready::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_channel_ready_run(data.as_ptr(), data.len());
+		msg_channel_ready_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_channel_ready_run(data.as_ptr(), data.len());
+			msg_channel_ready_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_channel_ready_run(data.as_ptr(), data.len());
+	msg_channel_ready_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_ready_run(data.as_ptr(), data.len());
+	msg_channel_ready_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_channel_ready_run(data.as_ptr(), data.len());
+		msg_channel_ready_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_channel_reestablish_target.rs
+++ b/fuzz/src/bin/msg_channel_reestablish_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_channel_reestablish::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_channel_reestablish_run(data.as_ptr(), data.len());
+		msg_channel_reestablish_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_channel_reestablish_run(data.as_ptr(), data.len());
+			msg_channel_reestablish_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_channel_reestablish_run(data.as_ptr(), data.len());
+	msg_channel_reestablish_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_reestablish_run(data.as_ptr(), data.len());
+	msg_channel_reestablish_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_channel_reestablish_run(data.as_ptr(), data.len());
+		msg_channel_reestablish_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_channel_update_target.rs
+++ b/fuzz/src/bin/msg_channel_update_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_channel_update::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_channel_update_run(data.as_ptr(), data.len());
+		msg_channel_update_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_channel_update_run(data.as_ptr(), data.len());
+			msg_channel_update_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_channel_update_run(data.as_ptr(), data.len());
+	msg_channel_update_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_update_run(data.as_ptr(), data.len());
+	msg_channel_update_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_channel_update_run(data.as_ptr(), data.len());
+		msg_channel_update_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_closing_complete_target.rs
+++ b/fuzz/src/bin/msg_closing_complete_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_closing_complete::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_closing_complete_run(data.as_ptr(), data.len());
+		msg_closing_complete_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_closing_complete_run(data.as_ptr(), data.len());
+			msg_closing_complete_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_closing_complete_run(data.as_ptr(), data.len());
+	msg_closing_complete_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_closing_complete_run(data.as_ptr(), data.len());
+	msg_closing_complete_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_closing_complete_run(data.as_ptr(), data.len());
+		msg_closing_complete_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_closing_sig_target.rs
+++ b/fuzz/src/bin/msg_closing_sig_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_closing_sig::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_closing_sig_run(data.as_ptr(), data.len());
+		msg_closing_sig_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_closing_sig_run(data.as_ptr(), data.len());
+			msg_closing_sig_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_closing_sig_run(data.as_ptr(), data.len());
+	msg_closing_sig_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_closing_sig_run(data.as_ptr(), data.len());
+	msg_closing_sig_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_closing_sig_run(data.as_ptr(), data.len());
+		msg_closing_sig_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_closing_signed_target.rs
+++ b/fuzz/src/bin/msg_closing_signed_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_closing_signed::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_closing_signed_run(data.as_ptr(), data.len());
+		msg_closing_signed_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_closing_signed_run(data.as_ptr(), data.len());
+			msg_closing_signed_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_closing_signed_run(data.as_ptr(), data.len());
+	msg_closing_signed_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_closing_signed_run(data.as_ptr(), data.len());
+	msg_closing_signed_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_closing_signed_run(data.as_ptr(), data.len());
+		msg_closing_signed_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_commitment_signed_target.rs
+++ b/fuzz/src/bin/msg_commitment_signed_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_commitment_signed::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_commitment_signed_run(data.as_ptr(), data.len());
+		msg_commitment_signed_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_commitment_signed_run(data.as_ptr(), data.len());
+			msg_commitment_signed_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_commitment_signed_run(data.as_ptr(), data.len());
+	msg_commitment_signed_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_commitment_signed_run(data.as_ptr(), data.len());
+	msg_commitment_signed_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_commitment_signed_run(data.as_ptr(), data.len());
+		msg_commitment_signed_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
+++ b/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_decoded_onion_error_packet::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_decoded_onion_error_packet_run(data.as_ptr(), data.len());
+		msg_decoded_onion_error_packet_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_decoded_onion_error_packet_run(data.as_ptr(), data.len());
+			msg_decoded_onion_error_packet_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_decoded_onion_error_packet_run(data.as_ptr(), data.len());
+	msg_decoded_onion_error_packet_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_decoded_onion_error_packet_run(data.as_ptr(), data.len());
+	msg_decoded_onion_error_packet_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_decoded_onion_error_packet_run(data.as_ptr(), data.len());
+		msg_decoded_onion_error_packet_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_error_message_target.rs
+++ b/fuzz/src/bin/msg_error_message_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_error_message::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_error_message_run(data.as_ptr(), data.len());
+		msg_error_message_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_error_message_run(data.as_ptr(), data.len());
+			msg_error_message_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_error_message_run(data.as_ptr(), data.len());
+	msg_error_message_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_error_message_run(data.as_ptr(), data.len());
+	msg_error_message_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_error_message_run(data.as_ptr(), data.len());
+		msg_error_message_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_funding_created_target.rs
+++ b/fuzz/src/bin/msg_funding_created_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_funding_created::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_funding_created_run(data.as_ptr(), data.len());
+		msg_funding_created_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_funding_created_run(data.as_ptr(), data.len());
+			msg_funding_created_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_funding_created_run(data.as_ptr(), data.len());
+	msg_funding_created_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_funding_created_run(data.as_ptr(), data.len());
+	msg_funding_created_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_funding_created_run(data.as_ptr(), data.len());
+		msg_funding_created_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_funding_signed_target.rs
+++ b/fuzz/src/bin/msg_funding_signed_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_funding_signed::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_funding_signed_run(data.as_ptr(), data.len());
+		msg_funding_signed_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_funding_signed_run(data.as_ptr(), data.len());
+			msg_funding_signed_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_funding_signed_run(data.as_ptr(), data.len());
+	msg_funding_signed_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_funding_signed_run(data.as_ptr(), data.len());
+	msg_funding_signed_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_funding_signed_run(data.as_ptr(), data.len());
+		msg_funding_signed_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_gossip_timestamp_filter_target.rs
+++ b/fuzz/src/bin/msg_gossip_timestamp_filter_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_gossip_timestamp_filter::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_gossip_timestamp_filter_run(data.as_ptr(), data.len());
+		msg_gossip_timestamp_filter_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_gossip_timestamp_filter_run(data.as_ptr(), data.len());
+			msg_gossip_timestamp_filter_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_gossip_timestamp_filter_run(data.as_ptr(), data.len());
+	msg_gossip_timestamp_filter_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_gossip_timestamp_filter_run(data.as_ptr(), data.len());
+	msg_gossip_timestamp_filter_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_gossip_timestamp_filter_run(data.as_ptr(), data.len());
+		msg_gossip_timestamp_filter_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_init_target.rs
+++ b/fuzz/src/bin/msg_init_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_init::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_init_run(data.as_ptr(), data.len());
+		msg_init_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_init_run(data.as_ptr(), data.len());
+			msg_init_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_init_run(data.as_ptr(), data.len());
+	msg_init_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_init_run(data.as_ptr(), data.len());
+	msg_init_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_init_run(data.as_ptr(), data.len());
+		msg_init_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_node_announcement_target.rs
+++ b/fuzz/src/bin/msg_node_announcement_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_node_announcement::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_node_announcement_run(data.as_ptr(), data.len());
+		msg_node_announcement_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_node_announcement_run(data.as_ptr(), data.len());
+			msg_node_announcement_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_node_announcement_run(data.as_ptr(), data.len());
+	msg_node_announcement_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_node_announcement_run(data.as_ptr(), data.len());
+	msg_node_announcement_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_node_announcement_run(data.as_ptr(), data.len());
+		msg_node_announcement_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_open_channel_target.rs
+++ b/fuzz/src/bin/msg_open_channel_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_open_channel::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_open_channel_run(data.as_ptr(), data.len());
+		msg_open_channel_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_open_channel_run(data.as_ptr(), data.len());
+			msg_open_channel_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_open_channel_run(data.as_ptr(), data.len());
+	msg_open_channel_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_open_channel_run(data.as_ptr(), data.len());
+	msg_open_channel_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_open_channel_run(data.as_ptr(), data.len());
+		msg_open_channel_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_open_channel_v2_target.rs
+++ b/fuzz/src/bin/msg_open_channel_v2_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_open_channel_v2::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_open_channel_v2_run(data.as_ptr(), data.len());
+		msg_open_channel_v2_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_open_channel_v2_run(data.as_ptr(), data.len());
+			msg_open_channel_v2_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_open_channel_v2_run(data.as_ptr(), data.len());
+	msg_open_channel_v2_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_open_channel_v2_run(data.as_ptr(), data.len());
+	msg_open_channel_v2_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_open_channel_v2_run(data.as_ptr(), data.len());
+		msg_open_channel_v2_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_ping_target.rs
+++ b/fuzz/src/bin/msg_ping_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_ping::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_ping_run(data.as_ptr(), data.len());
+		msg_ping_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_ping_run(data.as_ptr(), data.len());
+			msg_ping_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_ping_run(data.as_ptr(), data.len());
+	msg_ping_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_ping_run(data.as_ptr(), data.len());
+	msg_ping_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_ping_run(data.as_ptr(), data.len());
+		msg_ping_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_pong_target.rs
+++ b/fuzz/src/bin/msg_pong_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_pong::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_pong_run(data.as_ptr(), data.len());
+		msg_pong_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_pong_run(data.as_ptr(), data.len());
+			msg_pong_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_pong_run(data.as_ptr(), data.len());
+	msg_pong_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_pong_run(data.as_ptr(), data.len());
+	msg_pong_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_pong_run(data.as_ptr(), data.len());
+		msg_pong_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_query_channel_range_target.rs
+++ b/fuzz/src/bin/msg_query_channel_range_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_query_channel_range::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_query_channel_range_run(data.as_ptr(), data.len());
+		msg_query_channel_range_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_query_channel_range_run(data.as_ptr(), data.len());
+			msg_query_channel_range_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_query_channel_range_run(data.as_ptr(), data.len());
+	msg_query_channel_range_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_query_channel_range_run(data.as_ptr(), data.len());
+	msg_query_channel_range_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_query_channel_range_run(data.as_ptr(), data.len());
+		msg_query_channel_range_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_query_short_channel_ids_target.rs
+++ b/fuzz/src/bin/msg_query_short_channel_ids_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_query_short_channel_ids::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_query_short_channel_ids_run(data.as_ptr(), data.len());
+		msg_query_short_channel_ids_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_query_short_channel_ids_run(data.as_ptr(), data.len());
+			msg_query_short_channel_ids_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_query_short_channel_ids_run(data.as_ptr(), data.len());
+	msg_query_short_channel_ids_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_query_short_channel_ids_run(data.as_ptr(), data.len());
+	msg_query_short_channel_ids_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_query_short_channel_ids_run(data.as_ptr(), data.len());
+		msg_query_short_channel_ids_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_reply_channel_range_target.rs
+++ b/fuzz/src/bin/msg_reply_channel_range_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_reply_channel_range::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_reply_channel_range_run(data.as_ptr(), data.len());
+		msg_reply_channel_range_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_reply_channel_range_run(data.as_ptr(), data.len());
+			msg_reply_channel_range_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_reply_channel_range_run(data.as_ptr(), data.len());
+	msg_reply_channel_range_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_reply_channel_range_run(data.as_ptr(), data.len());
+	msg_reply_channel_range_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_reply_channel_range_run(data.as_ptr(), data.len());
+		msg_reply_channel_range_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_reply_short_channel_ids_end_target.rs
+++ b/fuzz/src/bin/msg_reply_short_channel_ids_end_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_reply_short_channel_ids_end::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_reply_short_channel_ids_end_run(data.as_ptr(), data.len());
+		msg_reply_short_channel_ids_end_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_reply_short_channel_ids_end_run(data.as_ptr(), data.len());
+			msg_reply_short_channel_ids_end_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_reply_short_channel_ids_end_run(data.as_ptr(), data.len());
+	msg_reply_short_channel_ids_end_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_reply_short_channel_ids_end_run(data.as_ptr(), data.len());
+	msg_reply_short_channel_ids_end_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_reply_short_channel_ids_end_run(data.as_ptr(), data.len());
+		msg_reply_short_channel_ids_end_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_revoke_and_ack_target.rs
+++ b/fuzz/src/bin/msg_revoke_and_ack_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_revoke_and_ack::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_revoke_and_ack_run(data.as_ptr(), data.len());
+		msg_revoke_and_ack_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_revoke_and_ack_run(data.as_ptr(), data.len());
+			msg_revoke_and_ack_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_revoke_and_ack_run(data.as_ptr(), data.len());
+	msg_revoke_and_ack_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_revoke_and_ack_run(data.as_ptr(), data.len());
+	msg_revoke_and_ack_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_revoke_and_ack_run(data.as_ptr(), data.len());
+		msg_revoke_and_ack_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_shutdown_target.rs
+++ b/fuzz/src/bin/msg_shutdown_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_shutdown::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_shutdown_run(data.as_ptr(), data.len());
+		msg_shutdown_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_shutdown_run(data.as_ptr(), data.len());
+			msg_shutdown_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_shutdown_run(data.as_ptr(), data.len());
+	msg_shutdown_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_shutdown_run(data.as_ptr(), data.len());
+	msg_shutdown_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_shutdown_run(data.as_ptr(), data.len());
+		msg_shutdown_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_splice_ack_target.rs
+++ b/fuzz/src/bin/msg_splice_ack_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_splice_ack::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_splice_ack_run(data.as_ptr(), data.len());
+		msg_splice_ack_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_splice_ack_run(data.as_ptr(), data.len());
+			msg_splice_ack_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_splice_ack_run(data.as_ptr(), data.len());
+	msg_splice_ack_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_splice_ack_run(data.as_ptr(), data.len());
+	msg_splice_ack_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_splice_ack_run(data.as_ptr(), data.len());
+		msg_splice_ack_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_splice_init_target.rs
+++ b/fuzz/src/bin/msg_splice_init_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_splice_init::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_splice_init_run(data.as_ptr(), data.len());
+		msg_splice_init_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_splice_init_run(data.as_ptr(), data.len());
+			msg_splice_init_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_splice_init_run(data.as_ptr(), data.len());
+	msg_splice_init_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_splice_init_run(data.as_ptr(), data.len());
+	msg_splice_init_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_splice_init_run(data.as_ptr(), data.len());
+		msg_splice_init_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_splice_locked_target.rs
+++ b/fuzz/src/bin/msg_splice_locked_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_splice_locked::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_splice_locked_run(data.as_ptr(), data.len());
+		msg_splice_locked_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_splice_locked_run(data.as_ptr(), data.len());
+			msg_splice_locked_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_splice_locked_run(data.as_ptr(), data.len());
+	msg_splice_locked_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_splice_locked_run(data.as_ptr(), data.len());
+	msg_splice_locked_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_splice_locked_run(data.as_ptr(), data.len());
+		msg_splice_locked_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_stfu_target.rs
+++ b/fuzz/src/bin/msg_stfu_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_stfu::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_stfu_run(data.as_ptr(), data.len());
+		msg_stfu_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_stfu_run(data.as_ptr(), data.len());
+			msg_stfu_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_stfu_run(data.as_ptr(), data.len());
+	msg_stfu_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_stfu_run(data.as_ptr(), data.len());
+	msg_stfu_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_stfu_run(data.as_ptr(), data.len());
+		msg_stfu_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_abort_target.rs
+++ b/fuzz/src/bin/msg_tx_abort_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_abort::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_abort_run(data.as_ptr(), data.len());
+		msg_tx_abort_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_abort_run(data.as_ptr(), data.len());
+			msg_tx_abort_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_abort_run(data.as_ptr(), data.len());
+	msg_tx_abort_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_abort_run(data.as_ptr(), data.len());
+	msg_tx_abort_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_abort_run(data.as_ptr(), data.len());
+		msg_tx_abort_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_ack_rbf_target.rs
+++ b/fuzz/src/bin/msg_tx_ack_rbf_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_ack_rbf::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_ack_rbf_run(data.as_ptr(), data.len());
+		msg_tx_ack_rbf_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_ack_rbf_run(data.as_ptr(), data.len());
+			msg_tx_ack_rbf_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_ack_rbf_run(data.as_ptr(), data.len());
+	msg_tx_ack_rbf_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_ack_rbf_run(data.as_ptr(), data.len());
+	msg_tx_ack_rbf_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_ack_rbf_run(data.as_ptr(), data.len());
+		msg_tx_ack_rbf_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_add_input_target.rs
+++ b/fuzz/src/bin/msg_tx_add_input_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_add_input::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_add_input_run(data.as_ptr(), data.len());
+		msg_tx_add_input_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_add_input_run(data.as_ptr(), data.len());
+			msg_tx_add_input_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_add_input_run(data.as_ptr(), data.len());
+	msg_tx_add_input_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_add_input_run(data.as_ptr(), data.len());
+	msg_tx_add_input_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_add_input_run(data.as_ptr(), data.len());
+		msg_tx_add_input_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_add_output_target.rs
+++ b/fuzz/src/bin/msg_tx_add_output_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_add_output::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_add_output_run(data.as_ptr(), data.len());
+		msg_tx_add_output_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_add_output_run(data.as_ptr(), data.len());
+			msg_tx_add_output_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_add_output_run(data.as_ptr(), data.len());
+	msg_tx_add_output_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_add_output_run(data.as_ptr(), data.len());
+	msg_tx_add_output_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_add_output_run(data.as_ptr(), data.len());
+		msg_tx_add_output_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_complete_target.rs
+++ b/fuzz/src/bin/msg_tx_complete_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_complete::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_complete_run(data.as_ptr(), data.len());
+		msg_tx_complete_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_complete_run(data.as_ptr(), data.len());
+			msg_tx_complete_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_complete_run(data.as_ptr(), data.len());
+	msg_tx_complete_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_complete_run(data.as_ptr(), data.len());
+	msg_tx_complete_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_complete_run(data.as_ptr(), data.len());
+		msg_tx_complete_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_init_rbf_target.rs
+++ b/fuzz/src/bin/msg_tx_init_rbf_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_init_rbf::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_init_rbf_run(data.as_ptr(), data.len());
+		msg_tx_init_rbf_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_init_rbf_run(data.as_ptr(), data.len());
+			msg_tx_init_rbf_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_init_rbf_run(data.as_ptr(), data.len());
+	msg_tx_init_rbf_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_init_rbf_run(data.as_ptr(), data.len());
+	msg_tx_init_rbf_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_init_rbf_run(data.as_ptr(), data.len());
+		msg_tx_init_rbf_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_remove_input_target.rs
+++ b/fuzz/src/bin/msg_tx_remove_input_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_remove_input::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_remove_input_run(data.as_ptr(), data.len());
+		msg_tx_remove_input_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_remove_input_run(data.as_ptr(), data.len());
+			msg_tx_remove_input_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_remove_input_run(data.as_ptr(), data.len());
+	msg_tx_remove_input_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_remove_input_run(data.as_ptr(), data.len());
+	msg_tx_remove_input_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_remove_input_run(data.as_ptr(), data.len());
+		msg_tx_remove_input_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_remove_output_target.rs
+++ b/fuzz/src/bin/msg_tx_remove_output_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_remove_output::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_remove_output_run(data.as_ptr(), data.len());
+		msg_tx_remove_output_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_remove_output_run(data.as_ptr(), data.len());
+			msg_tx_remove_output_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_remove_output_run(data.as_ptr(), data.len());
+	msg_tx_remove_output_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_remove_output_run(data.as_ptr(), data.len());
+	msg_tx_remove_output_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_remove_output_run(data.as_ptr(), data.len());
+		msg_tx_remove_output_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_tx_signatures_target.rs
+++ b/fuzz/src/bin/msg_tx_signatures_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_tx_signatures::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_tx_signatures_run(data.as_ptr(), data.len());
+		msg_tx_signatures_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_tx_signatures_run(data.as_ptr(), data.len());
+			msg_tx_signatures_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_tx_signatures_run(data.as_ptr(), data.len());
+	msg_tx_signatures_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_signatures_run(data.as_ptr(), data.len());
+	msg_tx_signatures_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_tx_signatures_run(data.as_ptr(), data.len());
+		msg_tx_signatures_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_update_add_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_add_htlc_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_update_add_htlc::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_update_add_htlc_run(data.as_ptr(), data.len());
+		msg_update_add_htlc_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_update_add_htlc_run(data.as_ptr(), data.len());
+			msg_update_add_htlc_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_update_add_htlc_run(data.as_ptr(), data.len());
+	msg_update_add_htlc_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_add_htlc_run(data.as_ptr(), data.len());
+	msg_update_add_htlc_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_update_add_htlc_run(data.as_ptr(), data.len());
+		msg_update_add_htlc_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_update_fail_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_htlc_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_update_fail_htlc::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_update_fail_htlc_run(data.as_ptr(), data.len());
+		msg_update_fail_htlc_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_update_fail_htlc_run(data.as_ptr(), data.len());
+			msg_update_fail_htlc_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_update_fail_htlc_run(data.as_ptr(), data.len());
+	msg_update_fail_htlc_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_fail_htlc_run(data.as_ptr(), data.len());
+	msg_update_fail_htlc_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_update_fail_htlc_run(data.as_ptr(), data.len());
+		msg_update_fail_htlc_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_update_fail_malformed_htlc::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_update_fail_malformed_htlc_run(data.as_ptr(), data.len());
+		msg_update_fail_malformed_htlc_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_update_fail_malformed_htlc_run(data.as_ptr(), data.len());
+			msg_update_fail_malformed_htlc_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_update_fail_malformed_htlc_run(data.as_ptr(), data.len());
+	msg_update_fail_malformed_htlc_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_fail_malformed_htlc_run(data.as_ptr(), data.len());
+	msg_update_fail_malformed_htlc_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_update_fail_malformed_htlc_run(data.as_ptr(), data.len());
+		msg_update_fail_malformed_htlc_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_update_fee_target.rs
+++ b/fuzz/src/bin/msg_update_fee_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_update_fee::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_update_fee_run(data.as_ptr(), data.len());
+		msg_update_fee_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_update_fee_run(data.as_ptr(), data.len());
+			msg_update_fee_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_update_fee_run(data.as_ptr(), data.len());
+	msg_update_fee_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_fee_run(data.as_ptr(), data.len());
+	msg_update_fee_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_update_fee_run(data.as_ptr(), data.len());
+		msg_update_fee_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::msg_targets::msg_update_fulfill_htlc::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		msg_update_fulfill_htlc_run(data.as_ptr(), data.len());
+		msg_update_fulfill_htlc_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			msg_update_fulfill_htlc_run(data.as_ptr(), data.len());
+			msg_update_fulfill_htlc_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	msg_update_fulfill_htlc_run(data.as_ptr(), data.len());
+	msg_update_fulfill_htlc_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_fulfill_htlc_run(data.as_ptr(), data.len());
+	msg_update_fulfill_htlc_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		msg_update_fulfill_htlc_run(data.as_ptr(), data.len());
+		msg_update_fulfill_htlc_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/offer_deser_target.rs
+++ b/fuzz/src/bin/offer_deser_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::offer_deser::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		offer_deser_run(data.as_ptr(), data.len());
+		offer_deser_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			offer_deser_run(data.as_ptr(), data.len());
+			offer_deser_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	offer_deser_run(data.as_ptr(), data.len());
+	offer_deser_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	offer_deser_run(data.as_ptr(), data.len());
+	offer_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		offer_deser_run(data.as_ptr(), data.len());
+		offer_deser_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/onion_hop_data_target.rs
+++ b/fuzz/src/bin/onion_hop_data_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::onion_hop_data::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		onion_hop_data_run(data.as_ptr(), data.len());
+		onion_hop_data_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			onion_hop_data_run(data.as_ptr(), data.len());
+			onion_hop_data_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	onion_hop_data_run(data.as_ptr(), data.len());
+	onion_hop_data_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	onion_hop_data_run(data.as_ptr(), data.len());
+	onion_hop_data_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		onion_hop_data_run(data.as_ptr(), data.len());
+		onion_hop_data_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/onion_message_target.rs
+++ b/fuzz/src/bin/onion_message_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::onion_message::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		onion_message_run(data.as_ptr(), data.len());
+		onion_message_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			onion_message_run(data.as_ptr(), data.len());
+			onion_message_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	onion_message_run(data.as_ptr(), data.len());
+	onion_message_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	onion_message_run(data.as_ptr(), data.len());
+	onion_message_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		onion_message_run(data.as_ptr(), data.len());
+		onion_message_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/peer_crypt_target.rs
+++ b/fuzz/src/bin/peer_crypt_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::peer_crypt::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		peer_crypt_run(data.as_ptr(), data.len());
+		peer_crypt_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			peer_crypt_run(data.as_ptr(), data.len());
+			peer_crypt_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	peer_crypt_run(data.as_ptr(), data.len());
+	peer_crypt_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	peer_crypt_run(data.as_ptr(), data.len());
+	peer_crypt_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		peer_crypt_run(data.as_ptr(), data.len());
+		peer_crypt_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/process_network_graph_target.rs
+++ b/fuzz/src/bin/process_network_graph_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::process_network_graph::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		process_network_graph_run(data.as_ptr(), data.len());
+		process_network_graph_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			process_network_graph_run(data.as_ptr(), data.len());
+			process_network_graph_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	process_network_graph_run(data.as_ptr(), data.len());
+	process_network_graph_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	process_network_graph_run(data.as_ptr(), data.len());
+	process_network_graph_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		process_network_graph_run(data.as_ptr(), data.len());
+		process_network_graph_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/process_onion_failure_target.rs
+++ b/fuzz/src/bin/process_onion_failure_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::process_onion_failure::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		process_onion_failure_run(data.as_ptr(), data.len());
+		process_onion_failure_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			process_onion_failure_run(data.as_ptr(), data.len());
+			process_onion_failure_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	process_onion_failure_run(data.as_ptr(), data.len());
+	process_onion_failure_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	process_onion_failure_run(data.as_ptr(), data.len());
+	process_onion_failure_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		process_onion_failure_run(data.as_ptr(), data.len());
+		process_onion_failure_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/refund_deser_target.rs
+++ b/fuzz/src/bin/refund_deser_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::refund_deser::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		refund_deser_run(data.as_ptr(), data.len());
+		refund_deser_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			refund_deser_run(data.as_ptr(), data.len());
+			refund_deser_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	refund_deser_run(data.as_ptr(), data.len());
+	refund_deser_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	refund_deser_run(data.as_ptr(), data.len());
+	refund_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		refund_deser_run(data.as_ptr(), data.len());
+		refund_deser_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/router_target.rs
+++ b/fuzz/src/bin/router_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::router::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		router_run(data.as_ptr(), data.len());
+		router_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			router_run(data.as_ptr(), data.len());
+			router_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	router_run(data.as_ptr(), data.len());
+	router_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	router_run(data.as_ptr(), data.len());
+	router_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		router_run(data.as_ptr(), data.len());
+		router_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/static_invoice_deser_target.rs
+++ b/fuzz/src/bin/static_invoice_deser_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::static_invoice_deser::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		static_invoice_deser_run(data.as_ptr(), data.len());
+		static_invoice_deser_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			static_invoice_deser_run(data.as_ptr(), data.len());
+			static_invoice_deser_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	static_invoice_deser_run(data.as_ptr(), data.len());
+	static_invoice_deser_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	static_invoice_deser_run(data.as_ptr(), data.len());
+	static_invoice_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		static_invoice_deser_run(data.as_ptr(), data.len());
+		static_invoice_deser_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/target_template.txt
+++ b/fuzz/src/bin/target_template.txt
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::TARGET_MOD::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		TARGET_NAME_run(data.as_ptr(), data.len());
+		TARGET_NAME_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			TARGET_NAME_run(data.as_ptr(), data.len());
+			TARGET_NAME_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	TARGET_NAME_run(data.as_ptr(), data.len());
+	TARGET_NAME_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	TARGET_NAME_run(data.as_ptr(), data.len());
+	TARGET_NAME_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		TARGET_NAME_run(data.as_ptr(), data.len());
+		TARGET_NAME_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/bin/zbase32_target.rs
+++ b/fuzz/src/bin/zbase32_target.rs
@@ -24,13 +24,14 @@ compile_error!("Fuzz targets need cfg=secp256k1_fuzz");
 
 extern crate lightning_fuzz;
 use lightning_fuzz::zbase32::*;
+use lightning_fuzz::utils::test_logger;
 
 #[cfg(feature = "afl")]
 #[macro_use] extern crate afl;
 #[cfg(feature = "afl")]
 fn main() {
 	fuzz!(|data| {
-		zbase32_run(data.as_ptr(), data.len());
+		zbase32_test(&data, test_logger::DevNull {});
 	});
 }
 
@@ -40,7 +41,7 @@ fn main() {
 fn main() {
 	loop {
 		fuzz!(|data| {
-			zbase32_run(data.as_ptr(), data.len());
+			zbase32_test(&data, test_logger::DevNull {});
 		});
 	}
 }
@@ -49,7 +50,7 @@ fn main() {
 #[macro_use] extern crate libfuzzer_sys;
 #[cfg(feature = "libfuzzer_fuzz")]
 fuzz_target!(|data: &[u8]| {
-	zbase32_run(data.as_ptr(), data.len());
+	zbase32_test(data, test_logger::DevNull {});
 });
 
 #[cfg(feature = "stdin_fuzz")]
@@ -58,7 +59,7 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	zbase32_run(data.as_ptr(), data.len());
+	zbase32_test(&data, lightning_fuzz::utils::test_logger::Stdout {});
 }
 
 #[test]
@@ -70,7 +71,7 @@ fn run_test_cases() {
 	use std::sync::{atomic, Arc};
 	{
 		let data: Vec<u8> = vec![0];
-		zbase32_run(data.as_ptr(), data.len());
+		zbase32_test(&data, test_logger::DevNull {});
 	}
 	let mut threads = Vec::new();
 	let threads_running = Arc::new(atomic::AtomicUsize::new(0));

--- a/fuzz/src/utils/test_logger.rs
+++ b/fuzz/src/utils/test_logger.rs
@@ -21,6 +21,13 @@ impl Output for DevNull {
 	fn locked_write(&self, _data: &[u8]) {}
 }
 #[derive(Clone)]
+pub struct Stdout {}
+impl Output for Stdout {
+	fn locked_write(&self, data: &[u8]) {
+		std::io::stdout().write_all(data).unwrap();
+	}
+}
+#[derive(Clone)]
 pub struct StringBuffer(Arc<Mutex<String>>);
 impl Output for StringBuffer {
 	fn locked_write(&self, data: &[u8]) {


### PR DESCRIPTION
Add `stdin_fuzz` feature support to all fuzz targets, allowing test cases to be replayed via stdin when built with `--features stdin_fuzz`. This is documented in a new section in the fuzz README. 
