### PR TITLE
Check that funder covers the fee spike buffer multiple after a splice

### DIFF
--- a/lightning-tests/src/upgrade_downgrade_tests.rs
+++ b/lightning-tests/src/upgrade_downgrade_tests.rs
@@ -457,7 +457,8 @@ fn do_test_0_1_htlc_forward_after_splice(fail_htlc: bool) {
 		script_pubkey: nodes[0].wallet_source.get_change_script().unwrap(),
 	}];
 	let channel_id = ChannelId(chan_id_bytes_a);
-	let funding_contribution = initiate_splice_out(&nodes[0], &nodes[1], channel_id, outputs);
+	let funding_contribution =
+		initiate_splice_out(&nodes[0], &nodes[1], channel_id, outputs).unwrap();
 	let (splice_tx, _) = splice_channel(&nodes[0], &nodes[1], channel_id, funding_contribution);
 	for node in nodes.iter() {
 		mine_transaction(node, &splice_tx);

--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -1576,7 +1576,7 @@ fn test_async_splice_initial_commit_sig() {
 		value: Amount::from_sat(1_000),
 		script_pubkey: nodes[0].wallet_source.get_change_script().unwrap(),
 	}];
-	let contribution = initiate_splice_out(initiator, acceptor, channel_id, outputs);
+	let contribution = initiate_splice_out(initiator, acceptor, channel_id, outputs).unwrap();
 	negotiate_splice_tx(initiator, acceptor, channel_id, contribution);
 
 	assert!(initiator.node.get_and_clear_pending_msg_events().is_empty());

--- a/lightning/src/sign/tx_builder.rs
+++ b/lightning/src/sign/tx_builder.rs
@@ -315,6 +315,7 @@ fn get_available_balances(
 	let fee_spike_buffer_htlc =
 		if channel_type.supports_anchor_zero_fee_commitments() { 0 } else { 1 };
 
+	// Note that the feerate is 0 in zero-fee commitment channels, so this statement is a noop
 	let local_feerate = feerate_per_kw
 		* if is_outbound_from_holder && !channel_type.supports_anchors_zero_fee_htlc_tx() {
 			crate::ln::channel::FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE as u32


### PR DESCRIPTION
```
    Assert that a balance under a post-splice reserve did not budge

    Notably, if a party splices funds into the channel, their new balance
    must be above the new reserve.
```
and
```
    Check that funder covers the fee spike buffer multiple after a splice

    We do this for HTLCs, so we should also do this for splices. This
    applies to `only_static_remote_key` channels alone.
```