### PR TITLE
Fix missing argument in splicing test

### DIFF
--- a/lightning/src/ln/splicing_tests.rs
+++ b/lightning/src/ln/splicing_tests.rs
@@ -2431,7 +2431,7 @@ fn do_abandon_splice_quiescent_action_on_shutdown(local_shutdown: bool) {
 	// splice, the `stfu` message is held back.
 	let (route, payment_hash, _payment_preimage, payment_secret) =
 		get_route_and_payment_hash!(&nodes[0], &nodes[1], 1_000_000);
-	let onion = RecipientOnionFields::secret_only(payment_secret);
+	let onion = RecipientOnionFields::secret_only(payment_secret, 1_000_000);
 	let payment_id = PaymentId(payment_hash.0);
 	nodes[0].node.send_payment_with_route(route, payment_hash, onion, payment_id).unwrap();
 	let update = get_htlc_update_msgs(&nodes[0], &node_id_1);


### PR DESCRIPTION
## Summary
- `RecipientOnionFields::secret_only` was updated to require a `total_mpp_amount_msat` parameter, but one call site in `do_abandon_splice_quiescent_action_on_shutdown` was not updated, breaking the test target compilation.

## Test plan
- [x] `cargo check -p lightning --lib --tests` compiles successfully
- [x] `abandon_splice_quiescent_action_on_shutdown` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)