### PR TITLE
Pad all sent TCP frames to the same size via `ChunkedMessageQueue`

### DIFF
--- a/fuzz/src/peer_crypt.rs
+++ b/fuzz/src/peer_crypt.rs
@@ -79,9 +79,11 @@ pub fn do_test(data: &[u8]) {
 	let mut buf = [0; 65536 + 16];
 	loop {
 		if get_slice!(1)[0] == 0 {
-			crypter.encrypt_buffer(MessageBuf::from_encoded(&get_slice!(slice_to_be16(
-				get_slice!(2)
-			))));
+			let mut dest = Vec::new();
+			crypter.encrypt_buffer_into(
+				&mut dest,
+				MessageBuf::from_encoded(&get_slice!(slice_to_be16(get_slice!(2)))),
+			);
 		} else {
 			let len = match crypter.decrypt_length_header(get_slice!(16 + 2)) {
 				Ok(len) => len,


### PR DESCRIPTION
In this PR we implement padding all sent TCP frames to the same size by ensuring all writes happen in chunks of length `CHUNK_SIZE` and any remainders are filled by adequately sized `Ping` messages.

This approach operating on the network-layer was discussed in the spec call and seems to be preferred by everybody. Hence it supersedes the approach taken in #4248.

TODO

- [ ] Measurement/evaluation of introduced overhead