### PR TITLE
fuzz: use process::exit panic hook in stdin_fuzz to avoid macOS hang

### DIFF
--- a/fuzz/src/bin/base32_target.rs
+++ b/fuzz/src/bin/base32_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	base32_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/bech32_parse_target.rs
+++ b/fuzz/src/bin/bech32_parse_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	bech32_parse_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/bolt11_deser_target.rs
+++ b/fuzz/src/bin/bolt11_deser_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	bolt11_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/chanmon_consistency_target.rs
+++ b/fuzz/src/bin/chanmon_consistency_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	chanmon_consistency_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/chanmon_deser_target.rs
+++ b/fuzz/src/bin/chanmon_deser_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	chanmon_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/feature_flags_target.rs
+++ b/fuzz/src/bin/feature_flags_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	feature_flags_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/fromstr_to_netaddress_target.rs
+++ b/fuzz/src/bin/fromstr_to_netaddress_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	fromstr_to_netaddress_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/fs_store_target.rs
+++ b/fuzz/src/bin/fs_store_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	fs_store_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/full_stack_target.rs
+++ b/fuzz/src/bin/full_stack_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	full_stack_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/indexedmap_target.rs
+++ b/fuzz/src/bin/indexedmap_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	indexedmap_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/invoice_deser_target.rs
+++ b/fuzz/src/bin/invoice_deser_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	invoice_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/invoice_request_deser_target.rs
+++ b/fuzz/src/bin/invoice_request_deser_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	invoice_request_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/lsps_message_target.rs
+++ b/fuzz/src/bin/lsps_message_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	lsps_message_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_accept_channel_target.rs
+++ b/fuzz/src/bin/msg_accept_channel_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_accept_channel_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_accept_channel_v2_target.rs
+++ b/fuzz/src/bin/msg_accept_channel_v2_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_accept_channel_v2_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_announcement_signatures_target.rs
+++ b/fuzz/src/bin/msg_announcement_signatures_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_announcement_signatures_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_blinded_message_path_target.rs
+++ b/fuzz/src/bin/msg_blinded_message_path_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_blinded_message_path_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_channel_announcement_target.rs
+++ b/fuzz/src/bin/msg_channel_announcement_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_channel_announcement_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_channel_details_target.rs
+++ b/fuzz/src/bin/msg_channel_details_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_channel_details_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_channel_ready_target.rs
+++ b/fuzz/src/bin/msg_channel_ready_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_channel_ready_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_channel_reestablish_target.rs
+++ b/fuzz/src/bin/msg_channel_reestablish_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_channel_reestablish_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_channel_update_target.rs
+++ b/fuzz/src/bin/msg_channel_update_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_channel_update_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_closing_complete_target.rs
+++ b/fuzz/src/bin/msg_closing_complete_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_closing_complete_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_closing_sig_target.rs
+++ b/fuzz/src/bin/msg_closing_sig_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_closing_sig_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_closing_signed_target.rs
+++ b/fuzz/src/bin/msg_closing_signed_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_closing_signed_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_commitment_signed_target.rs
+++ b/fuzz/src/bin/msg_commitment_signed_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_commitment_signed_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
+++ b/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_decoded_onion_error_packet_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_error_message_target.rs
+++ b/fuzz/src/bin/msg_error_message_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_error_message_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_funding_created_target.rs
+++ b/fuzz/src/bin/msg_funding_created_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_funding_created_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_funding_signed_target.rs
+++ b/fuzz/src/bin/msg_funding_signed_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_funding_signed_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_gossip_timestamp_filter_target.rs
+++ b/fuzz/src/bin/msg_gossip_timestamp_filter_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_gossip_timestamp_filter_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_init_target.rs
+++ b/fuzz/src/bin/msg_init_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_init_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_node_announcement_target.rs
+++ b/fuzz/src/bin/msg_node_announcement_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_node_announcement_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_open_channel_target.rs
+++ b/fuzz/src/bin/msg_open_channel_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_open_channel_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_open_channel_v2_target.rs
+++ b/fuzz/src/bin/msg_open_channel_v2_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_open_channel_v2_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_ping_target.rs
+++ b/fuzz/src/bin/msg_ping_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_ping_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_pong_target.rs
+++ b/fuzz/src/bin/msg_pong_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_pong_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_query_channel_range_target.rs
+++ b/fuzz/src/bin/msg_query_channel_range_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_query_channel_range_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_query_short_channel_ids_target.rs
+++ b/fuzz/src/bin/msg_query_short_channel_ids_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_query_short_channel_ids_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_reply_channel_range_target.rs
+++ b/fuzz/src/bin/msg_reply_channel_range_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_reply_channel_range_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_reply_short_channel_ids_end_target.rs
+++ b/fuzz/src/bin/msg_reply_short_channel_ids_end_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_reply_short_channel_ids_end_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_revoke_and_ack_target.rs
+++ b/fuzz/src/bin/msg_revoke_and_ack_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_revoke_and_ack_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_shutdown_target.rs
+++ b/fuzz/src/bin/msg_shutdown_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_shutdown_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_splice_ack_target.rs
+++ b/fuzz/src/bin/msg_splice_ack_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_splice_ack_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_splice_init_target.rs
+++ b/fuzz/src/bin/msg_splice_init_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_splice_init_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_splice_locked_target.rs
+++ b/fuzz/src/bin/msg_splice_locked_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_splice_locked_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_stfu_target.rs
+++ b/fuzz/src/bin/msg_stfu_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_stfu_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_abort_target.rs
+++ b/fuzz/src/bin/msg_tx_abort_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_abort_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_ack_rbf_target.rs
+++ b/fuzz/src/bin/msg_tx_ack_rbf_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_ack_rbf_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_add_input_target.rs
+++ b/fuzz/src/bin/msg_tx_add_input_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_add_input_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_add_output_target.rs
+++ b/fuzz/src/bin/msg_tx_add_output_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_add_output_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_complete_target.rs
+++ b/fuzz/src/bin/msg_tx_complete_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_complete_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_init_rbf_target.rs
+++ b/fuzz/src/bin/msg_tx_init_rbf_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_init_rbf_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_remove_input_target.rs
+++ b/fuzz/src/bin/msg_tx_remove_input_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_remove_input_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_remove_output_target.rs
+++ b/fuzz/src/bin/msg_tx_remove_output_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_remove_output_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_tx_signatures_target.rs
+++ b/fuzz/src/bin/msg_tx_signatures_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_tx_signatures_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_update_add_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_add_htlc_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_update_add_htlc_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_update_fail_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_htlc_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_update_fail_htlc_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_update_fail_malformed_htlc_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_update_fee_target.rs
+++ b/fuzz/src/bin/msg_update_fee_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_update_fee_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	msg_update_fulfill_htlc_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/offer_deser_target.rs
+++ b/fuzz/src/bin/offer_deser_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	offer_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/onion_hop_data_target.rs
+++ b/fuzz/src/bin/onion_hop_data_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	onion_hop_data_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/onion_message_target.rs
+++ b/fuzz/src/bin/onion_message_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	onion_message_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/peer_crypt_target.rs
+++ b/fuzz/src/bin/peer_crypt_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	peer_crypt_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/process_network_graph_target.rs
+++ b/fuzz/src/bin/process_network_graph_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	process_network_graph_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/process_onion_failure_target.rs
+++ b/fuzz/src/bin/process_onion_failure_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	process_onion_failure_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/refund_deser_target.rs
+++ b/fuzz/src/bin/refund_deser_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	refund_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/router_target.rs
+++ b/fuzz/src/bin/router_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	router_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/static_invoice_deser_target.rs
+++ b/fuzz/src/bin/static_invoice_deser_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	static_invoice_deser_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/target_template.txt
+++ b/fuzz/src/bin/target_template.txt
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	TARGET_NAME_test(&data, lightning_fuzz::utils::test_logger::Stdout {});

--- a/fuzz/src/bin/zbase32_target.rs
+++ b/fuzz/src/bin/zbase32_target.rs
@@ -57,6 +57,18 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
 	use std::io::Read;
 
+	// On macOS, panic=abort causes the process to send SIGABRT which can leave it
+	// stuck in an uninterruptible state due to the ReportCrash daemon. Using
+	// process::exit in a panic hook avoids this by terminating cleanly.
+	#[cfg(target_os = "macos")]
+	std::panic::set_hook(Box::new(|panic_info| {
+		use std::io::Write;
+		let _ = std::io::stdout().flush();
+		eprintln!("{}\n{}", panic_info, std::backtrace::Backtrace::force_capture());
+		let _ = std::io::stderr().flush();
+		std::process::exit(1);
+	}));
+
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
 	zbase32_test(&data, lightning_fuzz::utils::test_logger::Stdout {});


### PR DESCRIPTION
Unfortunately the final approach chosen in #4430 did not prevent the hang-on-panic. Must have made a mistake in the final validation of stdin_fuzz.