### PR TITLE
Remove Completed from Watch trait, making updates always-async

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -9193,8 +9193,6 @@ where
 	/// [`Self::monitor_updating_restored`] is called.
 	///
 	/// [`ChannelManager`]: super::channelmanager::ChannelManager
-	/// [`chain::Watch`]: crate::chain::Watch
-	/// [`ChannelMonitorUpdateStatus::InProgress`]: crate::chain::ChannelMonitorUpdateStatus::InProgress
 	fn monitor_updating_paused<L: Logger>(
 		&mut self, resend_raa: bool, resend_commitment: bool, resend_channel_ready: bool,
 		pending_forwards: Vec<(PendingHTLCInfo, u64)>,

--- a/lightning/src/util/errors.rs
+++ b/lightning/src/util/errors.rs
@@ -52,13 +52,11 @@ pub enum APIError {
 		err: String,
 	},
 	/// An attempt to call [`chain::Watch::watch_channel`]/[`chain::Watch::update_channel`]
-	/// returned a [`ChannelMonitorUpdateStatus::InProgress`] indicating the persistence of a
-	/// monitor update is awaiting async resolution. Once it resolves the attempted action should
-	/// complete automatically.
+	/// indicates the persistence of a monitor update is awaiting async resolution. Once it
+	/// resolves the attempted action should complete automatically.
 	///
 	/// [`chain::Watch::watch_channel`]: crate::chain::Watch::watch_channel
 	/// [`chain::Watch::update_channel`]: crate::chain::Watch::update_channel
-	/// [`ChannelMonitorUpdateStatus::InProgress`]: crate::chain::ChannelMonitorUpdateStatus::InProgress
 	MonitorUpdateInProgress,
 	/// [`SignerProvider::get_shutdown_scriptpubkey`] returned a shutdown scriptpubkey incompatible
 	/// with the channel counterparty as negotiated in [`InitFeatures`].


### PR DESCRIPTION
The complexity of maintaining both synchronous and asynchronous monitor update completion paths in `ChannelManager` has become increasingly difficult to reason about. Each new feature touching monitor updates must account for both modes, and subtle bugs have emerged from the interplay.

This PR removes the sync path by making the `Watch`-`ChannelManager` interface always-async. `ChainMonitor` maps `Persist::Completed` onto an immediately-queued `MonitorEvent::Completed`, so channels unblock on the next event processing round rather than inline. The `Persist` trait and `ChannelMonitorUpdateStatus` enum are unchanged.
