### PR TITLE
Pass github_token explicitly to claude-code-action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Work around claude-code-action OIDC token failure by passing GITHUB_TOKEN explicitly, avoiding the OIDC exchange flow. See https://github.com/anthropics/claude-code-action/issues/649

AI tools were used in preparing this commit.