### PR TITLE
Persistent `MonitorEvent`s

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -1639,7 +1639,7 @@ where
 
 	fn release_pending_monitor_events(
 		&self,
-	) -> Vec<(OutPoint, ChannelId, Vec<MonitorEvent>, PublicKey)> {
+	) -> Vec<(OutPoint, ChannelId, Vec<(u64, MonitorEvent)>, PublicKey)> {
 		for (channel_id, update_id) in self.persister.get_and_clear_completed_updates() {
 			let _ = self.channel_monitor_updated(channel_id, update_id);
 		}

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -366,9 +366,6 @@ pub struct ChainMonitor<
 	fee_estimator: F,
 	persister: P,
 	_entropy_source: ES,
-	/// "User-provided" (ie persistence-completion/-failed) [`MonitorEvent`]s. These came directly
-	/// from the user and not from a [`ChannelMonitor`].
-	pending_monitor_events: Mutex<Vec<(OutPoint, ChannelId, Vec<MonitorEvent>, PublicKey)>>,
 	/// The best block height seen, used as a proxy for the passage of time.
 	highest_chain_height: AtomicUsize,
 
@@ -436,7 +433,6 @@ where
 			logger,
 			fee_estimator: feeest,
 			_entropy_source,
-			pending_monitor_events: Mutex::new(Vec::new()),
 			highest_chain_height: AtomicUsize::new(0),
 			event_notifier: Arc::clone(&event_notifier),
 			persister: AsyncPersister { persister, event_notifier },
@@ -657,7 +653,6 @@ where
 			fee_estimator: feeest,
 			persister,
 			_entropy_source,
-			pending_monitor_events: Mutex::new(Vec::new()),
 			highest_chain_height: AtomicUsize::new(0),
 			event_notifier: Arc::new(Notifier::new()),
 			pending_send_only_events: Mutex::new(Vec::new()),
@@ -802,16 +797,11 @@ where
 			return Ok(());
 		}
 		let funding_txo = monitor_data.monitor.get_funding_txo();
-		self.pending_monitor_events.lock().unwrap().push((
+		monitor_data.monitor.push_monitor_event(MonitorEvent::Completed {
 			funding_txo,
 			channel_id,
-			vec![MonitorEvent::Completed {
-				funding_txo,
-				channel_id,
-				monitor_update_id: monitor_data.monitor.get_latest_update_id(),
-			}],
-			monitor_data.monitor.get_counterparty_node_id(),
-		));
+			monitor_update_id: monitor_data.monitor.get_latest_update_id(),
+		});
 
 		self.event_notifier.notify();
 		Ok(())
@@ -824,14 +814,11 @@ where
 	pub fn force_channel_monitor_updated(&self, channel_id: ChannelId, monitor_update_id: u64) {
 		let monitors = self.monitors.read().unwrap();
 		let monitor = &monitors.get(&channel_id).unwrap().monitor;
-		let counterparty_node_id = monitor.get_counterparty_node_id();
-		let funding_txo = monitor.get_funding_txo();
-		self.pending_monitor_events.lock().unwrap().push((
-			funding_txo,
+		monitor.push_monitor_event(MonitorEvent::Completed {
+			funding_txo: monitor.get_funding_txo(),
 			channel_id,
-			vec![MonitorEvent::Completed { funding_txo, channel_id, monitor_update_id }],
-			counterparty_node_id,
-		));
+			monitor_update_id,
+		});
 		self.event_notifier.notify();
 	}
 
@@ -1266,21 +1253,13 @@ where
 					// The channel is post-close (funding spend seen, lockdown, or
 					// holder tx signed). Return InProgress so ChannelManager freezes
 					// the channel until the force-close MonitorEvents are processed.
-					// Push a Completed event into pending_monitor_events so it gets
-					// picked up after the per-monitor events in the next
-					// release_pending_monitor_events call.
-					let funding_txo = monitor.get_funding_txo();
-					let channel_id = monitor.channel_id();
-					self.pending_monitor_events.lock().unwrap().push((
-						funding_txo,
-						channel_id,
-						vec![MonitorEvent::Completed {
-							funding_txo,
-							channel_id,
-							monitor_update_id: monitor.get_latest_update_id(),
-						}],
-						monitor.get_counterparty_node_id(),
-					));
+					// Push a Completed event into the monitor so it gets picked up
+					// in the next release_pending_monitor_events call.
+					monitor.push_monitor_event(MonitorEvent::Completed {
+						funding_txo: monitor.get_funding_txo(),
+						channel_id: monitor.channel_id(),
+						monitor_update_id: monitor.get_latest_update_id(),
+					});
 					log_debug!(
 						logger,
 						"Deferring completion of ChannelMonitorUpdate id {:?} (channel is post-close)",
@@ -1665,10 +1644,6 @@ where
 				));
 			}
 		}
-		// Drain pending_monitor_events (which includes deferred post-close
-		// completions) after per-monitor events so that force-close
-		// MonitorEvents are processed by ChannelManager first.
-		pending_monitor_events.extend(self.pending_monitor_events.lock().unwrap().split_off(0));
 		pending_monitor_events
 	}
 }

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -66,6 +66,21 @@ use core::iter::Cycle;
 use core::ops::Deref;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+/// Identifies the source of a [`MonitorEvent`] for acknowledgment via
+/// [`chain::Watch::ack_monitor_event`] once the event has been processed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MonitorEventSource {
+	/// The event ID assigned by the [`ChannelMonitor`].
+	pub event_id: u64,
+	/// The channel from which the [`MonitorEvent`] originated.
+	pub channel_id: ChannelId,
+}
+
+impl_ser_tlv_based!(MonitorEventSource, {
+	(1, event_id, required),
+	(3, channel_id, required),
+});
+
 /// A pending operation queued for later execution when `ChainMonitor` is in deferred mode.
 enum PendingMonitorOp<ChannelSigner: EcdsaChannelSigner> {
 	/// A new monitor to insert and persist.
@@ -1645,6 +1660,15 @@ where
 			}
 		}
 		pending_monitor_events
+	}
+
+	fn ack_monitor_event(&self, source: MonitorEventSource) {
+		let monitors = self.monitors.read().unwrap();
+		if let Some(monitor_state) = monitors.get(&source.channel_id) {
+			monitor_state.monitor.ack_monitor_event(source.event_id);
+		} else {
+			debug_assert!(false, "Ack'd monitor events should always have a corresponding monitor");
+		}
 	}
 }
 

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1296,6 +1296,12 @@ pub(crate) struct ChannelMonitorImpl<Signer: EcdsaChannelSigner> {
 	// block/transaction-connected events and *not* during block/transaction-disconnected events,
 	// we further MUST NOT generate events during block/transaction-disconnection.
 	pending_monitor_events: Vec<MonitorEvent>,
+	/// When set, monitor events are retained until explicitly acked rather than cleared on read.
+	///
+	/// Allows the ChannelManager to reconstruct pending HTLC state by replaying monitor events on
+	/// startup, and make the monitor responsible for both off- and on-chain payment resolution. Will
+	/// be always set once support for this feature is complete.
+	persistent_events_enabled: bool,
 
 	pub(super) pending_events: Vec<Event>,
 	pub(super) is_processing_pending_events: bool,
@@ -1747,8 +1753,12 @@ pub(crate) fn write_chanmon_internal<Signer: EcdsaChannelSigner, W: Writer>(
 		channel_monitor.pending_monitor_events.iter().chain(holder_force_closed_compat.as_ref()),
 	);
 
+	// Only write `persistent_events_enabled` if it's set to true, as it's an even TLV.
+	let persistent_events_enabled = channel_monitor.persistent_events_enabled.then_some(());
+
 	write_tlv_fields!(writer, {
 		(1, channel_monitor.funding_spend_confirmed, option),
+		(2, persistent_events_enabled, option),
 		(3, channel_monitor.htlcs_resolved_on_chain, required_vec),
 		(5, pending_monitor_events, required), // Equivalent to required_vec because Iterable also writes as WithoutLength
 		(7, channel_monitor.funding_spend_seen, required),
@@ -1956,6 +1966,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 
 			payment_preimages: new_hash_map(),
 			pending_monitor_events: Vec::new(),
+			persistent_events_enabled: false,
 			pending_events: Vec::new(),
 			is_processing_pending_events: false,
 
@@ -6742,8 +6753,10 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 		let mut funding_seen_onchain = RequiredWrapper(None);
 		let mut best_block_previous_blocks = None;
 		let mut current_funding_contribution = None;
+		let mut persistent_events_enabled: Option<()> = None;
 		read_tlv_fields!(reader, {
 			(1, funding_spend_confirmed, option),
+			(2, persistent_events_enabled, option),
 			(3, htlcs_resolved_on_chain, optional_vec),
 			(5, pending_monitor_events, optional_vec),
 			(7, funding_spend_seen, option),
@@ -6769,6 +6782,12 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 		});
 		if let Some(previous_blocks) = best_block_previous_blocks {
 			best_block.previous_blocks = previous_blocks;
+		}
+
+		#[cfg(not(any(feature = "_test_utils", test)))]
+		if persistent_events_enabled.is_some() {
+			// This feature isn't supported yet so error if the writer expected it to be.
+			return Err(DecodeError::InvalidValue)
 		}
 
 		// Note that `payment_preimages_with_info` was added (and is always written) in LDK 0.1, so
@@ -6920,6 +6939,7 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 
 			payment_preimages,
 			pending_monitor_events: pending_monitor_events.unwrap(),
+			persistent_events_enabled: persistent_events_enabled.is_some(),
 			pending_events,
 			is_processing_pending_events: false,
 

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -2190,6 +2190,12 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 		self.inner.lock().unwrap().push_monitor_event(event);
 	}
 
+	/// Removes a [`MonitorEvent`] by its event ID, acknowledging that it has been processed.
+	/// Generally called by [`chain::Watch::ack_monitor_event`].
+	pub fn ack_monitor_event(&self, _event_id: u64) {
+		// TODO: once events have ids, remove the corresponding event here
+	}
+
 	/// Processes [`SpendableOutputs`] events produced from each [`ChannelMonitor`] upon maturity.
 	///
 	/// For channels featuring anchor outputs, this method will also process [`BumpTransaction`]

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1751,7 +1751,7 @@ pub(crate) fn write_chanmon_internal<Signer: EcdsaChannelSigner, W: Writer>(
 			None
 		}
 	});
-	let pending_monitor_events = Iterable(
+	let pending_monitor_events_legacy = Iterable(
 		channel_monitor.pending_monitor_events.iter().chain(holder_force_closed_compat.as_ref()),
 	);
 
@@ -1762,7 +1762,7 @@ pub(crate) fn write_chanmon_internal<Signer: EcdsaChannelSigner, W: Writer>(
 		(1, channel_monitor.funding_spend_confirmed, option),
 		(2, persistent_events_enabled, option),
 		(3, channel_monitor.htlcs_resolved_on_chain, required_vec),
-		(5, pending_monitor_events, required), // Equivalent to required_vec because Iterable also writes as WithoutLength
+		(5, pending_monitor_events_legacy, required), // Equivalent to required_vec because Iterable also writes as WithoutLength
 		(7, channel_monitor.funding_spend_seen, required),
 		(9, channel_monitor.counterparty_node_id, required),
 		(11, channel_monitor.confirmed_commitment_tx_counterparty_output, option),
@@ -6691,16 +6691,16 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			}
 		}
 
-		let pending_monitor_events_len: u64 = Readable::read(reader)?;
-		let mut pending_monitor_events = Some(
-			Vec::with_capacity(cmp::min(pending_monitor_events_len as usize, MAX_ALLOC_SIZE / (32 + 8*3))));
-		for _ in 0..pending_monitor_events_len {
+		let pending_monitor_events_legacy_len: u64 = Readable::read(reader)?;
+		let mut pending_monitor_events_legacy = Some(
+			Vec::with_capacity(cmp::min(pending_monitor_events_legacy_len as usize, MAX_ALLOC_SIZE / (32 + 8*3))));
+		for _ in 0..pending_monitor_events_legacy_len {
 			let ev = match <u8 as Readable>::read(reader)? {
 				0 => MonitorEvent::HTLCEvent(Readable::read(reader)?),
 				1 => MonitorEvent::HolderForceClosed(outpoint),
 				_ => return Err(DecodeError::InvalidValue)
 			};
-			pending_monitor_events.as_mut().unwrap().push(ev);
+			pending_monitor_events_legacy.as_mut().unwrap().push(ev);
 		}
 
 		let pending_events_len: u64 = Readable::read(reader)?;
@@ -6768,7 +6768,7 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			(1, funding_spend_confirmed, option),
 			(2, persistent_events_enabled, option),
 			(3, htlcs_resolved_on_chain, optional_vec),
-			(5, pending_monitor_events, optional_vec),
+			(5, pending_monitor_events_legacy, optional_vec),
 			(7, funding_spend_seen, option),
 			(9, counterparty_node_id, option),
 			(11, confirmed_commitment_tx_counterparty_output, option),
@@ -6822,11 +6822,11 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 
 		// `HolderForceClosedWithInfo` replaced `HolderForceClosed` in v0.0.122. If we have both
 		// events, we can remove the `HolderForceClosed` event and just keep the `HolderForceClosedWithInfo`.
-		if let Some(ref mut pending_monitor_events) = pending_monitor_events {
-			if pending_monitor_events.iter().any(|e| matches!(e, MonitorEvent::HolderForceClosed(_))) &&
-				pending_monitor_events.iter().any(|e| matches!(e, MonitorEvent::HolderForceClosedWithInfo { .. }))
+		if let Some(ref mut evs) = pending_monitor_events_legacy {
+			if evs.iter().any(|e| matches!(e, MonitorEvent::HolderForceClosed(_))) &&
+				evs.iter().any(|e| matches!(e, MonitorEvent::HolderForceClosedWithInfo { .. }))
 			{
-				pending_monitor_events.retain(|e| !matches!(e, MonitorEvent::HolderForceClosed(_)));
+				evs.retain(|e| !matches!(e, MonitorEvent::HolderForceClosed(_)));
 			}
 		}
 
@@ -6948,7 +6948,7 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			current_holder_commitment_number,
 
 			payment_preimages,
-			pending_monitor_events: pending_monitor_events.unwrap(),
+			pending_monitor_events: pending_monitor_events_legacy.unwrap(),
 			persistent_events_enabled: persistent_events_enabled.is_some(),
 			pending_events,
 			is_processing_pending_events: false,

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -69,8 +69,8 @@ use crate::util::byte_utils;
 use crate::util::logger::{Logger, WithContext};
 use crate::util::persist::MonitorName;
 use crate::util::ser::{
-	MaybeReadable, Readable, ReadableArgs, RequiredWrapper, UpgradableRequired, Writeable, Writer,
-	U48,
+	Iterable, MaybeReadable, Readable, ReadableArgs, RequiredWrapper, UpgradableRequired,
+	Writeable, Writer, U48,
 };
 
 #[allow(unused_imports)]
@@ -1734,24 +1734,23 @@ pub(crate) fn write_chanmon_internal<Signer: EcdsaChannelSigner, W: Writer>(
 	channel_monitor.lockdown_from_offchain.write(writer)?;
 	channel_monitor.holder_tx_signed.write(writer)?;
 
-	// If we have a `HolderForceClosedWithInfo` event, we need to write the `HolderForceClosed` for backwards compatibility.
-	let pending_monitor_events =
-		match channel_monitor.pending_monitor_events.iter().find(|ev| match ev {
-			MonitorEvent::HolderForceClosedWithInfo { .. } => true,
-			_ => false,
-		}) {
-			Some(MonitorEvent::HolderForceClosedWithInfo { outpoint, .. }) => {
-				let mut pending_monitor_events = channel_monitor.pending_monitor_events.clone();
-				pending_monitor_events.push(MonitorEvent::HolderForceClosed(*outpoint));
-				pending_monitor_events
-			},
-			_ => channel_monitor.pending_monitor_events.clone(),
-		};
+	// If we have a `HolderForceClosedWithInfo` event, we need to write the `HolderForceClosed`
+	// for backwards compatibility.
+	let holder_force_closed_compat = channel_monitor.pending_monitor_events.iter().find_map(|ev| {
+		if let MonitorEvent::HolderForceClosedWithInfo { outpoint, .. } = ev {
+			Some(MonitorEvent::HolderForceClosed(*outpoint))
+		} else {
+			None
+		}
+	});
+	let pending_monitor_events = Iterable(
+		channel_monitor.pending_monitor_events.iter().chain(holder_force_closed_compat.as_ref()),
+	);
 
 	write_tlv_fields!(writer, {
 		(1, channel_monitor.funding_spend_confirmed, option),
 		(3, channel_monitor.htlcs_resolved_on_chain, required_vec),
-		(5, pending_monitor_events, required_vec),
+		(5, pending_monitor_events, required), // Equivalent to required_vec because Iterable also writes as WithoutLength
 		(7, channel_monitor.funding_spend_seen, required),
 		(9, channel_monitor.counterparty_node_id, required),
 		(11, channel_monitor.confirmed_commitment_tx_counterparty_output, option),

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -184,8 +184,13 @@ impl Readable for ChannelMonitorUpdate {
 	}
 }
 
-fn push_monitor_event(pending_monitor_events: &mut Vec<MonitorEvent>, event: MonitorEvent) {
-	pending_monitor_events.push(event);
+fn push_monitor_event(
+	pending_monitor_events: &mut Vec<(u64, MonitorEvent)>, event: MonitorEvent,
+	next_monitor_event_id: &mut u64,
+) {
+	let id = *next_monitor_event_id;
+	*next_monitor_event_id += 1;
+	pending_monitor_events.push((id, event));
 }
 
 /// An event to be processed by the ChannelManager.
@@ -1297,13 +1302,14 @@ pub(crate) struct ChannelMonitorImpl<Signer: EcdsaChannelSigner> {
 	// Note that because the `event_lock` in `ChainMonitor` is only taken in
 	// block/transaction-connected events and *not* during block/transaction-disconnected events,
 	// we further MUST NOT generate events during block/transaction-disconnection.
-	pending_monitor_events: Vec<MonitorEvent>,
+	pending_monitor_events: Vec<(u64, MonitorEvent)>,
 	/// When set, monitor events are retained until explicitly acked rather than cleared on read.
 	///
 	/// Allows the ChannelManager to reconstruct pending HTLC state by replaying monitor events on
 	/// startup, and make the monitor responsible for both off- and on-chain payment resolution. Will
 	/// be always set once support for this feature is complete.
 	persistent_events_enabled: bool,
+	next_monitor_event_id: u64,
 
 	pub(super) pending_events: Vec<Event>,
 	pub(super) is_processing_pending_events: bool,
@@ -1684,32 +1690,38 @@ pub(crate) fn write_chanmon_internal<Signer: EcdsaChannelSigner, W: Writer>(
 		writer.write_all(&payment_preimage.0[..])?;
 	}
 
-	writer.write_all(
-		&(channel_monitor
-			.pending_monitor_events
-			.iter()
-			.filter(|ev| match ev {
-				MonitorEvent::HTLCEvent(_) => true,
-				MonitorEvent::HolderForceClosed(_) => true,
-				MonitorEvent::HolderForceClosedWithInfo { .. } => true,
-				_ => false,
-			})
-			.count() as u64)
-			.to_be_bytes(),
-	)?;
-	for event in channel_monitor.pending_monitor_events.iter() {
-		match event {
-			MonitorEvent::HTLCEvent(upd) => {
-				0u8.write(writer)?;
-				upd.write(writer)?;
-			},
-			MonitorEvent::HolderForceClosed(_) => 1u8.write(writer)?,
-			// `HolderForceClosedWithInfo` replaced `HolderForceClosed` in v0.0.122. To keep
-			// backwards compatibility, we write a `HolderForceClosed` event along with the
-			// `HolderForceClosedWithInfo` event. This is deduplicated in the reader.
-			MonitorEvent::HolderForceClosedWithInfo { .. } => 1u8.write(writer)?,
-			_ => {}, // Covered in the TLV writes below
+	if !channel_monitor.persistent_events_enabled {
+		writer.write_all(
+			&(channel_monitor
+				.pending_monitor_events
+				.iter()
+				.filter(|(_, ev)| match ev {
+					MonitorEvent::HTLCEvent(_) => true,
+					MonitorEvent::HolderForceClosed(_) => true,
+					MonitorEvent::HolderForceClosedWithInfo { .. } => true,
+					_ => false,
+				})
+				.count() as u64)
+				.to_be_bytes(),
+		)?;
+		for (_, event) in channel_monitor.pending_monitor_events.iter() {
+			match event {
+				MonitorEvent::HTLCEvent(upd) => {
+					0u8.write(writer)?;
+					upd.write(writer)?;
+				},
+				MonitorEvent::HolderForceClosed(_) => 1u8.write(writer)?,
+				// `HolderForceClosedWithInfo` replaced `HolderForceClosed` in v0.0.122. To keep
+				// backwards compatibility, we write a `HolderForceClosed` event along with the
+				// `HolderForceClosedWithInfo` event. This is deduplicated in the reader.
+				MonitorEvent::HolderForceClosedWithInfo { .. } => 1u8.write(writer)?,
+				_ => {}, // Covered in the TLV writes below
+			}
 		}
+	} else {
+		// If `persistent_events_enabled` is set, we'll write the events with their event ids in the
+		// TLV section below.
+		writer.write_all(&(0u64).to_be_bytes())?;
 	}
 
 	writer.write_all(&(channel_monitor.pending_events.len() as u64).to_be_bytes())?;
@@ -1744,25 +1756,40 @@ pub(crate) fn write_chanmon_internal<Signer: EcdsaChannelSigner, W: Writer>(
 
 	// If we have a `HolderForceClosedWithInfo` event, we need to write the `HolderForceClosed`
 	// for backwards compatibility.
-	let holder_force_closed_compat = channel_monitor.pending_monitor_events.iter().find_map(|ev| {
-		if let MonitorEvent::HolderForceClosedWithInfo { outpoint, .. } = ev {
-			Some(MonitorEvent::HolderForceClosed(*outpoint))
-		} else {
-			None
-		}
-	});
-	let pending_monitor_events_legacy = Iterable(
-		channel_monitor.pending_monitor_events.iter().chain(holder_force_closed_compat.as_ref()),
-	);
+	let holder_force_closed_compat =
+		channel_monitor.pending_monitor_events.iter().find_map(|(_, ev)| {
+			if let MonitorEvent::HolderForceClosedWithInfo { outpoint, .. } = ev {
+				Some(MonitorEvent::HolderForceClosed(*outpoint))
+			} else {
+				None
+			}
+		});
+	let pending_monitor_events_legacy = if !channel_monitor.persistent_events_enabled {
+		Some(Iterable(
+			channel_monitor
+				.pending_monitor_events
+				.iter()
+				.map(|(_, ev)| ev)
+				.chain(holder_force_closed_compat.as_ref()),
+		))
+	} else {
+		None
+	};
 
 	// Only write `persistent_events_enabled` if it's set to true, as it's an even TLV.
 	let persistent_events_enabled = channel_monitor.persistent_events_enabled.then_some(());
+	let pending_mon_evs_with_ids = if persistent_events_enabled.is_some() {
+		Some(Iterable(channel_monitor.pending_monitor_events.iter()))
+	} else {
+		None
+	};
 
 	write_tlv_fields!(writer, {
 		(1, channel_monitor.funding_spend_confirmed, option),
 		(2, persistent_events_enabled, option),
 		(3, channel_monitor.htlcs_resolved_on_chain, required_vec),
-		(5, pending_monitor_events_legacy, required), // Equivalent to required_vec because Iterable also writes as WithoutLength
+		(4, pending_mon_evs_with_ids, option),
+		(5, pending_monitor_events_legacy, option), // Equivalent to optional_vec because Iterable also writes as WithoutLength
 		(7, channel_monitor.funding_spend_seen, required),
 		(9, channel_monitor.counterparty_node_id, required),
 		(11, channel_monitor.confirmed_commitment_tx_counterparty_output, option),
@@ -1783,6 +1810,7 @@ pub(crate) fn write_chanmon_internal<Signer: EcdsaChannelSigner, W: Writer>(
 		(37, channel_monitor.funding_seen_onchain, required),
 		(39, channel_monitor.best_block.previous_blocks, required),
 		(41, channel_monitor.funding.contribution, option),
+		(43, channel_monitor.next_monitor_event_id, required),
 	});
 
 	Ok(())
@@ -1969,6 +1997,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 			payment_preimages: new_hash_map(),
 			pending_monitor_events: Vec::new(),
 			persistent_events_enabled: false,
+			next_monitor_event_id: 0,
 			pending_events: Vec::new(),
 			is_processing_pending_events: false,
 
@@ -2182,7 +2211,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 
 	/// Get the list of HTLCs who's status has been updated on chain. This should be called by
 	/// ChannelManager via [`chain::Watch::release_pending_monitor_events`].
-	pub fn get_and_clear_pending_monitor_events(&self) -> Vec<MonitorEvent> {
+	pub fn get_and_clear_pending_monitor_events(&self) -> Vec<(u64, MonitorEvent)> {
 		self.inner.lock().unwrap().get_and_clear_pending_monitor_events()
 	}
 
@@ -2194,6 +2223,20 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 	/// Generally called by [`chain::Watch::ack_monitor_event`].
 	pub fn ack_monitor_event(&self, _event_id: u64) {
 		// TODO: once events have ids, remove the corresponding event here
+	}
+
+	/// Copies [`MonitorEvent`] state from `other` into `self`.
+	/// Used in tests to align transient runtime state before equality comparison after a
+	/// serialization round-trip.
+	#[cfg(any(test, feature = "_test_utils"))]
+	pub fn copy_monitor_event_state(&self, other: &ChannelMonitor<Signer>) {
+		let (pending, next_id) = {
+			let other_inner = other.inner.lock().unwrap();
+			(other_inner.pending_monitor_events.clone(), other_inner.next_monitor_event_id)
+		};
+		let mut self_inner = self.inner.lock().unwrap();
+		self_inner.pending_monitor_events = pending;
+		self_inner.next_monitor_event_id = next_id;
 	}
 
 	/// Processes [`SpendableOutputs`] events produced from each [`ChannelMonitor`] upon maturity.
@@ -3921,7 +3964,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 				outpoint: funding_outpoint,
 				channel_id: self.channel_id,
 			};
-			push_monitor_event(&mut self.pending_monitor_events, event);
+			push_monitor_event(&mut self.pending_monitor_events, event, &mut self.next_monitor_event_id);
 		}
 
 		// Although we aren't signing the transaction directly here, the transaction will be signed
@@ -4541,12 +4584,16 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 					"Failing HTLC from late counterparty commitment update immediately \
 					(funding spend already confirmed)"
 				);
-				self.pending_monitor_events.push(MonitorEvent::HTLCEvent(HTLCUpdate {
-					payment_hash,
-					payment_preimage: None,
-					source: source.clone(),
-					htlc_value_satoshis,
-				}));
+				push_monitor_event(
+					&mut self.pending_monitor_events,
+					MonitorEvent::HTLCEvent(HTLCUpdate {
+						payment_hash,
+						payment_preimage: None,
+						source: source.clone(),
+						htlc_value_satoshis,
+					}),
+					&mut self.next_monitor_event_id,
+				);
 				self.htlcs_resolved_on_chain.push(IrrevocablyResolvedHTLC {
 					commitment_tx_output_idx: None,
 					resolving_txid: Some(confirmed_txid),
@@ -4612,10 +4659,14 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 	}
 
 	fn push_monitor_event(&mut self, event: MonitorEvent) {
-		push_monitor_event(&mut self.pending_monitor_events, event);
+		push_monitor_event(
+			&mut self.pending_monitor_events,
+			event,
+			&mut self.next_monitor_event_id,
+		);
 	}
 
-	fn get_and_clear_pending_monitor_events(&mut self) -> Vec<MonitorEvent> {
+	fn get_and_clear_pending_monitor_events(&mut self) -> Vec<(u64, MonitorEvent)> {
 		let mut ret = Vec::new();
 		mem::swap(&mut ret, &mut self.pending_monitor_events);
 		ret
@@ -5945,7 +5996,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 					continue;
 				}
 				let duplicate_event = self.pending_monitor_events.iter().any(
-					|update| if let &MonitorEvent::HTLCEvent(ref upd) = update {
+					|(_, update)| if let &MonitorEvent::HTLCEvent(ref upd) = update {
 						upd.source == *source
 					} else { false });
 				if duplicate_event {
@@ -5963,7 +6014,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 						payment_preimage: None,
 						payment_hash: htlc.payment_hash,
 						htlc_value_satoshis: Some(htlc.amount_msat / 1000),
-					}));
+					}), &mut self.next_monitor_event_id);
 				}
 			}
 		}
@@ -6362,7 +6413,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 			if let Some((source, payment_hash, amount_msat)) = payment_data {
 				if accepted_preimage_claim {
 					if !self.pending_monitor_events.iter().any(
-						|update| if let &MonitorEvent::HTLCEvent(ref upd) = update { upd.source == source } else { false }) {
+						|(_, update)| if let &MonitorEvent::HTLCEvent(ref upd) = update { upd.source == source } else { false }) {
 						self.onchain_events_awaiting_threshold_conf.push(OnchainEventEntry {
 							txid: tx.compute_txid(),
 							height,
@@ -6380,11 +6431,11 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 							payment_preimage: Some(payment_preimage),
 							payment_hash,
 							htlc_value_satoshis: Some(amount_msat / 1000),
-						}));
+						}), &mut self.next_monitor_event_id);
 					}
 				} else if offered_preimage_claim {
 					if !self.pending_monitor_events.iter().any(
-						|update| if let &MonitorEvent::HTLCEvent(ref upd) = update {
+						|(_, update)| if let &MonitorEvent::HTLCEvent(ref upd) = update {
 							upd.source == source
 						} else { false }) {
 						self.onchain_events_awaiting_threshold_conf.push(OnchainEventEntry {
@@ -6404,7 +6455,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 							payment_preimage: Some(payment_preimage),
 							payment_hash,
 							htlc_value_satoshis: Some(amount_msat / 1000),
-						}));
+						}), &mut self.next_monitor_event_id);
 					}
 				} else {
 					self.onchain_events_awaiting_threshold_conf.retain(|ref entry| {
@@ -6770,10 +6821,13 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 		let mut best_block_previous_blocks = None;
 		let mut current_funding_contribution = None;
 		let mut persistent_events_enabled: Option<()> = None;
+		let mut next_monitor_event_id: Option<u64> = None;
+		let mut pending_mon_evs_with_ids: Option<Vec<ReadableIdMonitorEvent>> = None;
 		read_tlv_fields!(reader, {
 			(1, funding_spend_confirmed, option),
 			(2, persistent_events_enabled, option),
 			(3, htlcs_resolved_on_chain, optional_vec),
+			(4, pending_mon_evs_with_ids, optional_vec),
 			(5, pending_monitor_events_legacy, optional_vec),
 			(7, funding_spend_seen, option),
 			(9, counterparty_node_id, option),
@@ -6795,6 +6849,7 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			(37, funding_seen_onchain, (default_value, true)),
 			(39, best_block_previous_blocks, option), // Added and always set in 0.3
 			(41, current_funding_contribution, option),
+			(43, next_monitor_event_id, option),
 		});
 		if let Some(previous_blocks) = best_block_previous_blocks {
 			best_block.previous_blocks = previous_blocks;
@@ -6835,6 +6890,22 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 				evs.retain(|e| !matches!(e, MonitorEvent::HolderForceClosed(_)));
 			}
 		}
+
+		// If persistent events are enabled, use the events with their persisted IDs from TLV 4.
+		// Otherwise, use the legacy events from TLV 5 and assign sequential IDs.
+		let (next_monitor_event_id, pending_monitor_events): (u64, Vec<(u64, MonitorEvent)>) =
+			if persistent_events_enabled.is_some() {
+				let evs = pending_mon_evs_with_ids.unwrap_or_default()
+					.into_iter().map(|ev| (ev.0, ev.1)).collect();
+				(next_monitor_event_id.unwrap_or(0), evs)
+			} else if let Some(events) = pending_monitor_events_legacy {
+				let next_id = next_monitor_event_id.unwrap_or(events.len() as u64);
+				let evs = events.into_iter().enumerate()
+					.map(|(i, ev)| (i as u64, ev)).collect();
+				(next_id, evs)
+			} else {
+				(next_monitor_event_id.unwrap_or(0), Vec::new())
+			};
 
 		let channel_parameters = channel_parameters.unwrap_or_else(|| {
 			onchain_tx_handler.channel_parameters().clone()
@@ -6954,8 +7025,9 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			current_holder_commitment_number,
 
 			payment_preimages,
-			pending_monitor_events: pending_monitor_events_legacy.unwrap(),
+			pending_monitor_events,
 			persistent_events_enabled: persistent_events_enabled.is_some(),
+			next_monitor_event_id,
 			pending_events,
 			is_processing_pending_events: false,
 
@@ -7001,6 +7073,22 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 			}
 		}
 		Ok(Some((best_block, monitor)))
+	}
+}
+
+/// Deserialization wrapper for reading a `(u64, MonitorEvent)`.
+/// Necessary because we can't deserialize a (Readable, MaybeReadable) tuple due to trait
+/// conflicts.
+struct ReadableIdMonitorEvent(u64, MonitorEvent);
+
+impl MaybeReadable for ReadableIdMonitorEvent {
+	fn read<R: io::Read>(reader: &mut R) -> Result<Option<Self>, DecodeError> {
+		let id: u64 = Readable::read(reader)?;
+		let event_opt: Option<MonitorEvent> = MaybeReadable::read(reader)?;
+		match event_opt {
+			Some(ev) => Ok(Some(ReadableIdMonitorEvent(id, ev))),
+			None => Ok(None),
+		}
 	}
 }
 

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1303,6 +1303,11 @@ pub(crate) struct ChannelMonitorImpl<Signer: EcdsaChannelSigner> {
 	// block/transaction-connected events and *not* during block/transaction-disconnected events,
 	// we further MUST NOT generate events during block/transaction-disconnection.
 	pending_monitor_events: Vec<(u64, MonitorEvent)>,
+	// `MonitorEvent`s that have been provided to the `ChannelManager` via
+	// [`ChannelMonitor::get_and_clear_pending_monitor_events`] and are awaiting
+	// [`ChannelMonitor::ack_monitor_event`] for removal. If an event in this queue is not ack'd, it
+	// will be re-provided to the `ChannelManager` on startup.
+	provided_monitor_events: Vec<(u64, MonitorEvent)>,
 	/// When set, monitor events are retained until explicitly acked rather than cleared on read.
 	///
 	/// Allows the ChannelManager to reconstruct pending HTLC state by replaying monitor events on
@@ -1779,7 +1784,12 @@ pub(crate) fn write_chanmon_internal<Signer: EcdsaChannelSigner, W: Writer>(
 	// Only write `persistent_events_enabled` if it's set to true, as it's an even TLV.
 	let persistent_events_enabled = channel_monitor.persistent_events_enabled.then_some(());
 	let pending_mon_evs_with_ids = if persistent_events_enabled.is_some() {
-		Some(Iterable(channel_monitor.pending_monitor_events.iter()))
+		Some(Iterable(
+			channel_monitor
+				.provided_monitor_events
+				.iter()
+				.chain(channel_monitor.pending_monitor_events.iter()),
+		))
 	} else {
 		None
 	};
@@ -1996,6 +2006,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 
 			payment_preimages: new_hash_map(),
 			pending_monitor_events: Vec::new(),
+			provided_monitor_events: Vec::new(),
 			persistent_events_enabled: false,
 			next_monitor_event_id: 0,
 			pending_events: Vec::new(),
@@ -2221,8 +2232,15 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 
 	/// Removes a [`MonitorEvent`] by its event ID, acknowledging that it has been processed.
 	/// Generally called by [`chain::Watch::ack_monitor_event`].
-	pub fn ack_monitor_event(&self, _event_id: u64) {
-		// TODO: once events have ids, remove the corresponding event here
+	pub fn ack_monitor_event(&self, event_id: u64) {
+		let inner = &mut *self.inner.lock().unwrap();
+		inner.ack_monitor_event(event_id);
+	}
+
+	/// Enables persistent monitor events mode. When enabled, monitor events are retained until
+	/// explicitly acked rather than cleared on read.
+	pub(crate) fn set_persistent_events_enabled(&self, enabled: bool) {
+		self.inner.lock().unwrap().persistent_events_enabled = enabled;
 	}
 
 	/// Copies [`MonitorEvent`] state from `other` into `self`.
@@ -2230,11 +2248,16 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 	/// serialization round-trip.
 	#[cfg(any(test, feature = "_test_utils"))]
 	pub fn copy_monitor_event_state(&self, other: &ChannelMonitor<Signer>) {
-		let (pending, next_id) = {
+		let (provided, pending, next_id) = {
 			let other_inner = other.inner.lock().unwrap();
-			(other_inner.pending_monitor_events.clone(), other_inner.next_monitor_event_id)
+			(
+				other_inner.provided_monitor_events.clone(),
+				other_inner.pending_monitor_events.clone(),
+				other_inner.next_monitor_event_id,
+			)
 		};
 		let mut self_inner = self.inner.lock().unwrap();
+		self_inner.provided_monitor_events = provided;
 		self_inner.pending_monitor_events = pending;
 		self_inner.next_monitor_event_id = next_id;
 	}
@@ -4666,10 +4689,23 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 		);
 	}
 
+	fn ack_monitor_event(&mut self, event_id: u64) {
+		self.provided_monitor_events.retain(|(id, _)| *id != event_id);
+		// If this event was generated prior to a restart, it may be in this queue instead
+		self.pending_monitor_events.retain(|(id, _)| *id != event_id);
+	}
+
 	fn get_and_clear_pending_monitor_events(&mut self) -> Vec<(u64, MonitorEvent)> {
-		let mut ret = Vec::new();
-		mem::swap(&mut ret, &mut self.pending_monitor_events);
-		ret
+		if self.persistent_events_enabled {
+			let mut ret = Vec::new();
+			mem::swap(&mut ret, &mut self.pending_monitor_events);
+			self.provided_monitor_events.extend(ret.iter().cloned());
+			ret
+		} else {
+			let mut ret = Vec::new();
+			mem::swap(&mut ret, &mut self.pending_monitor_events);
+			ret
+		}
 	}
 
 	/// Gets the set of events that are repeated regularly (e.g. those which RBF bump
@@ -5995,8 +6031,8 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 				if inbound_htlc_expiry > max_expiry_height {
 					continue;
 				}
-				let duplicate_event = self.pending_monitor_events.iter().any(
-					|(_, update)| if let &MonitorEvent::HTLCEvent(ref upd) = update {
+				let duplicate_event = self.pending_monitor_events.iter().chain(self.provided_monitor_events.iter())
+					.any(|(_, update)| if let &MonitorEvent::HTLCEvent(ref upd) = update {
 						upd.source == *source
 					} else { false });
 				if duplicate_event {
@@ -6412,7 +6448,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 			// HTLC resolution backwards to and figure out whether we learned a preimage from it.
 			if let Some((source, payment_hash, amount_msat)) = payment_data {
 				if accepted_preimage_claim {
-					if !self.pending_monitor_events.iter().any(
+					if !self.pending_monitor_events.iter().chain(self.provided_monitor_events.iter()).any(
 						|(_, update)| if let &MonitorEvent::HTLCEvent(ref upd) = update { upd.source == source } else { false }) {
 						self.onchain_events_awaiting_threshold_conf.push(OnchainEventEntry {
 							txid: tx.compute_txid(),
@@ -6434,7 +6470,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 						}), &mut self.next_monitor_event_id);
 					}
 				} else if offered_preimage_claim {
-					if !self.pending_monitor_events.iter().any(
+					if !self.pending_monitor_events.iter().chain(self.provided_monitor_events.iter()).any(
 						|(_, update)| if let &MonitorEvent::HTLCEvent(ref upd) = update {
 							upd.source == source
 						} else { false }) {
@@ -7026,6 +7062,7 @@ impl<'a, 'b, ES: EntropySource, SP: SignerProvider> ReadableArgs<(&'a ES, &'b SP
 
 			payment_preimages,
 			pending_monitor_events,
+			provided_monitor_events: Vec::new(),
 			persistent_events_enabled: persistent_events_enabled.is_some(),
 			next_monitor_event_id,
 			pending_events,

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -184,6 +184,10 @@ impl Readable for ChannelMonitorUpdate {
 	}
 }
 
+fn push_monitor_event(pending_monitor_events: &mut Vec<MonitorEvent>, event: MonitorEvent) {
+	pending_monitor_events.push(event);
+}
+
 /// An event to be processed by the ChannelManager.
 #[derive(Clone, PartialEq, Eq)]
 pub enum MonitorEvent {
@@ -227,8 +231,6 @@ pub enum MonitorEvent {
 	},
 }
 impl_writeable_tlv_based_enum_upgradable_legacy!(MonitorEvent,
-	// Note that Completed is currently never serialized to disk as it is generated only in
-	// ChainMonitor.
 	(0, Completed) => {
 		(0, funding_txo, required),
 		(2, monitor_update_id, required),
@@ -2184,6 +2186,10 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitor<Signer> {
 		self.inner.lock().unwrap().get_and_clear_pending_monitor_events()
 	}
 
+	pub(super) fn push_monitor_event(&self, event: MonitorEvent) {
+		self.inner.lock().unwrap().push_monitor_event(event);
+	}
+
 	/// Processes [`SpendableOutputs`] events produced from each [`ChannelMonitor`] upon maturity.
 	///
 	/// For channels featuring anchor outputs, this method will also process [`BumpTransaction`]
@@ -3909,7 +3915,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 				outpoint: funding_outpoint,
 				channel_id: self.channel_id,
 			};
-			self.pending_monitor_events.push(event);
+			push_monitor_event(&mut self.pending_monitor_events, event);
 		}
 
 		// Although we aren't signing the transaction directly here, the transaction will be signed
@@ -4597,6 +4603,10 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 			self.outputs_to_watch.get(txid).expect("Counterparty commitment txn which have been broadcast should have outputs registered");
 		}
 		&self.outputs_to_watch
+	}
+
+	fn push_monitor_event(&mut self, event: MonitorEvent) {
+		push_monitor_event(&mut self.pending_monitor_events, event);
 	}
 
 	fn get_and_clear_pending_monitor_events(&mut self) -> Vec<MonitorEvent> {
@@ -5658,7 +5668,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 					);
 					log_info!(logger, "Channel closed by funding output spend in txid {txid}");
 					if !self.funding_spend_seen {
-						self.pending_monitor_events.push(MonitorEvent::CommitmentTxConfirmed(()));
+						self.push_monitor_event(MonitorEvent::CommitmentTxConfirmed(()));
 					}
 					self.funding_spend_seen = true;
 
@@ -5833,7 +5843,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 
 					log_debug!(logger, "HTLC {} failure update in {} has got enough confirmations to be passed upstream",
 						&payment_hash, entry.txid);
-					self.pending_monitor_events.push(MonitorEvent::HTLCEvent(HTLCUpdate {
+					self.push_monitor_event(MonitorEvent::HTLCEvent(HTLCUpdate {
 						payment_hash,
 						payment_preimage: None,
 						source,
@@ -5942,7 +5952,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 					log_error!(logger, "Failing back HTLC {} upstream to preserve the \
 						channel as the forward HTLC hasn't resolved and our backward HTLC \
 						expires soon at {}", log_bytes!(htlc.payment_hash.0), inbound_htlc_expiry);
-					self.pending_monitor_events.push(MonitorEvent::HTLCEvent(HTLCUpdate {
+					push_monitor_event(&mut self.pending_monitor_events, MonitorEvent::HTLCEvent(HTLCUpdate {
 						source: source.clone(),
 						payment_preimage: None,
 						payment_hash: htlc.payment_hash,
@@ -6359,7 +6369,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 							},
 						});
 						self.counterparty_fulfilled_htlcs.insert(SentHTLCId::from_source(&source), payment_preimage);
-						self.pending_monitor_events.push(MonitorEvent::HTLCEvent(HTLCUpdate {
+						push_monitor_event(&mut self.pending_monitor_events, MonitorEvent::HTLCEvent(HTLCUpdate {
 							source,
 							payment_preimage: Some(payment_preimage),
 							payment_hash,
@@ -6383,7 +6393,7 @@ impl<Signer: EcdsaChannelSigner> ChannelMonitorImpl<Signer> {
 							},
 						});
 						self.counterparty_fulfilled_htlcs.insert(SentHTLCId::from_source(&source), payment_preimage);
-						self.pending_monitor_events.push(MonitorEvent::HTLCEvent(HTLCUpdate {
+						push_monitor_event(&mut self.pending_monitor_events, MonitorEvent::HTLCEvent(HTLCUpdate {
 							source,
 							payment_preimage: Some(payment_preimage),
 							payment_hash,

--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -18,6 +18,7 @@ use bitcoin::network::Network;
 use bitcoin::script::{Script, ScriptBuf};
 use bitcoin::secp256k1::PublicKey;
 
+use crate::chain::chainmonitor::MonitorEventSource;
 use crate::chain::channelmonitor::{
 	ChannelMonitor, ChannelMonitorUpdate, MonitorEvent, ANTI_REORG_DELAY,
 };
@@ -427,6 +428,15 @@ pub trait Watch<ChannelSigner: EcdsaChannelSigner> {
 	fn release_pending_monitor_events(
 		&self,
 	) -> Vec<(OutPoint, ChannelId, Vec<MonitorEvent>, PublicKey)>;
+
+	/// Acknowledges and removes a [`MonitorEvent`] previously returned by
+	/// [`Watch::release_pending_monitor_events`] by its event ID.
+	///
+	/// Once acknowledged, the event will no longer be returned by future calls to
+	/// [`Watch::release_pending_monitor_events`] and will not be replayed on restart.
+	///
+	/// Events may be acknowledged in any order.
+	fn ack_monitor_event(&self, source: MonitorEventSource);
 }
 
 impl<ChannelSigner: EcdsaChannelSigner, T: Watch<ChannelSigner> + ?Sized, W: Deref<Target = T>>
@@ -448,6 +458,10 @@ impl<ChannelSigner: EcdsaChannelSigner, T: Watch<ChannelSigner> + ?Sized, W: Der
 		&self,
 	) -> Vec<(OutPoint, ChannelId, Vec<MonitorEvent>, PublicKey)> {
 		self.deref().release_pending_monitor_events()
+	}
+
+	fn ack_monitor_event(&self, source: MonitorEventSource) {
+		self.deref().ack_monitor_event(source)
 	}
 }
 

--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -419,6 +419,10 @@ pub trait Watch<ChannelSigner: EcdsaChannelSigner> {
 	/// Returns any monitor events since the last call. Subsequent calls must only return new
 	/// events.
 	///
+	/// Each event comes with a corresponding id. Once the event is processed, call
+	/// [`Watch::ack_monitor_event`] with the corresponding id and channel id. Unacknowledged events
+	/// will be re-provided by this method after startup.
+	///
 	/// Note that after any block- or transaction-connection calls to a [`ChannelMonitor`], no
 	/// further events may be returned here until the [`ChannelMonitor`] has been fully persisted
 	/// to disk.
@@ -427,7 +431,7 @@ pub trait Watch<ChannelSigner: EcdsaChannelSigner> {
 	/// [`MonitorEvent::Completed`] here, see [`ChannelMonitorUpdateStatus::InProgress`].
 	fn release_pending_monitor_events(
 		&self,
-	) -> Vec<(OutPoint, ChannelId, Vec<MonitorEvent>, PublicKey)>;
+	) -> Vec<(OutPoint, ChannelId, Vec<(u64, MonitorEvent)>, PublicKey)>;
 
 	/// Acknowledges and removes a [`MonitorEvent`] previously returned by
 	/// [`Watch::release_pending_monitor_events`] by its event ID.
@@ -456,7 +460,7 @@ impl<ChannelSigner: EcdsaChannelSigner, T: Watch<ChannelSigner> + ?Sized, W: Der
 
 	fn release_pending_monitor_events(
 		&self,
-	) -> Vec<(OutPoint, ChannelId, Vec<MonitorEvent>, PublicKey)> {
+	) -> Vec<(OutPoint, ChannelId, Vec<(u64, MonitorEvent)>, PublicKey)> {
 		self.deref().release_pending_monitor_events()
 	}
 

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -5021,7 +5021,7 @@ fn native_async_persist() {
 	let completed_persist = async_chain_monitor.release_pending_monitor_events();
 	assert_eq!(completed_persist.len(), 1);
 	assert_eq!(completed_persist[0].2.len(), 1);
-	assert!(matches!(completed_persist[0].2[0], MonitorEvent::Completed { .. }));
+	assert!(matches!(completed_persist[0].2[0].1, MonitorEvent::Completed { .. }));
 
 	// Now test two async `ChannelMonitorUpdate`s in flight at once, completing them in-order but
 	// separately.
@@ -5069,7 +5069,7 @@ fn native_async_persist() {
 	let completed_persist = async_chain_monitor.release_pending_monitor_events();
 	assert_eq!(completed_persist.len(), 1);
 	assert_eq!(completed_persist[0].2.len(), 1);
-	assert!(matches!(completed_persist[0].2[0], MonitorEvent::Completed { .. }));
+	assert!(matches!(completed_persist[0].2[0].1, MonitorEvent::Completed { .. }));
 
 	// Finally, test two async `ChanelMonitorUpdate`s in flight at once, completing them
 	// out-of-order and ensuring that no `MonitorEvent::Completed` is generated until they are both
@@ -5115,7 +5115,7 @@ fn native_async_persist() {
 	let completed_persist = async_chain_monitor.release_pending_monitor_events();
 	assert_eq!(completed_persist.len(), 1);
 	assert_eq!(completed_persist[0].2.len(), 1);
-	if let MonitorEvent::Completed { monitor_update_id, .. } = &completed_persist[0].2[0] {
+	if let (_, MonitorEvent::Completed { monitor_update_id, .. }) = &completed_persist[0].2[0] {
 		assert_eq!(*monitor_update_id, 4);
 	} else {
 		panic!();

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -42,6 +42,7 @@ use crate::chain::chaininterface::{
 	BroadcasterInterface, ConfirmationTarget, FeeEstimator, LowerBoundedFeeEstimator,
 	TransactionType,
 };
+use crate::chain::chainmonitor::MonitorEventSource;
 use crate::chain::channelmonitor::{
 	ChannelMonitor, ChannelMonitorUpdate, ChannelMonitorUpdateStep, MonitorEvent,
 	WithChannelMonitor, ANTI_REORG_DELAY, CLTV_CLAIM_BUFFER, HTLC_FAIL_BACK_BUFFER,
@@ -13823,7 +13824,8 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 		for (funding_outpoint, channel_id, mut monitor_events, counterparty_node_id) in
 			pending_monitor_events.drain(..)
 		{
-			for (_event_id, monitor_event) in monitor_events.drain(..) {
+			for (event_id, monitor_event) in monitor_events.drain(..) {
+				let monitor_event_source = MonitorEventSource { event_id, channel_id };
 				match monitor_event {
 					MonitorEvent::HTLCEvent(htlc_update) => {
 						needs_persist = true;
@@ -13874,6 +13876,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 								completion_update,
 							);
 						}
+						self.chain_monitor.ack_monitor_event(monitor_event_source);
 					},
 					MonitorEvent::HolderForceClosed(_)
 					| MonitorEvent::HolderForceClosedWithInfo { .. } => {
@@ -13908,6 +13911,9 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 								failed_channels.push((Err(e), counterparty_node_id));
 							}
 						}
+						// Channel close monitor events do not need to be replayed on startup because we
+						// already check the monitors to see if the channel is closed.
+						self.chain_monitor.ack_monitor_event(monitor_event_source);
 					},
 					MonitorEvent::CommitmentTxConfirmed(_) => {
 						needs_persist = true;
@@ -13930,6 +13936,9 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 								failed_channels.push((Err(e), counterparty_node_id));
 							}
 						}
+						// Channel close monitor events do not need to be replayed on startup because we
+						// already check the monitors to see if the channel is closed.
+						self.chain_monitor.ack_monitor_event(monitor_event_source);
 					},
 					MonitorEvent::Completed { channel_id, monitor_update_id, .. } => {
 						needs_persist |= self.channel_monitor_updated(
@@ -13937,6 +13946,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 							Some(monitor_update_id),
 							&counterparty_node_id,
 						);
+						self.chain_monitor.ack_monitor_event(monitor_event_source);
 					},
 				}
 			}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3734,6 +3734,8 @@ impl<
 			our_network_pubkey, current_timestamp, expanded_inbound_key,
 			node_signer.get_receive_auth_key(), secp_ctx.clone(), message_router, logger.clone(),
 		);
+		#[cfg(any(test, feature = "_test_utils"))]
+		let override_persistent_monitor_events = config.override_persistent_monitor_events;
 
 		ChannelManager {
 			config: RwLock::new(config),
@@ -3790,7 +3792,27 @@ impl<
 
 			logger,
 
-			persistent_monitor_events: false,
+			persistent_monitor_events: {
+				#[cfg(not(any(test, feature = "_test_utils")))]
+				{ false }
+				#[cfg(any(test, feature = "_test_utils"))]
+				{
+					override_persistent_monitor_events.unwrap_or_else(|| {
+						use core::hash::{BuildHasher, Hasher};
+						match std::env::var("LDK_TEST_PERSISTENT_MON_EVENTS") {
+							Ok(val) => match val.as_str() {
+								"1" => true,
+								"0" => false,
+								_ => panic!("LDK_TEST_PERSISTENT_MON_EVENTS must be 0 or 1, got: {}", val),
+							},
+							Err(_) => {
+								let rand_val = std::collections::hash_map::RandomState::new().build_hasher().finish();
+								rand_val % 2 == 0
+							},
+						}
+					})
+				}
+			},
 		}
 	}
 
@@ -11844,6 +11866,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 				fail_chan!("Already had channel with the new channel_id");
 			},
 			hash_map::Entry::Vacant(e) => {
+				monitor.set_persistent_events_enabled(self.persistent_monitor_events);
 				let monitor_res = self.chain_monitor.watch_channel(monitor.channel_id(), monitor);
 				if let Ok(persist_state) = monitor_res {
 					// There's no problem signing a counterparty's funding transaction if our monitor
@@ -12014,6 +12037,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 				match chan
 					.funding_signed(&msg, best_block, &self.signer_provider, &self.logger)
 					.and_then(|(funded_chan, monitor)| {
+						monitor.set_persistent_events_enabled(self.persistent_monitor_events);
 						self.chain_monitor
 							.watch_channel(funded_chan.context.channel_id(), monitor)
 							.map_err(|()| {
@@ -12919,6 +12943,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 
 				if let Some(chan) = chan.as_funded_mut() {
 					if let Some(monitor) = monitor_opt {
+						monitor.set_persistent_events_enabled(self.persistent_monitor_events);
 						let monitor_res =
 							self.chain_monitor.watch_channel(monitor.channel_id(), monitor);
 						if let Ok(persist_state) = monitor_res {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3028,6 +3028,15 @@ pub struct ChannelManager<
 	/// [`ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee`] estimate.
 	last_days_feerates: Mutex<VecDeque<(u32, u32)>>,
 
+	/// When set, monitors will repeatedly provide an event back to the `ChannelManager` on restart
+	/// until the event is explicitly acknowledged as processed.
+	///
+	/// Allows us to reconstruct pending HTLC state by replaying monitor events on startup, rather
+	/// than from complexly polling and reconciling Channel{Monitor} APIs, as well as move the
+	/// responsibility of off-chain payment resolution from the Channel to the monitor. Will be
+	/// always set once support is complete.
+	persistent_monitor_events: bool,
+
 	#[cfg(test)]
 	pub(super) entropy_source: ES,
 	#[cfg(not(test))]
@@ -3779,6 +3788,8 @@ impl<
 			signer_provider,
 
 			logger,
+
+			persistent_monitor_events: false,
 		}
 	}
 
@@ -18541,6 +18552,9 @@ impl<
 			}
 		}
 
+		// Only write `persistent_events_enabled` if it's set to true, as it's an even TLV.
+		let persistent_monitor_events = self.persistent_monitor_events.then_some(());
+
 		write_tlv_fields!(writer, {
 			(1, pending_outbound_payments_no_retry, required),
 			(2, pending_intercepted_htlcs, option),
@@ -18553,6 +18567,7 @@ impl<
 			(9, htlc_purposes, required_vec),
 			(10, legacy_in_flight_monitor_updates, option),
 			(11, self.probing_cookie_secret, required),
+			(12, persistent_monitor_events, option),
 			(13, htlc_onion_fields, optional_vec),
 			(14, decode_update_add_htlcs_opt, option),
 			(15, self.inbound_payment_id_secret, required),
@@ -18652,6 +18667,7 @@ pub(super) struct ChannelManagerData<SP: SignerProvider> {
 	forward_htlcs_legacy: HashMap<u64, Vec<HTLCForwardInfo>>,
 	pending_intercepted_htlcs_legacy: HashMap<InterceptId, PendingAddHTLCInfo>,
 	decode_update_add_htlcs_legacy: HashMap<u64, Vec<msgs::UpdateAddHTLC>>,
+	persistent_monitor_events: bool,
 	// The `ChannelManager` version that was written.
 	version: u8,
 }
@@ -18838,6 +18854,7 @@ impl<'a, ES: EntropySource, SP: SignerProvider, L: Logger>
 		let mut peer_storage_dir: Option<Vec<(PublicKey, Vec<u8>)>> = None;
 		let mut async_receive_offer_cache: AsyncReceiveOfferCache = AsyncReceiveOfferCache::new();
 		let mut best_block_previous_blocks = None;
+		let mut persistent_monitor_events: Option<()> = None;
 		read_tlv_fields!(reader, {
 			(1, pending_outbound_payments_no_retry, option),
 			(2, pending_intercepted_htlcs_legacy, option),
@@ -18850,6 +18867,7 @@ impl<'a, ES: EntropySource, SP: SignerProvider, L: Logger>
 			(9, claimable_htlc_purposes, optional_vec),
 			(10, legacy_in_flight_monitor_updates, option),
 			(11, probing_cookie_secret, option),
+			(12, persistent_monitor_events, option),
 			(13, amountless_claimable_htlc_onion_fields, optional_vec),
 			(14, decode_update_add_htlcs_legacy, option),
 			(15, inbound_payment_id_secret, option),
@@ -18858,6 +18876,12 @@ impl<'a, ES: EntropySource, SP: SignerProvider, L: Logger>
 			(21, async_receive_offer_cache, (default_value, async_receive_offer_cache)),
 			(23, best_block_previous_blocks, option),
 		});
+
+		#[cfg(not(any(feature = "_test_utils", test)))]
+		if persistent_monitor_events.is_some() {
+			// This feature isn't supported yet so error if the writer expected it to be.
+			return Err(DecodeError::InvalidValue);
+		}
 
 		// Merge legacy pending_outbound_payments fields into a single HashMap.
 		// Priority: pending_outbound_payments (TLV 3) > pending_outbound_payments_no_retry (TLV 1)
@@ -18978,6 +19002,7 @@ impl<'a, ES: EntropySource, SP: SignerProvider, L: Logger>
 			peer_storage_dir: peer_storage_dir.unwrap_or_default(),
 			async_receive_offer_cache,
 			version,
+			persistent_monitor_events: persistent_monitor_events.is_some(),
 		})
 	}
 }
@@ -19278,6 +19303,7 @@ impl<
 			mut in_flight_monitor_updates,
 			peer_storage_dir,
 			async_receive_offer_cache,
+			persistent_monitor_events,
 			version: _version,
 		} = data;
 
@@ -20544,6 +20570,8 @@ impl<
 
 			logger: args.logger,
 			config: RwLock::new(args.config),
+
+			persistent_monitor_events,
 		};
 
 		let mut processed_claims: HashSet<Vec<MPPClaimHTLCSource>> = new_hash_set();

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -13823,7 +13823,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 		for (funding_outpoint, channel_id, mut monitor_events, counterparty_node_id) in
 			pending_monitor_events.drain(..)
 		{
-			for monitor_event in monitor_events.drain(..) {
+			for (_event_id, monitor_event) in monitor_events.drain(..) {
 				match monitor_event {
 					MonitorEvent::HTLCEvent(htlc_update) => {
 						needs_persist = true;

--- a/lightning/src/ln/monitor_tests.rs
+++ b/lightning/src/ln/monitor_tests.rs
@@ -3594,6 +3594,9 @@ fn do_test_lost_timeout_monitor_events(confirm_tx: CommitmentType, dust_htlcs: b
 	let mut cfg = test_default_channel_config();
 	cfg.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx = true;
 	cfg.channel_handshake_config.negotiate_anchor_zero_fee_commitments = p2a_anchor;
+	// This test specifically tests lost monitor events, which requires the legacy
+	// (non-persistent) monitor event behavior.
+	cfg.override_persistent_monitor_events = Some(false);
 	let cfgs = [Some(cfg.clone()), Some(cfg.clone()), Some(cfg.clone())];
 
 	let chanmon_cfgs = create_chanmon_cfgs(3);

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -1134,6 +1134,10 @@ pub struct UserConfig {
 	///
 	/// [`ChannelManager::splice_channel`]: crate::ln::channelmanager::ChannelManager::splice_channel
 	pub reject_inbound_splices: bool,
+	/// If set to `Some`, overrides the random selection of whether to use persistent monitor
+	/// events. Only available in tests.
+	#[cfg(any(test, feature = "_test_utils"))]
+	pub override_persistent_monitor_events: Option<bool>,
 }
 
 impl Default for UserConfig {
@@ -1150,6 +1154,8 @@ impl Default for UserConfig {
 			enable_htlc_hold: false,
 			hold_outbound_htlcs_at_next_hop: false,
 			reject_inbound_splices: true,
+			#[cfg(any(test, feature = "_test_utils"))]
+			override_persistent_monitor_events: None,
 		}
 	}
 }
@@ -1172,6 +1178,8 @@ impl Readable for UserConfig {
 			hold_outbound_htlcs_at_next_hop: Readable::read(reader)?,
 			enable_htlc_hold: Readable::read(reader)?,
 			reject_inbound_splices: Readable::read(reader)?,
+			#[cfg(any(test, feature = "_test_utils"))]
+			override_persistent_monitor_events: None,
 		})
 	}
 }

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -665,6 +665,7 @@ impl<'a> chain::Watch<TestChannelSigner> for TestChainMonitor<'a> {
 		)
 		.unwrap()
 		.1;
+		new_monitor.copy_monitor_event_state(&monitor);
 		assert!(new_monitor == monitor);
 		self.latest_monitor_update_id
 			.lock()
@@ -726,6 +727,9 @@ impl<'a> chain::Watch<TestChannelSigner> for TestChainMonitor<'a> {
 		// it so it doesn't leak into the rest of the test.
 		let failed_back = monitor.inner.lock().unwrap().failed_back_htlc_ids.clone();
 		new_monitor.inner.lock().unwrap().failed_back_htlc_ids = failed_back;
+		// The deserialized monitor will reset the monitor event state, so copy it from the live
+		// monitor before comparing.
+		new_monitor.copy_monitor_event_state(&monitor);
 		if let Some(chan_id) = self.expect_monitor_round_trip_fail.lock().unwrap().take() {
 			assert_eq!(chan_id, channel_id);
 			assert!(new_monitor != *monitor);
@@ -739,7 +743,7 @@ impl<'a> chain::Watch<TestChannelSigner> for TestChainMonitor<'a> {
 
 	fn release_pending_monitor_events(
 		&self,
-	) -> Vec<(OutPoint, ChannelId, Vec<MonitorEvent>, PublicKey)> {
+	) -> Vec<(OutPoint, ChannelId, Vec<(u64, MonitorEvent)>, PublicKey)> {
 		// Auto-flush pending operations so that the ChannelManager can pick up monitor
 		// completion events. When not in deferred mode the queue is empty so this only
 		// costs a lock acquisition. It ensures standard test helpers (route_payment, etc.)

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -17,7 +17,7 @@ use crate::chain::chaininterface;
 #[cfg(any(test, feature = "_externalize_tests"))]
 use crate::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
 use crate::chain::chaininterface::{ConfirmationTarget, TransactionType};
-use crate::chain::chainmonitor::{ChainMonitor, Persist};
+use crate::chain::chainmonitor::{ChainMonitor, MonitorEventSource, Persist};
 use crate::chain::channelmonitor::{
 	ChannelMonitor, ChannelMonitorUpdate, ChannelMonitorUpdateStep, MonitorEvent,
 };
@@ -749,6 +749,10 @@ impl<'a> chain::Watch<TestChannelSigner> for TestChainMonitor<'a> {
 			self.chain_monitor.flush(count, &self.logger);
 		}
 		return self.chain_monitor.release_pending_monitor_events();
+	}
+
+	fn ack_monitor_event(&self, source: MonitorEventSource) {
+		self.chain_monitor.ack_monitor_event(source);
 	}
 }
 


### PR DESCRIPTION
As part of #4482, we're looking into changing our architecture -- currently, the `Channel{Manager}` is responsible for managing the resolution of off-chain HTLCs, and the `ChannelMonitor` is responsible for them once they're on-chain. See the issue description but there's complexity that results from this design. 

Quoting the issue, "Instead, we want to do all resolution in ChannelMonitors (in response to ChannelMonitorUpdates) and pass them back to ChannelManager in the form of MonitorEvents (similar to how HTLCs are resolved after channels are closed). In order to have reliable resolution, we'll need to keep MonitorEvents around in the ChannelMonitor until the ChannelManager has finished processing them - adding a new MonitorEvent resolution path through a new method (rather than via ChannelMonitorUpdates)."

Here we don't add any new `MonitorEvent`s but add support for making the ones we do have persistent across restarts until they are explicitly ack'd, via a new `chain::Watch` API. 

- [x] update commit messages