### PR TITLE
fuzz: improve CI iteration strategy, add corpus minimization and summary reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,21 @@ jobs:
       - name: Simulate docs.rs build
         run: ci/check-docsrs.sh
 
+  fuzz_sanity:
+    runs-on: self-hosted
+    env:
+      TOOLCHAIN: 1.75
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
+      - name: Sanity check fuzz targets on Rust ${{ env.TOOLCHAIN }}
+        run: |
+          cd fuzz
+          cargo test --quiet --color always --lib --bins -j8
+
   fuzz:
     runs-on: self-hosted
     env:
@@ -238,11 +253,6 @@ jobs:
           key: fuzz-corpus-refs/heads/main-${{ github.sha }}
           restore-keys: |
             fuzz-corpus-refs/heads/main-
-      - name: Sanity check fuzz targets on Rust ${{ env.TOOLCHAIN }}
-        run: |
-          cd fuzz
-          cargo test --verbose --color always --lib --bins -j8
-          cargo clean
       - name: Run fuzzers
         run: cd fuzz && ./ci-fuzz.sh && cd ..
       - name: Upload honggfuzz corpus
@@ -308,7 +318,7 @@ jobs:
           TOR_PROXY="127.0.0.1:9050" RUSTFLAGS="--cfg=tor" cargo test --verbose --color always -p lightning-net-tokio
 
   notify-failure:
-    needs: [build-workspace, build-features, build-bindings, build-nostd, build-cfg-flags, build-sync, fuzz, linting, rustfmt, check_release, check_docs, benchmark, ext-test, tor-connect, coverage]
+    needs: [build-workspace, build-features, build-bindings, build-nostd, build-cfg-flags, build-sync, fuzz_sanity, fuzz, linting, rustfmt, check_release, check_docs, benchmark, ext-test, tor-connect, coverage]
     if: failure() && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,8 @@ jobs:
             fuzz-corpus-refs/heads/main-
       - name: Run fuzzers
         run: cd fuzz && ./ci-fuzz.sh && cd ..
+        env:
+          FUZZ_MINIMIZE: ${{ contains(github.event.pull_request.labels.*.name, 'fuzz-minimize') }}
       - name: Upload honggfuzz corpus
         uses: actions/upload-artifact@v4
         with:

--- a/fuzz/ci-fuzz.sh
+++ b/fuzz/ci-fuzz.sh
@@ -30,20 +30,82 @@ sed -i 's/lto = true//' Cargo.toml
 export HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz"
 
 cargo --color always hfuzz build -j8
+
+SUMMARY=""
+
+check_crash() {
+	local FILE=$1
+	if [ -f "hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT" ]; then
+		cat "hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT"
+		for CASE in "hfuzz_workspace/$FILE"/SIG*; do
+			cat "$CASE" | xxd -p
+		done
+		exit 1
+	fi
+}
+
 for TARGET in src/bin/*.rs; do
 	FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"
-	HFUZZ_RUN_ARGS="--exit_upon_crash -v -n8 --run_time 30"
+	CORPUS_DIR="hfuzz_workspace/$FILE/input"
+	CORPUS_COUNT=$(find "$CORPUS_DIR" -type f 2>/dev/null | wc -l)
+	# Run 8x the corpus size plus a baseline, ensuring full corpus replay
+	# with room for new mutations. The 10-minute hard cap (--run_time 600)
+	# prevents slow-per-iteration targets from running too long.
+	ITERATIONS=$((CORPUS_COUNT * 8 + 1000))
+	HFUZZ_RUN_ARGS="--exit_upon_crash -q -n8 -t 3 -N $ITERATIONS --run_time 600"
 	if [ "$FILE" = "chanmon_consistency_target" -o "$FILE" = "fs_store_target" ]; then
 		HFUZZ_RUN_ARGS="$HFUZZ_RUN_ARGS -F 64"
 	fi
 	export HFUZZ_RUN_ARGS
+	FUZZ_START=$(date +%s)
 	cargo --color always hfuzz run $FILE
-	if [ -f hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT ]; then
-		cat hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT
-		for CASE in hfuzz_workspace/$FILE/SIG*; do
-			cat $CASE | xxd -p
-		done
-		exit 1
+	FUZZ_END=$(date +%s)
+	FUZZ_TIME=$((FUZZ_END - FUZZ_START))
+	FUZZ_CORPUS_COUNT=$(find "$CORPUS_DIR" -type f 2>/dev/null | wc -l)
+	check_crash "$FILE"
+	if [ "$GITHUB_REF" = "refs/heads/main" ] || [ "$FUZZ_MINIMIZE" = "true" ]; then
+		HFUZZ_RUN_ARGS="-M -q -n8 -t 3"
+		export HFUZZ_RUN_ARGS
+		MIN_START=$(date +%s)
+		cargo --color always hfuzz run $FILE
+		MIN_END=$(date +%s)
+		MIN_TIME=$((MIN_END - MIN_START))
+		MIN_CORPUS_COUNT=$(find "$CORPUS_DIR" -type f 2>/dev/null | wc -l)
+		check_crash "$FILE"
+		SUMMARY="${SUMMARY}${FILE}|${ITERATIONS}|${CORPUS_COUNT}|${FUZZ_CORPUS_COUNT}|${FUZZ_TIME}|${MIN_CORPUS_COUNT}|${MIN_TIME}\n"
+	else
+		SUMMARY="${SUMMARY}${FILE}|${ITERATIONS}|${CORPUS_COUNT}|${FUZZ_CORPUS_COUNT}|${FUZZ_TIME}|-|-\n"
 	fi
 done
+
+fmt_time() {
+	local secs=$1
+	local m=$((secs / 60))
+	local s=$((secs % 60))
+	if [ "$m" -gt 0 ]; then
+		printf "%dm %ds" "$m" "$s"
+	else
+		printf "%ds" "$s"
+	fi
+}
+
+# Print summary table
+set +x
+echo ""
+echo "==== Fuzz Summary ===="
+HDR="%-40s %7s %7s  %-15s %9s  %-15s %9s\n"
+FMT="%-40s %7s %7s %6s %-9s %9s %6s %-9s %9s\n"
+printf "$HDR" "Target" "Iters" "Corpus" "   Fuzzed" "Fuzz time" "  Minimized" "Min. time"
+printf "$HDR" "------" "-----" "------" "---------------" "---------" "---------------" "---------"
+echo -e "$SUMMARY" | while IFS='|' read -r name iters orig fuzzed ftime minimized mtime; do
+	[ -z "$name" ] && continue
+	fuzz_delta=$((fuzzed - orig))
+	if [ "$minimized" = "-" ]; then
+		printf "$FMT" "$name" "$iters" "$orig" "$fuzzed" "(+$fuzz_delta)" "$(fmt_time "$ftime")" "-" "" "-"
+	else
+		min_delta=$((minimized - fuzzed))
+		printf "$FMT" "$name" "$iters" "$orig" "$fuzzed" "(+$fuzz_delta)" "$(fmt_time "$ftime")" "$minimized" "($min_delta)" "$(fmt_time "$mtime")"
+	fi
+done
+echo "======================"


### PR DESCRIPTION
Fuzzing has become increasingly important with the recent wave of changes: async persist, channel manager refactors, splicing, and zero-fee channels. These are complex state machine changes where the fuzzer is one of our best tools for catching edge cases.

This PR gives the fuzz CI some overdue attention. The main goals are visibility into what the fuzzer is actually doing, and making the iteration budget more meaningful:

- The old fixed 30-second wall clock limit meant fast targets wasted time while slow targets barely got through their corpus. Iteration counts now scale with corpus size, so every target replays its full corpus with room for new mutations.
- On main, corpus minimization runs after each target to prune redundant inputs and keep the cache from growing indefinitely. PRs can opt in via the `fuzz-minimize` label.
- A summary table is printed at the end of each run, giving visibility into per-target corpus sizes, deltas, and timings:
  ```
  ==== Fuzz Summary ====
  Target                                     Iters  Corpus     Fuzzed       Fuzz time    Minimized     Min. time
  ------                                     -----  ------  --------------- ---------  --------------- ---------
  base32_target                              27216    3277   3286 (+9)           0m4s    346 (-2940)        0m4s
  bech32_parse_target                        91160   11270  11285 (+15)          0m4s    959 (-10326)       0m8s
  bolt11_deser_target                        99144   12268  12273 (+5)           0m5s   1288 (-10985)      0m26s
  chanmon_consistency_target                 11904    1363   2531 (+1168)       6m56s   1908 (-623)       36m44s
  chanmon_deser_target                      150112   18639  18675 (+36)          0m8s   1250 (-17425)      0m15s
  ======================
  ```
- The fuzz sanity check (cargo test on fuzz targets) is split into its own parallel job since it doesn't depend on the corpus.
