### PR TITLE
Add .cargo/config.toml for fuzz cfg flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Sanity check fuzz targets on Rust ${{ env.TOOLCHAIN }}
         run: |
           cd fuzz
-          RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz" cargo test --verbose --color always --lib --bins -j8
+          cargo test --verbose --color always --lib --bins -j8
           cargo clean
       - name: Run fuzzers
         run: cd fuzz && ./ci-fuzz.sh && cd ..

--- a/contrib/generate_fuzz_coverage.sh
+++ b/contrib/generate_fuzz_coverage.sh
@@ -55,8 +55,6 @@ fi
 # Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
 
-export RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz"
-
 # dont run this command when running in CI
 if [ "$OUTPUT_CODECOV_JSON" = "0" ]; then
     cargo llvm-cov --html --ignore-filename-regex "fuzz/" --output-dir "$OUTPUT_DIR"

--- a/fuzz/.cargo/config.toml
+++ b/fuzz/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg=fuzzing", "--cfg=secp256k1_fuzz", "--cfg=hashes_fuzz"]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -134,7 +134,6 @@ mkdir -p ./test_cases/$TARGET
 echo $HEX | xxd -r -p > ./test_cases/$TARGET/any_filename_works
 
 export RUST_BACKTRACE=1
-export RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz"
 cargo test
 ```
 
@@ -152,7 +151,7 @@ Alternatively, you can use the `stdin_fuzz` feature to pipe the crash input dire
 creating test case files on disk:
 
 ```shell
-echo -ne '\x2d\x31\x36\x38\x37\x34\x09\x01...' | RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz" cargo run --features stdin_fuzz --bin full_stack_target
+echo -ne '\x2d\x31\x36\x38\x37\x34\x09\x01...' | cargo run --features stdin_fuzz --bin full_stack_target
 ```
 
 Panics will abort the process directly (the crate uses `panic = "abort"`), resulting in a


### PR DESCRIPTION
Previously, these flags had to be manually passed via `RUSTFLAGS` every time. This was a recurring source of confusion and wasted time, both for humans and AI agents, who would forget to set the flags or get the command line wrong. By moving them into cargo config, fuzz commands just work without any special environment setup.