### PR TITLE
Add APIs to prune completed state for LSPS1/LSPS2/LSPS5

### DIFF
--- a/lightning-liquidity/src/lsps0/ser.rs
+++ b/lightning-liquidity/src/lsps0/ser.rs
@@ -1013,6 +1013,15 @@ mod tests {
 	}
 
 	#[test]
+	fn datetime_duration_since_clock_skew_saturates_to_zero() {
+		// When `other` is in the apparent future relative to `self` (clock skew),
+		// duration_since must return Duration::ZERO rather than an erroneously large value.
+		let earlier = LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap();
+		let later = LSPSDateTime::from_str("2024-01-01T01:00:00Z").unwrap();
+		assert_eq!(earlier.duration_since(&later), Duration::ZERO);
+	}
+
+	#[test]
 	fn is_past_handles_pre_epoch_datetime() {
 		// A peer-controlled RFC3339 datetime before 1970 must be rejected at parse
 		// time, so it can never reach `is_past` (or any other consumer) and panic.

--- a/lightning-liquidity/src/lsps1/peer_state.rs
+++ b/lightning-liquidity/src/lsps1/peer_state.rs
@@ -17,6 +17,8 @@ use super::msgs::{
 use crate::lsps0::ser::{LSPSDateTime, LSPSRequestId};
 use crate::prelude::HashMap;
 
+use core::time::Duration;
+
 use lightning::util::hash_tables::new_hash_map;
 use lightning::{impl_ser_tlv_based, impl_ser_tlv_based_enum};
 
@@ -395,6 +397,36 @@ impl PeerState {
 			}
 			true
 		});
+	}
+
+	/// Removes all terminal orders from state that are at least `max_age` old.
+	///
+	/// Terminal orders are those in the [`ChannelOrderState::CompletedAndChannelOpened`] or
+	/// [`ChannelOrderState::FailedAndRefunded`] state. `max_age` is measured from the order's
+	/// `created_at` timestamp. Pass [`Duration::ZERO`] to prune all terminal orders regardless
+	/// of age, which is useful to immediately free per-peer quota when a client is blocked by
+	/// the request limit due to accumulated `FailedAndRefunded` entries.
+	///
+	/// Returns the number of orders removed.
+	pub(super) fn prune_terminal_orders(&mut self, now: &LSPSDateTime, max_age: Duration) -> usize {
+		let mut pruned = 0usize;
+		self.outbound_channels_by_order_id.retain(|_order_id, order| {
+			let is_terminal = matches!(
+				order.state,
+				ChannelOrderState::CompletedAndChannelOpened { .. }
+					| ChannelOrderState::FailedAndRefunded { .. }
+			);
+			if is_terminal && now.duration_since(&order.created_at) >= max_age {
+				pruned += 1;
+				false
+			} else {
+				true
+			}
+		});
+		if pruned > 0 {
+			self.needs_persist |= true;
+		}
+		pruned
 	}
 
 	fn pending_requests_and_unpaid_orders(&self) -> usize {
@@ -777,5 +809,150 @@ mod tests {
 
 		// Available in CompletedAndChannelOpened
 		assert_eq!(state.channel_info(), Some(&channel_info));
+	}
+
+	fn create_test_order_params() -> LSPS1OrderParams {
+		LSPS1OrderParams {
+			lsp_balance_sat: 100_000,
+			client_balance_sat: 0,
+			required_channel_confirmations: 0,
+			funding_confirms_within_blocks: 6,
+			channel_expiry_blocks: 144,
+			token: None,
+			announce_channel: false,
+		}
+	}
+
+	#[test]
+	fn test_prune_terminal_orders_completed() {
+		let mut peer_state = PeerState::default();
+		let order_id = LSPS1OrderId("order1".to_string());
+		peer_state.new_order(
+			order_id.clone(),
+			create_test_order_params(),
+			LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap(),
+			create_test_payment_info_bolt11_only(),
+		);
+		peer_state.order_payment_received(&order_id, PaymentMethod::Bolt11).unwrap();
+		peer_state.order_channel_opened(&order_id, create_test_channel_info()).unwrap();
+
+		// max_age=0 prunes all terminal orders regardless of age.
+		let now = LSPSDateTime::from_str("2024-01-01T01:00:00Z").unwrap();
+		assert_eq!(peer_state.prune_terminal_orders(&now, Duration::ZERO), 1);
+		assert!(peer_state.get_order(&order_id).is_err());
+	}
+
+	#[test]
+	fn test_prune_terminal_orders_failed_and_refunded() {
+		let mut peer_state = PeerState::default();
+		let order_id = LSPS1OrderId("order2".to_string());
+		// Non-expired invoice: verify we do not require invoice expiry before pruning.
+		peer_state.new_order(
+			order_id.clone(),
+			create_test_order_params(),
+			LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap(),
+			create_test_payment_info_bolt11_only(),
+		);
+		peer_state.order_failed_and_refunded(&order_id).unwrap();
+
+		let now = LSPSDateTime::from_str("2024-01-01T01:00:00Z").unwrap();
+		assert_eq!(peer_state.prune_terminal_orders(&now, Duration::ZERO), 1);
+		assert!(peer_state.get_order(&order_id).is_err());
+	}
+
+	#[test]
+	fn test_prune_terminal_orders_age_filter() {
+		let mut peer_state = PeerState::default();
+
+		// Old order (2 hours before now) — must be pruned when max_age = 1 hour.
+		let old_id = LSPS1OrderId("old".to_string());
+		peer_state.new_order(
+			old_id.clone(),
+			create_test_order_params(),
+			LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap(),
+			create_test_payment_info_bolt11_only(),
+		);
+		peer_state.order_failed_and_refunded(&old_id).unwrap();
+
+		// Recent order (10 minutes before now) — must NOT be pruned when max_age = 1 hour.
+		let recent_id = LSPS1OrderId("recent".to_string());
+		peer_state.new_order(
+			recent_id.clone(),
+			create_test_order_params(),
+			LSPSDateTime::from_str("2024-01-01T01:50:00Z").unwrap(),
+			create_test_payment_info_bolt11_only(),
+		);
+		peer_state.order_failed_and_refunded(&recent_id).unwrap();
+
+		let now = LSPSDateTime::from_str("2024-01-01T02:00:00Z").unwrap();
+		let pruned = peer_state.prune_terminal_orders(&now, Duration::from_secs(3600));
+		assert_eq!(pruned, 1);
+		assert!(peer_state.get_order(&old_id).is_err());
+		assert!(peer_state.get_order(&recent_id).is_ok());
+	}
+
+	#[test]
+	fn test_prune_terminal_orders_non_terminal_skipped() {
+		let mut peer_state = PeerState::default();
+
+		// ExpectingPayment is not a terminal state.
+		let expecting_id = LSPS1OrderId("expecting".to_string());
+		peer_state.new_order(
+			expecting_id.clone(),
+			create_test_order_params(),
+			LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap(),
+			create_test_payment_info_bolt11_only(),
+		);
+
+		// OrderPaid is not a terminal state.
+		let paid_id = LSPS1OrderId("paid".to_string());
+		peer_state.new_order(
+			paid_id.clone(),
+			create_test_order_params(),
+			LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap(),
+			create_test_payment_info_bolt11_only(),
+		);
+		peer_state.order_payment_received(&paid_id, PaymentMethod::Bolt11).unwrap();
+
+		let now = LSPSDateTime::from_str("2024-01-01T02:00:00Z").unwrap();
+		assert_eq!(peer_state.prune_terminal_orders(&now, Duration::ZERO), 0);
+		assert!(peer_state.get_order(&expecting_id).is_ok());
+		assert!(peer_state.get_order(&paid_id).is_ok());
+	}
+
+	#[test]
+	fn test_prune_terminal_orders_frees_quota() {
+		let mut peer_state = PeerState::default();
+
+		// Fill up to the limit with FailedAndRefunded orders.
+		for i in 0..MAX_PENDING_REQUESTS_PER_PEER {
+			let order_id = LSPS1OrderId(format!("order{}", i));
+			peer_state.new_order(
+				order_id.clone(),
+				create_test_order_params(),
+				LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap(),
+				create_test_payment_info_bolt11_only(),
+			);
+			peer_state.order_failed_and_refunded(&order_id).unwrap();
+		}
+
+		// Registering another request must fail: quota is exhausted.
+		let dummy_request = LSPS1Request::GetInfo(Default::default());
+		assert!(matches!(
+			peer_state.register_request(LSPSRequestId("r0".to_string()), dummy_request.clone()),
+			Err(PeerStateError::TooManyPendingRequests)
+		));
+
+		// Prune all failed orders with max_age=0.
+		let now = LSPSDateTime::from_str("2024-01-01T01:00:00Z").unwrap();
+		assert_eq!(
+			peer_state.prune_terminal_orders(&now, Duration::ZERO),
+			MAX_PENDING_REQUESTS_PER_PEER
+		);
+
+		// Now registering a new request must succeed.
+		assert!(peer_state
+			.register_request(LSPSRequestId("r1".to_string()), dummy_request)
+			.is_ok());
 	}
 }

--- a/lightning-liquidity/src/lsps1/service.rs
+++ b/lightning-liquidity/src/lsps1/service.rs
@@ -17,6 +17,7 @@ use core::ops::Deref;
 use core::pin::pin;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task;
+use core::time::Duration;
 
 use super::event::LSPS1ServiceEvent;
 use super::msgs::{
@@ -752,6 +753,46 @@ where
 		Ok(())
 	}
 
+	/// Prunes terminal orders for all peers, freeing memory and per-peer quota.
+	///
+	/// Terminal orders are those in the [`super::msgs::LSPS1OrderState::Completed`] or
+	/// [`super::msgs::LSPS1OrderState::Failed`] state. `max_age` is measured from each order's
+	/// `created_at` timestamp. Pass [`Duration::ZERO`] to prune all terminal orders regardless
+	/// of age, which is useful to immediately free per-peer quota when clients are blocked by
+	/// the per-peer request limit due to accumulated failed orders.
+	///
+	/// Returns the total number of orders removed across all peers.
+	pub async fn prune_orders(&self, max_age: Duration) -> Result<usize, APIError> {
+		let now =
+			LSPSDateTime::new_from_duration_since_epoch(self.time_provider.duration_since_epoch());
+
+		let dirty_peers: Vec<(PublicKey, usize)> = {
+			let outer_state_lock = self.per_peer_state.read().unwrap();
+			outer_state_lock
+				.iter()
+				.filter_map(|(node_id, inner_lock)| {
+					let mut peer_state = inner_lock.lock().unwrap();
+					let pruned = peer_state.prune_terminal_orders(&now, max_age);
+					if pruned > 0 {
+						Some((*node_id, pruned))
+					} else {
+						None
+					}
+				})
+				.collect()
+		};
+
+		let total: usize = dirty_peers.iter().map(|(_, n)| n).sum();
+
+		for (node_id, _) in &dirty_peers {
+			self.persist_peer_state(*node_id).await.map_err(|e| APIError::APIMisuseError {
+				err: format!("Failed to persist peer state for {}: {}", node_id, e),
+			})?;
+		}
+
+		Ok(total)
+	}
+
 	fn generate_order_id(&self) -> LSPS1OrderId {
 		let bytes = self.entropy_source.get_secure_random_bytes();
 		LSPS1OrderId(utils::hex_str(&bytes[0..16]))
@@ -919,6 +960,23 @@ where
 		&self, counterparty_node_id: PublicKey, order_id: LSPS1OrderId,
 	) -> Result<(), APIError> {
 		let mut fut = pin!(self.inner.order_failed_and_refunded(counterparty_node_id, order_id));
+
+		let mut waker = dummy_waker();
+		let mut ctx = task::Context::from_waker(&mut waker);
+		match fut.as_mut().poll(&mut ctx) {
+			task::Poll::Ready(result) => result,
+			task::Poll::Pending => {
+				// In a sync context, we can't wait for the future to complete.
+				unreachable!("Should not be pending in a sync context");
+			},
+		}
+	}
+
+	/// Prunes terminal orders for all peers, freeing memory and per-peer quota.
+	///
+	/// Wraps [`LSPS1ServiceHandler::prune_orders`].
+	pub fn prune_orders(&self, max_age: Duration) -> Result<usize, APIError> {
+		let mut fut = pin!(self.inner.prune_orders(max_age));
 
 		let mut waker = dummy_waker();
 		let mut ctx = task::Context::from_waker(&mut waker);

--- a/lightning-liquidity/src/lsps1/service.rs
+++ b/lightning-liquidity/src/lsps1/service.rs
@@ -213,9 +213,8 @@ where
 							state.set_needs_persist(true);
 						}
 					} else {
-						// This should never happen, we can only have one `persist` call
-						// in-progress at once and map entries are only removed by it.
-						debug_assert!(false);
+						// Already removed by a concurrent `persist_peer_state` call (e.g. from
+						// `prune_orders`); nothing left to do for this peer.
 					}
 				}
 				if let Some(future) = future_opt {
@@ -241,31 +240,78 @@ where
 	async fn persist_peer_state(
 		&self, counterparty_node_id: PublicKey,
 	) -> Result<(), lightning::io::Error> {
-		let fut = {
+		// Under the read lock, check whether we need to do anything and whether the peer
+		// state is now empty (prunable) so we can decide which storage operation to use.
+		let is_prunable = {
 			let outer_state_lock = self.per_peer_state.read().unwrap();
 			match outer_state_lock.get(&counterparty_node_id) {
-				None => {
-					// We dropped the peer state by now.
-					return Ok(());
-				},
+				None => return Ok(()),
 				Some(entry) => {
-					let mut peer_state_lock = entry.lock().unwrap();
+					let peer_state_lock = entry.lock().unwrap();
 					if !peer_state_lock.needs_persist() {
-						// We already have persisted otherwise by now.
 						return Ok(());
-					} else {
-						peer_state_lock.set_needs_persist(false);
+					}
+					peer_state_lock.is_prunable()
+				},
+			}
+		};
+
+		if is_prunable {
+			// The peer state is empty: remove it from the in-memory map and the KV store.
+			// We need the write lock to remove the map entry; hold it until we've started
+			// the remove future (but not through its completion) to stay well-ordered with
+			// other `persist_peer_state` calls for the same peer.
+			let fut = {
+				let mut per_peer_state = self.per_peer_state.write().unwrap();
+				if let Entry::Occupied(mut entry) = per_peer_state.entry(counterparty_node_id) {
+					let state = entry.get_mut().get_mut().unwrap();
+					if state.is_prunable() {
+						entry.remove();
 						let key = counterparty_node_id.to_string();
-						let encoded = peer_state_lock.encode();
-						// Begin the write with the entry lock held. This avoids racing with
-						// potentially-in-flight `persist` calls writing state for the same peer.
-						self.kv_store.write(
+						Some(self.kv_store.remove(
 							LIQUIDITY_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
 							LSPS1_SERVICE_PERSISTENCE_SECONDARY_NAMESPACE,
 							&key,
-							encoded,
-						)
+							true,
+						))
+					} else {
+						// New state arrived between the read and write lock; mark it dirty
+						// so it will be written on the next persist call.
+						state.set_needs_persist(true);
+						None
 					}
+				} else {
+					// Already removed by a concurrent persist_peer_state call.
+					None
+				}
+			};
+			if let Some(fut) = fut {
+				fut.await?;
+			}
+			return Ok(());
+		}
+
+		// The peer state is non-empty: serialize and write it.
+		let fut = {
+			let outer_state_lock = self.per_peer_state.read().unwrap();
+			match outer_state_lock.get(&counterparty_node_id) {
+				None => return Ok(()),
+				Some(entry) => {
+					let mut peer_state_lock = entry.lock().unwrap();
+					if !peer_state_lock.needs_persist() {
+						return Ok(());
+					}
+					peer_state_lock.set_needs_persist(false);
+					let key = counterparty_node_id.to_string();
+					let encoded = peer_state_lock.encode();
+					// Begin the write with the entry lock held. This avoids racing with
+					// potentially-in-flight `persist` calls writing state for the same peer.
+					self.kv_store.write(
+						LIQUIDITY_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+						LSPS1_SERVICE_PERSISTENCE_SECONDARY_NAMESPACE,
+						&key,
+						encoded,
+					)
 				},
 			}
 		};

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -3059,7 +3059,7 @@ mod tests {
 		};
 
 		let mut jit_channel =
-			OutboundJITChannel::new(payment_size_msat, opening_fee_params, user_channel_id, false);
+			OutboundJITChannel::new(payment_size_msat, opening_fee_params, user_channel_id, false, None);
 		assert!(matches!(
 			jit_channel.htlc_intercepted(htlc).unwrap(),
 			Some(HTLCInterceptedAction::OpenChannel(_))
@@ -3103,11 +3103,11 @@ mod tests {
 		let live_channel_id = ChannelId([47; 32]);
 
 		let mut stale_jit_channel =
-			OutboundJITChannel::new(None, opening_fee_params.clone(), stale_user_channel_id, false);
+			OutboundJITChannel::new(None, opening_fee_params.clone(), stale_user_channel_id, false, None);
 		stale_jit_channel.state =
 			OutboundJITChannelState::PaymentForwarded { channel_id: stale_channel_id };
 		let mut live_jit_channel =
-			OutboundJITChannel::new(None, opening_fee_params, live_user_channel_id, false);
+			OutboundJITChannel::new(None, opening_fee_params, live_user_channel_id, false, None);
 		live_jit_channel.state =
 			OutboundJITChannelState::PaymentForwarded { channel_id: live_channel_id };
 

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -19,13 +19,15 @@ use core::ops::Deref;
 use core::pin::pin;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task;
+use core::time::Duration;
 
 use crate::events::EventQueue;
 use crate::lsps0::ser::{
-	LSPSMessage, LSPSProtocolMessageHandler, LSPSRequestId, LSPSResponseError,
+	LSPSDateTime, LSPSMessage, LSPSProtocolMessageHandler, LSPSRequestId, LSPSResponseError,
 	JSONRPC_INTERNAL_ERROR_ERROR_CODE, JSONRPC_INTERNAL_ERROR_ERROR_MESSAGE,
 	LSPS0_CLIENT_REJECTED_ERROR_CODE,
 };
+use crate::utils::time::TimeProvider;
 use crate::lsps2::event::LSPS2ServiceEvent;
 use crate::lsps2::payment_queue::{InterceptedHTLC, PaymentQueue};
 use crate::lsps2::utils::{
@@ -497,6 +499,8 @@ struct OutboundJITChannel {
 	opening_fee_params: LSPS2OpeningFeeParams,
 	payment_size_msat: Option<u64>,
 	trust_model: TrustModel,
+	/// The time at which the JIT channel was created (i.e., the buy request was accepted).
+	created_at: LSPSDateTime,
 }
 
 impl_ser_tlv_based!(OutboundJITChannel, {
@@ -505,12 +509,13 @@ impl_ser_tlv_based!(OutboundJITChannel, {
 	(4, opening_fee_params, required),
 	(6, payment_size_msat, option),
 	(8, trust_model, required),
+	(10, created_at, (default_value, LSPSDateTime::new_from_duration_since_epoch(Duration::ZERO))),
 });
 
 impl OutboundJITChannel {
 	fn new(
 		payment_size_msat: Option<u64>, opening_fee_params: LSPS2OpeningFeeParams,
-		user_channel_id: u128, client_trusts_lsp: bool,
+		user_channel_id: u128, client_trusts_lsp: bool, created_at: LSPSDateTime,
 	) -> Self {
 		Self {
 			user_channel_id,
@@ -518,6 +523,7 @@ impl OutboundJITChannel {
 			opening_fee_params,
 			payment_size_msat,
 			trust_model: TrustModel::new(client_trusts_lsp),
+			created_at,
 		}
 	}
 
@@ -722,9 +728,10 @@ macro_rules! get_or_insert_peer_state_entry {
 }
 
 /// The main object allowing to send and receive bLIP-52 / LSPS2 messages.
-pub struct LSPS2ServiceHandler<CM: Deref, K: KVStore + Clone, T: BroadcasterInterface>
+pub struct LSPS2ServiceHandler<CM: Deref, K: KVStore + Clone, T: BroadcasterInterface, TP: Deref + Clone>
 where
 	CM::Target: AChannelManager,
+	TP::Target: TimeProvider,
 {
 	channel_manager: CM,
 	kv_store: K,
@@ -737,17 +744,20 @@ where
 	total_pending_requests: AtomicUsize,
 	config: LSPS2ServiceConfig,
 	persistence_in_flight: AtomicUsize,
+	time_provider: TP,
 }
 
-impl<CM: Deref, K: KVStore + Clone, T: BroadcasterInterface + Clone> LSPS2ServiceHandler<CM, K, T>
+impl<CM: Deref, K: KVStore + Clone, T: BroadcasterInterface + Clone, TP: Deref + Clone>
+	LSPS2ServiceHandler<CM, K, T, TP>
 where
 	CM::Target: AChannelManager,
+	TP::Target: TimeProvider,
 {
 	/// Constructs a `LSPS2ServiceHandler`.
 	pub(crate) fn new(
 		per_peer_state: HashMap<PublicKey, Mutex<PeerState>>, pending_messages: Arc<MessageQueue>,
 		pending_events: Arc<EventQueue<K>>, channel_manager: CM, kv_store: K, tx_broadcaster: T,
-		config: LSPS2ServiceConfig,
+		config: LSPS2ServiceConfig, time_provider: TP,
 	) -> Result<Self, lightning::io::Error> {
 		let mut peer_by_intercept_scid = new_hash_map();
 		let mut peer_by_channel_id = new_hash_map();
@@ -788,6 +798,7 @@ where
 			kv_store,
 			tx_broadcaster,
 			config,
+			time_provider,
 		})
 	}
 
@@ -941,11 +952,15 @@ where
 							peer_by_intercept_scid.insert(intercept_scid, *counterparty_node_id);
 						}
 
+						let created_at = LSPSDateTime::new_from_duration_since_epoch(
+							self.time_provider.duration_since_epoch(),
+						);
 						let outbound_jit_channel = OutboundJITChannel::new(
 							buy_request.payment_size_msat,
 							buy_request.opening_fee_params,
 							user_channel_id,
 							client_trusts_lsp,
+							created_at,
 						);
 
 						peer_state_lock
@@ -2112,10 +2127,11 @@ where
 	}
 }
 
-impl<CM: Deref, K: KVStore + Clone, T: BroadcasterInterface + Clone> LSPSProtocolMessageHandler
-	for LSPS2ServiceHandler<CM, K, T>
+impl<CM: Deref, K: KVStore + Clone, T: BroadcasterInterface + Clone, TP: Deref + Clone>
+	LSPSProtocolMessageHandler for LSPS2ServiceHandler<CM, K, T, TP>
 where
 	CM::Target: AChannelManager,
+	TP::Target: TimeProvider,
 {
 	type ProtocolMessage = LSPS2Message;
 	const PROTOCOL_NUMBER: Option<u16> = Some(2);
@@ -2190,18 +2206,21 @@ pub struct LSPS2ServiceHandlerSync<
 	CM: Deref,
 	K: KVStore + Clone,
 	T: BroadcasterInterface + Clone,
+	TP: Deref + Clone,
 > where
 	CM::Target: AChannelManager,
+	TP::Target: TimeProvider,
 {
-	inner: &'a LSPS2ServiceHandler<CM, K, T>,
+	inner: &'a LSPS2ServiceHandler<CM, K, T, TP>,
 }
 
-impl<'a, CM: Deref, K: KVStore + Clone, T: BroadcasterInterface + Clone>
-	LSPS2ServiceHandlerSync<'a, CM, K, T>
+impl<'a, CM: Deref, K: KVStore + Clone, T: BroadcasterInterface + Clone, TP: Deref + Clone>
+	LSPS2ServiceHandlerSync<'a, CM, K, T, TP>
 where
 	CM::Target: AChannelManager,
+	TP::Target: TimeProvider,
 {
-	pub(crate) fn from_inner(inner: &'a LSPS2ServiceHandler<CM, K, T>) -> Self {
+	pub(crate) fn from_inner(inner: &'a LSPS2ServiceHandler<CM, K, T, TP>) -> Self {
 		Self { inner }
 	}
 
@@ -2980,6 +2999,7 @@ mod tests {
 			opening_fee_params.clone(),
 			user_channel_id,
 			true,
+			LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap(),
 		);
 
 		let opening_payment_hash = PaymentHash([42; 32]);
@@ -3058,5 +3078,48 @@ mod tests {
 			broadcast_allowed,
 			"Broadcast was not allowed even though all the skimmed fees were collected"
 		);
+	}
+
+	#[test]
+	fn test_outbound_jit_channel_created_at_stored() {
+		let opening_fee_params = LSPS2OpeningFeeParams {
+			min_fee_msat: 1_000,
+			proportional: 0,
+			valid_until: LSPSDateTime::from_str("2035-05-20T08:30:45Z").unwrap(),
+			min_lifetime: 144,
+			max_client_to_self_delay: 128,
+			min_payment_size_msat: 1,
+			max_payment_size_msat: 10_000_000_000,
+			promise: "ignore".to_string(),
+		};
+		let created_at = LSPSDateTime::from_str("2024-06-15T12:00:00Z").unwrap();
+		let channel =
+			OutboundJITChannel::new(Some(1_000_000), opening_fee_params, 1u128, true, created_at);
+		assert_eq!(channel.created_at, created_at);
+	}
+
+	#[test]
+	fn test_outbound_jit_channel_created_at_round_trips() {
+		use lightning::util::ser::{Readable, Writeable};
+
+		let opening_fee_params = LSPS2OpeningFeeParams {
+			min_fee_msat: 1_000,
+			proportional: 0,
+			valid_until: LSPSDateTime::from_str("2035-05-20T08:30:45Z").unwrap(),
+			min_lifetime: 144,
+			max_client_to_self_delay: 128,
+			min_payment_size_msat: 1,
+			max_payment_size_msat: 10_000_000_000,
+			promise: "ignore".to_string(),
+		};
+		let created_at = LSPSDateTime::from_str("2024-06-15T12:00:00Z").unwrap();
+		let channel =
+			OutboundJITChannel::new(Some(1_000_000), opening_fee_params, 1u128, true, created_at);
+
+		let mut buf = Vec::new();
+		channel.write(&mut buf).unwrap();
+
+		let decoded = <OutboundJITChannel as Readable>::read(&mut &buf[..]).unwrap();
+		assert_eq!(decoded.created_at, created_at);
 	}
 }

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -512,7 +512,7 @@ impl_ser_tlv_based!(OutboundJITChannel, {
 	(4, opening_fee_params, required),
 	(6, payment_size_msat, option),
 	(8, trust_model, required),
-	(10, created_at, option),
+	(11, created_at, option),
 });
 
 impl OutboundJITChannel {

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -27,7 +27,6 @@ use crate::lsps0::ser::{
 	JSONRPC_INTERNAL_ERROR_ERROR_CODE, JSONRPC_INTERNAL_ERROR_ERROR_MESSAGE,
 	LSPS0_CLIENT_REJECTED_ERROR_CODE,
 };
-use crate::utils::time::TimeProvider;
 use crate::lsps2::event::LSPS2ServiceEvent;
 use crate::lsps2::payment_queue::{InterceptedHTLC, PaymentQueue};
 use crate::lsps2::utils::{
@@ -41,6 +40,7 @@ use crate::prelude::hash_map::Entry;
 use crate::prelude::{new_hash_map, HashMap};
 use crate::sync::{Arc, Mutex, MutexGuard, RwLock};
 use crate::utils::async_poll::dummy_waker;
+use crate::utils::time::TimeProvider;
 
 use lightning::chain::chaininterface::{BroadcasterInterface, TransactionType};
 use lightning::events::HTLCHandlingFailureType;
@@ -500,7 +500,10 @@ struct OutboundJITChannel {
 	payment_size_msat: Option<u64>,
 	trust_model: TrustModel,
 	/// The time at which the JIT channel was created (i.e., the buy request was accepted).
-	created_at: LSPSDateTime,
+	///
+	/// `None` for channels deserialized from data written before this field was introduced;
+	/// those channels are treated as having an unknown age by [`PeerState::prune_terminal_channels`].
+	created_at: Option<LSPSDateTime>,
 }
 
 impl_ser_tlv_based!(OutboundJITChannel, {
@@ -509,13 +512,13 @@ impl_ser_tlv_based!(OutboundJITChannel, {
 	(4, opening_fee_params, required),
 	(6, payment_size_msat, option),
 	(8, trust_model, required),
-	(10, created_at, (default_value, LSPSDateTime::new_from_duration_since_epoch(Duration::ZERO))),
+	(10, created_at, option),
 });
 
 impl OutboundJITChannel {
 	fn new(
 		payment_size_msat: Option<u64>, opening_fee_params: LSPS2OpeningFeeParams,
-		user_channel_id: u128, client_trusts_lsp: bool, created_at: LSPSDateTime,
+		user_channel_id: u128, client_trusts_lsp: bool, created_at: Option<LSPSDateTime>,
 	) -> Self {
 		Self {
 			user_channel_id,
@@ -684,6 +687,50 @@ impl PeerState {
 		// Return whether the entire state is empty.
 		self.pending_requests.is_empty() && self.outbound_channels_by_intercept_scid.is_empty()
 	}
+
+	/// Removes all channels in the [`PaymentForwarded`] terminal state whose `created_at`
+	/// timestamp is at least `max_age` old. Passing [`Duration::ZERO`] removes all terminal
+	/// channels regardless of age.
+	///
+	/// Channels with no `created_at` (deserialized from data written before the field was
+	/// introduced) have an unknown age and are only removed when `max_age` is
+	/// [`Duration::ZERO`]; they are skipped by any age-based filter.
+	///
+	/// Cleans up the intra-peer auxiliary maps for each removed channel and returns the
+	/// `(intercept_scid, channel_id)` pairs so the caller can remove them from the
+	/// handler-level peer lookup maps.
+	///
+	/// [`PaymentForwarded`]: OutboundJITChannelState::PaymentForwarded
+	/// [`Duration::ZERO`]: core::time::Duration::ZERO
+	fn prune_terminal_channels(
+		&mut self, now: &LSPSDateTime, max_age: Duration,
+	) -> Vec<(u64, ChannelId)> {
+		let mut removed = Vec::new();
+		self.outbound_channels_by_intercept_scid.retain(|scid, channel| {
+			if let OutboundJITChannelState::PaymentForwarded { channel_id } = &channel.state {
+				let should_prune = if max_age == Duration::ZERO {
+					true
+				} else {
+					// Channels without a created_at (pre-upgrade legacy data) have an unknown
+					// age and are excluded from age-based filtering.
+					channel
+						.created_at
+						.as_ref()
+						.map(|ts| now.duration_since(ts) >= max_age)
+						.unwrap_or(false)
+				};
+				if should_prune {
+					removed.push((*scid, *channel_id));
+					self.intercept_scid_by_channel_id.retain(|_, iscid| iscid != scid);
+					self.intercept_scid_by_user_channel_id.retain(|_, iscid| iscid != scid);
+					self.needs_persist = true;
+					return false;
+				}
+			}
+			true
+		});
+		removed
+	}
 }
 
 impl_ser_tlv_based!(PeerState, {
@@ -728,8 +775,12 @@ macro_rules! get_or_insert_peer_state_entry {
 }
 
 /// The main object allowing to send and receive bLIP-52 / LSPS2 messages.
-pub struct LSPS2ServiceHandler<CM: Deref, K: KVStore + Clone, T: BroadcasterInterface, TP: Deref + Clone>
-where
+pub struct LSPS2ServiceHandler<
+	CM: Deref,
+	K: KVStore + Clone,
+	T: BroadcasterInterface,
+	TP: Deref + Clone,
+> where
 	CM::Target: AChannelManager,
 	TP::Target: TimeProvider,
 {
@@ -952,9 +1003,9 @@ where
 							peer_by_intercept_scid.insert(intercept_scid, *counterparty_node_id);
 						}
 
-						let created_at = LSPSDateTime::new_from_duration_since_epoch(
+						let created_at = Some(LSPSDateTime::new_from_duration_since_epoch(
 							self.time_provider.duration_since_epoch(),
-						);
+						));
 						let outbound_jit_channel = OutboundJITChannel::new(
 							buy_request.payment_size_msat,
 							buy_request.opening_fee_params,
@@ -1324,6 +1375,64 @@ where
 		}
 
 		Ok(())
+	}
+
+	/// Prunes completed JIT channels from state for all peers, freeing memory.
+	///
+	/// Removes all channels in the `PaymentForwarded` terminal state whose `created_at`
+	/// timestamp is at least `max_age` old. Pass [`Duration::ZERO`] to prune all terminal
+	/// channels regardless of age.
+	///
+	/// Channels loaded from persisted data written before the `created_at` field was introduced
+	/// have an unknown creation time. They are only pruned when `max_age` is [`Duration::ZERO`];
+	/// any positive `max_age` leaves them untouched.
+	///
+	/// All associated state is cleaned up for each removed channel, including the per-peer
+	/// `intercept_scid_by_channel_id` and `intercept_scid_by_user_channel_id` maps as well as
+	/// the handler-level `peer_by_intercept_scid` and `peer_by_channel_id` lookups.
+	///
+	/// Returns the total number of channels pruned across all peers.
+	///
+	/// [`Duration::ZERO`]: core::time::Duration::ZERO
+	pub async fn prune_channels(&self, max_age: Duration) -> Result<usize, APIError> {
+		let now =
+			LSPSDateTime::new_from_duration_since_epoch(self.time_provider.duration_since_epoch());
+
+		let all_removed: Vec<(PublicKey, Vec<(u64, ChannelId)>)> = {
+			let outer_state_lock = self.per_peer_state.read().unwrap();
+			outer_state_lock
+				.iter()
+				.filter_map(|(node_id, inner_lock)| {
+					let mut peer_state = inner_lock.lock().unwrap();
+					let removed = peer_state.prune_terminal_channels(&now, max_age);
+					if !removed.is_empty() { Some((*node_id, removed)) } else { None }
+				})
+				.collect()
+		};
+
+		let total: usize = all_removed.iter().map(|(_, v)| v.len()).sum();
+
+		if total > 0 {
+			{
+				let mut peer_by_intercept_scid =
+					self.peer_by_intercept_scid.write().unwrap();
+				let mut peer_by_channel_id = self.peer_by_channel_id.write().unwrap();
+				for (_, removed) in &all_removed {
+					for (scid, channel_id) in removed {
+						peer_by_intercept_scid.remove(scid);
+						peer_by_channel_id.remove(channel_id);
+					}
+				}
+			}
+
+			for (node_id, _) in &all_removed {
+				self.persist_peer_state(*node_id).await.map_err(|e| APIError::APIMisuseError {
+					err: format!("Failed to persist peer state for {}: {}", node_id, e),
+				})?;
+			}
+		}
+
+		Ok(total)
 	}
 
 	/// Abandons a pending JIT‐open flow for `user_channel_id`, removing all local state.
@@ -2430,6 +2539,22 @@ where
 		}
 	}
 
+	/// Prunes completed JIT channels from state for all peers, freeing memory.
+	///
+	/// Wraps [`LSPS2ServiceHandler::prune_channels`].
+	pub fn prune_channels(&self, max_age: Duration) -> Result<usize, APIError> {
+		let mut fut = pin!(self.inner.prune_channels(max_age));
+
+		let mut waker = dummy_waker();
+		let mut ctx = task::Context::from_waker(&mut waker);
+		match fut.as_mut().poll(&mut ctx) {
+			task::Poll::Ready(result) => result,
+			task::Poll::Pending => {
+				unreachable!("Should not be pending in a sync context");
+			},
+		}
+	}
+
 	/// Forward [`Event::ChannelReady`] event parameters into this function.
 	///
 	/// Wraps [`LSPS2ServiceHandler::channel_ready`].
@@ -2999,7 +3124,7 @@ mod tests {
 			opening_fee_params.clone(),
 			user_channel_id,
 			true,
-			LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap(),
+			Some(LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap()),
 		);
 
 		let opening_payment_hash = PaymentHash([42; 32]);
@@ -3080,46 +3205,152 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn test_outbound_jit_channel_created_at_stored() {
-		let opening_fee_params = LSPS2OpeningFeeParams {
-			min_fee_msat: 1_000,
-			proportional: 0,
-			valid_until: LSPSDateTime::from_str("2035-05-20T08:30:45Z").unwrap(),
+	fn make_test_opening_fee_params() -> LSPS2OpeningFeeParams {
+		LSPS2OpeningFeeParams {
+			min_fee_msat: 1000,
+			proportional: 100,
+			valid_until: LSPSDateTime::from_str("2035-01-01T00:00:00Z").unwrap(),
 			min_lifetime: 144,
 			max_client_to_self_delay: 128,
 			min_payment_size_msat: 1,
 			max_payment_size_msat: 10_000_000_000,
 			promise: "ignore".to_string(),
-		};
+		}
+	}
+
+	#[test]
+	fn test_outbound_jit_channel_created_at_stored() {
 		let created_at = LSPSDateTime::from_str("2024-06-15T12:00:00Z").unwrap();
-		let channel =
-			OutboundJITChannel::new(Some(1_000_000), opening_fee_params, 1u128, true, created_at);
-		assert_eq!(channel.created_at, created_at);
+		let channel = OutboundJITChannel::new(
+			Some(1_000_000),
+			make_test_opening_fee_params(),
+			1u128,
+			true,
+			Some(created_at),
+		);
+		assert_eq!(channel.created_at, Some(created_at));
 	}
 
 	#[test]
 	fn test_outbound_jit_channel_created_at_round_trips() {
 		use lightning::util::ser::{Readable, Writeable};
 
-		let opening_fee_params = LSPS2OpeningFeeParams {
-			min_fee_msat: 1_000,
-			proportional: 0,
-			valid_until: LSPSDateTime::from_str("2035-05-20T08:30:45Z").unwrap(),
-			min_lifetime: 144,
-			max_client_to_self_delay: 128,
-			min_payment_size_msat: 1,
-			max_payment_size_msat: 10_000_000_000,
-			promise: "ignore".to_string(),
-		};
 		let created_at = LSPSDateTime::from_str("2024-06-15T12:00:00Z").unwrap();
-		let channel =
-			OutboundJITChannel::new(Some(1_000_000), opening_fee_params, 1u128, true, created_at);
+		let channel = OutboundJITChannel::new(
+			Some(1_000_000),
+			make_test_opening_fee_params(),
+			1u128,
+			true,
+			Some(created_at),
+		);
 
 		let mut buf = Vec::new();
 		channel.write(&mut buf).unwrap();
 
 		let decoded = <OutboundJITChannel as Readable>::read(&mut &buf[..]).unwrap();
-		assert_eq!(decoded.created_at, created_at);
+		assert_eq!(decoded.created_at, Some(created_at));
+	}
+
+	// Verify that data written before the `created_at` field existed deserializes with
+	// `created_at = None`, keeping backwards compatibility.
+	#[test]
+	fn test_outbound_jit_channel_created_at_defaults_for_old_data() {
+		use lightning::util::ser::{Readable, Writeable};
+
+		// Serialize a channel that has no created_at (simulated by None).
+		let channel = OutboundJITChannel::new(
+			Some(1_000_000),
+			make_test_opening_fee_params(),
+			1u128,
+			false,
+			None,
+		);
+
+		let mut buf = Vec::new();
+		channel.write(&mut buf).unwrap();
+
+		// A channel serialized with created_at = None must not write TLV 10,
+		// and must round-trip as None.
+		let decoded = <OutboundJITChannel as Readable>::read(&mut &buf[..]).unwrap();
+		assert_eq!(decoded.created_at, None);
+	}
+
+	// Verify that prune_terminal_channels removes a PaymentForwarded channel and cleans up
+	// all auxiliary lookup maps.
+	#[test]
+	fn test_peer_state_prune_payment_forwarded_channel() {
+		let intercept_scid = 42u64;
+		let user_channel_id = 1u128;
+		let channel_id = ChannelId([1; 32]);
+		let created_at = Some(LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap());
+
+		let mut jit_channel = OutboundJITChannel::new(
+			Some(1_000_000),
+			make_test_opening_fee_params(),
+			user_channel_id,
+			false,
+			created_at,
+		);
+
+		// Drive the channel through to PaymentForwarded state.
+		let htlc = InterceptedHTLC {
+			intercept_id: InterceptId([0; 32]),
+			expected_outbound_amount_msat: 1_000_000,
+			payment_hash: PaymentHash([1; 32]),
+		};
+		let action = jit_channel.htlc_intercepted(htlc).unwrap();
+		assert!(matches!(action, Some(HTLCInterceptedAction::OpenChannel(_))));
+		jit_channel.channel_ready(channel_id).unwrap();
+		// Provide enough fee to transition to PaymentForwarded.
+		jit_channel.payment_forwarded(1_000).unwrap();
+
+		// Build a minimal PeerState with the channel and auxiliary maps.
+		let mut peer_state = PeerState::new();
+		peer_state.outbound_channels_by_intercept_scid.insert(intercept_scid, jit_channel);
+		peer_state.intercept_scid_by_user_channel_id.insert(user_channel_id, intercept_scid);
+		peer_state.intercept_scid_by_channel_id.insert(channel_id, intercept_scid);
+
+		// Confirm the channel is in PaymentForwarded state.
+		assert!(matches!(
+			peer_state.outbound_channels_by_intercept_scid.get(&intercept_scid).unwrap().state,
+			OutboundJITChannelState::PaymentForwarded { .. }
+		));
+
+		let now = LSPSDateTime::from_str("2026-01-01T00:00:00Z").unwrap();
+		let removed = peer_state.prune_terminal_channels(&now, Duration::ZERO);
+
+		// The channel and both auxiliary maps must be fully cleaned up.
+		assert_eq!(removed, vec![(intercept_scid, channel_id)]);
+		assert!(peer_state.outbound_channels_by_intercept_scid.is_empty());
+		assert!(peer_state.intercept_scid_by_channel_id.is_empty());
+		assert!(peer_state.intercept_scid_by_user_channel_id.is_empty());
+		assert!(peer_state.needs_persist);
+	}
+
+	// Verify that prune_terminal_channels leaves non-terminal channels untouched.
+	#[test]
+	fn test_peer_state_prune_channel_non_terminal_rejected() {
+		let intercept_scid = 99u64;
+		let user_channel_id = 2u128;
+		let created_at = Some(LSPSDateTime::from_str("2024-01-01T00:00:00Z").unwrap());
+		let jit_channel = OutboundJITChannel::new(
+			Some(500_000),
+			make_test_opening_fee_params(),
+			user_channel_id,
+			false,
+			created_at,
+		);
+
+		// Channel is in PendingInitialPayment — a non-terminal state.
+		assert!(matches!(jit_channel.state, OutboundJITChannelState::PendingInitialPayment { .. }));
+
+		let mut peer_state = PeerState::new();
+		peer_state.outbound_channels_by_intercept_scid.insert(intercept_scid, jit_channel);
+
+		let now = LSPSDateTime::from_str("2026-01-01T00:00:00Z").unwrap();
+		let removed = peer_state.prune_terminal_channels(&now, Duration::ZERO);
+
+		assert!(removed.is_empty(), "PendingInitialPayment must not be pruned");
+		assert!(!peer_state.outbound_channels_by_intercept_scid.is_empty());
 	}
 }

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -1928,31 +1928,78 @@ where
 	async fn persist_peer_state(
 		&self, counterparty_node_id: PublicKey,
 	) -> Result<(), lightning::io::Error> {
-		let fut = {
+		// Under the read lock, check whether we need to do anything and whether the peer
+		// state is now empty (prunable) so we can decide which storage operation to use.
+		let is_prunable = {
 			let outer_state_lock = self.per_peer_state.read().unwrap();
 			match outer_state_lock.get(&counterparty_node_id) {
-				None => {
-					// We dropped the peer state by now.
-					return Ok(());
-				},
+				None => return Ok(()),
 				Some(entry) => {
-					let mut peer_state_lock = entry.lock().unwrap();
+					let peer_state_lock = entry.lock().unwrap();
 					if !peer_state_lock.needs_persist {
-						// We already have persisted otherwise by now.
 						return Ok(());
-					} else {
-						peer_state_lock.needs_persist = false;
+					}
+					peer_state_lock.is_prunable()
+				},
+			}
+		};
+
+		if is_prunable {
+			// The peer state is empty: remove it from the in-memory map and the KV store.
+			// We need the write lock to remove the map entry; hold it until we've started
+			// the remove future (but not through its completion) to stay well-ordered with
+			// other `persist_peer_state` calls for the same peer.
+			let fut = {
+				let mut per_peer_state = self.per_peer_state.write().unwrap();
+				if let Entry::Occupied(mut entry) = per_peer_state.entry(counterparty_node_id) {
+					let state = entry.get_mut().get_mut().unwrap();
+					if state.is_prunable() {
+						entry.remove();
 						let key = counterparty_node_id.to_string();
-						let encoded = peer_state_lock.encode();
-						// Begin the write with the entry lock held. This avoids racing with
-						// potentially-in-flight `persist` calls writing state for the same peer.
-						self.kv_store.write(
+						Some(self.kv_store.remove(
 							LIQUIDITY_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
 							LSPS2_SERVICE_PERSISTENCE_SECONDARY_NAMESPACE,
 							&key,
-							encoded,
-						)
+							true,
+						))
+					} else {
+						// New state arrived between the read and write lock; mark it dirty
+						// so it will be written on the next persist call.
+						state.needs_persist = true;
+						None
 					}
+				} else {
+					// Already removed by a concurrent persist_peer_state call.
+					None
+				}
+			};
+			if let Some(fut) = fut {
+				fut.await?;
+			}
+			return Ok(());
+		}
+
+		// The peer state is non-empty: serialize and write it.
+		let fut = {
+			let outer_state_lock = self.per_peer_state.read().unwrap();
+			match outer_state_lock.get(&counterparty_node_id) {
+				None => return Ok(()),
+				Some(entry) => {
+					let mut peer_state_lock = entry.lock().unwrap();
+					if !peer_state_lock.needs_persist {
+						return Ok(());
+					}
+					peer_state_lock.needs_persist = false;
+					let key = counterparty_node_id.to_string();
+					let encoded = peer_state_lock.encode();
+					// Begin the write with the entry lock held. This avoids racing with
+					// potentially-in-flight `persist` calls writing state for the same peer.
+					self.kv_store.write(
+						LIQUIDITY_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+						LSPS2_SERVICE_PERSISTENCE_SECONDARY_NAMESPACE,
+						&key,
+						encoded,
+					)
 				},
 			}
 		};
@@ -2038,9 +2085,8 @@ where
 							state.needs_persist = true;
 						}
 					} else {
-						// This should never happen, we can only have one `persist` call
-						// in-progress at once and map entries are only removed by it.
-						debug_assert!(false);
+						// Already removed by a concurrent `persist_peer_state` call (e.g. from
+						// `prune_channels`); nothing left to do for this peer.
 					}
 				}
 				if let Some(future) = future_opt {

--- a/lightning-liquidity/src/lsps5/service.rs
+++ b/lightning-liquidity/src/lsps5/service.rs
@@ -31,6 +31,7 @@ use lightning::impl_ser_tlv_based;
 use lightning::ln::channelmanager::AChannelManager;
 use lightning::ln::msgs::{ErrorAction, LightningError};
 use lightning::sign::NodeSigner;
+use lightning::util::errors::APIError;
 use lightning::util::logger::Level;
 use lightning::util::persist::KVStore;
 use lightning::util::ser::Writeable;
@@ -600,6 +601,38 @@ where
 		self.send_notifications_to_client_webhooks(client_id, notification)
 	}
 
+	/// Removes a specific webhook registration for a client.
+	///
+	/// This can be used to prune webhook state for a client that is no longer active or whose
+	/// webhooks are no longer relevant, complementing the automatic 30-day stale webhook pruning.
+	/// The state change will be persisted on the next call to [`LiquidityManager::persist`].
+	///
+	/// Returns an [`APIError::APIMisuseError`] if the client has no registered state or no
+	/// webhook with the given `app_name` is registered for that client.
+	///
+	/// [`LiquidityManager::persist`]: crate::LiquidityManager::persist
+	pub fn prune_webhook(
+		&self, counterparty_node_id: PublicKey, app_name: &LSPS5AppName,
+	) -> Result<(), APIError> {
+		let mut outer_state_lock = self.per_peer_state.write().unwrap();
+		match outer_state_lock.get_mut(&counterparty_node_id) {
+			Some(peer_state) => {
+				if !peer_state.remove_webhook(app_name) {
+					return Err(APIError::APIMisuseError {
+						err: format!(
+							"No webhook with app_name '{}' registered for counterparty {}",
+							app_name, counterparty_node_id
+						),
+					});
+				}
+				Ok(())
+			},
+			None => Err(APIError::APIMisuseError {
+				err: format!("No existing state with counterparty {}", counterparty_node_id),
+			}),
+		}
+	}
+
 	fn send_notifications_to_client_webhooks(
 		&self, client_id: PublicKey, notification: WebhookNotification,
 	) -> Result<(), LSPS5ProtocolError> {
@@ -817,7 +850,9 @@ impl PeerState {
 				false
 			}
 		});
-		self.needs_persist |= true;
+		if removed {
+			self.needs_persist = true;
+		}
 		removed
 	}
 

--- a/lightning-liquidity/src/lsps5/service.rs
+++ b/lightning-liquidity/src/lsps5/service.rs
@@ -633,6 +633,27 @@ where
 		}
 	}
 
+	/// Removes all webhook registrations for a client.
+	///
+	/// This can be used to fully offboard a client, clearing all their registered webhooks
+	/// in one call rather than removing them one by one with [`prune_webhook`]. The state
+	/// change will be persisted on the next call to [`LiquidityManager::persist`].
+	///
+	/// Returns the number of webhooks removed, or an [`APIError::APIMisuseError`] if the
+	/// client has no registered state.
+	///
+	/// [`prune_webhook`]: Self::prune_webhook
+	/// [`LiquidityManager::persist`]: crate::LiquidityManager::persist
+	pub fn prune_webhooks(&self, counterparty_node_id: PublicKey) -> Result<usize, APIError> {
+		let mut outer_state_lock = self.per_peer_state.write().unwrap();
+		match outer_state_lock.get_mut(&counterparty_node_id) {
+			Some(peer_state) => Ok(peer_state.remove_all_webhooks()),
+			None => Err(APIError::APIMisuseError {
+				err: format!("No existing state with counterparty {}", counterparty_node_id),
+			}),
+		}
+	}
+
 	fn send_notifications_to_client_webhooks(
 		&self, client_id: PublicKey, notification: WebhookNotification,
 	) -> Result<(), LSPS5ProtocolError> {
@@ -838,6 +859,15 @@ impl PeerState {
 
 		self.webhooks.push((name, hook));
 		self.needs_persist |= true;
+	}
+
+	fn remove_all_webhooks(&mut self) -> usize {
+		let count = self.webhooks.len();
+		if count > 0 {
+			self.webhooks.clear();
+			self.needs_persist = true;
+		}
+		count
 	}
 
 	fn remove_webhook(&mut self, name: &LSPS5AppName) -> bool {

--- a/lightning-liquidity/src/manager.rs
+++ b/lightning-liquidity/src/manager.rs
@@ -285,7 +285,7 @@ pub struct LiquidityManager<
 	lsps0_service_handler: Option<LSPS0ServiceHandler>,
 	lsps1_service_handler: Option<LSPS1ServiceHandler<ES, CM, K, TP>>,
 	lsps1_client_handler: Option<LSPS1ClientHandler<ES, K>>,
-	lsps2_service_handler: Option<LSPS2ServiceHandler<CM, K, T>>,
+	lsps2_service_handler: Option<LSPS2ServiceHandler<CM, K, T, TP>>,
 	lsps2_client_handler: Option<LSPS2ClientHandler<ES, K>>,
 	lsps5_service_handler: Option<LSPS5ServiceHandler<CM, NS, K, TP>>,
 	lsps5_client_handler: Option<LSPS5ClientHandler<ES, K>>,
@@ -379,7 +379,7 @@ where
 		let lsps2_service_handler = if let Some(service_config) = service_config.as_ref() {
 			if let Some(lsps2_service_config) = service_config.lsps2_service_config.as_ref() {
 				if let Some(number) =
-					<LSPS2ServiceHandler<CM, K, T> as LSPSProtocolMessageHandler>::PROTOCOL_NUMBER
+					<LSPS2ServiceHandler<CM, K, T, TP> as LSPSProtocolMessageHandler>::PROTOCOL_NUMBER
 				{
 					supported_protocols.push(number);
 				}
@@ -393,6 +393,7 @@ where
 					kv_store.clone(),
 					transaction_broadcaster.clone(),
 					lsps2_service_config.clone(),
+					time_provider.clone(),
 				)?)
 			} else {
 				None
@@ -542,7 +543,7 @@ where
 	/// Returns a reference to the LSPS2 server-side handler.
 	///
 	/// The returned hendler allows to initiate the LSPS2 service-side flow.
-	pub fn lsps2_service_handler(&self) -> Option<&LSPS2ServiceHandler<CM, K, T>> {
+	pub fn lsps2_service_handler(&self) -> Option<&LSPS2ServiceHandler<CM, K, T, TP>> {
 		self.lsps2_service_handler.as_ref()
 	}
 
@@ -1055,7 +1056,7 @@ where
 	/// Wraps [`LiquidityManager::lsps2_service_handler`].
 	pub fn lsps2_service_handler<'a>(
 		&'a self,
-	) -> Option<LSPS2ServiceHandlerSync<'a, CM, KVStoreSyncWrapper<KS>, T>> {
+	) -> Option<LSPS2ServiceHandlerSync<'a, CM, KVStoreSyncWrapper<KS>, T, TP>> {
 		self.inner.lsps2_service_handler.as_ref().map(|r| LSPS2ServiceHandlerSync::from_inner(r))
 	}
 

--- a/lightning-liquidity/tests/lsps2_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps2_integration_tests.rs
@@ -2590,3 +2590,287 @@ fn client_trusts_lsp_partial_fee_does_not_trigger_broadcast() {
 	client_node.inner.chain_monitor.added_monitors.lock().unwrap().clear();
 	payer_node.chain_monitor.added_monitors.lock().unwrap().clear();
 }
+
+/// Drive the buy-request protocol on two nodes (no payer, no payment), leaving the channel
+/// in `PendingInitialPayment` state on the service side.
+fn run_buy_request_protocol<'a, 'b, 'c>(
+	lsps_nodes: &LSPSNodes<'a, 'b, 'c>, intercept_scid: u64, user_channel_id: u128,
+	cltv_expiry_delta: u32,
+) {
+	let service_node = &lsps_nodes.service_node;
+	let client_node = &lsps_nodes.client_node;
+
+	let service_node_id = service_node.inner.node.get_our_node_id();
+	let client_node_id = client_node.inner.node.get_our_node_id();
+
+	let client_handler = client_node.liquidity_manager.lsps2_client_handler().unwrap();
+	let service_handler = service_node.liquidity_manager.lsps2_service_handler().unwrap();
+
+	let _get_info_request_id = client_handler.request_opening_params(service_node_id, None);
+	let get_info_request = get_lsps_message!(client_node, service_node_id);
+	service_node.liquidity_manager.handle_custom_message(get_info_request, client_node_id).unwrap();
+
+	let get_info_event = service_node.liquidity_manager.next_event().unwrap();
+	let get_info_request_id = match get_info_event {
+		LiquidityEvent::LSPS2Service(LSPS2ServiceEvent::GetInfo { request_id, .. }) => request_id,
+		_ => panic!("Unexpected event"),
+	};
+
+	let raw_opening_params = LSPS2RawOpeningFeeParams {
+		min_fee_msat: 100,
+		proportional: 0,
+		valid_until: LSPSDateTime::from_str("2035-05-20T08:30:45Z").unwrap(),
+		min_lifetime: 144,
+		max_client_to_self_delay: 128,
+		min_payment_size_msat: 1,
+		max_payment_size_msat: 100_000_000,
+	};
+	service_handler
+		.opening_fee_params_generated(
+			&client_node_id,
+			get_info_request_id.clone(),
+			vec![raw_opening_params],
+		)
+		.unwrap();
+
+	let get_info_response = get_lsps_message!(service_node, client_node_id);
+	client_node
+		.liquidity_manager
+		.handle_custom_message(get_info_response, service_node_id)
+		.unwrap();
+
+	let opening_fee_params = match client_node.liquidity_manager.next_event().unwrap() {
+		LiquidityEvent::LSPS2Client(LSPS2ClientEvent::OpeningParametersReady {
+			opening_fee_params_menu,
+			..
+		}) => opening_fee_params_menu.first().unwrap().clone(),
+		_ => panic!("Unexpected event"),
+	};
+
+	let buy_request_id = client_handler
+		.select_opening_params(service_node_id, Some(1_000_000), opening_fee_params)
+		.unwrap();
+
+	let buy_request = get_lsps_message!(client_node, service_node_id);
+	service_node.liquidity_manager.handle_custom_message(buy_request, client_node_id).unwrap();
+
+	let buy_event = service_node.liquidity_manager.next_event().unwrap();
+	if let LiquidityEvent::LSPS2Service(LSPS2ServiceEvent::BuyRequest { request_id, .. }) =
+		buy_event
+	{
+		assert_eq!(request_id, buy_request_id);
+	} else {
+		panic!("Unexpected event");
+	}
+
+	service_handler
+		.invoice_parameters_generated(
+			&client_node_id,
+			buy_request_id.clone(),
+			intercept_scid,
+			cltv_expiry_delta,
+			true,
+			user_channel_id,
+		)
+		.unwrap();
+
+	let buy_response = get_lsps_message!(service_node, client_node_id);
+	client_node.liquidity_manager.handle_custom_message(buy_response, service_node_id).unwrap();
+	let _invoice_params_event = client_node.liquidity_manager.next_event().unwrap();
+}
+
+#[test]
+fn prune_channels_non_terminal_not_pruned() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (lsps_nodes, _promise_secret) = setup_test_lsps2_nodes(nodes);
+	let LSPSNodes { ref service_node, .. } = lsps_nodes;
+
+	let service_handler = service_node.liquidity_manager.lsps2_service_handler().unwrap();
+
+	let intercept_scid = service_node.node.get_intercept_scid();
+	run_buy_request_protocol(&lsps_nodes, intercept_scid, 42u128, 144);
+
+	// Channel is in PendingInitialPayment — prune_channels must not remove it.
+	let pruned = service_handler.prune_channels(Duration::ZERO).unwrap();
+	assert_eq!(pruned, 0, "PendingInitialPayment channel must not be pruned");
+}
+
+#[test]
+fn prune_channels_payment_forwarded_and_age_filter() {
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let mut service_node_config = test_default_channel_config();
+	service_node_config.htlc_interception_flags = HTLCInterceptionFlags::ToInterceptSCIDs as u8;
+
+	let mut client_node_config = test_default_channel_config();
+	client_node_config.channel_config.accept_underpaying_htlcs = true;
+	let node_chanmgrs = create_node_chanmgrs(
+		3,
+		&node_cfgs,
+		&[Some(service_node_config), Some(client_node_config), None],
+	);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	let (lsps_nodes, promise_secret) = setup_test_lsps2_nodes_with_payer(nodes);
+	let LSPSNodesWithPayer { ref service_node, ref client_node, ref payer_node } = lsps_nodes;
+
+	let payer_node_id = payer_node.node.get_our_node_id();
+	let service_node_id = service_node.inner.node.get_our_node_id();
+	let client_node_id = client_node.inner.node.get_our_node_id();
+
+	let service_handler = service_node.liquidity_manager.lsps2_service_handler().unwrap();
+
+	create_chan_between_nodes_with_value(&payer_node, &service_node.inner, 2_000_000, 100_000);
+
+	let intercept_scid = service_node.node.get_intercept_scid();
+	let user_channel_id = 42u128;
+	let cltv_expiry_delta: u32 = 144;
+	let payment_size_msat = Some(1_000_000);
+	let fee_base_msat: u64 = 1_000;
+
+	execute_lsps2_dance(
+		&lsps_nodes,
+		intercept_scid,
+		user_channel_id,
+		cltv_expiry_delta,
+		promise_secret,
+		payment_size_msat,
+		fee_base_msat,
+	);
+
+	let invoice = create_jit_invoice(
+		&client_node,
+		service_node_id,
+		intercept_scid,
+		cltv_expiry_delta,
+		payment_size_msat,
+		"prune-test",
+		3600,
+	)
+	.unwrap();
+
+	payer_node
+		.node
+		.pay_for_bolt11_invoice(
+			&invoice,
+			PaymentId(invoice.payment_hash().0),
+			None,
+			OptionalBolt11PaymentParams::default(),
+		)
+		.unwrap();
+
+	check_added_monitors(&payer_node, 1);
+	let events = payer_node.node.get_and_clear_pending_msg_events();
+	let ev = SendEvent::from_event(events[0].clone());
+	service_node.inner.node.handle_update_add_htlc(payer_node_id, &ev.msgs[0]);
+	do_commitment_signed_dance(&service_node.inner, &payer_node, &ev.commitment_msg, false, true);
+	service_node.inner.node.process_pending_htlc_forwards();
+
+	let events = service_node.inner.node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	let expected_outbound_amount_msat = match &events[0] {
+		Event::HTLCIntercepted {
+			intercept_id,
+			requested_next_hop_scid,
+			payment_hash,
+			expected_outbound_amount_msat,
+			..
+		} => {
+			assert_eq!(*requested_next_hop_scid, intercept_scid);
+			service_handler
+				.htlc_intercepted(
+					*requested_next_hop_scid,
+					*intercept_id,
+					*expected_outbound_amount_msat,
+					*payment_hash,
+				)
+				.unwrap();
+			*expected_outbound_amount_msat
+		},
+		other => panic!("Expected HTLCIntercepted, got {:?}", other),
+	};
+
+	let open_channel_event = service_node.liquidity_manager.next_event().unwrap();
+	match open_channel_event {
+		LiquidityEvent::LSPS2Service(LSPS2ServiceEvent::OpenChannel { .. }) => {},
+		other => panic!("Expected OpenChannel, got: {:?}", other),
+	};
+
+	let (channel_id, funding_tx) = create_channel_with_manual_broadcast(
+		&service_node_id,
+		&client_node_id,
+		&service_node,
+		&client_node,
+		user_channel_id,
+		&expected_outbound_amount_msat,
+		true,
+	);
+
+	service_handler.channel_ready(user_channel_id, &channel_id, &client_node_id).unwrap();
+	service_node.inner.node.process_pending_htlc_forwards();
+
+	{
+		let mut added_monitors = service_node.inner.chain_monitor.added_monitors.lock().unwrap();
+		assert_eq!(added_monitors.len(), 1);
+		added_monitors.clear();
+	}
+	let mut events = service_node.inner.node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let pay_event = SendEvent::from_event(events.remove(0));
+
+	client_node.inner.node.handle_update_add_htlc(service_node_id, &pay_event.msgs[0]);
+	do_commitment_signed_dance(
+		&client_node.inner,
+		&service_node.inner,
+		&pay_event.commitment_msg,
+		false,
+		true,
+	);
+	client_node.inner.node.process_pending_htlc_forwards();
+
+	let client_events = client_node.inner.node.get_and_clear_pending_events();
+	assert_eq!(client_events.len(), 1);
+	let preimage = match &client_events[0] {
+		Event::PaymentClaimable { purpose, .. } => purpose.preimage(),
+		other => panic!("Expected PaymentClaimable, got {:?}", other),
+	};
+
+	client_node.inner.node.claim_funds(preimage.unwrap());
+
+	claim_and_assert_forwarded_only(
+		&payer_node,
+		&service_node.inner,
+		&client_node.inner,
+		preimage.unwrap(),
+	);
+
+	let service_events = service_node.node.get_and_clear_pending_events();
+	assert_eq!(service_events.len(), 1);
+	let total_fee_msat = match service_events[0].clone() {
+		Event::PaymentForwarded { skimmed_fee_msat, total_fee_earned_msat, .. } => {
+			service_handler.payment_forwarded(channel_id, skimmed_fee_msat.unwrap_or(0)).unwrap();
+			total_fee_earned_msat.map(|total| total - skimmed_fee_msat.unwrap_or(0))
+		},
+		_ => panic!("Expected PaymentForwarded, got: {:?}", service_events[0]),
+	};
+
+	// Channel is now in PaymentForwarded. Verify age filtering: a max_age of 1 year should
+	// not prune a channel created moments ago.
+	let pruned = service_handler.prune_channels(Duration::from_secs(365 * 24 * 3600)).unwrap();
+	assert_eq!(pruned, 0, "Channel created moments ago must not exceed 1-year max_age");
+
+	// Duration::ZERO prunes all terminal channels regardless of age.
+	let pruned = service_handler.prune_channels(Duration::ZERO).unwrap();
+	assert_eq!(pruned, 1, "Expected one PaymentForwarded channel to be pruned");
+
+	// A second call must find nothing to prune.
+	let pruned = service_handler.prune_channels(Duration::ZERO).unwrap();
+	assert_eq!(pruned, 0, "Second call must find nothing to prune");
+
+	let broadcasted = service_node.inner.tx_broadcaster.txn_broadcasted.lock().unwrap();
+	assert!(broadcasted.iter().any(|b| b.compute_txid() == funding_tx.compute_txid()));
+
+	expect_payment_sent(&payer_node, preimage.unwrap(), Some(total_fee_msat), true, true);
+}

--- a/lightning-liquidity/tests/lsps5_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps5_integration_tests.rs
@@ -40,6 +40,7 @@ use lightning_liquidity::utils::time::{DefaultTimeProvider, TimeProvider};
 use lightning_liquidity::LiquidityManagerSync;
 use lightning_liquidity::{LiquidityClientConfig, LiquidityServiceConfig};
 
+use bitcoin::secp256k1::PublicKey;
 use lightning_types::payment::PaymentHash;
 
 use std::str::FromStr;
@@ -1923,4 +1924,58 @@ fn prune_webhook_fails_for_unknown_app_name() {
 	let unknown_app_name = LSPS5AppName::from_string("UnknownApp".to_string()).unwrap();
 	let result = service_handler.prune_webhook(client_node_id, &unknown_app_name);
 	assert!(result.is_err(), "prune_webhook should fail for an unregistered app_name");
+}
+
+#[test]
+fn prune_webhooks_removes_all_webhooks() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (lsps_nodes, _) = lsps5_test_setup(nodes, Arc::new(DefaultTimeProvider));
+	let LSPSNodes { service_node, client_node, .. } = lsps_nodes;
+	create_chan_between_nodes(&service_node.inner, &client_node.inner);
+
+	let client_node_id = client_node.inner.node.get_our_node_id();
+	let service_handler = service_node.liquidity_manager.lsps5_service_handler().unwrap();
+
+	// Register a webhook through the normal request flow.
+	assert_lsps5_accept(&service_node, &client_node);
+
+	// Confirm the webhook is active before pruning.
+	assert!(service_handler.notify_payment_incoming(client_node_id).is_ok());
+	assert!(service_node.liquidity_manager.next_event().is_some(), "Webhook notification expected");
+
+	// prune_webhooks removes all webhooks and returns the count.
+	let pruned = service_handler.prune_webhooks(client_node_id).unwrap();
+	assert_eq!(pruned, 1, "Expected one webhook to be removed");
+
+	// After pruning, notifications produce no events (no webhooks left).
+	assert!(service_handler.notify_payment_incoming(client_node_id).is_ok());
+	assert!(
+		service_node.liquidity_manager.next_event().is_none(),
+		"No notification event expected after pruning all webhooks"
+	);
+
+	// A second call returns 0 (idempotent).
+	let pruned_again = service_handler.prune_webhooks(client_node_id).unwrap();
+	assert_eq!(pruned_again, 0, "Second prune_webhooks call should return 0");
+}
+
+#[test]
+fn prune_webhooks_fails_for_unknown_counterparty() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (lsps_nodes, _) = lsps5_test_setup(nodes, Arc::new(DefaultTimeProvider));
+	let LSPSNodes { service_node, client_node, .. } = lsps_nodes;
+	create_chan_between_nodes(&service_node.inner, &client_node.inner);
+
+	let _ = client_node;
+	let service_handler = service_node.liquidity_manager.lsps5_service_handler().unwrap();
+
+	let unknown_pubkey = PublicKey::from_slice(&[2u8; 33]).unwrap();
+	let result = service_handler.prune_webhooks(unknown_pubkey);
+	assert!(result.is_err(), "prune_webhooks should fail when counterparty has no state");
 }

--- a/lightning-liquidity/tests/lsps5_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps5_integration_tests.rs
@@ -1838,3 +1838,89 @@ fn lsps5_service_persist_resets_in_flight_counter_on_io_error() {
 		res2,
 	);
 }
+
+#[test]
+fn prune_webhook_removes_registered_webhook() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (lsps_nodes, _) = lsps5_test_setup(nodes, Arc::new(DefaultTimeProvider));
+	let LSPSNodes { service_node, client_node, .. } = lsps_nodes;
+	create_chan_between_nodes(&service_node.inner, &client_node.inner);
+
+	let service_node_id = service_node.inner.node.get_our_node_id();
+	let client_node_id = client_node.inner.node.get_our_node_id();
+	let service_handler = service_node.liquidity_manager.lsps5_service_handler().unwrap();
+
+	// assert_lsps5_accept registers a webhook with app_name "App".
+	let app_name = LSPS5AppName::from_string("App".to_string()).unwrap();
+
+	// Register a webhook through the normal request flow.
+	assert_lsps5_accept(&service_node, &client_node);
+
+	// The notification must be emitted before pruning to confirm the webhook is registered.
+	let result = service_handler.notify_payment_incoming(client_node_id);
+	assert!(result.is_ok());
+	assert!(service_node.liquidity_manager.next_event().is_some(), "Webhook notification expected");
+
+	// Prune the webhook.
+	let prune_result = service_handler.prune_webhook(client_node_id, &app_name);
+	assert!(prune_result.is_ok(), "prune_webhook should succeed for a registered webhook");
+
+	// After pruning, notify should succeed but produce no event (no webhooks left).
+	let result_after = service_handler.notify_payment_incoming(client_node_id);
+	assert!(result_after.is_ok());
+	assert!(
+		service_node.liquidity_manager.next_event().is_none(),
+		"No notification event expected after pruning"
+	);
+
+	// A second prune of the same app_name must fail.
+	let second_prune = service_handler.prune_webhook(client_node_id, &app_name);
+	assert!(second_prune.is_err(), "prune_webhook should fail when the webhook is already removed");
+
+	let _ = service_node_id; // suppress unused warning
+}
+
+#[test]
+fn prune_webhook_fails_for_unknown_counterparty() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (lsps_nodes, _) = lsps5_test_setup(nodes, Arc::new(DefaultTimeProvider));
+	let LSPSNodes { service_node, client_node, .. } = lsps_nodes;
+	create_chan_between_nodes(&service_node.inner, &client_node.inner);
+
+	let client_node_id = client_node.inner.node.get_our_node_id();
+	let service_handler = service_node.liquidity_manager.lsps5_service_handler().unwrap();
+
+	let app_name = LSPS5AppName::from_string("SomeApp".to_string()).unwrap();
+
+	// Pruning for a peer with no state must return an error.
+	let result = service_handler.prune_webhook(client_node_id, &app_name);
+	assert!(result.is_err(), "prune_webhook should fail when counterparty has no state");
+}
+
+#[test]
+fn prune_webhook_fails_for_unknown_app_name() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (lsps_nodes, _) = lsps5_test_setup(nodes, Arc::new(DefaultTimeProvider));
+	let LSPSNodes { service_node, client_node, .. } = lsps_nodes;
+	create_chan_between_nodes(&service_node.inner, &client_node.inner);
+
+	let client_node_id = client_node.inner.node.get_our_node_id();
+	let service_handler = service_node.liquidity_manager.lsps5_service_handler().unwrap();
+
+	// Register one webhook.
+	assert_lsps5_accept(&service_node, &client_node);
+
+	// Pruning with a different app_name must fail.
+	let unknown_app_name = LSPS5AppName::from_string("UnknownApp".to_string()).unwrap();
+	let result = service_handler.prune_webhook(client_node_id, &unknown_app_name);
+	assert!(result.is_err(), "prune_webhook should fail for an unregistered app_name");
+}


### PR DESCRIPTION
Closes #4444.

  Add explicit pruning APIs to `LSPS1ServiceHandler`, `LSPS2ServiceHandler`, and `LSPS5ServiceHandler` so LSP operators can reclaim memory from completed historical state.