### PR TITLE
Bump CI action dependencies to latest major versions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,8 +11,8 @@ jobs:
       issues: write
       checks: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v1.4.1
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ignore: "RUSTSEC-2021-0145"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust stable toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain stable
@@ -64,7 +64,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Rust stable toolchain
@@ -83,7 +83,7 @@ jobs:
           ./codecov --verbose upload-process --disable-search --fail-on-error -f target/codecov.json -t "f421b687-4dc2-4387-ac3d-dc3b2528af57" -F 'tests'
           cargo clean
       - name: Download honggfuzz corpus
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: hfuzz-corpus
           path: fuzz/hfuzz_workspace
@@ -101,13 +101,13 @@ jobs:
       TOOLCHAIN: stable
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
       - name: Cache routing graph snapshot
         id: cache-graph
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: lightning/net_graph-2023-12-10.bin
           key: ldk-net_graph-v0.0.118-2023-12-10.bin
@@ -124,7 +124,7 @@ jobs:
           EXPECTED_ROUTING_GRAPH_SNAPSHOT_SHASUM: e94b38ef4b3ce683893bf6a3ee28d60cb37c73b059403ff77b7e7458157968c2
       - name: Cache scorer snapshot
         id: cache-scorer
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: lightning/scorer-2023-12-10.bin
           key: ldk-scorer-v0.0.118-2023-12-10.bin
@@ -165,7 +165,7 @@ jobs:
       TOOLCHAIN: stable
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
@@ -196,7 +196,7 @@ jobs:
       TOOLCHAIN: beta
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
@@ -211,7 +211,7 @@ jobs:
       TOOLCHAIN: 1.75
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
@@ -226,7 +226,7 @@ jobs:
       TOOLCHAIN: 1.75
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
@@ -235,7 +235,7 @@ jobs:
       # the `restore-keys` to find the latest global cache from the `main` branch.
       - name: Restore persistent fuzz corpus (PR)
         if: ${{ github.ref != 'refs/heads/main' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: fuzz/hfuzz_workspace
           key: fuzz-corpus-${{ github.ref }}-${{ github.sha }}
@@ -247,7 +247,7 @@ jobs:
       # as caches are immutable.
       - name: Restore/Save persistent honggfuzz corpus (Main)
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: fuzz/hfuzz_workspace
           key: fuzz-corpus-refs/heads/main-${{ github.sha }}
@@ -258,7 +258,7 @@ jobs:
         env:
           FUZZ_MINIMIZE: ${{ contains(github.event.pull_request.labels.*.name, 'fuzz-minimize') }}
       - name: Upload honggfuzz corpus
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hfuzz-corpus
           path: fuzz/hfuzz_workspace
@@ -270,7 +270,7 @@ jobs:
       TOOLCHAIN: stable
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
@@ -291,7 +291,7 @@ jobs:
       TOOLCHAIN: 1.75.0
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust ${{ env.TOOLCHAIN }} toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ env.TOOLCHAIN }}
@@ -308,7 +308,7 @@ jobs:
       TOOLCHAIN: 1.75.0
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install tor
         run: |
           sudo apt install -y tor

--- a/.github/workflows/check_commits.yml
+++ b/.github/workflows/check_commits.yml
@@ -16,7 +16,7 @@ jobs:
       TOOLCHAIN: stable
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Rust ${{ env.TOOLCHAIN }} toolchain

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust ${{ matrix.toolchain }} toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ matrix.toolchain }}
@@ -49,14 +49,14 @@ jobs:
       - name: Enable caching for bitcoind
         if: matrix.platform != 'windows-latest'
         id: cache-bitcoind
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: bin/bitcoind-${{ runner.os }}-${{ runner.arch }}
           key: bitcoind-${{ runner.os }}-${{ runner.arch }}
       - name: Enable caching for electrs
         if: matrix.platform != 'windows-latest'
         id: cache-electrs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: bin/electrs-${{ runner.os }}-${{ runner.arch }}
           key: electrs-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/ldk-node-integration.yml
+++ b/.github/workflows/ldk-node-integration.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: rust-lightning
       - name: Checkout LDK Node
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: lightningdevkit/ldk-node
           path: ldk-node

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Rust stable toolchain


### PR DESCRIPTION
GitHub is deprecating Node.js 20 for Actions runners, with enforcement starting June 2026. Bump all action dependencies to their latest major versions which use Node.js 22+.

Co-Authored-By: HAL 9000