### PR TITLE
Bypass monitor sync requests when no partition key given in `update_monitor_with_chain_data`

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -555,7 +555,7 @@ where
 				channel_id_bytes[2],
 				channel_id_bytes[3],
 			]);
-			channel_id_u32.wrapping_add(best_height.unwrap_or_default())
+			best_height.map(|height| channel_id_u32.wrapping_add(height))
 		};
 
 		let partition_factor = if channel_count < 15 {
@@ -565,7 +565,7 @@ where
 		};
 
 		let has_pending_claims = monitor_state.monitor.has_pending_claims();
-		if has_pending_claims || get_partition_key(channel_id) % partition_factor == 0 {
+		if has_pending_claims || get_partition_key(channel_id).is_some_and(|key| key % partition_factor == 0) {
 			log_trace!(logger, "Syncing Channel Monitor");
 			// Even though we don't track monitor updates from chain-sync as pending, we still want
 			// updates per-channel to be well-ordered so that users don't see a

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -565,7 +565,9 @@ where
 		};
 
 		let has_pending_claims = monitor_state.monitor.has_pending_claims();
-		if has_pending_claims || get_partition_key(channel_id).is_some_and(|key| key % partition_factor == 0) {
+		if has_pending_claims
+			|| get_partition_key(channel_id).is_some_and(|key| key % partition_factor == 0)
+		{
 			log_trace!(logger, "Syncing Channel Monitor");
 			// Even though we don't track monitor updates from chain-sync as pending, we still want
 			// updates per-channel to be well-ordered so that users don't see a

--- a/lightning/src/ln/funding.rs
+++ b/lightning/src/ln/funding.rs
@@ -386,7 +386,17 @@ impl FundingTemplate {
 			return Err(FundingContributionError::InvalidSpliceValue);
 		}
 		let FundingTemplate { shared_input, min_rbf_feerate, .. } = self;
-		build_funding_contribution!(value_added, vec![], shared_input, min_rbf_feerate, min_feerate, max_feerate, false, wallet, await)
+		build_funding_contribution!(
+			value_added,
+			vec![],
+			shared_input,
+			min_rbf_feerate,
+			min_feerate,
+			max_feerate,
+			false,
+			wallet,
+			await
+		)
 	}
 
 	/// Creates a [`FundingContribution`] for adding funds to a channel using `wallet` to perform
@@ -426,7 +436,17 @@ impl FundingTemplate {
 			return Err(FundingContributionError::InvalidSpliceValue);
 		}
 		let FundingTemplate { shared_input, min_rbf_feerate, .. } = self;
-		build_funding_contribution!(Amount::ZERO, outputs, shared_input, min_rbf_feerate, min_feerate, max_feerate, false, wallet, await)
+		build_funding_contribution!(
+			Amount::ZERO,
+			outputs,
+			shared_input,
+			min_rbf_feerate,
+			min_feerate,
+			max_feerate,
+			false,
+			wallet,
+			await
+		)
 	}
 
 	/// Creates a [`FundingContribution`] for removing funds from a channel using `wallet` to
@@ -467,7 +487,17 @@ impl FundingTemplate {
 			return Err(FundingContributionError::InvalidSpliceValue);
 		}
 		let FundingTemplate { shared_input, min_rbf_feerate, .. } = self;
-		build_funding_contribution!(value_added, outputs, shared_input, min_rbf_feerate, min_feerate, max_feerate, false, wallet, await)
+		build_funding_contribution!(
+			value_added,
+			outputs,
+			shared_input,
+			min_rbf_feerate,
+			min_feerate,
+			max_feerate,
+			false,
+			wallet,
+			await
+		)
 	}
 
 	/// Creates a [`FundingContribution`] for both adding and removing funds from a channel using
@@ -550,10 +580,30 @@ impl FundingTemplate {
 						return Ok(adjusted);
 					}
 				}
-				build_funding_contribution!(contribution.value_added, contribution.outputs, shared_input, min_rbf_feerate, rbf_feerate, max_feerate, true, wallet, await)
+				build_funding_contribution!(
+					contribution.value_added,
+					contribution.outputs,
+					shared_input,
+					min_rbf_feerate,
+					rbf_feerate,
+					max_feerate,
+					true,
+					wallet,
+					await
+				)
 			},
 			None => {
-				build_funding_contribution!(Amount::ZERO, vec![], shared_input, min_rbf_feerate, rbf_feerate, max_feerate, true, wallet, await)
+				build_funding_contribution!(
+					Amount::ZERO,
+					vec![],
+					shared_input,
+					min_rbf_feerate,
+					rbf_feerate,
+					max_feerate,
+					true,
+					wallet,
+					await
+				)
 			},
 		}
 	}


### PR DESCRIPTION
This proposed patch concerns `chain::ChainMonitor`.

**Context**
- In `ChainMonitor`, `process_chain_data` takes a `best_height: Option<u32>` parameter, which is used as a partition key in `update_monitor_with_chain_data`. Each channel monitor is partitioned by its `channel_id` mod `50`, and only when `best_height` matches the `channel_id` partition does a sync request get sent to the `persister`.
- This is mainly intended for use with `best_block_updated`, which "must be called whenever a new chain tip becomes available" ([doc comment](https://github.com/lightningdevkit/rust-lightning/blob/790ffa3800a637ec11f9abfd82404db0d998e7fe/lightning/src/chain/mod.rs#L265)).
  - Side note: `best_block_updated` and `transactions_confirmed` are `Confirm` trait functions
- This design distributes sync requests so that a channel (if it doesn't urgently need to sync) will sync once every 50 blocks, since `process_chain_data` is called each time `best_block_updated` is called.
- The doc comment for `process_chain_data` also supports this intent: "Calls which represent a new blockchain tip height should set `best_height`." ([doc comment](https://github.com/lightningdevkit/rust-lightning/blob/790ffa3800a637ec11f9abfd82404db0d998e7fe/lightning/src/chain/chainmonitor.rs#L475))

**Issue**
- In `update_monitor_with_chain_data`, where the partition logic is stored, a partition key/`best_height` of `None` will be defaulted to partition key `0`, triggering unnecessary syncs for partition `0` of channel monitors.
- Each time `transactions_confirmed` is called, `process_chain_data` iterates through all channels/monitors, triggering syncs for partition `0`.
- In `lightning-transaction-sync`, the user of `ChainMonitor`'s `Confirm` trait, when `common::sync_confirmed_transactions` is called, each confirmed transaction will trigger a call to `transactions_confirmed`.

We can use some numbers and trace to be really concrete. Suppose we have 250 channels, 10 of which have pending transactions:
- Invoke `lightning-transaction-sync::esplora::sync()` with `chain_monitor` in args (`esplora.rs` line `85`)
- → `else` branch, line `187`: `self.get_confirmed_transactions(&sync_state)`
  - (stepping inside,)
  - → lines `295` - `302`: Put all unique confirmed `txid` into `confirmed_txs`
  - → line `339`: Return `confirmed_txs`, which is a **250 long `Vec`** (1 transaction per channel)
- → line `202`: `sync_state.sync_confirmed_transactions(<chain_monitor>, confirmed_txs)`
- → `common.rs` line `75`: **for each `ctx` in `confirmed_txs` (250)**, do `chain_monitor.transactions_confirmed(<tx info>)`
- → `chainmonitor.rs` line `1515`: `self.process_chain_data(...)`
- → line `484`: **for each channel (250)**, `self.update_monitor_with_chain_data(<associated monitor/channel/tx data>)` (line `487`)
- → line `568`: Send a persist request if channel monitor `has_pending_claims` OR if channel falls into the partition (1/50 chance)
  - So **out of these 250 inner calls**, we expect 10 + 240/50 = **~15** to make a persist request
    - 10 pending; (250-10) non-pending roll the dice to see if they land in the special partition
  - 15 * (250 outer calls) = 3750
  - Notice that if just 1 more of our channels had a pending request, this would result in ~+250 more persist requests = ~4000

In the case of the application I'm working on, this means that sync is destroying buffers... which is causing problems. 😅

**Solution**
The problem is that syncs are being scheduled even when they shouldn't be, because a `best_height` of `None` causes partition channels `0` to sync. So the solution is to skip this syncing step conditional on the presence of `best_height`.

**Follow-up question**
We experience the `NxM` amplification issue with pending transactions, since these are persisted every `transactions_confirmed` call as well. Is there a reason why these need to be persisted on every confirmed transaction, or would it be safe to condition that persist request on `best_height` as well?