### PR TITLE
Document that LSPS5 services should double-check the destination

### DIFF
--- a/lightning-liquidity/src/lsps5/event.rs
+++ b/lightning-liquidity/src/lsps5/event.rs
@@ -56,6 +56,9 @@ pub enum LSPS5ServiceEvent {
 		///
 		/// This is the [`webhook URL`] provided by the client during registration.
 		///
+		/// Obviously as the URL provided here is untrusted you should check whether it would
+		/// access any internal or private resources and decline to send the request if it is.
+		///
 		/// [`webhook URL`]: super::msgs::LSPS5WebhookUrl
 		url: LSPS5WebhookUrl,
 		/// Notification method with its parameters.


### PR DESCRIPTION
It would be easy to implement an LSPS5 service and forget that the webhook calls are going out based on a URI and headers provided by an untrusted client, so such implementations need to make sure to check if the destination is some internal resource before sending.

Reported by Jordan Mecom of Block's Security Team