### PR TITLE
fuzz: skip broken splicing paths and handle broadcast channel updates

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -62,4 +62,5 @@ check-cfg = [
     "cfg(fuzzing)",
     "cfg(secp256k1_fuzz)",
     "cfg(hashes_fuzz)",
+    "cfg(splicing)",
 ]

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -1333,7 +1333,9 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 	let (node_c, mut monitor_c, keys_manager_c, logger_c) = make_node!(2, fee_est_c, broadcast_c);
 
 	let mut nodes = [node_a, node_b, node_c];
+	#[allow(unused_variables)]
 	let loggers = [logger_a, logger_b, logger_c];
+	#[allow(unused_variables)]
 	let fee_estimators = [Arc::clone(&fee_est_a), Arc::clone(&fee_est_b), Arc::clone(&fee_est_c)];
 
 	// Connect peers first, then create channels
@@ -2426,24 +2428,36 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 			},
 
 			0xa0 => {
+				if !cfg!(splicing) {
+					test_return!();
+				}
 				let cp_node_id = nodes[1].get_our_node_id();
 				let wallet = WalletSync::new(&wallets[0], Arc::clone(&loggers[0]));
 				let feerate_sat_per_kw = fee_estimators[0].feerate_sat_per_kw();
 				splice_in(&nodes[0], &cp_node_id, &chan_a_id, &wallet, feerate_sat_per_kw);
 			},
 			0xa1 => {
+				if !cfg!(splicing) {
+					test_return!();
+				}
 				let cp_node_id = nodes[0].get_our_node_id();
 				let wallet = WalletSync::new(&wallets[1], Arc::clone(&loggers[1]));
 				let feerate_sat_per_kw = fee_estimators[1].feerate_sat_per_kw();
 				splice_in(&nodes[1], &cp_node_id, &chan_a_id, &wallet, feerate_sat_per_kw);
 			},
 			0xa2 => {
+				if !cfg!(splicing) {
+					test_return!();
+				}
 				let cp_node_id = nodes[2].get_our_node_id();
 				let wallet = WalletSync::new(&wallets[1], Arc::clone(&loggers[1]));
 				let feerate_sat_per_kw = fee_estimators[1].feerate_sat_per_kw();
 				splice_in(&nodes[1], &cp_node_id, &chan_b_id, &wallet, feerate_sat_per_kw);
 			},
 			0xa3 => {
+				if !cfg!(splicing) {
+					test_return!();
+				}
 				let cp_node_id = nodes[1].get_our_node_id();
 				let wallet = WalletSync::new(&wallets[2], Arc::clone(&loggers[2]));
 				let feerate_sat_per_kw = fee_estimators[2].feerate_sat_per_kw();
@@ -2451,6 +2465,9 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 			},
 
 			0xa4 => {
+				if !cfg!(splicing) {
+					test_return!();
+				}
 				let cp_node_id = nodes[1].get_our_node_id();
 				let wallet = &wallets[0];
 				let logger = Arc::clone(&loggers[0]);
@@ -2458,6 +2475,9 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 				splice_out(&nodes[0], &cp_node_id, &chan_a_id, wallet, logger, feerate_sat_per_kw);
 			},
 			0xa5 => {
+				if !cfg!(splicing) {
+					test_return!();
+				}
 				let cp_node_id = nodes[0].get_our_node_id();
 				let wallet = &wallets[1];
 				let logger = Arc::clone(&loggers[1]);
@@ -2465,6 +2485,9 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 				splice_out(&nodes[1], &cp_node_id, &chan_a_id, wallet, logger, feerate_sat_per_kw);
 			},
 			0xa6 => {
+				if !cfg!(splicing) {
+					test_return!();
+				}
 				let cp_node_id = nodes[2].get_our_node_id();
 				let wallet = &wallets[1];
 				let logger = Arc::clone(&loggers[1]);
@@ -2472,6 +2495,9 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 				splice_out(&nodes[1], &cp_node_id, &chan_b_id, wallet, logger, feerate_sat_per_kw);
 			},
 			0xa7 => {
+				if !cfg!(splicing) {
+					test_return!();
+				}
 				let cp_node_id = nodes[1].get_our_node_id();
 				let wallet = &wallets[2];
 				let logger = Arc::clone(&loggers[2]);

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -1608,6 +1608,7 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 						},
 						MessageSendEvent::SendChannelReady { .. } => continue,
 						MessageSendEvent::SendAnnouncementSignatures { .. } => continue,
+						MessageSendEvent::BroadcastChannelUpdate { .. } => continue,
 						MessageSendEvent::SendChannelUpdate { ref node_id, .. } => {
 							if Some(*node_id) == expect_drop_id { panic!("peer_disconnected should drop msgs bound for the disconnected peer"); }
 							*node_id == a_id
@@ -1894,6 +1895,7 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 							MessageSendEvent::SendStfu { .. } => {},
 							MessageSendEvent::SendChannelReady { .. } => {},
 							MessageSendEvent::SendAnnouncementSignatures { .. } => {},
+							MessageSendEvent::BroadcastChannelUpdate { .. } => {},
 							MessageSendEvent::SendChannelUpdate { .. } => {},
 							MessageSendEvent::HandleError { ref action, .. } => {
 								assert_action_timeout_awaiting_response(action);
@@ -1916,6 +1918,7 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 							MessageSendEvent::SendStfu { .. } => {},
 							MessageSendEvent::SendChannelReady { .. } => {},
 							MessageSendEvent::SendAnnouncementSignatures { .. } => {},
+							MessageSendEvent::BroadcastChannelUpdate { .. } => {},
 							MessageSendEvent::SendChannelUpdate { .. } => {},
 							MessageSendEvent::HandleError { ref action, .. } => {
 								assert_action_timeout_awaiting_response(action);


### PR DESCRIPTION
This PR tightens `chanmon_consistency` so it stays focused on failures we can currently act on.

Splicing fuzzing has been broken for quite a while, and leaving splice opcodes active in the default configuration makes it harder to spot unrelated regressions because runs terminate in known-bad splicing paths instead of continuing toward other failures. This change makes those opcodes bail out unless the target is built with `cfg(splicing)` enabled, while still keeping the opcode slots in place for dedicated splicing fuzzing later.

This PR also corrects a message-passing issue in `chanmon_consistency` introduced by #4508. After broadcast channel announcements started flowing through the broadcast queue, the fuzz target was no longer handling that path correctly, which meant it could trip over a known routing mismatch instead of exercising the rest of the state machine.