### PR TITLE
Expose inner ProbabilisticScorer accessors on CombinedScorer

### DIFF
--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -1871,6 +1871,21 @@ impl<G: Deref<Target = NetworkGraph<L>> + Clone, L: Logger + Clone> CombinedScor
 	}
 }
 
+impl<G: Deref<Target = NetworkGraph<L>>, L: Logger> CombinedScorer<G, L> {
+	/// Returns a reference to the merged [`ProbabilisticScorer`] used for routing decisions,
+	/// which combines locally acquired data with any externally supplied scores.
+	pub fn scorer(&self) -> &ProbabilisticScorer<G, L> {
+		&self.scorer
+	}
+
+	/// Returns a reference to the [`ProbabilisticScorer`] tracking only locally acquired data
+	/// (i.e. excluding any externally supplied scores merged via [`Self::merge`] or
+	/// [`Self::set_scores`]).
+	pub fn local_only_scorer(&self) -> &ProbabilisticScorer<G, L> {
+		&self.local_only_scorer
+	}
+}
+
 impl<G: Deref<Target = NetworkGraph<L>>, L: Logger> ScoreLookUp for CombinedScorer<G, L> {
 	type ScoreParams = ProbabilisticScoringFeeParameters;
 


### PR DESCRIPTION
This PR adds public accessors to `CombinedScorer` for its inner `ProbabilisticScorer`s.

Placed in a new `impl` block without the `G: Clone` / `L: Clone` bounds required by `new` / `merge` / `set_scores`, matching the bounds on the other `&self` impls.

Motivation: while working on adding a probing service to ldk-node (https://github.com/lightningdevkit/ldk-node/pull/815), I realized that it is useful to have scorer's internal liquidity estimates to evaluate the performance of a particular probing strategy. 

Right now it is  done via an ugly workaround of serializing and de-serializing the scorer to reach `estimated_channel_liquidity_range` and this PR aims to fix that. 

It will be used in for further development of probing service, in strategy efficiency ranking.
