### PR TITLE
Add workflow to prime chanmon_consistency fuzz corpus

### DIFF
--- a/.github/workflows/prime-chanmon-consistency-fuzz-corpus.yml
+++ b/.github/workflows/prime-chanmon-consistency-fuzz-corpus.yml
@@ -1,0 +1,70 @@
+name: Prime chanmon consistency fuzz corpus
+
+on:
+  workflow_dispatch:
+    inputs:
+      seeds_hex:
+        description: "Comma-separated hex byte strings (e.g. 00,0102,deadbeef)"
+        type: string
+        required: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  prime-chanmon-consistency:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore latest main corpus
+        uses: actions/cache/restore@v4
+        with:
+          path: fuzz/hfuzz_workspace
+          key: fuzz-corpus-refs/heads/main-prime-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-refs/heads/main-
+
+      - name: Decode and layer seeds
+        env:
+          SEEDS_HEX: ${{ inputs.seeds_hex }}
+        run: |
+          set -euo pipefail
+          TARGET="chanmon_consistency_target"
+          INPUT_DIR="fuzz/hfuzz_workspace/${TARGET}/input"
+          if [ -d "$INPUT_DIR" ]; then
+            RESTORED_COUNT=$(find "$INPUT_DIR" -type f | wc -l)
+          else
+            RESTORED_COUNT=0
+          fi
+          mkdir -p "$INPUT_DIR"
+          echo "Restored $RESTORED_COUNT seed(s)"
+          FIELD_COUNT=0
+          SEED_COUNT=0
+          SEEDS_HEX_CLEAN="${SEEDS_HEX//$'\n'/,}"
+          IFS=',' read -r -a SEED_HEXES <<< "$SEEDS_HEX_CLEAN"
+          for SEED_HEX in "${SEED_HEXES[@]}"; do
+            FIELD_COUNT=$((FIELD_COUNT + 1))
+            SEED_HEX="${SEED_HEX%$'\r'}"
+            SEED_HEX="${SEED_HEX//[[:space:]]/}"
+            [ -n "$SEED_HEX" ] || continue
+            if ! [[ "$SEED_HEX" =~ ^([[:xdigit:]]{2})+$ ]]; then
+              echo "Invalid hex seed in input field $FIELD_COUNT"
+              exit 1
+            fi
+            SEED_COUNT=$((SEED_COUNT + 1))
+            SEED_FILE="$(printf '%s/primed-%s-%04d' "$INPUT_DIR" "$GITHUB_RUN_ID" "$SEED_COUNT")"
+            printf '%s' "$SEED_HEX" | xxd -r -p > "$SEED_FILE"
+            test -s "$SEED_FILE"
+            echo "Wrote seed: $SEED_FILE ($SEED_HEX)"
+          done
+          test "$SEED_COUNT" -gt 0
+          SAVE_COUNT=$(find "$INPUT_DIR" -type f | wc -l)
+          echo "Added $SEED_COUNT seed(s)"
+          echo "Saving $SAVE_COUNT seed(s)"
+
+      - name: Save primed corpus
+        uses: actions/cache/save@v4
+        with:
+          path: fuzz/hfuzz_workspace
+          key: fuzz-corpus-refs/heads/main-prime-${{ github.run_id }}


### PR DESCRIPTION
Add a manual workflow for priming the persistent `chanmon_consistency_target` honggfuzz corpus with known interesting inputs.

The goal is to preserve failing or challenging fuzz strings discovered during larger offline runs and feed them back into regular CI, so current and future code keeps being exercised against those cases instead of letting the inputs get lost. The workflow restores the latest rolling main corpus, decodes comma-separated hex seeds from the dispatch input into the chanmon consistency corpus, and saves a fresh main-prefix cache entry for subsequent fuzz runs to restore.

The normal fuzz job still owns execution and minimization. Once the primed cache is picked up by a main fuzz run, honggfuzz minimization removes duplicate or non-contributing inputs, so only seeds that add useful coverage remain in the rolling corpus.

Tested on my fork.

<img width="1321" height="600" alt="image" src="https://github.com/user-attachments/assets/79020838-e9f2-469d-a29c-6cd00a565fee" />
