### PR TITLE
Channelmanager: improve block connection logging

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -15968,8 +15968,14 @@ impl<
 
 		let block_hash = header.block_hash();
 		log_trace!(self.logger, "{} transactions included in block {} at height {} provided", txdata.len(), block_hash, height);
+		struct LazyTxid<'a>(&'a Transaction);
+		impl<'a> core::fmt::Display for LazyTxid<'a> {
+			fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+				write!(f, "{}", self.0.compute_txid())
+			}
+		}
 		for (_, tx) in txdata.iter() {
-			log_debug!(self.logger, "Confirmed transaction {} in block {} at height {}", tx.compute_txid(), block_hash, height);
+			log_debug!(self.logger, "Confirmed transaction {} in block {} at height {}", LazyTxid(tx), block_hash, height);
 		}
 
 		let _persistence_guard =

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -15968,6 +15968,9 @@ impl<
 
 		let block_hash = header.block_hash();
 		log_trace!(self.logger, "{} transactions included in block {} at height {} provided", txdata.len(), block_hash, height);
+		for (_, tx) in txdata.iter() {
+			log_debug!(self.logger, "Confirmed transaction {} in block {} at height {}", tx.compute_txid(), block_hash, height);
+		}
 
 		let _persistence_guard =
 			PersistenceNotifierGuard::optionally_notify_skipping_background_events(
@@ -15999,7 +16002,7 @@ impl<
 		// See the docs for `ChannelManagerReadArgs` for more.
 
 		let block_hash = header.block_hash();
-		log_trace!(self.logger, "New best block: {} at height {}", block_hash, height);
+		log_info!(self.logger, "New best block: {} at height {}", block_hash, height);
 
 		let _persistence_guard =
 			PersistenceNotifierGuard::optionally_notify_skipping_background_events(


### PR DESCRIPTION
Channelmanager: improve block connection logging                                                                                                                                              

Fixes #2348. Supersedes #4420.
                                                                                                                                                                                                
`best_block_updated `was logging at TRACE, making it impossible to track chain tip progress without enabling full trace logging. This upgrades it to INFO.                                      
                                                                                                                                                                                                
Also adds per-txid DEBUG logs in `transactions_confirmed` so individual transactions triggering channel updates are visible at a useful log level.                                              
                                                            
The original PR #4420 also added an INFO log in `filtered_block_connected`, but that duplicates the one in `best_block_updated` (which filtered_block_connected calls directly). That log is left out here.                                                 
                                                                                                                                                                                                