### PR TITLE
Validate Esplora merkle proof against the block header's merkle root

### DIFF
--- a/lightning-transaction-sync/src/esplora.rs
+++ b/lightning-transaction-sync/src/esplora.rs
@@ -361,8 +361,13 @@ impl<L: Logger> EsploraSyncClient<L> {
 
 			let mut matches = Vec::new();
 			let mut indexes = Vec::new();
-			let _ = merkle_block.txn.extract_matches(&mut matches, &mut indexes);
-			if indexes.len() != 1 || matches.len() != 1 || matches[0] != txid {
+			let computed_merkle_root =
+				merkle_block.txn.extract_matches(&mut matches, &mut indexes).ok();
+			if computed_merkle_root != Some(block_header.merkle_root)
+				|| indexes.len() != 1
+				|| matches.len() != 1
+				|| matches[0] != txid
+			{
 				log_error!(self.logger, "Retrieved Merkle block for txid {} doesn't match expectations. This should not happen. Please verify server integrity.", txid);
 				return Err(InternalError::Failed);
 			}


### PR DESCRIPTION
`EsploraSyncClient::get_confirmed_tx` parsed the SPV proof returned by the Esplora server but threw away the security check: the merkle root computed by `PartialMerkleTree::extract_matches` was discarded (`let _ = …`), and only the leaf-equality check (`matches[0] == txid`) remained. Anyone can construct a single-leaf partial tree advertising an arbitrary txid via `PartialMerkleTree::from_txids(&[txid], &[true])`, so this gate was vacuous.

**Note**: I recall that at implementation time we decided doing this check wasn't necessary/redundant. But, it can surely not hurt to be more strict here.