### PR TITLE
fuzz: add chanmon stuck HTLC invariant

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -2726,6 +2726,23 @@ impl<'a, Out: Output + MaybeSend + MaybeSync> Harness<'a, Out> {
 		// PaymentSent event at the sender.
 		self.payments.assert_claims_reported();
 
+		// All HTLCs should have been claimed or failed once we reach quiescence.
+		for (idx, node) in self.nodes.iter().enumerate() {
+			for chan in node.list_channels() {
+				assert!(
+					chan.pending_inbound_htlcs.is_empty() && chan.pending_outbound_htlcs.is_empty(),
+					"Node {} channel {:?} has stuck HTLCs after settling all state: \
+					 {} inbound {:?}, {} outbound {:?}",
+					idx,
+					chan.channel_id,
+					chan.pending_inbound_htlcs.len(),
+					chan.pending_inbound_htlcs,
+					chan.pending_outbound_htlcs.len(),
+					chan.pending_outbound_htlcs
+				);
+			}
+		}
+
 		// Finally, make sure that at least one end of each channel can make a substantial payment.
 		let chan_ab_ids = self.ab_link.channel_ids().clone();
 		let chan_bc_ids = self.bc_link.channel_ids().clone();


### PR DESCRIPTION
This adds a chanmon consistency fuzz invariant that checks for stuck channel HTLCs after the harness has settled all state. The previous corpus signal was indirect, usually showing up as a later capacity assertion failure, so the new invariant makes the oracle point at the actual leftover HTLC state.

The invariant reproduced the stuck-HTLC issue on upstream/main with this corpus entry:

- `0270801109191109191f1f10b6ff`

Verified that #4520 fixes the issue.