### PR TITLE
Include NegotiationFailureReason in InteractiveTxMsgError

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1187,6 +1187,35 @@ pub(super) struct InteractiveTxMsgError {
 	/// If a splice was in progress when processing the message, this contains the splice funding
 	/// information for emitting a `SpliceNegotiationFailed` event.
 	pub(super) splice_funding_failed: Option<SpliceFundingFailed>,
+	/// The event reason to use if this error causes a `SpliceNegotiationFailed` event.
+	pub(super) negotiation_failure_reason: Option<NegotiationFailureReason>,
+}
+
+impl InteractiveTxMsgError {
+	fn new(err: ChannelError, splice_funding_failed: Option<SpliceFundingFailed>) -> Self {
+		Self { err, splice_funding_failed, negotiation_failure_reason: None }
+	}
+
+	fn with_negotiation_failure_reason(mut self, reason: NegotiationFailureReason) -> Self {
+		self.negotiation_failure_reason = Some(reason);
+		self
+	}
+
+	pub(super) fn into_parts(
+		self,
+	) -> (ChannelError, Option<(SpliceFundingFailed, NegotiationFailureReason)>) {
+		let Self { err, splice_funding_failed, negotiation_failure_reason } = self;
+		let splice_failure = splice_funding_failed.map(|splice_funding_failed| {
+			let reason =
+				negotiation_failure_reason.unwrap_or_else(|| Self::reason_from_channel_error(&err));
+			(splice_funding_failed, reason)
+		});
+		(err, splice_failure)
+	}
+
+	fn reason_from_channel_error(err: &ChannelError) -> NegotiationFailureReason {
+		NegotiationFailureReason::NegotiationError { msg: format!("{:?}", err) }
+	}
 }
 
 /// The return value of `monitor_updating_restored`
@@ -1850,7 +1879,7 @@ where
 			},
 		};
 
-		InteractiveTxMsgError { err: ChannelError::Abort(reason), splice_funding_failed }
+		InteractiveTxMsgError::new(ChannelError::Abort(reason), splice_funding_failed)
 	}
 
 	pub fn tx_add_input<L: Logger>(
@@ -1860,12 +1889,12 @@ where
 			Some(interactive_tx_constructor) => interactive_tx_constructor
 				.handle_tx_add_input(msg)
 				.map_err(|reason| self.fail_interactive_tx_negotiation(reason, logger)),
-			None => Err(InteractiveTxMsgError {
-				err: ChannelError::WarnAndDisconnect(
+			None => Err(InteractiveTxMsgError::new(
+				ChannelError::WarnAndDisconnect(
 					"Received unexpected interactive transaction negotiation message".to_owned(),
 				),
-				splice_funding_failed: None,
-			}),
+				None,
+			)),
 		}
 	}
 
@@ -1876,12 +1905,12 @@ where
 			Some(interactive_tx_constructor) => interactive_tx_constructor
 				.handle_tx_add_output(msg)
 				.map_err(|reason| self.fail_interactive_tx_negotiation(reason, logger)),
-			None => Err(InteractiveTxMsgError {
-				err: ChannelError::WarnAndDisconnect(
+			None => Err(InteractiveTxMsgError::new(
+				ChannelError::WarnAndDisconnect(
 					"Received unexpected interactive transaction negotiation message".to_owned(),
 				),
-				splice_funding_failed: None,
-			}),
+				None,
+			)),
 		}
 	}
 
@@ -1892,12 +1921,12 @@ where
 			Some(interactive_tx_constructor) => interactive_tx_constructor
 				.handle_tx_remove_input(msg)
 				.map_err(|reason| self.fail_interactive_tx_negotiation(reason, logger)),
-			None => Err(InteractiveTxMsgError {
-				err: ChannelError::WarnAndDisconnect(
+			None => Err(InteractiveTxMsgError::new(
+				ChannelError::WarnAndDisconnect(
 					"Received unexpected interactive transaction negotiation message".to_owned(),
 				),
-				splice_funding_failed: None,
-			}),
+				None,
+			)),
 		}
 	}
 
@@ -1908,12 +1937,12 @@ where
 			Some(interactive_tx_constructor) => interactive_tx_constructor
 				.handle_tx_remove_output(msg)
 				.map_err(|reason| self.fail_interactive_tx_negotiation(reason, logger)),
-			None => Err(InteractiveTxMsgError {
-				err: ChannelError::WarnAndDisconnect(
+			None => Err(InteractiveTxMsgError::new(
+				ChannelError::WarnAndDisconnect(
 					"Received unexpected interactive transaction negotiation message".to_owned(),
 				),
-				splice_funding_failed: None,
-			}),
+				None,
+			)),
 		}
 	}
 
@@ -1926,10 +1955,10 @@ where
 				.map_err(|reason| self.fail_interactive_tx_negotiation(reason, logger))?,
 			None => {
 				let err = "Received unexpected interactive transaction negotiation message";
-				return Err(InteractiveTxMsgError {
-					err: ChannelError::WarnAndDisconnect(err.to_owned()),
-					splice_funding_failed: None,
-				});
+				return Err(InteractiveTxMsgError::new(
+					ChannelError::WarnAndDisconnect(err.to_owned()),
+					None,
+				));
 			},
 		};
 
@@ -12797,7 +12826,8 @@ where
 				// quiescent for it.
 				ChannelError::Ignore(str.into())
 			};
-			return Ok(InteractiveTxMsgError { err, splice_funding_failed });
+			return Ok(InteractiveTxMsgError::new(err, splice_funding_failed)
+				.with_negotiation_failure_reason(NegotiationFailureReason::LocallyCanceled));
 		}
 
 		let funding_negotiation = self
@@ -12864,10 +12894,11 @@ where
 		debug_assert!(self.context.channel_state.is_quiescent());
 		let splice_funding_failed = self.reset_pending_splice_state();
 		debug_assert!(splice_funding_failed.is_some());
-		Ok(InteractiveTxMsgError {
-			err: ChannelError::Abort(AbortReason::ManualIntervention),
+		Ok(InteractiveTxMsgError::new(
+			ChannelError::Abort(AbortReason::ManualIntervention),
 			splice_funding_failed,
-		})
+		)
+		.with_negotiation_failure_reason(NegotiationFailureReason::LocallyCanceled))
 	}
 
 	/// Checks during handling splice_init
@@ -14520,7 +14551,7 @@ where
 			debug_assert!(self.context.channel_state.is_quiescent());
 			self.exit_quiescence();
 		}
-		InteractiveTxMsgError { err, splice_funding_failed: None }
+		InteractiveTxMsgError::new(err, None)
 	}
 
 	pub fn remove_legacy_scids_before_block(&mut self, height: u32) -> alloc::vec::Drain<'_, u64> {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4982,7 +4982,6 @@ impl<
 							*channel_id,
 							counterparty_node_id,
 							user_channel_id,
-							Some(events::NegotiationFailureReason::LocallyCanceled),
 						);
 						let _ = self.handle_error(Err::<(), _>(err), *counterparty_node_id);
 						self.event_persist_notifier.notify();
@@ -11956,9 +11955,10 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 
 	fn handle_interactive_tx_msg_err(
 		&self, err: InteractiveTxMsgError, channel_id: ChannelId, counterparty_node_id: &PublicKey,
-		user_channel_id: u128, reason: Option<events::NegotiationFailureReason>,
+		user_channel_id: u128,
 	) -> MsgHandleErrInternal {
-		if let Some(splice_funding_failed) = err.splice_funding_failed {
+		let (err, splice_failure) = err.into_parts();
+		if let Some((splice_funding_failed, reason)) = splice_failure {
 			let (funding_info, contribution) = splice_funding_failed.into_parts();
 			let pending_events = &mut self.pending_events.lock().unwrap();
 			if let Some(funding_info) = funding_info {
@@ -11971,14 +11971,12 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					counterparty_node_id: *counterparty_node_id,
 					user_channel_id,
 					contribution,
-					reason: reason.unwrap_or(events::NegotiationFailureReason::NegotiationError {
-						msg: format!("{:?}", err.err),
-					}),
+					reason,
 				},
 				None,
 			));
 		}
-		MsgHandleErrInternal::from_chan_no_close(err.err, channel_id)
+		MsgHandleErrInternal::from_chan_no_close(err, channel_id)
 	}
 
 	fn internal_tx_msg<
@@ -12009,7 +12007,6 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 							channel_id,
 							counterparty_node_id,
 							user_channel_id,
-							None,
 						))
 					},
 				}
@@ -12145,7 +12142,6 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 							msg.channel_id,
 							&counterparty_node_id,
 							user_channel_id,
-							None,
 						))
 					},
 				}
@@ -13391,7 +13387,6 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 								msg.channel_id,
 								counterparty_node_id,
 								user_channel_id,
-								None,
 							))
 						},
 					}
@@ -13449,7 +13444,6 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 								msg.channel_id,
 								counterparty_node_id,
 								user_channel_id,
-								None,
 							))
 						},
 					}


### PR DESCRIPTION
Each `SpliceNegotiationFailed` event originating from an `InteractiveTxMsgError` needs a `NegotiationFailureReason`, so it makes sense to track it in the same place. In most cases, the `NegotiationFailureReason` included uses the `NegotiationError` variant, but other cases may require their own specific variant, such as `LocallyCanceled` after calling `ChannelManager::cancel_funding_contributed`.

Fixes https://github.com/lightningdevkit/rust-lightning/pull/4490#discussion_r3205426794