### PR TITLE
Bound sync loops in lightning-transaction-sync

### DIFF
--- a/lightning-transaction-sync/src/electrum.rs
+++ b/lightning-transaction-sync/src/electrum.rs
@@ -96,7 +96,13 @@ impl<L: Logger> ElectrumSyncClient<L> {
 		let mut tip_header = tip_notification.header;
 		let mut tip_height = tip_notification.height as u32;
 
-		loop {
+		for i in 0..100 {
+			if i >= 10 {
+				log_debug!(self.logger, "Giving up trying to sync transactions after 10 attempts.");
+				sync_state.pending_sync = true;
+				return Err(TxSyncError::Failed);
+			}
+
 			let pending_registrations = self.queue.lock().unwrap().process_queues(&mut sync_state);
 			let tip_is_new = Some(tip_header.block_hash()) != sync_state.last_sync_hash;
 

--- a/lightning-transaction-sync/src/esplora.rs
+++ b/lightning-transaction-sync/src/esplora.rs
@@ -100,7 +100,13 @@ impl<L: Logger> EsploraSyncClient<L> {
 
 		let mut tip_hash = maybe_await!(self.client.get_tip_hash())?;
 
-		loop {
+		for i in 0..100 {
+			if i >= 10 {
+				log_debug!(self.logger, "Giving up trying to sync transactions after 10 attempts.");
+				sync_state.pending_sync = true;
+				return Err(TxSyncError::Failed);
+			}
+
 			let pending_registrations = self.queue.lock().unwrap().process_queues(&mut sync_state);
 			let tip_is_new = Some(tip_hash) != sync_state.last_sync_hash;
 


### PR DESCRIPTION
If we start syncing from an electrum or esplora server and find that the chain moved during our sync, we reset and start fresh. However, if that happens repeatedly, we probably shouldn't just spin forever. Here we give up after ten attempts and just hope we can sync properly later.