### PR TITLE
Speed up TLV serialization length accounting

### DIFF
--- a/lightning-liquidity/src/lsps1/msgs.rs
+++ b/lightning-liquidity/src/lsps1/msgs.rs
@@ -21,7 +21,7 @@ use crate::lsps0::ser::{
 use bitcoin::{Address, FeeRate, OutPoint};
 use lightning::offers::offer::Offer;
 use lightning::util::ser::{Readable, Writeable};
-use lightning::{impl_writeable_tlv_based, impl_writeable_tlv_based_enum};
+use lightning::{impl_ser_tlv_based, impl_ser_tlv_based_enum};
 use lightning_invoice::Bolt11Invoice;
 
 use serde::{Deserialize, Serialize};
@@ -145,7 +145,7 @@ pub struct LSPS1OrderParams {
 	pub announce_channel: bool,
 }
 
-impl_writeable_tlv_based!(LSPS1OrderParams, {
+impl_ser_tlv_based!(LSPS1OrderParams, {
 	(0, lsp_balance_sat, required),
 	(2, client_balance_sat, required),
 	(4, required_channel_confirmations, required),
@@ -185,7 +185,7 @@ pub enum LSPS1OrderState {
 	Failed,
 }
 
-impl_writeable_tlv_based_enum!(LSPS1OrderState,
+impl_ser_tlv_based_enum!(LSPS1OrderState,
 	(0, Created) => {},
 	(2, Completed) => {},
 	(4, Failed) => {}
@@ -202,7 +202,7 @@ pub struct LSPS1PaymentInfo {
 	pub onchain: Option<LSPS1OnchainPaymentInfo>,
 }
 
-impl_writeable_tlv_based!(LSPS1PaymentInfo, {
+impl_ser_tlv_based!(LSPS1PaymentInfo, {
 	(0, bolt11, option),
 	(2, bolt12, option),
 	(4, onchain, option),
@@ -225,7 +225,7 @@ pub struct LSPS1Bolt11PaymentInfo {
 	pub invoice: Bolt11Invoice,
 }
 
-impl_writeable_tlv_based!(LSPS1Bolt11PaymentInfo, {
+impl_ser_tlv_based!(LSPS1Bolt11PaymentInfo, {
 	(0, state, required),
 	(2, expires_at, required),
 	(4, fee_total_sat, required),
@@ -251,7 +251,7 @@ pub struct LSPS1Bolt12PaymentInfo {
 	pub offer: Offer,
 }
 
-impl_writeable_tlv_based!(LSPS1Bolt12PaymentInfo, {
+impl_ser_tlv_based!(LSPS1Bolt12PaymentInfo, {
 	(0, state, required),
 	(2, expires_at, required),
 	(4, fee_total_sat, required),
@@ -290,7 +290,7 @@ pub struct LSPS1OnchainPaymentInfo {
 	pub refund_onchain_address: Option<Address>,
 }
 
-impl_writeable_tlv_based!(LSPS1OnchainPaymentInfo, {
+impl_ser_tlv_based!(LSPS1OnchainPaymentInfo, {
 	(0, state, required),
 	(2, expires_at, required),
 	(4, fee_total_sat, required),
@@ -322,7 +322,7 @@ pub enum LSPS1PaymentState {
 	Refunded,
 }
 
-impl_writeable_tlv_based_enum!(LSPS1PaymentState,
+impl_ser_tlv_based_enum!(LSPS1PaymentState,
 	(0, ExpectPayment) => {},
 	(2, Hold) => {},
 	(4, Paid) => {},
@@ -340,7 +340,7 @@ pub struct LSPS1ChannelInfo {
 	pub expires_at: LSPSDateTime,
 }
 
-impl_writeable_tlv_based!(LSPS1ChannelInfo, {
+impl_ser_tlv_based!(LSPS1ChannelInfo, {
 	(0, funded_at, required),
 	(2, funding_outpoint, required),
 	(4, expires_at, required),

--- a/lightning-liquidity/src/lsps1/peer_state.rs
+++ b/lightning-liquidity/src/lsps1/peer_state.rs
@@ -18,7 +18,7 @@ use crate::lsps0::ser::{LSPSDateTime, LSPSRequestId};
 use crate::prelude::HashMap;
 
 use lightning::util::hash_tables::new_hash_map;
-use lightning::{impl_writeable_tlv_based, impl_writeable_tlv_based_enum};
+use lightning::{impl_ser_tlv_based, impl_ser_tlv_based_enum};
 
 use core::fmt;
 
@@ -251,7 +251,7 @@ impl ChannelOrderState {
 	}
 }
 
-impl_writeable_tlv_based_enum!(ChannelOrderState,
+impl_ser_tlv_based_enum!(ChannelOrderState,
 	(0, ExpectingPayment) => {
 		(0, payment_details, required),
 	},
@@ -415,7 +415,7 @@ impl PeerState {
 	}
 }
 
-impl_writeable_tlv_based!(PeerState, {
+impl_ser_tlv_based!(PeerState, {
 	(0, outbound_channels_by_order_id, required),
 	(_unused, pending_requests, (static_value, new_hash_map())),
 	(_unused, needs_persist, (static_value, false)),
@@ -491,7 +491,7 @@ impl ChannelOrder {
 	}
 }
 
-impl_writeable_tlv_based!(ChannelOrder, {
+impl_ser_tlv_based!(ChannelOrder, {
 	(0, order_params, required),
 	(2, state, required),
 	(4, created_at, required),

--- a/lightning-liquidity/src/lsps2/event.rs
+++ b/lightning-liquidity/src/lsps2/event.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 
 use bitcoin::secp256k1::PublicKey;
 
-use lightning::impl_writeable_tlv_based_enum;
+use lightning::impl_ser_tlv_based_enum;
 
 /// An event which an LSPS2 client should take some action in response to.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -181,7 +181,7 @@ pub enum LSPS2ServiceEvent {
 	},
 }
 
-impl_writeable_tlv_based_enum!(LSPS2ServiceEvent,
+impl_ser_tlv_based_enum!(LSPS2ServiceEvent,
 	(0, GetInfo) => {
 		(0, request_id, required),
 		(2, counterparty_node_id, required),

--- a/lightning-liquidity/src/lsps2/msgs.rs
+++ b/lightning-liquidity/src/lsps2/msgs.rs
@@ -21,7 +21,7 @@ use bitcoin::secp256k1::PublicKey;
 
 use serde::{Deserialize, Serialize};
 
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::util::scid_utils;
 
 use crate::lsps0::ser::{
@@ -123,7 +123,7 @@ pub struct LSPS2OpeningFeeParams {
 	pub promise: String,
 }
 
-impl_writeable_tlv_based!(LSPS2OpeningFeeParams, {
+impl_ser_tlv_based!(LSPS2OpeningFeeParams, {
 	(0, min_fee_msat, required),
 	(2, proportional, required),
 	(4, valid_until, required),

--- a/lightning-liquidity/src/lsps2/payment_queue.rs
+++ b/lightning-liquidity/src/lsps2/payment_queue.rs
@@ -9,7 +9,7 @@
 
 use alloc::vec::Vec;
 
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::ln::channelmanager::InterceptId;
 use lightning_types::payment::PaymentHash;
 
@@ -63,7 +63,7 @@ impl PaymentQueue {
 	}
 }
 
-impl_writeable_tlv_based!(PaymentQueue, {
+impl_ser_tlv_based!(PaymentQueue, {
 	(0, payments, optional_vec),
 });
 
@@ -73,7 +73,7 @@ pub(crate) struct PaymentQueueEntry {
 	pub(crate) htlcs: Vec<InterceptedHTLC>,
 }
 
-impl_writeable_tlv_based!(PaymentQueueEntry, {
+impl_ser_tlv_based!(PaymentQueueEntry, {
 	(0, payment_hash, required),
 	(2, htlcs, optional_vec),
 });
@@ -85,7 +85,7 @@ pub(crate) struct InterceptedHTLC {
 	pub(crate) payment_hash: PaymentHash,
 }
 
-impl_writeable_tlv_based!(InterceptedHTLC, {
+impl_ser_tlv_based!(InterceptedHTLC, {
 	(0, intercept_id, required),
 	(2, expected_outbound_amount_msat, required),
 	(4, payment_hash, required),

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -48,7 +48,7 @@ use lightning::ln::types::ChannelId;
 use lightning::util::errors::APIError;
 use lightning::util::logger::Level;
 use lightning::util::ser::Writeable;
-use lightning::{impl_writeable_tlv_based, impl_writeable_tlv_based_enum};
+use lightning::{impl_ser_tlv_based, impl_ser_tlv_based_enum};
 
 use lightning_types::payment::PaymentHash;
 
@@ -181,7 +181,7 @@ impl TrustModel {
 	}
 }
 
-impl_writeable_tlv_based_enum!(TrustModel,
+impl_ser_tlv_based_enum!(TrustModel,
 	(0, ClientTrustsLsp) => {
 		(0, funding_tx_broadcast_safe, required),
 		(2, funding_tx, option),
@@ -468,7 +468,7 @@ impl OutboundJITChannelState {
 	}
 }
 
-impl_writeable_tlv_based_enum!(OutboundJITChannelState,
+impl_ser_tlv_based_enum!(OutboundJITChannelState,
 	(0, PendingInitialPayment) => {
 		(0, payment_queue, required),
 	},
@@ -499,7 +499,7 @@ struct OutboundJITChannel {
 	trust_model: TrustModel,
 }
 
-impl_writeable_tlv_based!(OutboundJITChannel, {
+impl_ser_tlv_based!(OutboundJITChannel, {
 	(0, state, required),
 	(2, user_channel_id, required),
 	(4, opening_fee_params, required),
@@ -660,7 +660,7 @@ impl PeerState {
 	}
 }
 
-impl_writeable_tlv_based!(PeerState, {
+impl_ser_tlv_based!(PeerState, {
 	(0, outbound_channels_by_intercept_scid, required),
 	(2, intercept_scid_by_user_channel_id, required),
 	(4, intercept_scid_by_channel_id, required),

--- a/lightning-liquidity/src/lsps5/event.rs
+++ b/lightning-liquidity/src/lsps5/event.rs
@@ -14,7 +14,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use bitcoin::secp256k1::PublicKey;
 
-use lightning::impl_writeable_tlv_based_enum;
+use lightning::impl_ser_tlv_based_enum;
 
 use super::msgs::LSPS5AppName;
 use super::msgs::LSPS5Error;
@@ -76,7 +76,7 @@ pub enum LSPS5ServiceEvent {
 	},
 }
 
-impl_writeable_tlv_based_enum!(LSPS5ServiceEvent,
+impl_ser_tlv_based_enum!(LSPS5ServiceEvent,
 	(0, SendWebhookNotification) => {
 		(0, counterparty_node_id, required),
 		(2, app_name, required),

--- a/lightning-liquidity/src/lsps5/msgs.rs
+++ b/lightning-liquidity/src/lsps5/msgs.rs
@@ -18,7 +18,7 @@ use super::url_utils::LSPSUrl;
 
 use lightning::ln::msgs::DecodeError;
 use lightning::util::ser::{Readable, Writeable};
-use lightning::{impl_writeable_tlv_based, impl_writeable_tlv_based_enum};
+use lightning::{impl_ser_tlv_based, impl_ser_tlv_based_enum};
 use lightning_types::string::UntrustedString;
 
 use serde::de::{self, Deserializer, MapAccess, Visitor};
@@ -527,7 +527,7 @@ pub enum WebhookNotificationMethod {
 	LSPS5OnionMessageIncoming,
 }
 
-impl_writeable_tlv_based_enum!(WebhookNotificationMethod,
+impl_ser_tlv_based_enum!(WebhookNotificationMethod,
 	(0, LSPS5WebhookRegistered) => {},
 	(2, LSPS5PaymentIncoming) => {},
 	(4, LSPS5ExpirySoon) => {
@@ -688,7 +688,7 @@ impl<'de> Deserialize<'de> for WebhookNotification {
 	}
 }
 
-impl_writeable_tlv_based!(WebhookNotification, {
+impl_ser_tlv_based!(WebhookNotification, {
 	(0, method, required),
 });
 

--- a/lightning-liquidity/src/lsps5/service.rs
+++ b/lightning-liquidity/src/lsps5/service.rs
@@ -27,7 +27,7 @@ use crate::utils::time::TimeProvider;
 
 use bitcoin::secp256k1::PublicKey;
 
-use lightning::impl_writeable_tlv_based;
+use lightning::impl_ser_tlv_based;
 use lightning::ln::channelmanager::AChannelManager;
 use lightning::ln::msgs::{ErrorAction, LightningError};
 use lightning::sign::NodeSigner;
@@ -66,7 +66,7 @@ struct Webhook {
 	last_notification_sent: Option<LSPSDateTime>,
 }
 
-impl_writeable_tlv_based!(Webhook, {
+impl_ser_tlv_based!(Webhook, {
 	(0, _app_name, required),
 	(2, url, required),
 	(4, _counterparty_node_id, required),
@@ -834,7 +834,7 @@ impl Default for PeerState {
 	}
 }
 
-impl_writeable_tlv_based!(PeerState, {
+impl_ser_tlv_based!(PeerState, {
 	(0, webhooks, required_vec),
 	(_unused, needs_persist, (static_value, false)),
 });

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -660,7 +660,7 @@ pub enum AsyncPaymentsContext {
 	},
 }
 
-impl_writeable_tlv_based_enum!(MessageContext,
+impl_ser_tlv_based_enum!(MessageContext,
 	{0, Offers} => (),
 	{1, Custom} => (),
 	{2, AsyncPayments} => (),
@@ -671,7 +671,7 @@ impl_writeable_tlv_based_enum!(MessageContext,
 // introduction of `ReceiveAuthKey`-based authentication for inbound `BlindedMessagePath`s. Because
 // we do not support receiving to those contexts anymore (they will fail the `ReceiveAuthKey`-based
 // authentication checks), we can reuse those fields here.
-impl_writeable_tlv_based_enum!(OffersContext,
+impl_ser_tlv_based_enum!(OffersContext,
 	(0, InvoiceRequest) => {
 		(0, nonce, required),
 		(1, payment_metadata, (option, encoding: (BTreeMap<u64, Vec<u8>>, BigSizeKeyedMap))),
@@ -694,7 +694,7 @@ impl_writeable_tlv_based_enum!(OffersContext,
 	},
 );
 
-impl_writeable_tlv_based_enum!(AsyncPaymentsContext,
+impl_ser_tlv_based_enum!(AsyncPaymentsContext,
 	(0, OutboundPayment) => {
 		(0, payment_id, required),
 	},
@@ -737,7 +737,7 @@ pub struct DNSResolverContext {
 	pub nonce: [u8; 16],
 }
 
-impl_writeable_tlv_based!(DNSResolverContext, {
+impl_ser_tlv_based!(DNSResolverContext, {
 	(0, nonce, required),
 });
 

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -1083,7 +1083,7 @@ impl Readable for PaymentConstraints {
 	}
 }
 
-impl_writeable_tlv_based_enum_legacy!(PaymentContext,
+impl_ser_tlv_based_enum_legacy!(PaymentContext,
 	;
 	// 0 for Unknown removed in version 0.1.
 	(1, Bolt12Offer),
@@ -1108,18 +1108,18 @@ impl<'a> Writeable for PaymentContextRef<'a> {
 	}
 }
 
-impl_writeable_tlv_based!(Bolt12OfferContext, {
+impl_ser_tlv_based!(Bolt12OfferContext, {
 	(0, offer_id, required),
 	(1, payment_metadata, (option, encoding: (BTreeMap<u64, Vec<u8>>, BigSizeKeyedMap))),
 	(2, invoice_request, required),
 });
 
-impl_writeable_tlv_based!(AsyncBolt12OfferContext, {
+impl_ser_tlv_based!(AsyncBolt12OfferContext, {
 	(0, offer_nonce, required),
 	(1, payment_metadata, (option, encoding: (BTreeMap<u64, Vec<u8>>, BigSizeKeyedMap))),
 });
 
-impl_writeable_tlv_based!(Bolt12RefundContext, {
+impl_ser_tlv_based!(Bolt12RefundContext, {
 	(1, payment_metadata, (option, encoding: (BTreeMap<u64, Vec<u8>>, BigSizeKeyedMap))),
 });
 

--- a/lightning/src/chain/chaininterface.rs
+++ b/lightning/src/chain/chaininterface.rs
@@ -159,19 +159,19 @@ pub enum FundingPurpose {
 
 // Needed so downstream consumers can persist these without needing to define wrapper types
 // mirroring the type structure.
-impl_writeable_tlv_based!(FundingCandidate, {
+impl_ser_tlv_based!(FundingCandidate, {
 	(1, txid, required),
 	(3, channels, required_vec),
 });
 
-impl_writeable_tlv_based!(ChannelFunding, {
+impl_ser_tlv_based!(ChannelFunding, {
 	(1, counterparty_node_id, required),
 	(3, channel_id, required),
 	(5, purpose, required),
 	(7, contribution, option),
 });
 
-impl_writeable_tlv_based_enum!(FundingPurpose,
+impl_ser_tlv_based_enum!(FundingPurpose,
 	(0, Establishment) => {},
 	(2, Splice) => {},
 );

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -256,7 +256,7 @@ pub struct HTLCUpdate {
 	pub(crate) source: HTLCSource,
 	pub(crate) htlc_value_satoshis: Option<u64>,
 }
-impl_writeable_tlv_based!(HTLCUpdate, {
+impl_ser_tlv_based!(HTLCUpdate, {
 	(0, payment_hash, required),
 	(1, htlc_value_satoshis, option),
 	(2, source, required),
@@ -345,7 +345,7 @@ struct HolderSignedTx {
 }
 
 // Any changes made here must also reflect in `write_legacy_holder_commitment_data`.
-impl_writeable_tlv_based!(HolderSignedTx, {
+impl_ser_tlv_based!(HolderSignedTx, {
 	(0, txid, required),
 	(1, to_self_value_sat, required), // Added in 0.0.100, required in 0.2.
 	(2, revocation_key, required),
@@ -1104,7 +1104,7 @@ impl CommitmentHTLCData {
 	}
 }
 
-impl_writeable_tlv_based!(CommitmentHTLCData, {
+impl_ser_tlv_based!(CommitmentHTLCData, {
 	(1, nondust_htlc_sources, required_vec),
 	(3, dust_htlcs, required_vec),
 });
@@ -1201,7 +1201,7 @@ impl FundingScope {
 	}
 }
 
-impl_writeable_tlv_based!(FundingScope, {
+impl_ser_tlv_based!(FundingScope, {
 	(1, channel_parameters, (required: ReadableArgs, None)),
 	(3, current_counterparty_commitment_txid, required),
 	(5, prev_counterparty_commitment_txid, option),

--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -143,7 +143,7 @@ impl BlockLocator {
 	}
 }
 
-impl_writeable_tlv_based!(BlockLocator, {
+impl_ser_tlv_based!(BlockLocator, {
 	(0, block_hash, required),
 	// Note that any change to the previous_blocks array length will change the serialization
 	// format and thus it is specified without constants here.

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -172,7 +172,7 @@ impl RevokedOutput {
 	}
 }
 
-impl_writeable_tlv_based!(RevokedOutput, {
+impl_ser_tlv_based!(RevokedOutput, {
 	(0, per_commitment_point, required),
 	(1, outpoint_confirmation_height, option), // Added in 0.1.4/0.2 and always set
 	(2, counterparty_delayed_payment_base_key, required),
@@ -238,7 +238,7 @@ impl RevokedHTLCOutput {
 	}
 }
 
-impl_writeable_tlv_based!(RevokedHTLCOutput, {
+impl_ser_tlv_based!(RevokedHTLCOutput, {
 	(0, per_commitment_point, required),
 	(1, outpoint_confirmation_height, option), // Added in 0.1.4/0.2 and always set
 	(2, counterparty_delayed_payment_base_key, required),
@@ -1066,7 +1066,7 @@ impl PackageSolvingData {
 	}
 }
 
-impl_writeable_tlv_based_enum_legacy!(PackageSolvingData, ;
+impl_ser_tlv_based_enum_legacy!(PackageSolvingData, ;
 	(0, RevokedOutput),
 	(1, RevokedHTLCOutput),
 	(2, CounterpartyOfferedHTLCOutput),

--- a/lightning/src/crypto/streams.rs
+++ b/lightning/src/crypto/streams.rs
@@ -358,7 +358,7 @@ mod tests {
 		field2: Vec<u8>,
 		field3: Vec<u8>,
 	}
-	impl_writeable_tlv_based!(TestWriteable, {
+	impl_ser_tlv_based!(TestWriteable, {
 		(1, field1, required_vec),
 		(2, field2, required_vec),
 		(3, field3, required_vec),

--- a/lightning/src/events/mod.rs
+++ b/lightning/src/events/mod.rs
@@ -87,7 +87,7 @@ pub enum FundingInfo {
 	},
 }
 
-impl_writeable_tlv_based_enum!(FundingInfo,
+impl_ser_tlv_based_enum!(FundingInfo,
 	(0, Tx) => {
 		(0, transaction, required)
 	},
@@ -341,7 +341,7 @@ impl PaymentPurpose {
 	}
 }
 
-impl_writeable_tlv_based_enum_legacy!(PaymentPurpose,
+impl_ser_tlv_based_enum_legacy!(PaymentPurpose,
 	(0, Bolt11InvoicePayment) => {
 		(0, payment_preimage, option),
 		(2, payment_secret, required),
@@ -391,7 +391,7 @@ pub struct ClaimedHTLC {
 	/// 0.0.119.
 	pub counterparty_skimmed_fee_msat: u64,
 }
-impl_writeable_tlv_based!(ClaimedHTLC, {
+impl_ser_tlv_based!(ClaimedHTLC, {
 	(0, channel_id, required),
 	(1, counterparty_skimmed_fee_msat, (default_value, 0u64)),
 	(2, user_channel_id, required),
@@ -736,7 +736,7 @@ pub enum HTLCHandlingFailureReason {
 	},
 }
 
-impl_writeable_tlv_based_enum!(HTLCHandlingFailureReason,
+impl_ser_tlv_based_enum!(HTLCHandlingFailureReason,
 	(1, Downstream) => {},
 	(3, Local) => {
 		(0, reason, required),
@@ -757,7 +757,7 @@ enum InterceptNextHop {
 	FakeScid { requested_next_hop_scid: u64 },
 }
 
-impl_writeable_tlv_based_enum!(InterceptNextHop,
+impl_ser_tlv_based_enum!(InterceptNextHop,
 	(0, FakeScid) => {
 		(0, requested_next_hop_scid, required),
 	},
@@ -878,7 +878,7 @@ pub struct HTLCLocator {
 	pub node_id: Option<PublicKey>,
 }
 
-impl_writeable_tlv_based!(HTLCLocator, {
+impl_ser_tlv_based!(HTLCLocator, {
 	(1, channel_id, required),
 	(3, user_channel_id, option),
 	(5, node_id, option),
@@ -3290,7 +3290,7 @@ pub enum PaidBolt12Invoice {
 	StaticInvoice(StaticInvoice),
 }
 
-impl_writeable_tlv_based_enum!(PaidBolt12Invoice,
+impl_ser_tlv_based_enum!(PaidBolt12Invoice,
 	{0, Bolt12Invoice} => (),
 	{2, StaticInvoice} => (),
 );

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -1169,24 +1169,21 @@ impl_ser_tlv_based!(CounterpartyChannelTransactionParameters, {
 	(2, selected_contest_delay, required),
 });
 
-impl Writeable for ChannelTransactionParameters {
-	#[rustfmt::skip]
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
-		let legacy_deserialization_prevention_marker = legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features);
-		write_tlv_fields!(writer, {
-			(0, self.holder_pubkeys, required),
-			(2, self.holder_selected_contest_delay, required),
-			(4, self.is_outbound_from_holder, required),
-			(6, self.counterparty_parameters, option),
-			(8, self.funding_outpoint, option),
-			(10, legacy_deserialization_prevention_marker, option),
-			(11, self.channel_type_features, required),
-			(12, self.splice_parent_funding_txid, option),
-			(13, self.channel_value_satoshis, required),
-		});
-		Ok(())
-	}
-}
+impl_writeable_tlv_based!(ChannelTransactionParameters, self, {
+	(0, self.holder_pubkeys, required),
+	(2, self.holder_selected_contest_delay, required),
+	(4, self.is_outbound_from_holder, required),
+	(6, self.counterparty_parameters, option),
+	(8, self.funding_outpoint, option),
+	(
+		10,
+		legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features),
+		option
+	),
+	(11, self.channel_type_features, required),
+	(12, self.splice_parent_funding_txid, option),
+	(13, self.channel_value_satoshis, required),
+});
 
 impl ReadableArgs<Option<u64>> for ChannelTransactionParameters {
 	#[rustfmt::skip]
@@ -1634,25 +1631,22 @@ impl PartialEq for CommitmentTransaction {
 	}
 }
 
-impl Writeable for CommitmentTransaction {
-	#[rustfmt::skip]
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
-		let legacy_deserialization_prevention_marker = legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features);
-		write_tlv_fields!(writer, {
-			(0, self.commitment_number, required),
-			(1, self.to_broadcaster_delay, option),
-			(2, self.to_broadcaster_value_sat, required),
-			(4, self.to_countersignatory_value_sat, required),
-			(6, self.feerate_per_kw, required),
-			(8, self.keys, required),
-			(10, self.built, required),
-			(12, self.nondust_htlcs, required_vec),
-			(14, legacy_deserialization_prevention_marker, option),
-			(15, self.channel_type_features, required),
-		});
-		Ok(())
-	}
-}
+impl_writeable_tlv_based!(CommitmentTransaction, self, {
+	(0, self.commitment_number, required),
+	(1, self.to_broadcaster_delay, option),
+	(2, self.to_broadcaster_value_sat, required),
+	(4, self.to_countersignatory_value_sat, required),
+	(6, self.feerate_per_kw, required),
+	(8, self.keys, required),
+	(10, self.built, required),
+	(12, self.nondust_htlcs, required_vec),
+	(
+		14,
+		legacy_deserialization_prevention_marker_for_channel_type_features(&self.channel_type_features),
+		option
+	),
+	(15, self.channel_type_features, required),
+});
 
 impl Readable for CommitmentTransaction {
 	#[rustfmt::skip]

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -590,7 +590,7 @@ pub struct TxCreationKeys {
 	pub broadcaster_delayed_payment_key: DelayedPaymentKey,
 }
 
-impl_writeable_tlv_based!(TxCreationKeys, {
+impl_ser_tlv_based!(TxCreationKeys, {
 	(0, per_commitment_point, required),
 	(2, revocation_key, required),
 	(4, broadcaster_htlc_key, required),
@@ -622,7 +622,7 @@ pub struct ChannelPublicKeys {
 	pub htlc_basepoint: HtlcBasepoint,
 }
 
-impl_writeable_tlv_based!(ChannelPublicKeys, {
+impl_ser_tlv_based!(ChannelPublicKeys, {
 	(0, funding_pubkey, required),
 	(2, revocation_basepoint, required),
 	(4, payment_point, required),
@@ -738,7 +738,7 @@ impl HTLCOutputInCommitment {
 	}
 }
 
-impl_writeable_tlv_based!(HTLCOutputInCommitment, {
+impl_ser_tlv_based!(HTLCOutputInCommitment, {
 	(0, offered, required),
 	(2, amount_msat, required),
 	(4, cltv_expiry, required),
@@ -1164,7 +1164,7 @@ impl ChannelTransactionParameters {
 	}
 }
 
-impl_writeable_tlv_based!(CounterpartyChannelTransactionParameters, {
+impl_ser_tlv_based!(CounterpartyChannelTransactionParameters, {
 	(0, pubkeys, required),
 	(2, selected_contest_delay, required),
 });
@@ -1336,7 +1336,7 @@ impl PartialEq for HolderCommitmentTransaction {
 	}
 }
 
-impl_writeable_tlv_based!(HolderCommitmentTransaction, {
+impl_ser_tlv_based!(HolderCommitmentTransaction, {
 	(0, inner, required),
 	(2, counterparty_sig, required),
 	(4, holder_sig_first, required),
@@ -1424,7 +1424,7 @@ pub struct BuiltCommitmentTransaction {
 	pub txid: Txid,
 }
 
-impl_writeable_tlv_based!(BuiltCommitmentTransaction, {
+impl_ser_tlv_based!(BuiltCommitmentTransaction, {
 	(0, transaction, required),
 	(2, txid, required),
 });

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -172,7 +172,7 @@ enum InboundHTLCResolution {
 	Pending { update_add_htlc: msgs::UpdateAddHTLC },
 }
 
-impl_writeable_tlv_based_enum!(InboundHTLCResolution,
+impl_ser_tlv_based_enum!(InboundHTLCResolution,
 	(0, Resolved) => {
 		(0, pending_htlc_status, required),
 	},
@@ -337,7 +337,7 @@ pub(super) struct OutboundHop {
 	pub(super) user_channel_id: u128,
 }
 
-impl_writeable_tlv_based!(OutboundHop, {
+impl_ser_tlv_based!(OutboundHop, {
 	(0, amt_msat, required),
 	(2, channel_id, required),
 	(4, node_id, required),
@@ -1517,7 +1517,7 @@ struct PendingChannelMonitorUpdate {
 	update: ChannelMonitorUpdate,
 }
 
-impl_writeable_tlv_based!(PendingChannelMonitorUpdate, {
+impl_ser_tlv_based!(PendingChannelMonitorUpdate, {
 	(0, update, required),
 });
 
@@ -2994,7 +2994,7 @@ struct PendingFunding {
 	contributions: Vec<FundingContribution>,
 }
 
-impl_writeable_tlv_based!(PendingFunding, {
+impl_ser_tlv_based!(PendingFunding, {
 	(1, funding_negotiation, upgradable_option),
 	(3, negotiated_candidates, required_vec),
 	(5, sent_funding_txid, option),

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2596,22 +2596,17 @@ pub(super) struct FundingScope {
 	minimum_depth_override: Option<u32>,
 }
 
-impl Writeable for FundingScope {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
-		write_tlv_fields!(writer, {
-			(1, self.value_to_self_msat, required),
-			(3, self.counterparty_selected_channel_reserve_satoshis, option),
-			(5, self.holder_selected_channel_reserve_satoshis, required),
-			(7, self.channel_transaction_parameters, (required: ReadableArgs, None)),
-			(9, self.funding_transaction, option),
-			(11, self.funding_tx_confirmed_in, option),
-			(13, self.funding_tx_confirmation_height, required),
-			(15, self.short_channel_id, option),
-			(17, self.minimum_depth_override, option),
-		});
-		Ok(())
-	}
-}
+impl_writeable_tlv_based!(FundingScope, self, {
+	(1, self.value_to_self_msat, required),
+	(3, self.counterparty_selected_channel_reserve_satoshis, option),
+	(5, self.holder_selected_channel_reserve_satoshis, required),
+	(7, self.channel_transaction_parameters, (required: ReadableArgs, None)),
+	(9, self.funding_transaction, option),
+	(11, self.funding_tx_confirmed_in, option),
+	(13, self.funding_tx_confirmation_height, required),
+	(15, self.short_channel_id, option),
+	(17, self.minimum_depth_override, option),
+});
 
 impl Readable for FundingScope {
 	#[rustfmt::skip]

--- a/lightning/src/ln/channel_state.rs
+++ b/lightning/src/ln/channel_state.rs
@@ -106,7 +106,7 @@ pub struct InboundHTLCDetails {
 	pub is_dust: bool,
 }
 
-impl_writeable_tlv_based!(InboundHTLCDetails, {
+impl_ser_tlv_based!(InboundHTLCDetails, {
 	(0, htlc_id, required),
 	(2, amount_msat, required),
 	(4, cltv_expiry, required),
@@ -200,7 +200,7 @@ pub struct OutboundHTLCDetails {
 	pub is_dust: bool,
 }
 
-impl_writeable_tlv_based!(OutboundHTLCDetails, {
+impl_ser_tlv_based!(OutboundHTLCDetails, {
 	(0, htlc_id, required),
 	(2, amount_msat, required),
 	(4, cltv_expiry, required),
@@ -223,7 +223,7 @@ pub struct CounterpartyForwardingInfo {
 	pub cltv_expiry_delta: u16,
 }
 
-impl_writeable_tlv_based!(CounterpartyForwardingInfo, {
+impl_ser_tlv_based!(CounterpartyForwardingInfo, {
 	(2, fee_base_msat, required),
 	(4, fee_proportional_millionths, required),
 	(6, cltv_expiry_delta, required),
@@ -258,7 +258,7 @@ pub struct ChannelCounterparty {
 	pub outbound_htlc_maximum_msat: Option<u64>,
 }
 
-impl_writeable_tlv_based!(ChannelCounterparty, {
+impl_ser_tlv_based!(ChannelCounterparty, {
 	(2, node_id, required),
 	(4, features, required),
 	(6, unspendable_punishment_reserve, required),
@@ -621,7 +621,7 @@ impl ChannelDetails {
 	}
 }
 
-impl_writeable_tlv_based!(ChannelDetails, {
+impl_ser_tlv_based!(ChannelDetails, {
 	(1, inbound_scid_alias, option),
 	(2, channel_id, required),
 	(3, channel_type, option),
@@ -686,7 +686,7 @@ pub enum ChannelShutdownState {
 	ShutdownComplete,
 }
 
-impl_writeable_tlv_based_enum!(ChannelShutdownState,
+impl_ser_tlv_based_enum!(ChannelShutdownState,
 	(0, NotShuttingDown) => {},
 	(2, ShutdownInitiated) => {},
 	(4, ResolvingHTLCs) => {},

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -819,7 +819,7 @@ impl SentHTLCId {
 		}
 	}
 }
-impl_writeable_tlv_based_enum!(SentHTLCId,
+impl_ser_tlv_based_enum!(SentHTLCId,
 	(0, PreviousHopData) => {
 		(0, prev_outbound_scid_alias, required),
 		(2, htlc_id, required),
@@ -1228,7 +1228,7 @@ struct ClaimingPayment {
 	/// outpoint), allowing us to remove this field.
 	durable_preimage_channel: Option<(OutPoint, PublicKey, ChannelId)>,
 }
-impl_writeable_tlv_based!(ClaimingPayment, {
+impl_ser_tlv_based!(ClaimingPayment, {
 	(0, amount_msat, required),
 	(1, durable_preimage_channel, option),
 	(2, payment_purpose, required),
@@ -1614,7 +1614,7 @@ pub(crate) struct PaymentCompleteUpdate {
 	htlc_id: SentHTLCId,
 }
 
-impl_writeable_tlv_based!(PaymentCompleteUpdate, {
+impl_ser_tlv_based!(PaymentCompleteUpdate, {
 	(1, channel_funding_outpoint, required),
 	(3, counterparty_node_id, required),
 	(5, channel_id, required),
@@ -1636,7 +1636,7 @@ pub(crate) enum EventCompletionAction {
 	/// Note that this action will be dropped on downgrade to LDK prior to 0.2!
 	ReleasePaymentCompleteChannelMonitorUpdate(PaymentCompleteUpdate),
 }
-impl_writeable_tlv_based_enum!(EventCompletionAction,
+impl_ser_tlv_based_enum!(EventCompletionAction,
 	(0, ReleaseRAAChannelMonitorUpdate) => {
 		(0, channel_funding_outpoint, option),
 		(2, counterparty_node_id, required),
@@ -1691,7 +1691,7 @@ struct MPPClaimHTLCSource {
 	htlc_id: u64,
 }
 
-impl_writeable_tlv_based!(MPPClaimHTLCSource, {
+impl_ser_tlv_based!(MPPClaimHTLCSource, {
 	(0, counterparty_node_id, required),
 	(2, funding_txo, required),
 	(4, channel_id, required),
@@ -1710,7 +1710,7 @@ pub(crate) struct PaymentClaimDetails {
 	claiming_payment: ClaimingPayment,
 }
 
-impl_writeable_tlv_based!(PaymentClaimDetails, {
+impl_ser_tlv_based!(PaymentClaimDetails, {
 	(0, mpp_parts, required_vec),
 	(2, claiming_payment, required),
 });
@@ -17835,19 +17835,19 @@ const MIN_SERIALIZATION_VERSION: u8 = 1;
 // Left as `None` for now until we are committed to writing inbound committed onions in `Channel`s.
 const RECONSTRUCT_HTLCS_FROM_CHANS_VERSION: Option<u8> = None;
 
-impl_writeable_tlv_based!(PhantomRouteHints, {
+impl_ser_tlv_based!(PhantomRouteHints, {
 	(2, channels, required_vec),
 	(4, phantom_scid, required),
 	(6, real_node_pubkey, required),
 });
 
-impl_writeable_tlv_based!(BlindedForward, {
+impl_ser_tlv_based!(BlindedForward, {
 	(0, inbound_blinding_point, required),
 	(1, failure, (default_value, BlindedFailure::FromIntroductionNode)),
 	(3, next_blinding_override, option),
 });
 
-impl_writeable_tlv_based_enum!(PendingHTLCRouting,
+impl_ser_tlv_based_enum!(PendingHTLCRouting,
 	(0, Forward) => {
 		(0, onion_packet, required),
 		(1, blinded, option),
@@ -17885,7 +17885,7 @@ impl_writeable_tlv_based_enum!(PendingHTLCRouting,
 	}
 );
 
-impl_writeable_tlv_based!(PendingHTLCInfo, {
+impl_ser_tlv_based!(PendingHTLCInfo, {
 	(0, routing, required),
 	(2, incoming_shared_secret, required),
 	(4, payment_hash, required),
@@ -17970,17 +17970,17 @@ impl Readable for HTLCFailureMsg {
 	}
 }
 
-impl_writeable_tlv_based_enum_legacy!(PendingHTLCStatus, ;
+impl_ser_tlv_based_enum_legacy!(PendingHTLCStatus, ;
 	(0, Forward),
 	(1, Fail),
 );
 
-impl_writeable_tlv_based_enum!(BlindedFailure,
+impl_ser_tlv_based_enum!(BlindedFailure,
 	(0, FromIntroductionNode) => {},
 	(2, FromBlindedNode) => {},
 );
 
-impl_writeable_tlv_based!(HTLCPreviousHopData, {
+impl_ser_tlv_based!(HTLCPreviousHopData, {
 	(0, prev_outbound_scid_alias, required),
 	(1, phantom_shared_secret, option),
 	(2, outpoint, required),
@@ -18155,7 +18155,7 @@ impl Writeable for HTLCSource {
 	}
 }
 
-impl_writeable_tlv_based!(PendingAddHTLCInfo, {
+impl_ser_tlv_based!(PendingAddHTLCInfo, {
 	(0, forward_info, required),
 	(1, prev_user_channel_id, (default_value, 0)),
 	(2, prev_outbound_scid_alias, required),
@@ -18167,7 +18167,7 @@ impl_writeable_tlv_based!(PendingAddHTLCInfo, {
 	(9, prev_counterparty_node_id, required),
 });
 
-impl_writeable_tlv_based!(TrampolineDispatch, {
+impl_ser_tlv_based!(TrampolineDispatch, {
 	(1, payment_id, required),
 	(3, path, required),
 	(5, session_priv, required),
@@ -18244,7 +18244,7 @@ impl Readable for HTLCForwardInfo {
 	}
 }
 
-impl_writeable_tlv_based!(PendingInboundPayment, {
+impl_ser_tlv_based!(PendingInboundPayment, {
 	(0, payment_secret, required),
 	(2, expiry_time, required),
 	(4, user_payment_id, required),

--- a/lightning/src/ln/funding.rs
+++ b/lightning/src/ln/funding.rs
@@ -598,7 +598,7 @@ enum FundingInputMode {
 	ManuallySelected,
 }
 
-impl_writeable_tlv_based_enum!(FundingInputMode,
+impl_ser_tlv_based_enum!(FundingInputMode,
 	(1, CoinSelected) => {},
 	(3, ManuallySelected) => {}
 );
@@ -640,7 +640,7 @@ pub struct FundingContribution {
 	input_mode: Option<FundingInputMode>,
 }
 
-impl_writeable_tlv_based!(FundingContribution, {
+impl_ser_tlv_based!(FundingContribution, {
 	(1, estimated_fee, required),
 	(3, inputs, optional_vec),
 	(5, outputs, optional_vec),

--- a/lightning/src/ln/interactivetxs.rs
+++ b/lightning/src/ln/interactivetxs.rs
@@ -253,16 +253,16 @@ impl TxOutMetadata {
 	}
 }
 
-impl_writeable_tlv_based!(TxInMetadata, {
+impl_ser_tlv_based!(TxInMetadata, {
 	(1, serial_id, required),
 	(3, prev_output, required),
 });
 
-impl_writeable_tlv_based!(TxOutMetadata, {
+impl_ser_tlv_based!(TxOutMetadata, {
 	(1, serial_id, required),
 });
 
-impl_writeable_tlv_based!(ConstructedTransaction, {
+impl_ser_tlv_based!(ConstructedTransaction, {
 	(1, holder_is_initiator, required),
 	(3, input_metadata, required),
 	(5, output_metadata, required),
@@ -530,7 +530,7 @@ pub(crate) struct SharedInputSignature {
 	witness_script: ScriptBuf,
 }
 
-impl_writeable_tlv_based!(SharedInputSignature, {
+impl_ser_tlv_based!(SharedInputSignature, {
 	(1, holder_signature_first, required),
 	(3, witness_script, required),
 });
@@ -930,7 +930,7 @@ impl InteractiveTxSigningSession {
 	}
 }
 
-impl_writeable_tlv_based!(InteractiveTxSigningSession, {
+impl_ser_tlv_based!(InteractiveTxSigningSession, {
 	(1, unsigned_tx, required),
 	(3, has_received_commitment_signed, required),
 	(5, holder_tx_signatures, required),
@@ -1656,7 +1656,7 @@ enum AddingRole {
 	Remote,
 }
 
-impl_writeable_tlv_based_enum!(AddingRole,
+impl_ser_tlv_based_enum!(AddingRole,
 	(1, Local) => {},
 	(3, Remote) => {},
 );
@@ -1806,7 +1806,7 @@ pub(super) struct SharedOwnedOutput {
 	local_owned: u64,
 }
 
-impl_writeable_tlv_based!(SharedOwnedOutput, {
+impl_ser_tlv_based!(SharedOwnedOutput, {
 	(1, tx_out, required),
 	(3, local_owned, required),
 });
@@ -1836,7 +1836,7 @@ enum OutputOwned {
 	Shared(SharedOwnedOutput),
 }
 
-impl_writeable_tlv_based_enum!(OutputOwned,
+impl_ser_tlv_based_enum!(OutputOwned,
 	{1, Single} => (),
 	{3, Shared} => (),
 );

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1960,7 +1960,7 @@ impl Readable for HTLCFailReason {
 	}
 }
 
-impl_writeable_tlv_based_enum!(HTLCFailReasonRepr,
+impl_ser_tlv_based_enum!(HTLCFailReasonRepr,
 	(0, LightningError) => {
 		(0, data, (legacy, Vec<u8>, |_| Ok(()), |us|
 			if let &HTLCFailReasonRepr::LightningError { err: msgs::OnionErrorPacket { ref data, .. }, .. } = us {

--- a/lightning/src/ln/our_peer_storage.rs
+++ b/lightning/src/ln/our_peer_storage.rs
@@ -170,7 +170,7 @@ pub(crate) struct PeerStorageMonitorHolder {
 	pub(crate) monitor_bytes: Vec<u8>,
 }
 
-impl_writeable_tlv_based!(PeerStorageMonitorHolder, {
+impl_ser_tlv_based!(PeerStorageMonitorHolder, {
 	(0, channel_id, required),
 	(2, counterparty_node_id, required),
 	(4, min_seen_secret, required),

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -174,7 +174,7 @@ pub(crate) struct RetryableInvoiceRequest {
 	pub(super) needs_retry: bool,
 }
 
-impl_writeable_tlv_based!(RetryableInvoiceRequest, {
+impl_ser_tlv_based!(RetryableInvoiceRequest, {
 	(0, invoice_request, required),
 	(1, needs_retry, (default_value, true)),
 	(2, nonce, required),
@@ -427,13 +427,13 @@ pub enum Retry {
 }
 
 #[cfg(not(feature = "std"))]
-impl_writeable_tlv_based_enum_legacy!(Retry,
+impl_ser_tlv_based_enum_legacy!(Retry,
 	;
 	(0, Attempts)
 );
 
 #[cfg(feature = "std")]
-impl_writeable_tlv_based_enum_legacy!(Retry,
+impl_ser_tlv_based_enum_legacy!(Retry,
 	;
 	(0, Attempts),
 	(2, Timeout)
@@ -517,7 +517,7 @@ pub(crate) enum StaleExpiration {
 	AbsoluteTimeout(core::time::Duration),
 }
 
-impl_writeable_tlv_based_enum_legacy!(StaleExpiration,
+impl_ser_tlv_based_enum_legacy!(StaleExpiration,
 	;
 	(0, TimerTicks),
 	(2, AbsoluteTimeout)

--- a/lightning/src/ln/script.rs
+++ b/lightning/src/ln/script.rs
@@ -56,7 +56,7 @@ impl Readable for ShutdownScript {
 	}
 }
 
-impl_writeable_tlv_based_enum_legacy!(ShutdownScriptImpl, ;
+impl_ser_tlv_based_enum_legacy!(ShutdownScriptImpl, ;
 	(0, Legacy),
 	(1, Bolt2),
 );

--- a/lightning/src/offers/async_receive_offer_cache.rs
+++ b/lightning/src/offers/async_receive_offer_cache.rs
@@ -76,7 +76,7 @@ impl AsyncReceiveOffer {
 	}
 }
 
-impl_writeable_tlv_based_enum!(OfferStatus,
+impl_ser_tlv_based_enum!(OfferStatus,
 	(0, Used) => {
 		(0, invoice_created_at, required),
 	},
@@ -86,7 +86,7 @@ impl_writeable_tlv_based_enum!(OfferStatus,
 	(2, Pending) => {},
 );
 
-impl_writeable_tlv_based!(AsyncReceiveOffer, {
+impl_ser_tlv_based!(AsyncReceiveOffer, {
 	(0, offer, required),
 	(2, offer_nonce, required),
 	(4, status, required),

--- a/lightning/src/onion_message/async_payments.rs
+++ b/lightning/src/onion_message/async_payments.rs
@@ -279,25 +279,25 @@ impl OnionMessageContents for ReleaseHeldHtlc {
 	}
 }
 
-impl_writeable_tlv_based!(OfferPathsRequest, {
+impl_ser_tlv_based!(OfferPathsRequest, {
 	(0, invoice_slot, required),
 });
 
-impl_writeable_tlv_based!(OfferPaths, {
+impl_ser_tlv_based!(OfferPaths, {
 	(0, paths, required_vec),
 	(2, paths_absolute_expiry, option),
 });
 
-impl_writeable_tlv_based!(ServeStaticInvoice, {
+impl_ser_tlv_based!(ServeStaticInvoice, {
 	(0, invoice, required),
 	(2, forward_invoice_request_path, required),
 });
 
-impl_writeable_tlv_based!(StaticInvoicePersisted, {});
+impl_ser_tlv_based!(StaticInvoicePersisted, {});
 
-impl_writeable_tlv_based!(HeldHtlcAvailable, {});
+impl_ser_tlv_based!(HeldHtlcAvailable, {});
 
-impl_writeable_tlv_based!(ReleaseHeldHtlc, {});
+impl_ser_tlv_based!(ReleaseHeldHtlc, {});
 
 impl AsyncPaymentsMessage {
 	/// Returns whether `tlv_type` corresponds to a TLV record for async payment messages.

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -358,7 +358,7 @@ pub struct Responder {
 	reply_path: BlindedMessagePath,
 }
 
-impl_writeable_tlv_based!(Responder, {
+impl_ser_tlv_based!(Responder, {
 	(0, reply_path, required),
 });
 

--- a/lightning/src/routing/gossip.rs
+++ b/lightning/src/routing/gossip.rs
@@ -1350,7 +1350,7 @@ impl EffectiveCapacity {
 	}
 }
 
-impl_writeable_tlv_based!(RoutingFees, {
+impl_ser_tlv_based!(RoutingFees, {
 	(0, base_msat, required),
 	(2, proportional_millionths, required)
 });

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -545,7 +545,7 @@ pub struct RouteHop {
 	pub maybe_announced_channel: bool,
 }
 
-impl_writeable_tlv_based!(RouteHop, {
+impl_ser_tlv_based!(RouteHop, {
 	(0, pubkey, required),
 	(1, maybe_announced_channel, (default_value, true)),
 	(2, node_features, required),
@@ -574,7 +574,7 @@ pub struct TrampolineHop {
 	pub cltv_expiry_delta: u32,
 }
 
-impl_writeable_tlv_based!(TrampolineHop, {
+impl_ser_tlv_based!(TrampolineHop, {
 	(0, pubkey, required),
 	(2, node_features, required),
 	(4, fee_msat, required),
@@ -604,7 +604,7 @@ pub struct BlindedTail {
 	pub final_value_msat: u64,
 }
 
-impl_writeable_tlv_based!(BlindedTail, {
+impl_ser_tlv_based!(BlindedTail, {
 	(0, hops, required_vec),
 	(2, blinding_point, required),
 	(4, excess_final_cltv_expiry_delta, required),
@@ -666,7 +666,7 @@ impl Path {
 	}
 }
 
-impl_writeable_tlv_based!(Path,{
+impl_ser_tlv_based!(Path,{
 	(1, hops, required_vec),
 	(3, blinded_tail, option),
 });
@@ -1373,7 +1373,7 @@ pub struct RouteParametersConfig {
 	pub max_channel_saturation_power_of_half: u8,
 }
 
-impl_writeable_tlv_based!(RouteParametersConfig, {
+impl_ser_tlv_based!(RouteParametersConfig, {
 	(1, max_total_routing_fee_msat, option),
 	(3, max_total_cltv_expiry_delta, required),
 	(5, max_path_count, required),
@@ -1578,7 +1578,7 @@ impl Readable for RouteHint {
 	}
 }
 
-impl_writeable_tlv_based!(RouteHintHop, {
+impl_ser_tlv_based!(RouteHintHop, {
 	(0, src_node_id, required),
 	(1, htlc_minimum_msat, option),
 	(2, short_channel_id, required),

--- a/lightning/src/routing/scoring.rs
+++ b/lightning/src/routing/scoring.rs
@@ -2131,8 +2131,8 @@ mod bucketed_history {
 		}
 	}
 
-	impl_writeable_tlv_based!(HistoricalBucketRangeTracker, { (0, buckets, required) });
-	impl_writeable_tlv_based!(LegacyHistoricalBucketRangeTracker, { (0, buckets, required) });
+	impl_ser_tlv_based!(HistoricalBucketRangeTracker, { (0, buckets, required) });
+	impl_ser_tlv_based!(LegacyHistoricalBucketRangeTracker, { (0, buckets, required) });
 
 	#[derive(Clone, Copy)]
 	#[repr(C)] // Force the fields in memory to be in the order we specify.

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -119,7 +119,7 @@ impl DelayedPaymentOutputDescriptor {
 		+ chan_utils::REVOKEABLE_REDEEMSCRIPT_MAX_LENGTH) as u64;
 }
 
-impl_writeable_tlv_based!(DelayedPaymentOutputDescriptor, {
+impl_ser_tlv_based!(DelayedPaymentOutputDescriptor, {
 	(0, outpoint, required),
 	(2, per_commitment_point, required),
 	(4, to_self_delay, required),
@@ -217,7 +217,7 @@ impl StaticPaymentOutputDescriptor {
 		chan_params.is_some_and(|p| p.channel_type_features.supports_anchors_zero_fee_htlc_tx())
 	}
 }
-impl_writeable_tlv_based!(StaticPaymentOutputDescriptor, {
+impl_ser_tlv_based!(StaticPaymentOutputDescriptor, {
 	(0, outpoint, required),
 	(2, output, required),
 	(4, channel_keys_id, required),
@@ -320,7 +320,7 @@ pub enum SpendableOutputDescriptor {
 	StaticPaymentOutput(StaticPaymentOutputDescriptor),
 }
 
-impl_writeable_tlv_based_enum_legacy!(SpendableOutputDescriptor,
+impl_ser_tlv_based_enum_legacy!(SpendableOutputDescriptor,
 	(0, StaticOutput) => {
 		(0, outpoint, required),
 		(1, channel_keys_id, option),
@@ -582,7 +582,7 @@ pub struct ChannelDerivationParameters {
 	pub transaction_parameters: ChannelTransactionParameters,
 }
 
-impl_writeable_tlv_based!(ChannelDerivationParameters, {
+impl_ser_tlv_based!(ChannelDerivationParameters, {
 	(0, value_satoshis, required),
 	(2, keys_id, required),
 	(4, transaction_parameters, (required: ReadableArgs, Some(value_satoshis.0.unwrap()))),
@@ -616,7 +616,7 @@ pub struct HTLCDescriptor {
 	pub counterparty_sig: Signature,
 }
 
-impl_writeable_tlv_based!(HTLCDescriptor, {
+impl_ser_tlv_based!(HTLCDescriptor, {
 	(0, channel_derivation_parameters, required),
 	(1, feerate_per_kw, (default_value, 0)),
 	(2, commitment_txid, required),

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -481,7 +481,7 @@ pub enum MaxDustHTLCExposure {
 	FeeRateMultiplier(u64),
 }
 
-impl_writeable_tlv_based_enum_legacy!(MaxDustHTLCExposure, ;
+impl_ser_tlv_based_enum_legacy!(MaxDustHTLCExposure, ;
 	(1, FixedLimitMsat),
 	(3, FeeRateMultiplier),
 );

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -317,6 +317,11 @@ impl<'a, T: Writeable> Writeable for &'a T {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
 		(*self).write(writer)
 	}
+
+	#[inline]
+	fn serialized_length(&self) -> usize {
+		(*self).serialized_length()
+	}
 }
 
 /// A trait that various LDK types implement allowing them to be read in from a [`Read`].
@@ -846,6 +851,11 @@ impl<S: AsWriteableSlice> Writeable for WithoutLength<S> {
 		}
 		Ok(())
 	}
+
+	#[inline]
+	fn serialized_length(&self) -> usize {
+		self.0.as_slice().iter().map(|v| v.serialized_length()).sum()
+	}
 }
 
 impl<T: MaybeReadable> LengthReadable for WithoutLength<Vec<T>> {
@@ -1366,6 +1376,11 @@ impl<T: Writeable> Writeable for Box<T> {
 	fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
 		T::write(&**self, w)
 	}
+
+	#[inline]
+	fn serialized_length(&self) -> usize {
+		T::serialized_length(&**self)
+	}
 }
 
 impl<T: Readable> Readable for Box<T> {
@@ -1384,6 +1399,17 @@ impl<T: Writeable> Writeable for Option<T> {
 			},
 		}
 		Ok(())
+	}
+
+	#[inline]
+	fn serialized_length(&self) -> usize {
+		match *self {
+			None => 1,
+			Some(ref data) => {
+				let data_len = data.serialized_length();
+				BigSize(data_len as u64 + 1).serialized_length() + data_len
+			},
+		}
 	}
 }
 

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -839,6 +839,58 @@ macro_rules! write_tlv_fields {
 	}
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _tlv_fields_serialized_length {
+	({$(($type: expr, $field: expr, $fieldty: tt $(, $self: ident)?)),* $(,)*}) => { {
+		use $crate::util::ser::BigSize;
+		let len = {
+			#[allow(unused_mut)]
+			let mut len = $crate::util::ser::LengthCalculatingWriter(0);
+			$(
+				$crate::_get_varint_length_prefixed_tlv_length!(len, $type, &$field, $fieldty $(, $self)?);
+			)*
+			len.0
+		};
+		let mut len_calc = $crate::util::ser::LengthCalculatingWriter(0);
+		BigSize(len as u64).write(&mut len_calc).expect("No in-memory data may fail to serialize");
+		len + len_calc.0
+	} }
+}
+
+/// Implements [`Writeable`] for a type serialized as a length-prefixed TLV stream.
+///
+/// This is useful for types that share the TLV-writing format used by
+/// [`impl_ser_tlv_based`] but need a custom read implementation. The field list uses the
+/// same entries accepted by [`write_tlv_fields`], and the macro derives both `write` and
+/// `serialized_length` from that list so the two paths stay aligned.
+///
+/// The `$self` argument names the generated `self` binding, allowing field expressions to refer
+/// to it explicitly.
+///
+/// [`Writeable`]: crate::util::ser::Writeable
+/// [`impl_ser_tlv_based`]: crate::impl_ser_tlv_based
+/// [`write_tlv_fields`]: crate::write_tlv_fields
+macro_rules! impl_writeable_tlv_based {
+	($st: ty, $self: ident, {$(($type: expr, $field: expr, $fieldty: tt)),* $(,)*}) => {
+		impl $crate::util::ser::Writeable for $st {
+			fn write<W: $crate::util::ser::Writer>(&$self, writer: &mut W) -> Result<(), $crate::io::Error> {
+				write_tlv_fields!(writer, {
+					$(($type, $field, $fieldty)),*
+				});
+				Ok(())
+			}
+
+			#[inline]
+			fn serialized_length(&$self) -> usize {
+				$crate::_tlv_fields_serialized_length!({
+					$(($type, $field, $fieldty)),*
+				})
+			}
+		}
+	}
+}
+
 /// Reads a prefix added by [`write_ver_prefix`], above. Takes the current version of the
 /// serialization logic for this object. This is compared against the
 /// `$min_version_that_can_read_this` added by [`write_ver_prefix`].
@@ -1095,18 +1147,9 @@ macro_rules! impl_ser_tlv_based {
 
 			#[inline]
 			fn serialized_length(&self) -> usize {
-				use $crate::util::ser::BigSize;
-				let len = {
-					#[allow(unused_mut)]
-					let mut len = $crate::util::ser::LengthCalculatingWriter(0);
-					$(
-						$crate::_get_varint_length_prefixed_tlv_length!(len, $type, &self.$field, $fieldty, self);
-					)*
-					len.0
-				};
-				let mut len_calc = $crate::util::ser::LengthCalculatingWriter(0);
-				BigSize(len as u64).write(&mut len_calc).expect("No in-memory data may fail to serialize");
-				len + len_calc.0
+				$crate::_tlv_fields_serialized_length!({
+					$(($type, self.$field, $fieldty, self)),*
+				})
 			}
 		}
 

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -1059,7 +1059,7 @@ macro_rules! _decode_and_build {
 ///
 /// For example,
 /// ```
-/// # use lightning::impl_writeable_tlv_based;
+/// # use lightning::impl_ser_tlv_based;
 /// struct LightningMessage {
 /// 	tlv_integer: u32,
 /// 	tlv_default_integer: u32,
@@ -1068,7 +1068,7 @@ macro_rules! _decode_and_build {
 ///		tlv_upgraded_integer: u32,
 /// }
 ///
-/// impl_writeable_tlv_based!(LightningMessage, {
+/// impl_ser_tlv_based!(LightningMessage, {
 /// 	(0, tlv_integer, required),
 /// 	(1, tlv_default_integer, (default_value, 7)),
 /// 	(2, tlv_optional_integer, option),
@@ -1083,7 +1083,7 @@ macro_rules! _decode_and_build {
 /// [`Writeable`]: crate::util::ser::Writeable
 /// [`Vec`]: crate::prelude::Vec
 #[macro_export]
-macro_rules! impl_writeable_tlv_based {
+macro_rules! impl_ser_tlv_based {
 	($st: ident, {$(($type: expr, $field: ident, $fieldty: tt)),* $(,)*}) => {
 		impl $crate::util::ser::Writeable for $st {
 			fn write<W: $crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), $crate::io::Error> {
@@ -1206,9 +1206,9 @@ macro_rules! _impl_writeable_tlv_based_enum_common {
 	($st: ident, $(($variant_id: expr, $variant_name: ident) =>
 		{$(($type: expr, $field: ident, $fieldty: tt)),* $(,)*}
 	),* $(,)?;
-	// $tuple_variant_* are only passed from `impl_writeable_tlv_based_enum_*_legacy`
+	// $tuple_variant_* are only passed from legacy enum macros.
 	$(($tuple_variant_id: expr, $tuple_variant_name: ident)),* $(,)?;
-	// $length_prefixed_* are only passed from `impl_writeable_tlv_based_enum_*` non-`legacy`
+	// $length_prefixed_* are only passed from non-legacy enum macros.
 	$(($length_prefixed_tuple_variant_id: expr, $length_prefixed_tuple_variant_name: ident)),* $(,)?) => {
 		impl $crate::util::ser::Writeable for $st {
 			fn write<W: $crate::util::ser::Writer>(&self, writer: &mut W) -> Result<(), $crate::io::Error> {
@@ -1256,8 +1256,8 @@ macro_rules! _impl_writeable_tlv_based_enum_common {
 ///   TupleVariantA(),
 ///   TupleVariantB(Vec<u8>),
 /// }
-/// # use lightning::impl_writeable_tlv_based_enum;
-/// impl_writeable_tlv_based_enum!(EnumName,
+/// # use lightning::impl_ser_tlv_based_enum;
+/// impl_ser_tlv_based_enum!(EnumName,
 ///   (0, StructVariantA) => {(0, required_variant_field, required), (1, optional_variant_field, option)},
 ///   (1, StructVariantB) => {(0, variant_field_a, required), (1, variant_field_b, required), (2, variant_vec_field, optional_vec)},
 ///   (2, TupleVariantA) => {}, // Note that empty tuple variants have to use the struct syntax due to rust limitations
@@ -1276,7 +1276,7 @@ macro_rules! _impl_writeable_tlv_based_enum_common {
 /// [`Writeable`]: crate::util::ser::Writeable
 /// [`DecodeError::UnknownRequiredFeature`]: crate::ln::msgs::DecodeError::UnknownRequiredFeature
 #[macro_export]
-macro_rules! impl_writeable_tlv_based_enum {
+macro_rules! impl_ser_tlv_based_enum {
 	($st: ident,
 		$(($variant_id: expr, $variant_name: ident) =>
 			{$(($type: expr, $field: ident, $fieldty: tt)),* $(,)*}
@@ -1321,9 +1321,9 @@ macro_rules! impl_writeable_tlv_based_enum {
 	}
 }
 
-/// See [`impl_writeable_tlv_based_enum`] and use that unless backwards-compatibility with tuple
+/// See [`impl_ser_tlv_based_enum`] and use that unless backwards-compatibility with tuple
 /// variants is required.
-macro_rules! impl_writeable_tlv_based_enum_legacy {
+macro_rules! impl_ser_tlv_based_enum_legacy {
 	($st: ident, $(($variant_id: expr, $variant_name: ident) =>
 		{$(($type: expr, $field: ident, $fieldty: tt)),* $(,)*}
 	),* $(,)*;
@@ -1359,7 +1359,7 @@ macro_rules! impl_writeable_tlv_based_enum_legacy {
 /// Implement [`MaybeReadable`] and [`Writeable`] for an enum, with struct variants stored as TLVs and
 /// tuple variants stored directly.
 ///
-/// This is largely identical to [`impl_writeable_tlv_based_enum`], except that odd variants will
+/// This is largely identical to [`impl_ser_tlv_based_enum`], except that odd variants will
 /// return `Ok(None)` instead of `Err(`[`DecodeError::UnknownRequiredFeature`]`)`. It should generally be preferred
 /// when [`MaybeReadable`] is practical instead of just [`Readable`] as it provides an upgrade path for
 /// new variants to be added which are simply ignored by existing clients.
@@ -1620,7 +1620,7 @@ mod tests {
 		other_field: u32,
 	}
 
-	impl_writeable_tlv_based!(OuterStructOptionalEnumV1, {
+	impl_ser_tlv_based!(OuterStructOptionalEnumV1, {
 		(0, inner_enum, upgradable_option),
 		(2, other_field, required),
 	});
@@ -1645,7 +1645,7 @@ mod tests {
 		other_field: u32,
 	}
 
-	impl_writeable_tlv_based!(OuterStructOptionalEnumV2, {
+	impl_ser_tlv_based!(OuterStructOptionalEnumV2, {
 		(0, inner_enum, upgradable_option),
 		(2, other_field, required),
 	});
@@ -1696,7 +1696,7 @@ mod tests {
 		other_field: u32,
 	}
 
-	impl_writeable_tlv_based!(OuterOuterStruct, {
+	impl_ser_tlv_based!(OuterOuterStruct, {
 		(0, outer_struct, upgradable_option),
 		(2, other_field, required),
 	});
@@ -1964,7 +1964,7 @@ mod tests {
 		// old_field: u8,
 		new_field: (u8, u8),
 	}
-	impl_writeable_tlv_based!(ExpandedField, {
+	impl_ser_tlv_based!(ExpandedField, {
 		(0, old_field, (legacy, u8, |_| Ok(()), |us: &ExpandedField| Some(us.new_field.0))),
 		(1, new_field, (default_value, (old_field.ok_or(DecodeError::InvalidValue)?, 0))),
 	});
@@ -1990,7 +1990,7 @@ mod tests {
 	struct DefaultValueVecStruct {
 		items: Vec<u32>,
 	}
-	impl_writeable_tlv_based!(DefaultValueVecStruct, {
+	impl_ser_tlv_based!(DefaultValueVecStruct, {
 		(1, items, (default_value_vec, vec![4, 5, 6])),
 	});
 
@@ -2018,7 +2018,7 @@ mod tests {
 	struct LegacyToVecStruct {
 		new_items: Vec<u32>,
 	}
-	impl_writeable_tlv_based!(LegacyToVecStruct, {
+	impl_ser_tlv_based!(LegacyToVecStruct, {
 		(0, old_item, (legacy, u32, |_| Ok(()),
 			|us: &LegacyToVecStruct| us.new_items.first().copied())),
 		(1, new_items, (default_value_vec,
@@ -2047,7 +2047,7 @@ mod tests {
 		struct MyCustomStruct {
 			tlv_field: Vec<u8>,
 		}
-		impl_writeable_tlv_based!(MyCustomStruct, {
+		impl_ser_tlv_based!(MyCustomStruct, {
 			(0, tlv_field, (required_vec, encoding: (Vec<u8>, WithoutLength))),
 		});
 

--- a/lightning/src/util/sweep.rs
+++ b/lightning/src/util/sweep.rs
@@ -97,7 +97,7 @@ impl TrackedSpendableOutput {
 	}
 }
 
-impl_writeable_tlv_based!(TrackedSpendableOutput, {
+impl_ser_tlv_based!(TrackedSpendableOutput, {
 	(0, descriptor, required),
 	(2, channel_id, option),
 	(3, counterparty_node_id, option),
@@ -309,7 +309,7 @@ impl OutputSpendStatus {
 	}
 }
 
-impl_writeable_tlv_based_enum!(OutputSpendStatus,
+impl_ser_tlv_based_enum!(OutputSpendStatus,
 	(0, PendingInitialBroadcast) => {
 		(0, delayed_until_height, option),
 	},
@@ -864,7 +864,7 @@ struct SweeperState {
 	dirty: bool,
 }
 
-impl_writeable_tlv_based!(SweeperState, {
+impl_ser_tlv_based!(SweeperState, {
 	(0, outputs, required_vec),
 	(2, best_block, required),
 	(_unused, dirty, (static_value, false)),

--- a/lightning/src/util/wallet_utils.rs
+++ b/lightning/src/util/wallet_utils.rs
@@ -79,7 +79,7 @@ pub struct Utxo {
 	pub sequence: Sequence,
 }
 
-impl_writeable_tlv_based!(Utxo, {
+impl_ser_tlv_based!(Utxo, {
 	(1, outpoint, required),
 	(3, output, required),
 	(5, satisfaction_weight, required),
@@ -164,7 +164,7 @@ pub struct ConfirmedUtxo {
 	pub(crate) prevtx: Transaction,
 }
 
-impl_writeable_tlv_based!(ConfirmedUtxo, {
+impl_ser_tlv_based!(ConfirmedUtxo, {
 	(1, utxo, required),
 	(3, _sequence, (legacy, Sequence,
 		|read_val: Option<&Sequence>| {


### PR DESCRIPTION
Recent splice fuzzing coverage made it clear that some chanmon consistency inputs spend a surprising amount of time encoding snapshots. This PR tightens the serialization length path used by those snapshots.

Slow fuzz byte string used while checking this:

`a1a0a3ffa2a1ffffa2a1ff00a2a1ffa2a1a0a3ffa2a1ff19ffffffffffffffac`

For that byte string, median real time over 5 runs with target output suppressed:

| Profile | Pre changes | Post changes |
|---|---:|---:|
| Debug | 17.17s | 3.61s |
| Release | 0.60s | 0.24s |