### PR TITLE
Allow stdin fuzz targets to suppress logs

### DIFF
--- a/fuzz/fuzz-fake-hashes/src/bin/base32_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/base32_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	base32_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		base32_test(&data, test_logger::DevNull {});
+	} else {
+		base32_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/bech32_parse_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/bech32_parse_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	bech32_parse_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		bech32_parse_test(&data, test_logger::DevNull {});
+	} else {
+		bech32_parse_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/bolt11_deser_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/bolt11_deser_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	bolt11_deser_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		bolt11_deser_test(&data, test_logger::DevNull {});
+	} else {
+		bolt11_deser_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/chanmon_deser_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/chanmon_deser_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	chanmon_deser_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		chanmon_deser_test(&data, test_logger::DevNull {});
+	} else {
+		chanmon_deser_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/feature_flags_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/feature_flags_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	feature_flags_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		feature_flags_test(&data, test_logger::DevNull {});
+	} else {
+		feature_flags_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/fromstr_to_netaddress_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/fromstr_to_netaddress_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	fromstr_to_netaddress_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		fromstr_to_netaddress_test(&data, test_logger::DevNull {});
+	} else {
+		fromstr_to_netaddress_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/fs_store_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/fs_store_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	fs_store_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		fs_store_test(&data, test_logger::DevNull {});
+	} else {
+		fs_store_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/full_stack_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/full_stack_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	full_stack_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		full_stack_test(&data, test_logger::DevNull {});
+	} else {
+		full_stack_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/gossip_discovery_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/gossip_discovery_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	gossip_discovery_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		gossip_discovery_test(&data, test_logger::DevNull {});
+	} else {
+		gossip_discovery_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/indexedmap_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/indexedmap_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	indexedmap_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		indexedmap_test(&data, test_logger::DevNull {});
+	} else {
+		indexedmap_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/invoice_deser_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/invoice_deser_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	invoice_deser_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		invoice_deser_test(&data, test_logger::DevNull {});
+	} else {
+		invoice_deser_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/invoice_request_deser_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/invoice_request_deser_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	invoice_request_deser_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		invoice_request_deser_test(&data, test_logger::DevNull {});
+	} else {
+		invoice_request_deser_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/lsps_message_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/lsps_message_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	lsps_message_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		lsps_message_test(&data, test_logger::DevNull {});
+	} else {
+		lsps_message_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_accept_channel_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_accept_channel_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_accept_channel_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_accept_channel_test(&data, test_logger::DevNull {});
+	} else {
+		msg_accept_channel_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_accept_channel_v2_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_accept_channel_v2_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_accept_channel_v2_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_accept_channel_v2_test(&data, test_logger::DevNull {});
+	} else {
+		msg_accept_channel_v2_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_announcement_signatures_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_announcement_signatures_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_announcement_signatures_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_announcement_signatures_test(&data, test_logger::DevNull {});
+	} else {
+		msg_announcement_signatures_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_blinded_message_path_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_blinded_message_path_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_blinded_message_path_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_blinded_message_path_test(&data, test_logger::DevNull {});
+	} else {
+		msg_blinded_message_path_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_channel_announcement_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_channel_announcement_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_announcement_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_channel_announcement_test(&data, test_logger::DevNull {});
+	} else {
+		msg_channel_announcement_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_channel_details_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_channel_details_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_details_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_channel_details_test(&data, test_logger::DevNull {});
+	} else {
+		msg_channel_details_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_channel_ready_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_channel_ready_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_ready_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_channel_ready_test(&data, test_logger::DevNull {});
+	} else {
+		msg_channel_ready_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_channel_reestablish_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_channel_reestablish_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_reestablish_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_channel_reestablish_test(&data, test_logger::DevNull {});
+	} else {
+		msg_channel_reestablish_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_channel_update_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_channel_update_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_channel_update_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_channel_update_test(&data, test_logger::DevNull {});
+	} else {
+		msg_channel_update_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_closing_complete_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_closing_complete_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_closing_complete_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_closing_complete_test(&data, test_logger::DevNull {});
+	} else {
+		msg_closing_complete_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_closing_sig_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_closing_sig_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_closing_sig_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_closing_sig_test(&data, test_logger::DevNull {});
+	} else {
+		msg_closing_sig_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_closing_signed_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_closing_signed_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_closing_signed_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_closing_signed_test(&data, test_logger::DevNull {});
+	} else {
+		msg_closing_signed_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_commitment_signed_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_commitment_signed_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_commitment_signed_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_commitment_signed_test(&data, test_logger::DevNull {});
+	} else {
+		msg_commitment_signed_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_decoded_onion_error_packet_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_decoded_onion_error_packet_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_decoded_onion_error_packet_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_decoded_onion_error_packet_test(&data, test_logger::DevNull {});
+	} else {
+		msg_decoded_onion_error_packet_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_error_message_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_error_message_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_error_message_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_error_message_test(&data, test_logger::DevNull {});
+	} else {
+		msg_error_message_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_funding_created_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_funding_created_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_funding_created_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_funding_created_test(&data, test_logger::DevNull {});
+	} else {
+		msg_funding_created_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_funding_signed_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_funding_signed_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_funding_signed_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_funding_signed_test(&data, test_logger::DevNull {});
+	} else {
+		msg_funding_signed_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_gossip_timestamp_filter_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_gossip_timestamp_filter_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_gossip_timestamp_filter_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_gossip_timestamp_filter_test(&data, test_logger::DevNull {});
+	} else {
+		msg_gossip_timestamp_filter_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_init_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_init_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_init_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_init_test(&data, test_logger::DevNull {});
+	} else {
+		msg_init_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_node_announcement_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_node_announcement_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_node_announcement_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_node_announcement_test(&data, test_logger::DevNull {});
+	} else {
+		msg_node_announcement_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_open_channel_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_open_channel_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_open_channel_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_open_channel_test(&data, test_logger::DevNull {});
+	} else {
+		msg_open_channel_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_open_channel_v2_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_open_channel_v2_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_open_channel_v2_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_open_channel_v2_test(&data, test_logger::DevNull {});
+	} else {
+		msg_open_channel_v2_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_ping_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_ping_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_ping_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_ping_test(&data, test_logger::DevNull {});
+	} else {
+		msg_ping_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_pong_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_pong_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_pong_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_pong_test(&data, test_logger::DevNull {});
+	} else {
+		msg_pong_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_query_channel_range_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_query_channel_range_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_query_channel_range_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_query_channel_range_test(&data, test_logger::DevNull {});
+	} else {
+		msg_query_channel_range_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_query_short_channel_ids_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_query_short_channel_ids_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_query_short_channel_ids_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_query_short_channel_ids_test(&data, test_logger::DevNull {});
+	} else {
+		msg_query_short_channel_ids_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_reply_channel_range_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_reply_channel_range_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_reply_channel_range_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_reply_channel_range_test(&data, test_logger::DevNull {});
+	} else {
+		msg_reply_channel_range_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_reply_short_channel_ids_end_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_reply_short_channel_ids_end_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_reply_short_channel_ids_end_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_reply_short_channel_ids_end_test(&data, test_logger::DevNull {});
+	} else {
+		msg_reply_short_channel_ids_end_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_revoke_and_ack_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_revoke_and_ack_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_revoke_and_ack_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_revoke_and_ack_test(&data, test_logger::DevNull {});
+	} else {
+		msg_revoke_and_ack_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_shutdown_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_shutdown_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_shutdown_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_shutdown_test(&data, test_logger::DevNull {});
+	} else {
+		msg_shutdown_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_splice_ack_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_splice_ack_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_splice_ack_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_splice_ack_test(&data, test_logger::DevNull {});
+	} else {
+		msg_splice_ack_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_splice_init_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_splice_init_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_splice_init_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_splice_init_test(&data, test_logger::DevNull {});
+	} else {
+		msg_splice_init_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_splice_locked_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_splice_locked_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_splice_locked_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_splice_locked_test(&data, test_logger::DevNull {});
+	} else {
+		msg_splice_locked_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_stfu_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_stfu_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_stfu_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_stfu_test(&data, test_logger::DevNull {});
+	} else {
+		msg_stfu_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_abort_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_abort_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_abort_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_abort_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_abort_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_ack_rbf_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_ack_rbf_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_ack_rbf_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_ack_rbf_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_ack_rbf_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_add_input_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_add_input_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_add_input_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_add_input_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_add_input_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_add_output_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_add_output_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_add_output_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_add_output_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_add_output_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_complete_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_complete_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_complete_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_complete_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_complete_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_init_rbf_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_init_rbf_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_init_rbf_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_init_rbf_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_init_rbf_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_remove_input_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_remove_input_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_remove_input_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_remove_input_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_remove_input_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_remove_output_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_remove_output_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_remove_output_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_remove_output_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_remove_output_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_tx_signatures_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_tx_signatures_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_tx_signatures_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_tx_signatures_test(&data, test_logger::DevNull {});
+	} else {
+		msg_tx_signatures_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_update_add_htlc_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_update_add_htlc_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_add_htlc_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_update_add_htlc_test(&data, test_logger::DevNull {});
+	} else {
+		msg_update_add_htlc_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_update_fail_htlc_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_update_fail_htlc_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_fail_htlc_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_update_fail_htlc_test(&data, test_logger::DevNull {});
+	} else {
+		msg_update_fail_htlc_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_update_fail_malformed_htlc_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_update_fail_malformed_htlc_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_fail_malformed_htlc_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_update_fail_malformed_htlc_test(&data, test_logger::DevNull {});
+	} else {
+		msg_update_fail_malformed_htlc_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_update_fee_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_update_fee_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_fee_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_update_fee_test(&data, test_logger::DevNull {});
+	} else {
+		msg_update_fee_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/msg_update_fulfill_htlc_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/msg_update_fulfill_htlc_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	msg_update_fulfill_htlc_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		msg_update_fulfill_htlc_test(&data, test_logger::DevNull {});
+	} else {
+		msg_update_fulfill_htlc_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/offer_deser_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/offer_deser_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	offer_deser_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		offer_deser_test(&data, test_logger::DevNull {});
+	} else {
+		offer_deser_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/onion_hop_data_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/onion_hop_data_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	onion_hop_data_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		onion_hop_data_test(&data, test_logger::DevNull {});
+	} else {
+		onion_hop_data_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/onion_message_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/onion_message_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	onion_message_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		onion_message_test(&data, test_logger::DevNull {});
+	} else {
+		onion_message_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/peer_crypt_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/peer_crypt_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	peer_crypt_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		peer_crypt_test(&data, test_logger::DevNull {});
+	} else {
+		peer_crypt_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/process_network_graph_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/process_network_graph_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	process_network_graph_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		process_network_graph_test(&data, test_logger::DevNull {});
+	} else {
+		process_network_graph_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/process_onion_failure_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/process_onion_failure_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	process_onion_failure_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		process_onion_failure_test(&data, test_logger::DevNull {});
+	} else {
+		process_onion_failure_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/refund_deser_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/refund_deser_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	refund_deser_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		refund_deser_test(&data, test_logger::DevNull {});
+	} else {
+		refund_deser_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/router_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/router_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	router_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		router_test(&data, test_logger::DevNull {});
+	} else {
+		router_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/static_invoice_deser_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/static_invoice_deser_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	static_invoice_deser_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		static_invoice_deser_test(&data, test_logger::DevNull {});
+	} else {
+		static_invoice_deser_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-fake-hashes/src/bin/zbase32_target.rs
+++ b/fuzz/fuzz-fake-hashes/src/bin/zbase32_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	zbase32_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		zbase32_test(&data, test_logger::DevNull {});
+	} else {
+		zbase32_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/fuzz-real-hashes/src/bin/chanmon_consistency_target.rs
+++ b/fuzz/fuzz-real-hashes/src/bin/chanmon_consistency_target.rs
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	chanmon_consistency_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		chanmon_consistency_test(&data, test_logger::DevNull {});
+	} else {
+		chanmon_consistency_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]

--- a/fuzz/src/bin/target_template.txt
+++ b/fuzz/src/bin/target_template.txt
@@ -71,7 +71,11 @@ fn main() {
 
 	let mut data = Vec::with_capacity(8192);
 	std::io::stdin().read_to_end(&mut data).unwrap();
-	TARGET_NAME_test(&data, test_logger::Stdout {});
+	if std::env::var_os("LDK_FUZZ_SUPPRESS_LOGS").is_some() {
+		TARGET_NAME_test(&data, test_logger::DevNull {});
+	} else {
+		TARGET_NAME_test(&data, test_logger::Stdout {});
+	}
 }
 
 #[test]


### PR DESCRIPTION
Add an environment-variable switch that lets stdin fuzz targets use the dev-null test logger. This keeps direct invocations verbose by default, while external runners can opt into quieter passing-case replays.

I use stdin_fuzz also to run big sets of test cases using a runner that parallelizes and also continues on failure to examine the rest. Cargo test and test_cases dir approach do not work for that. The logging is a big slow down.