### PR TITLE
Splice fixes for `chanmon_consistency` fuzz target

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -2814,9 +2814,20 @@ impl<'a, Out: Output + MaybeSend + MaybeSync> Harness<'a, Out> {
 					..
 				} => {
 					let signed_tx = nodes[node_idx].wallet.sign_tx(unsigned_transaction).unwrap();
-					nodes[node_idx]
-						.funding_transaction_signed(&channel_id, &counterparty_node_id, signed_tx)
-						.unwrap();
+					match nodes[node_idx].funding_transaction_signed(
+						&channel_id,
+						&counterparty_node_id,
+						signed_tx,
+					) {
+						Ok(()) => {},
+						Err(APIError::APIMisuseError { ref err })
+							if err.contains("not expecting funding signatures") =>
+						{
+							// A queued signing event can be invalidated by a later `tx_abort`
+							// before the application handles it.
+						},
+						Err(e) => panic!("{e:?}"),
+					}
 				},
 				events::Event::SpliceNegotiated { new_funding_txo, .. } => {
 					let mut txs = nodes[node_idx].broadcaster.txn_broadcasted.borrow_mut();

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -102,6 +102,7 @@ use std::sync::atomic;
 use std::sync::{Arc, Mutex};
 
 const MAX_FEE: u32 = 10_000;
+const MAX_SETTLE_ITERATIONS: usize = 256;
 struct FuzzEstimator {
 	ret_val: atomic::AtomicU32,
 }
@@ -2865,9 +2866,9 @@ impl<'a, Out: Output + MaybeSend + MaybeSync> Harness<'a, Out> {
 	fn process_all_events(&mut self) {
 		let mut last_pass_no_updates = false;
 		for i in 0..std::usize::MAX {
-			if i == 100 {
+			if i == MAX_SETTLE_ITERATIONS {
 				panic!(
-					"It may take may iterations to settle the state, but it should not take forever"
+					"It may take many iterations to settle the state, but it should not take forever"
 				);
 			}
 			let mut made_progress = self.checkpoint_manager_persistences();


### PR DESCRIPTION
While this target found several issues in our production code, there were also issues with the fuzz target itself, which this PR addresses. It fixes the following payloads from #4363:
```
00a6a61b1b1b211b211e1b1b1b1b211b211b211e1b1b261b1b211b1ba1
e8a3a3201ba31b201ba3a3201ba3a3201b201ba3a3201b040d80c113ff
a3cd00a2a1181021181118101810211811181000bb10181021ffff38
ffa1ffffa0414da373ff
a2cd00a2a118102118602700cda2a000a100733a3a6b73a3ffb4ffb7a1
ffa1ffacab211b11baff
88a4a6ffacadab21bcff
```