### PR TITLE
Add async variant of `MigratableKVStore`

### DIFF
--- a/lightning-persister/src/fs_store/common.rs
+++ b/lightning-persister/src/fs_store/common.rs
@@ -470,6 +470,94 @@ impl FilesystemStoreInner {
 
 		Ok(keys)
 	}
+
+	fn list_all_keys(
+		&self, use_empty_ns_dir: bool,
+	) -> Result<Vec<(String, String, String)>, lightning::io::Error> {
+		let prefixed_dest = &self.data_dir;
+		if !prefixed_dest.exists() {
+			return Ok(Vec::new());
+		}
+
+		let mut keys = Vec::new();
+
+		'primary_loop: for primary_entry in fs::read_dir(prefixed_dest)? {
+			let primary_entry = primary_entry?;
+			let primary_path = primary_entry.path();
+			if dir_entry_is_store_artifact(&primary_path) {
+				continue 'primary_loop;
+			}
+
+			if dir_entry_is_key(&primary_entry)? {
+				let primary_namespace = String::new();
+				let secondary_namespace = String::new();
+				let key = get_key_from_dir_entry_path(&primary_path, prefixed_dest, false)?;
+				keys.push((primary_namespace, secondary_namespace, key));
+				continue 'primary_loop;
+			}
+
+			// The primary_entry is actually also a directory.
+			'secondary_loop: for secondary_entry in fs::read_dir(&primary_path)? {
+				let secondary_entry = secondary_entry?;
+				let secondary_path = secondary_entry.path();
+				if dir_entry_is_store_artifact(&secondary_path) {
+					continue 'secondary_loop;
+				}
+
+				if dir_entry_is_key(&secondary_entry)? {
+					let primary_namespace = get_key_from_dir_entry_path(
+						&primary_path,
+						prefixed_dest,
+						use_empty_ns_dir,
+					)?;
+					let secondary_namespace = String::new();
+					let key = get_key_from_dir_entry_path(&secondary_path, &primary_path, false)?;
+					keys.push((primary_namespace, secondary_namespace, key));
+					continue 'secondary_loop;
+				}
+
+				// The secondary_entry is actually also a directory.
+				for tertiary_entry in fs::read_dir(&secondary_path)? {
+					let tertiary_entry = tertiary_entry?;
+					let tertiary_path = tertiary_entry.path();
+					if dir_entry_is_store_artifact(&tertiary_path) {
+						continue;
+					}
+
+					if dir_entry_is_key(&tertiary_entry)? {
+						let primary_namespace = get_key_from_dir_entry_path(
+							&primary_path,
+							prefixed_dest,
+							use_empty_ns_dir,
+						)?;
+						let secondary_namespace = get_key_from_dir_entry_path(
+							&secondary_path,
+							&primary_path,
+							use_empty_ns_dir,
+						)?;
+						let key =
+							get_key_from_dir_entry_path(&tertiary_path, &secondary_path, false)?;
+						keys.push((primary_namespace, secondary_namespace, key));
+					} else {
+						debug_assert!(
+							false,
+							"Failed to list keys of path {}: only two levels of namespaces are supported",
+							PrintableString(tertiary_path.to_str().unwrap_or_default())
+						);
+						let msg = format!(
+							"Failed to list keys of path {}: only two levels of namespaces are supported",
+							PrintableString(tertiary_path.to_str().unwrap_or_default())
+						);
+						return Err(lightning::io::Error::new(
+							lightning::io::ErrorKind::Other,
+							msg,
+						));
+					}
+				}
+			}
+		}
+		Ok(keys)
+	}
 }
 
 impl FilesystemStoreState {
@@ -640,92 +728,26 @@ impl FilesystemStoreState {
 		}
 	}
 
+	#[cfg(feature = "tokio")]
+	pub(crate) fn list_all_keys_async(
+		&self, use_empty_ns_dir: bool,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, lightning::io::Error>> + 'static + Send
+	{
+		let this = Arc::clone(&self.inner);
+
+		async move {
+			tokio::task::spawn_blocking(move || this.list_all_keys(use_empty_ns_dir))
+				.await
+				.unwrap_or_else(|e| {
+					Err(lightning::io::Error::new(lightning::io::ErrorKind::Other, e))
+				})
+		}
+	}
+
 	pub(crate) fn list_all_keys_impl(
 		&self, use_empty_ns_dir: bool,
 	) -> Result<Vec<(String, String, String)>, lightning::io::Error> {
-		let prefixed_dest = &self.inner.data_dir;
-		if !prefixed_dest.exists() {
-			return Ok(Vec::new());
-		}
-
-		let mut keys = Vec::new();
-
-		'primary_loop: for primary_entry in fs::read_dir(prefixed_dest)? {
-			let primary_entry = primary_entry?;
-			let primary_path = primary_entry.path();
-			if dir_entry_is_store_artifact(&primary_path) {
-				continue 'primary_loop;
-			}
-
-			if dir_entry_is_key(&primary_entry)? {
-				let primary_namespace = String::new();
-				let secondary_namespace = String::new();
-				let key = get_key_from_dir_entry_path(&primary_path, prefixed_dest, false)?;
-				keys.push((primary_namespace, secondary_namespace, key));
-				continue 'primary_loop;
-			}
-
-			// The primary_entry is actually also a directory.
-			'secondary_loop: for secondary_entry in fs::read_dir(&primary_path)? {
-				let secondary_entry = secondary_entry?;
-				let secondary_path = secondary_entry.path();
-				if dir_entry_is_store_artifact(&secondary_path) {
-					continue 'secondary_loop;
-				}
-
-				if dir_entry_is_key(&secondary_entry)? {
-					let primary_namespace = get_key_from_dir_entry_path(
-						&primary_path,
-						prefixed_dest,
-						use_empty_ns_dir,
-					)?;
-					let secondary_namespace = String::new();
-					let key = get_key_from_dir_entry_path(&secondary_path, &primary_path, false)?;
-					keys.push((primary_namespace, secondary_namespace, key));
-					continue 'secondary_loop;
-				}
-
-				// The secondary_entry is actually also a directory.
-				for tertiary_entry in fs::read_dir(&secondary_path)? {
-					let tertiary_entry = tertiary_entry?;
-					let tertiary_path = tertiary_entry.path();
-					if dir_entry_is_store_artifact(&tertiary_path) {
-						continue;
-					}
-
-					if dir_entry_is_key(&tertiary_entry)? {
-						let primary_namespace = get_key_from_dir_entry_path(
-							&primary_path,
-							prefixed_dest,
-							use_empty_ns_dir,
-						)?;
-						let secondary_namespace = get_key_from_dir_entry_path(
-							&secondary_path,
-							&primary_path,
-							use_empty_ns_dir,
-						)?;
-						let key =
-							get_key_from_dir_entry_path(&tertiary_path, &secondary_path, false)?;
-						keys.push((primary_namespace, secondary_namespace, key));
-					} else {
-						debug_assert!(
-							false,
-							"Failed to list keys of path {}: only two levels of namespaces are supported",
-							PrintableString(tertiary_path.to_str().unwrap_or_default())
-						);
-						let msg = format!(
-							"Failed to list keys of path {}: only two levels of namespaces are supported",
-							PrintableString(tertiary_path.to_str().unwrap_or_default())
-						);
-						return Err(lightning::io::Error::new(
-							lightning::io::ErrorKind::Other,
-							msg,
-						));
-					}
-				}
-			}
-		}
-		Ok(keys)
+		self.inner.list_all_keys(use_empty_ns_dir)
 	}
 }
 

--- a/lightning-persister/src/fs_store/v1.rs
+++ b/lightning-persister/src/fs_store/v1.rs
@@ -94,9 +94,21 @@ impl MigratableKVStoreSync for FilesystemStore {
 	}
 }
 
+#[cfg(feature = "tokio")]
+impl lightning::util::persist::MigratableKVStore for FilesystemStore {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, lightning::io::Error>> + 'static + Send
+	{
+		self.state.list_all_keys_async(false)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+	#[cfg(feature = "tokio")]
+	use crate::test_utils::do_test_data_migration_async;
 	use crate::test_utils::{
 		do_read_write_remove_list_persist, do_test_data_migration, do_test_store,
 	};
@@ -219,6 +231,20 @@ mod tests {
 		let mut target_store = FilesystemStore::new(target_temp_path);
 
 		do_test_data_migration(&mut source_store, &mut target_store);
+	}
+
+	#[cfg(feature = "tokio")]
+	#[tokio::test]
+	async fn test_data_migration_async() {
+		let mut source_temp_path = std::env::temp_dir();
+		source_temp_path.push("test_data_migration_source_async");
+		let source_store = FilesystemStore::new(source_temp_path);
+
+		let mut target_temp_path = std::env::temp_dir();
+		target_temp_path.push("test_data_migration_target_async");
+		let target_store = FilesystemStore::new(target_temp_path);
+
+		do_test_data_migration_async(&source_store, &target_store).await;
 	}
 
 	#[test]

--- a/lightning-persister/src/fs_store/v1.rs
+++ b/lightning-persister/src/fs_store/v1.rs
@@ -1,7 +1,7 @@
 //! Objects related to [`FilesystemStore`] live here.
 use crate::fs_store::common::FilesystemStoreState;
 
-use lightning::util::persist::{KVStoreSync, MigratableKVStore};
+use lightning::util::persist::{KVStoreSync, MigratableKVStoreSync};
 
 use std::path::PathBuf;
 
@@ -88,7 +88,7 @@ impl KVStore for FilesystemStore {
 	}
 }
 
-impl MigratableKVStore for FilesystemStore {
+impl MigratableKVStoreSync for FilesystemStore {
 	fn list_all_keys(&self) -> Result<Vec<(String, String, String)>, lightning::io::Error> {
 		self.state.list_all_keys_impl(false)
 	}

--- a/lightning-persister/src/fs_store/v2.rs
+++ b/lightning-persister/src/fs_store/v2.rs
@@ -321,6 +321,16 @@ impl MigratableKVStoreSync for FilesystemStoreV2 {
 	}
 }
 
+#[cfg(feature = "tokio")]
+impl lightning::util::persist::MigratableKVStore for FilesystemStoreV2 {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, lightning::io::Error>> + 'static + Send
+	{
+		self.inner.list_all_keys_async(true)
+	}
+}
+
 /// Formats a page token from mtime (millis since epoch) and key.
 pub(crate) fn format_page_token(mtime_millis: u64, key: &str) -> String {
 	format!("{mtime_millis:016}:{key}")
@@ -351,6 +361,8 @@ pub(crate) fn parse_page_token(token: &str) -> lightning::io::Result<(u64, Strin
 mod tests {
 	use super::*;
 	use crate::fs_store::common::EMPTY_NAMESPACE_DIR;
+	#[cfg(feature = "tokio")]
+	use crate::test_utils::do_test_data_migration_async;
 	use crate::test_utils::{
 		do_read_write_remove_list_persist, do_test_data_migration, do_test_store,
 	};
@@ -443,6 +455,20 @@ mod tests {
 		let mut target_store = FilesystemStoreV2::new(target_temp_path).unwrap();
 
 		do_test_data_migration(&mut source_store, &mut target_store);
+	}
+
+	#[cfg(feature = "tokio")]
+	#[tokio::test]
+	async fn test_data_migration_async() {
+		let mut source_temp_path = std::env::temp_dir();
+		source_temp_path.push("test_data_migration_source_async_v2");
+		let source_store = FilesystemStoreV2::new(source_temp_path).unwrap();
+
+		let mut target_temp_path = std::env::temp_dir();
+		target_temp_path.push("test_data_migration_target_async_v2");
+		let target_store = FilesystemStoreV2::new(target_temp_path).unwrap();
+
+		do_test_data_migration_async(&source_store, &target_store).await;
 	}
 
 	#[test]

--- a/lightning-persister/src/fs_store/v2.rs
+++ b/lightning-persister/src/fs_store/v2.rs
@@ -4,7 +4,7 @@ use crate::fs_store::common::{
 };
 
 use lightning::util::persist::{
-	KVStoreSync, MigratableKVStore, PageToken, PaginatedKVStoreSync, PaginatedListResponse,
+	KVStoreSync, MigratableKVStoreSync, PageToken, PaginatedKVStoreSync, PaginatedListResponse,
 };
 
 use std::fs;
@@ -315,7 +315,7 @@ impl PaginatedKVStore for FilesystemStoreV2 {
 	}
 }
 
-impl MigratableKVStore for FilesystemStoreV2 {
+impl MigratableKVStoreSync for FilesystemStoreV2 {
 	fn list_all_keys(&self) -> Result<Vec<(String, String, String)>, lightning::io::Error> {
 		self.inner.list_all_keys_impl(true)
 	}

--- a/lightning-persister/src/test_utils.rs
+++ b/lightning-persister/src/test_utils.rs
@@ -1,7 +1,7 @@
 use lightning::events::ClosureReason;
 use lightning::ln::functional_test_utils::*;
 use lightning::util::persist::{
-	migrate_kv_store_data, read_channel_monitors, KVStoreSync, MigratableKVStore,
+	migrate_kv_store_data, read_channel_monitors, KVStoreSync, MigratableKVStoreSync,
 	KVSTORE_NAMESPACE_KEY_ALPHABET, KVSTORE_NAMESPACE_KEY_MAX_LEN,
 };
 use lightning::util::test_utils;
@@ -59,7 +59,7 @@ pub(crate) fn do_read_write_remove_list_persist<K: KVStoreSync + RefUnwindSafe>(
 	assert_eq!(listed_keys.len(), 0);
 }
 
-pub(crate) fn do_test_data_migration<S: MigratableKVStore, T: MigratableKVStore>(
+pub(crate) fn do_test_data_migration<S: MigratableKVStoreSync, T: MigratableKVStoreSync>(
 	source_store: &mut S, target_store: &mut T,
 ) {
 	// We fill the source with some bogus keys.

--- a/lightning-persister/src/test_utils.rs
+++ b/lightning-persister/src/test_utils.rs
@@ -59,15 +59,11 @@ pub(crate) fn do_read_write_remove_list_persist<K: KVStoreSync + RefUnwindSafe>(
 	assert_eq!(listed_keys.len(), 0);
 }
 
-pub(crate) fn do_test_data_migration<S: MigratableKVStoreSync, T: MigratableKVStoreSync>(
-	source_store: &mut S, target_store: &mut T,
-) {
-	// We fill the source with some bogus keys.
-	let dummy_data = vec![42u8; 32];
+fn data_migration_test_keys() -> Vec<(String, String, String)> {
 	let num_primary_namespaces = 3;
 	let num_secondary_namespaces = 3;
 	let num_keys = 3;
-	let mut expected_keys = Vec::new();
+	let mut keys = Vec::new();
 	for i in 0..num_primary_namespaces {
 		let primary_namespace = if i == 0 {
 			String::new()
@@ -83,12 +79,24 @@ pub(crate) fn do_test_data_migration<S: MigratableKVStoreSync, T: MigratableKVSt
 			for k in 0..num_keys {
 				let key =
 					format!("testkey{}", KVSTORE_NAMESPACE_KEY_ALPHABET.chars().nth(k).unwrap());
-				source_store
-					.write(&primary_namespace, &secondary_namespace, &key, dummy_data.clone())
-					.unwrap();
-				expected_keys.push((primary_namespace.clone(), secondary_namespace.clone(), key));
+				keys.push((primary_namespace.clone(), secondary_namespace.clone(), key));
 			}
 		}
+	}
+
+	keys
+}
+
+pub(crate) fn do_test_data_migration<S: MigratableKVStoreSync, T: MigratableKVStoreSync>(
+	source_store: &mut S, target_store: &mut T,
+) {
+	// We fill the source with some bogus keys.
+	let dummy_data = vec![42u8; 32];
+	let mut expected_keys = data_migration_test_keys();
+	for (primary_namespace, secondary_namespace, key) in &expected_keys {
+		source_store
+			.write(primary_namespace, secondary_namespace, key, dummy_data.clone())
+			.unwrap();
 	}
 	expected_keys.sort();
 	expected_keys.dedup();
@@ -105,6 +113,47 @@ pub(crate) fn do_test_data_migration<S: MigratableKVStoreSync, T: MigratableKVSt
 
 	for (p, s, k) in expected_keys.iter() {
 		assert_eq!(target_store.read(p, s, k).unwrap(), dummy_data.clone());
+	}
+}
+
+#[cfg(feature = "tokio")]
+pub(crate) async fn do_test_data_migration_async<
+	S: lightning::util::persist::MigratableKVStore,
+	T: lightning::util::persist::MigratableKVStore,
+>(
+	source_store: &S, target_store: &T,
+) {
+	use lightning::util::persist::{migrate_kv_store_data_async, KVStore, MigratableKVStore};
+
+	// We fill the source with some bogus keys.
+	let dummy_data = vec![42u8; 32];
+	let mut expected_keys = data_migration_test_keys();
+	for (primary_namespace, secondary_namespace, key) in &expected_keys {
+		KVStore::write(
+			source_store,
+			primary_namespace,
+			secondary_namespace,
+			key,
+			dummy_data.clone(),
+		)
+		.await
+		.unwrap();
+	}
+	expected_keys.sort();
+	expected_keys.dedup();
+
+	let mut source_list = MigratableKVStore::list_all_keys(source_store).await.unwrap();
+	source_list.sort();
+	assert_eq!(source_list, expected_keys);
+
+	migrate_kv_store_data_async(source_store, target_store).await.unwrap();
+
+	let mut target_list = MigratableKVStore::list_all_keys(target_store).await.unwrap();
+	target_list.sort();
+	assert_eq!(target_list, expected_keys);
+
+	for (p, s, k) in expected_keys.iter() {
+		assert_eq!(KVStore::read(target_store, p, s, k).await.unwrap(), dummy_data.clone());
 	}
 }
 

--- a/lightning/src/util/persist.rs
+++ b/lightning/src/util/persist.rs
@@ -567,6 +567,128 @@ pub trait MigratableKVStoreSync: KVStoreSync {
 	fn list_all_keys(&self) -> Result<Vec<(String, String, String)>, io::Error>;
 }
 
+/// Provides additional interface methods that are required for [`KVStore`]-to-[`KVStore`]
+/// data migration.
+///
+/// This is not exported to bindings users as async is only supported in Rust.
+pub trait MigratableKVStore: KVStore {
+	/// Returns *all* known keys as a list of `primary_namespace`, `secondary_namespace`, `key` tuples.
+	///
+	/// This is useful for migrating data from [`KVStore`] implementation to [`KVStore`]
+	/// implementation.
+	///
+	/// Must exhaustively return all entries known to the store to ensure no data is missed, but
+	/// may return the items in arbitrary order.
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, io::Error>> + 'static + MaybeSend;
+}
+
+impl<K> MigratableKVStore for K
+where
+	K: Deref,
+	K::Target: MigratableKVStore,
+{
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, io::Error>> + 'static + MaybeSend
+	{
+		self.deref().list_all_keys()
+	}
+}
+
+/// This is not exported to bindings users as async is only supported in Rust.
+impl<K: Deref> MigratableKVStore for KVStoreSyncWrapper<K>
+where
+	K::Target: MigratableKVStoreSync,
+{
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<(String, String, String)>, io::Error>> + 'static + MaybeSend
+	{
+		let res = self.0.list_all_keys();
+
+		async move { res }
+	}
+}
+
+type MigrationKey = (String, String, String);
+
+trait MigrationKVStore {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<MigrationKey>, io::Error>> + MaybeSend;
+	fn read(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str,
+	) -> impl Future<Output = Result<Vec<u8>, io::Error>> + MaybeSend;
+	fn write(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: Vec<u8>,
+	) -> impl Future<Output = Result<(), io::Error>> + MaybeSend;
+}
+
+struct MigrationKVStoreSyncAdapter<'a, K: ?Sized>(&'a K);
+
+impl<K: MigratableKVStoreSync + ?Sized> MigrationKVStore for MigrationKVStoreSyncAdapter<'_, K> {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<MigrationKey>, io::Error>> + MaybeSend {
+		let res = MigratableKVStoreSync::list_all_keys(self.0);
+
+		async move { res }
+	}
+
+	fn read(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str,
+	) -> impl Future<Output = Result<Vec<u8>, io::Error>> + MaybeSend {
+		let res = KVStoreSync::read(self.0, primary_namespace, secondary_namespace, key);
+
+		async move { res }
+	}
+
+	fn write(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: Vec<u8>,
+	) -> impl Future<Output = Result<(), io::Error>> + MaybeSend {
+		let res = KVStoreSync::write(self.0, primary_namespace, secondary_namespace, key, buf);
+
+		async move { res }
+	}
+}
+
+struct MigrationKVStoreAsyncAdapter<'a, K: ?Sized>(&'a K);
+
+impl<K: MigratableKVStore + ?Sized> MigrationKVStore for MigrationKVStoreAsyncAdapter<'_, K> {
+	fn list_all_keys(
+		&self,
+	) -> impl Future<Output = Result<Vec<MigrationKey>, io::Error>> + MaybeSend {
+		MigratableKVStore::list_all_keys(self.0)
+	}
+
+	fn read(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str,
+	) -> impl Future<Output = Result<Vec<u8>, io::Error>> + MaybeSend {
+		KVStore::read(self.0, primary_namespace, secondary_namespace, key)
+	}
+
+	fn write(
+		&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: Vec<u8>,
+	) -> impl Future<Output = Result<(), io::Error>> + MaybeSend {
+		KVStore::write(self.0, primary_namespace, secondary_namespace, key, buf)
+	}
+}
+
+async fn migrate_kv_store_data_inner<S: MigrationKVStore, T: MigrationKVStore>(
+	source_store: S, target_store: T,
+) -> Result<(), io::Error> {
+	let keys_to_migrate = source_store.list_all_keys().await?;
+
+	for (primary_namespace, secondary_namespace, key) in &keys_to_migrate {
+		let data = source_store.read(primary_namespace, secondary_namespace, key).await?;
+		target_store.write(primary_namespace, secondary_namespace, key, data).await?;
+	}
+
+	Ok(())
+}
+
 /// Migrates all data from one store to another.
 ///
 /// This operation assumes that `target_store` is empty, i.e., any data present under copied keys
@@ -578,14 +700,28 @@ pub trait MigratableKVStoreSync: KVStoreSync {
 pub fn migrate_kv_store_data<S: MigratableKVStoreSync, T: MigratableKVStoreSync>(
 	source_store: &mut S, target_store: &mut T,
 ) -> Result<(), io::Error> {
-	let keys_to_migrate = source_store.list_all_keys()?;
+	poll_sync_future(migrate_kv_store_data_inner(
+		MigrationKVStoreSyncAdapter(source_store),
+		MigrationKVStoreSyncAdapter(target_store),
+	))
+}
 
-	for (primary_namespace, secondary_namespace, key) in &keys_to_migrate {
-		let data = source_store.read(primary_namespace, secondary_namespace, key)?;
-		target_store.write(primary_namespace, secondary_namespace, key, data)?;
-	}
-
-	Ok(())
+/// Migrates all data from one asynchronous store to another.
+///
+/// This operation assumes that `target_store` is empty, i.e., any data present under copied keys
+/// might get overriden. User must ensure `source_store` is not modified during operation,
+/// otherwise no consistency guarantees can be given.
+///
+/// Will abort and return an error if any IO operation fails. Note that in this case the
+/// `target_store` might get left in an intermediate state.
+pub async fn migrate_kv_store_data_async<S: MigratableKVStore, T: MigratableKVStore>(
+	source_store: &S, target_store: &T,
+) -> Result<(), io::Error> {
+	migrate_kv_store_data_inner(
+		MigrationKVStoreAsyncAdapter(source_store),
+		MigrationKVStoreAsyncAdapter(target_store),
+	)
+	.await
 }
 
 impl<ChannelSigner: EcdsaChannelSigner, K: KVStoreSync + ?Sized> Persist<ChannelSigner> for K {

--- a/lightning/src/util/persist.rs
+++ b/lightning/src/util/persist.rs
@@ -554,9 +554,9 @@ pub trait PaginatedKVStore: KVStore {
 	) -> impl Future<Output = Result<PaginatedListResponse, io::Error>> + 'static + MaybeSend;
 }
 
-/// Provides additional interface methods that are required for [`KVStore`]-to-[`KVStore`]
+/// Provides additional interface methods that are required for [`KVStoreSync`]-to-[`KVStoreSync`]
 /// data migration.
-pub trait MigratableKVStore: KVStoreSync {
+pub trait MigratableKVStoreSync: KVStoreSync {
 	/// Returns *all* known keys as a list of `primary_namespace`, `secondary_namespace`, `key` tuples.
 	///
 	/// This is useful for migrating data from [`KVStoreSync`] implementation to [`KVStoreSync`]
@@ -575,7 +575,7 @@ pub trait MigratableKVStore: KVStoreSync {
 ///
 /// Will abort and return an error if any IO operation fails. Note that in this case the
 /// `target_store` might get left in an intermediate state.
-pub fn migrate_kv_store_data<S: MigratableKVStore, T: MigratableKVStore>(
+pub fn migrate_kv_store_data<S: MigratableKVStoreSync, T: MigratableKVStoreSync>(
 	source_store: &mut S, target_store: &mut T,
 ) -> Result<(), io::Error> {
 	let keys_to_migrate = source_store.list_all_keys()?;


### PR DESCRIPTION
It became apparent that for the upcoming LDK Node version we really want to switch fully over to the async `KVStore`. However, as we now also introduced `FilesystemStoreV2` recently, we're now leaning on `MigratableKVStore` interface in our code, which hence is the last remaining point where we'd depend on `KVStoreSync`.

Hence, here we add an async variant of `MigratableKVStore`, rename the old variant `MigratableKVStoreSync` (to be aligned with `KVStore`/`KVStoreSync`) and DRY up the migration helper logic as a far as possible.