### PR TITLE
Only log if we actually persisted `LiquidityManager` data (0.2 backport)

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -1230,12 +1230,20 @@ where
 		}
 
 		if let Some(liquidity_manager) = liquidity_manager.as_ref() {
-			log_trace!(logger, "Persisting LiquidityManager...");
 			let fut = async {
-				liquidity_manager.get_lm().persist().await.map_err(|e| {
-					log_error!(logger, "Persisting LiquidityManager failed: {}", e);
-					e
-				})
+				liquidity_manager
+					.get_lm()
+					.persist()
+					.await
+					.map(|did_persist| {
+						if did_persist {
+							log_trace!(logger, "Persisted LiquidityManager.");
+						}
+					})
+					.map_err(|e| {
+						log_error!(logger, "Persisting LiquidityManager failed: {}", e);
+						e
+					})
 			};
 			futures.set_e(Box::pin(fut));
 		}

--- a/lightning-liquidity/src/events/event_queue.rs
+++ b/lightning-liquidity/src/events/event_queue.rs
@@ -129,12 +129,12 @@ where
 		EventQueueNotifierGuard(self)
 	}
 
-	pub async fn persist(&self) -> Result<(), lightning::io::Error> {
+	pub async fn persist(&self) -> Result<bool, lightning::io::Error> {
 		let fut = {
 			let mut state_lock = self.state.lock().unwrap();
 
 			if !state_lock.needs_persist {
-				return Ok(());
+				return Ok(false);
 			}
 
 			state_lock.needs_persist = false;
@@ -153,7 +153,7 @@ where
 			e
 		})?;
 
-		Ok(())
+		Ok(true)
 	}
 }
 

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -1782,15 +1782,16 @@ where
 		})
 	}
 
-	pub(crate) async fn persist(&self) -> Result<(), lightning::io::Error> {
+	pub(crate) async fn persist(&self) -> Result<bool, lightning::io::Error> {
 		// TODO: We should eventually persist in parallel, however, when we do, we probably want to
 		// introduce some batching to upper-bound the number of requests inflight at any given
 		// time.
+		let mut did_persist = false;
 
 		if self.persistence_in_flight.fetch_add(1, Ordering::AcqRel) > 0 {
 			// If we're not the first event processor to get here, just return early, the increment
 			// we just did will be treated as "go around again" at the end.
-			return Ok(());
+			return Ok(did_persist);
 		}
 
 		loop {
@@ -1816,6 +1817,7 @@ where
 			for counterparty_node_id in need_persist.into_iter() {
 				debug_assert!(!need_remove.contains(&counterparty_node_id));
 				self.persist_peer_state(counterparty_node_id).await?;
+				did_persist = true;
 			}
 
 			for counterparty_node_id in need_remove {
@@ -1850,6 +1852,7 @@ where
 				}
 				if let Some(future) = future_opt {
 					future.await?;
+					did_persist = true;
 				} else {
 					self.persist_peer_state(counterparty_node_id).await?;
 				}
@@ -1864,7 +1867,7 @@ where
 			break;
 		}
 
-		Ok(())
+		Ok(did_persist)
 	}
 
 	pub(crate) fn peer_disconnected(&self, counterparty_node_id: PublicKey) {


### PR DESCRIPTION
Backport of #4246.

Previously, we logged "Persisting LiquidityManager..." on each background processor wakeup, which can be very spammy, even on TRACE level.

Here, we opt to only log if something actually needed to be repersisted and we did so (in case of failure we're logging that anyways, too).