### PR TITLE
Reject quantity of 0 for offers with bounded quantity

### DIFF
--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -2221,6 +2221,19 @@ mod tests {
 			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidQuantity),
 		}
 
+		match OfferBuilder::new(recipient_pubkey())
+			.amount_msats(1000)
+			.supported_quantity(Quantity::Bounded(ten))
+			.build()
+			.unwrap()
+			.request_invoice(&expanded_key, nonce, &secp_ctx, payment_id)
+			.unwrap()
+			.quantity(0)
+		{
+			Ok(_) => panic!("expected error"),
+			Err(e) => assert_eq!(e, Bolt12SemanticError::InvalidQuantity),
+		}
+
 		let invoice_request = OfferBuilder::new(recipient_pubkey())
 			.amount_msats(1000)
 			.supported_quantity(Quantity::Unbounded)

--- a/lightning/src/offers/offer.rs
+++ b/lightning/src/offers/offer.rs
@@ -975,7 +975,7 @@ impl OfferContents {
 
 	fn is_valid_quantity(&self, quantity: u64) -> bool {
 		match self.supported_quantity {
-			Quantity::Bounded(n) => quantity <= n.get(),
+			Quantity::Bounded(n) => quantity > 0 && quantity <= n.get(),
 			Quantity::Unbounded => quantity > 0,
 			Quantity::One => quantity == 1,
 		}


### PR DESCRIPTION
An offer advertising `Quantity::Bounded` expects at least one item, but `is_valid_quantity` accepted a quantity of 0 since it only checked the upper bound. Require the quantity to be greater than 0 so that an invoice request for 0 items is rejected as an `InvalidQuantity`.