### PR TITLE
Account for UTXO base weight in anchor reserve checks

### DIFF
--- a/lightning/src/util/anchor_channel_reserves.rs
+++ b/lightning/src/util/anchor_channel_reserves.rs
@@ -24,7 +24,7 @@ use crate::chain::chaininterface::FeeEstimator;
 use crate::chain::chainmonitor::ChainMonitor;
 use crate::chain::chainmonitor::Persist;
 use crate::chain::Filter;
-use crate::ln::chan_utils::max_htlcs;
+use crate::ln::chan_utils::{max_htlcs, BASE_INPUT_WEIGHT};
 use crate::ln::channelmanager::AChannelManager;
 use crate::prelude::new_hash_set;
 use crate::sign::ecdsa::EcdsaChannelSigner;
@@ -240,11 +240,11 @@ pub fn get_supportable_anchor_channels(
 	let mut total_fractional_amount = Amount::from_sat(0);
 	let mut num_whole_utxos = 0;
 	for utxo in utxos {
-		let satisfaction_fee = context
+		let spend_fee = context
 			.upper_bound_fee_rate
-			.fee_wu(Weight::from_wu(utxo.satisfaction_weight))
+			.fee_wu(Weight::from_wu(BASE_INPUT_WEIGHT + utxo.satisfaction_weight))
 			.unwrap_or(Amount::MAX);
-		let amount = utxo.output.value.checked_sub(satisfaction_fee).unwrap_or(Amount::MIN);
+		let amount = utxo.output.value.checked_sub(spend_fee).unwrap_or(Amount::MIN);
 		if amount >= reserve_per_channel {
 			num_whole_utxos += 1;
 		} else {
@@ -368,6 +368,15 @@ mod test {
 			make_p2wpkh_utxo(reserve_per_channel * 20 / 100),
 		];
 		assert_eq!(get_supportable_anchor_channels(&context, utxos.as_slice()), 3);
+	}
+
+	#[test]
+	fn test_get_supportable_anchor_channels_accounts_for_input_weight() {
+		let context = AnchorChannelReserveContext::default();
+		let reserve = get_reserve_per_channel(&context);
+		let utxo = make_p2wpkh_utxo(reserve - Amount::from_sat(1));
+
+		assert_eq!(get_supportable_anchor_channels(&context, &[utxo]), 0);
 	}
 
 	#[test]


### PR DESCRIPTION
get_supportable_anchor_channels estimates how much each reserve UTXO can contribute after spending fees. Include the base input weight in that fee so UTXOs just below the public per-channel reserve are not counted as supporting another anchor channel.

Co-Authored-By: HAL 9000

This finding was discovered by Project Loupe