### PR TITLE
Queue async monitor update writes synchronously

### DIFF
--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -5031,9 +5031,8 @@ fn native_async_persist() {
 	let update_status = async_chain_monitor.update_channel(chan_id, &updates[1]);
 	assert_eq!(update_status, ChannelMonitorUpdateStatus::InProgress);
 
-	persist_futures.poll_futures();
-	assert_eq!(async_chain_monitor.release_pending_monitor_events().len(), 0);
-
+	// Monitor update writes should be handed to the KVStore before the spawned persistence
+	// future is polled, matching the async KVStore call-order contract.
 	let pending_writes = kv_store.list_pending_async_writes(
 		CHANNEL_MONITOR_UPDATE_PERSISTENCE_PRIMARY_NAMESPACE,
 		&key,
@@ -5046,6 +5045,9 @@ fn native_async_persist() {
 		"2",
 	);
 	assert_eq!(pending_writes.len(), 1);
+
+	persist_futures.poll_futures();
+	assert_eq!(async_chain_monitor.release_pending_monitor_events().len(), 0);
 
 	kv_store.complete_async_writes_through(
 		CHANNEL_MONITOR_UPDATE_PERSISTENCE_PRIMARY_NAMESPACE,

--- a/lightning/src/util/persist.rs
+++ b/lightning/src/util/persist.rs
@@ -1549,10 +1549,18 @@ impl<
 		// completion of the write. This ensures monitor persistence ordering is preserved.
 		let primary = CHANNEL_MONITOR_PERSISTENCE_PRIMARY_NAMESPACE;
 		let secondary = CHANNEL_MONITOR_PERSISTENCE_SECONDARY_NAMESPACE;
-		// There's no real reason why this needs to be boxed, but dropping it rams into the "hidden
-		// type for impl... captures lifetime that does not appear in bounds" issue. This can
-		// trivially be dropped once we upgrade to edition 2024/MSRV 1.85.
+		// There's no real reason why this and `persist_monitor_update` need to be boxed, but
+		// dropping it rams into the "hidden type for impl... captures lifetime that does not
+		// appear in bounds" issue. This can trivially be dropped once we upgrade to edition
+		// 2024/MSRV 1.85.
 		Box::pin(self.kv_store.write(primary, secondary, monitor_key.as_str(), monitor_bytes))
+	}
+
+	fn persist_monitor_update(
+		&self, monitor_key: &str, update_name: &str, encoded: Vec<u8>,
+	) -> Pin<Box<dyn MaybeSendableFuture<Output = Result<(), io::Error>> + 'static>> {
+		let primary = CHANNEL_MONITOR_UPDATE_PERSISTENCE_PRIMARY_NAMESPACE;
+		Box::pin(self.kv_store.write(primary, monitor_key, update_name, encoded))
 	}
 
 	fn update_persisted_channel<'a, ChannelSigner: EcdsaChannelSigner + 'a>(
@@ -1573,15 +1581,14 @@ impl<
 			if persist_update {
 				let monitor_key = monitor_name.to_string();
 				let update_name = UpdateName::from(update.update_id);
-				let primary = CHANNEL_MONITOR_UPDATE_PERSISTENCE_PRIMARY_NAMESPACE;
 				// Note that this is NOT an async function, but rather calls the *sync* KVStore
 				// write method, allowing it to do its queueing immediately, and then return a
 				// future for the completion of the write. This ensures monitor persistence
 				// ordering is preserved.
 				let encoded = update.encode();
-				res_a = Some(async move {
-					self.kv_store.write(primary, &monitor_key, update_name.as_str(), encoded).await
-				});
+				let write_fut =
+					self.persist_monitor_update(&monitor_key, update_name.as_str(), encoded);
+				res_a = Some(async move { write_fut.await });
 			} else {
 				// We could write this update, but it meets criteria of our design that calls for a full monitor write.
 				// Note that this is NOT an async function, but rather calls the *sync* KVStore


### PR DESCRIPTION
Monitor update persistence relies on KVStore write calls being queued in call order. The incremental async update path deferred that write until executor polling, allowing async scheduling to reorder persistence operations relative to later updates or cleanup.

Add a regression test that builds an incremental update future without polling it and verifies that the write has already been queued.

Co-Authored-By: HAL 9000

This finding was discovered by Project Loupe