### PR TITLE
Add pending `SpliceDetails` to `ChannelDetails`

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -3854,6 +3854,13 @@ pub fn do_test<Out: Output + MaybeSend + MaybeSync>(data: &[u8], out: Out) {
 			},
 			_ => break 'fuzz_loop,
 		}
+
+		// Compute `ChannelDetails` for every channel after each step (ignoring the result) so the
+		// fuzzer exercises the splice-details derivation in `to_details` across as many states as
+		// possible.
+		for node in harness.nodes.iter() {
+			let _ = node.list_channels();
+		}
 	}
 	harness.finish();
 }

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -257,6 +257,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							pending_inbound_htlcs: Vec::new(),
 							pending_outbound_htlcs: Vec::new(),
 							current_dust_exposure_msat: None,
+							splice_details: None,
 						});
 					}
 					Some(&$first_hops_vec[..])

--- a/lightning-tests/src/upgrade_downgrade_tests.rs
+++ b/lightning-tests/src/upgrade_downgrade_tests.rs
@@ -11,6 +11,7 @@
 //! LDK.
 
 use lightning_0_2::commitment_signed_dance as commitment_signed_dance_0_2;
+use lightning_0_2::events::bump_transaction::sync::WalletSourceSync as WalletSourceSync_0_2;
 use lightning_0_2::events::Event as Event_0_2;
 use lightning_0_2::get_monitor as get_monitor_0_2;
 use lightning_0_2::ln::channelmanager::PaymentId as PaymentId_0_2;
@@ -818,4 +819,211 @@ fn test_onion_message_intercepted_scid_downgrade_to_0_2() {
 	let mut reader = Cursor::new(&serialized);
 	let result = <Event_0_2 as MaybeReadable_0_2>::read(&mut reader);
 	assert!(result.is_err(), "LDK 0.2 should fail to decode a ShortChannelId variant");
+}
+
+fn downgrade_setup_single_splice() -> (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, ChannelId) {
+	// Build a current node with a single pending (negotiated, not yet locked) splice that node 0
+	// funded (so node 0 is contributory, node 1 is a non-contributory acceptor). Return both
+	// nodes' serialized ChannelManager + ChannelMonitor and the channel id.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let (_, _, channel_id, _) =
+		create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100_000, 0);
+
+	let added_value = Amount::from_sat(50_000);
+	provide_utxo_reserves(&nodes, 2, added_value * 2);
+	let contribution = do_initiate_splice_in(&nodes[0], &nodes[1], channel_id, added_value);
+	let (splice_tx, _) = splice_channel(&nodes[0], &nodes[1], channel_id, contribution);
+	mine_transaction(&nodes[0], &splice_tx);
+	mine_transaction(&nodes[1], &splice_tx);
+
+	let node_0_ser = nodes[0].node.encode();
+	let node_1_ser = nodes[1].node.encode();
+	let mon_0_ser = get_monitor!(nodes[0], channel_id).encode();
+	let mon_1_ser = get_monitor!(nodes[1], channel_id).encode();
+	(node_0_ser, node_1_ser, mon_0_ser, mon_1_ser, channel_id)
+}
+
+#[test]
+fn downgrade_single_splice_loads_on_0_2() {
+	// A current node with a single pending splice serializes in a form LDK 0.2 can still read,
+	// whether or not we funded it: only odd TLVs are written (the even RBF gate is omitted for a
+	// single round), so 0.2 skips the contribution it can't track and loads the channel. RBF is
+	// the only state that blocks downgrade (see downgrade_rbf_refused_by_0_2).
+	let (node_0_ser, node_1_ser, mon_0_ser, mon_1_ser, _) = downgrade_setup_single_splice();
+
+	let mut chanmon_cfgs = lightning_0_2_utils::create_chanmon_cfgs(2);
+	chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+	let node_cfgs = lightning_0_2_utils::create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = lightning_0_2_utils::create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = lightning_0_2_utils::create_network(2, &node_cfgs, &node_chanmgrs);
+	let mut config = lightning_0_2_utils::test_default_channel_config();
+	// The current side uses the anchors channel type by default; 0.2 only accepts a channel whose
+	// type it advertises support for, so enable anchors here too (otherwise the read is refused on
+	// the channel type, before the splice serialization is ever exercised).
+	config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx = true;
+
+	// Node 0 (contributory initiator): the contribution lives in an odd TLV that 0.2 skips.
+	let mgr_0 = lightning_0_2_utils::_reload_node(
+		&nodes[0],
+		config.clone(),
+		&node_0_ser,
+		&[&mon_0_ser[..]],
+	);
+	assert_eq!(mgr_0.list_channels().len(), 1);
+	// Node 1 (non-contributory acceptor): nothing 0.2 can't represent.
+	let mgr_1 =
+		lightning_0_2_utils::_reload_node(&nodes[1], config, &node_1_ser, &[&mon_1_ser[..]]);
+	assert_eq!(mgr_1.list_channels().len(), 1);
+}
+
+#[test]
+fn downgrade_rbf_refused_by_0_2() {
+	// RBF (more than one negotiation round) is the one splice state LDK 0.2 cannot operate. Current
+	// writes the even RBF-gate TLV for it, which 0.2 rejects as an unknown even (required) field,
+	// so reading the ChannelManager fails rather than silently mishandling the extra candidate.
+	let (node_0_ser, mon_0_ser);
+	{
+		let chanmon_cfgs = create_chanmon_cfgs(2);
+		let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+		let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+		let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+		let node_id_0 = nodes[0].node.get_our_node_id();
+		let node_id_1 = nodes[1].node.get_our_node_id();
+		let (_, _, channel_id, _) =
+			create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100_000, 0);
+
+		let added_value = Amount::from_sat(50_000);
+		provide_utxo_reserves(&nodes, 2, added_value * 2);
+		let contribution = do_initiate_splice_in(&nodes[0], &nodes[1], channel_id, added_value);
+		let (first_splice_tx, new_funding_script) =
+			splice_channel(&nodes[0], &nodes[1], channel_id, contribution);
+
+		// RBF the splice, producing a second negotiated candidate.
+		provide_utxo_reserves(&nodes, 2, added_value * 2);
+		let rbf_feerate = bitcoin::FeeRate::from_sat_per_kwu(1000);
+		let rbf_contribution =
+			do_initiate_rbf_splice_in(&nodes[0], &nodes[1], channel_id, rbf_feerate);
+		complete_rbf_handshake(&nodes[0], &nodes[1]);
+		complete_interactive_funding_negotiation(
+			&nodes[0],
+			&nodes[1],
+			channel_id,
+			rbf_contribution,
+			new_funding_script,
+		);
+		let _ = sign_interactive_funding_tx(
+			SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+				.replacing(first_splice_tx.compute_txid()),
+		);
+		expect_splice_pending_event(&nodes[0], &node_id_1);
+		expect_splice_pending_event(&nodes[1], &node_id_0);
+
+		node_0_ser = nodes[0].node.encode();
+		mon_0_ser = get_monitor!(nodes[0], channel_id).encode();
+	}
+
+	let mut chanmon_cfgs = lightning_0_2_utils::create_chanmon_cfgs(2);
+	chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+	let node_cfgs = lightning_0_2_utils::create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = lightning_0_2_utils::create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = lightning_0_2_utils::create_network(2, &node_cfgs, &node_chanmgrs);
+	let mut config = lightning_0_2_utils::test_default_channel_config();
+	// Match the anchors channel type used on the current side, so the manager read reaches (and
+	// fails on) the even RBF-gate TLV rather than refusing the channel type itself.
+	config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx = true;
+	// _reload_node unwraps the manager read, which fails on the even RBF-gate TLV. Catch the panic
+	// here so it stays contained to the read we expect to fail.
+	let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+		lightning_0_2_utils::_reload_node(&nodes[0], config, &node_0_ser, &[&mon_0_ser[..]]);
+	}))
+	.expect_err("0.2 should refuse to read the RBF splice");
+	let panic_msg = panic
+		.downcast_ref::<String>()
+		.map(String::as_str)
+		.or_else(|| panic.downcast_ref::<&str>().copied())
+		.unwrap_or("");
+	assert!(
+		panic_msg.contains("UnknownRequiredFeature"),
+		"expected an UnknownRequiredFeature decode failure, got: {panic_msg}",
+	);
+}
+
+#[test]
+fn upgrade_single_splice_from_0_2() {
+	// A pending single splice written by LDK 0.2 -- which never tracked our contribution -- is read
+	// by current: the candidate comes back via the TLV-3 fallback with `contribution: None`.
+	let (node_0_ser, node_1_ser, mon_0_ser, mon_1_ser, chan_id_bytes);
+	{
+		let chanmon_cfgs = lightning_0_2_utils::create_chanmon_cfgs(2);
+		let node_cfgs = lightning_0_2_utils::create_node_cfgs(2, &chanmon_cfgs);
+		let node_chanmgrs = lightning_0_2_utils::create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+		let nodes = lightning_0_2_utils::create_network(2, &node_cfgs, &node_chanmgrs);
+		let channel_id = lightning_0_2_utils::create_announced_chan_between_nodes_with_value(
+			&nodes, 0, 1, 100_000, 0,
+		)
+		.2;
+		chan_id_bytes = channel_id.0;
+
+		let contribution = lightning_0_2::ln::funding::SpliceContribution::SpliceOut {
+			outputs: vec![bitcoin::TxOut {
+				value: bitcoin::Amount::from_sat(1_000),
+				script_pubkey: nodes[0].wallet_source.get_change_script().unwrap(),
+			}],
+		};
+		// 0.2 drives the splice through tx_signatures, leaving one negotiated (unlocked) candidate.
+		let _ = lightning_0_2::ln::splicing_tests::splice_channel(
+			&nodes[0],
+			&nodes[1],
+			channel_id,
+			contribution,
+		);
+
+		node_0_ser = nodes[0].node.encode();
+		node_1_ser = nodes[1].node.encode();
+		mon_0_ser = get_monitor_0_2!(nodes[0], channel_id).encode();
+		mon_1_ser = get_monitor_0_2!(nodes[1], channel_id).encode();
+	}
+
+	let mut chanmon_cfgs = create_chanmon_cfgs(2);
+	chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let (persister_a, persister_b, chain_mon_a, chain_mon_b);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let (node_a, node_b);
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let config = test_default_channel_config();
+	reload_node!(
+		nodes[0],
+		config.clone(),
+		&node_0_ser,
+		&[&mon_0_ser[..]],
+		persister_a,
+		chain_mon_a,
+		node_a
+	);
+	reload_node!(
+		nodes[1],
+		config,
+		&node_1_ser,
+		&[&mon_1_ser[..]],
+		persister_b,
+		chain_mon_b,
+		node_b
+	);
+
+	// Current reads the 0.2 splice: one negotiated candidate, no contribution recorded.
+	let channel_id = ChannelId(chan_id_bytes);
+	for node in nodes.iter() {
+		let channels = node.node.list_channels();
+		let details = channels.iter().find(|c| c.channel_id == channel_id).unwrap();
+		let splice = details.splice_details.as_ref().expect("pending splice");
+		assert_eq!(splice.candidates.len(), 1);
+		assert_eq!(splice.candidates[0].contribution, None);
+	}
 }

--- a/lightning-tests/src/upgrade_downgrade_tests.rs
+++ b/lightning-tests/src/upgrade_downgrade_tests.rs
@@ -61,6 +61,7 @@ use lightning::ln::splicing_tests::*;
 use lightning::ln::types::ChannelId;
 use lightning::onion_message::packet::Packet;
 use lightning::sign::OutputSpender;
+use lightning::util::errors::APIError;
 use lightning::util::ser::{MaybeReadable, Writeable};
 use lightning::util::wallet_utils::WalletSourceSync;
 
@@ -1025,5 +1026,71 @@ fn upgrade_single_splice_from_0_2() {
 		let splice = details.splice_details.as_ref().expect("pending splice");
 		assert_eq!(splice.candidates.len(), 1);
 		assert_eq!(splice.candidates[0].contribution, None);
+	}
+
+	// The splice cannot be RBF'd: 0.2 persisted no feerate, so splice_channel refuses it.
+	let node_id_1 = nodes[1].node.get_our_node_id();
+	let err = nodes[0].node.splice_channel(&channel_id, &node_id_1).unwrap_err();
+	let expected = format!(
+		"Channel {} has a pending splice from a prior LDK version and cannot be spliced again",
+		channel_id,
+	);
+	match err {
+		APIError::APIMisuseError { err } => assert_eq!(err, expected),
+		_ => panic!("unexpected error: {:?}", err),
+	}
+}
+
+#[test]
+fn splice_inherited_across_0_2_cannot_be_rbfed() {
+	// Negotiate a contributory splice on current, downgrade to LDK 0.2, then upgrade back. LDK 0.2
+	// persists neither our contribution nor the splice feerate and does not retain the odd TLVs that
+	// carry them, so the splice returns to current without either. `splice_channel` needs the prior
+	// feerate to derive the RBF floor, so it refuses such a channel with a clean error rather than
+	// operating on incomplete state (which would otherwise trip a debug assertion that a pending
+	// splice always has a known feerate).
+	// Same single-splice setup as the downgrade tests; we only need node 0 here.
+	let (v3_mgr, _, v3_mon, _, channel_id) = downgrade_setup_single_splice();
+	let chan_id_bytes = channel_id.0;
+
+	// Downgrade node 0 to LDK 0.2 and re-serialize there, stripping the contribution and feerate.
+	let (v2_mgr, v2_mon);
+	{
+		let mut chanmon_cfgs = lightning_0_2_utils::create_chanmon_cfgs(2);
+		chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+		chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+		let node_cfgs = lightning_0_2_utils::create_node_cfgs(2, &chanmon_cfgs);
+		let node_chanmgrs = lightning_0_2_utils::create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+		let nodes = lightning_0_2_utils::create_network(2, &node_cfgs, &node_chanmgrs);
+		let mut config = lightning_0_2_utils::test_default_channel_config();
+		config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx = true;
+		let mgr = lightning_0_2_utils::_reload_node(&nodes[0], config, &v3_mgr, &[&v3_mon[..]]);
+		assert_eq!(mgr.list_channels().len(), 1);
+		let v2_channel_id = lightning_0_2::ln::types::ChannelId(chan_id_bytes);
+		v2_mgr = mgr.encode();
+		v2_mon = get_monitor_0_2!(nodes[0], v2_channel_id).encode();
+	}
+
+	// Upgrade back to current and attempt to RBF the inherited splice.
+	let mut chanmon_cfgs = create_chanmon_cfgs(2);
+	chanmon_cfgs[0].keys_manager.disable_all_state_policy_checks = true;
+	chanmon_cfgs[1].keys_manager.disable_all_state_policy_checks = true;
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let (persister, chain_mon, new_node);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let config = test_default_channel_config();
+	reload_node!(nodes[0], config, &v2_mgr, &[&v2_mon[..]], persister, chain_mon, new_node);
+
+	let channel_id = ChannelId(chan_id_bytes);
+	let node_id_1 = nodes[1].node.get_our_node_id();
+	let err = nodes[0].node.splice_channel(&channel_id, &node_id_1).unwrap_err();
+	let expected = format!(
+		"Channel {} has a pending splice from a prior LDK version and cannot be spliced again",
+		channel_id,
+	);
+	match err {
+		APIError::APIMisuseError { err } => assert_eq!(err, expected),
+		_ => panic!("unexpected error: {:?}", err),
 	}
 }

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -47,8 +47,9 @@ use crate::ln::chan_utils::{
 	EMPTY_SCRIPT_SIG_WEIGHT, FUNDING_TRANSACTION_WITNESS_WEIGHT,
 };
 use crate::ln::channel_state::{
-	ChannelShutdownState, CounterpartyForwardingInfo, InboundHTLCDetails, InboundHTLCStateDetails,
-	OutboundHTLCDetails, OutboundHTLCStateDetails,
+	ChannelShutdownState, ConfirmedSpliceCandidate, CounterpartyForwardingInfo, InboundHTLCDetails,
+	InboundHTLCStateDetails, OutboundHTLCDetails, OutboundHTLCStateDetails, SpliceCandidateDetails,
+	SpliceDetails, SpliceNegotiationDetails, SpliceNegotiationStatus,
 };
 use crate::ln::channelmanager::{
 	self, BlindedFailure, ChannelReadyOrder, FundingConfirmedMessage, HTLCFailureMsg,
@@ -3358,6 +3359,77 @@ impl PendingFunding {
 		self.negotiation_contribution.as_ref().or_else(|| {
 			self.negotiated_candidates.last().and_then(|candidate| candidate.contribution.as_ref())
 		})
+	}
+
+	fn to_details<SP: SignerProvider>(
+		&self, context: &ChannelContext<SP>, best_block_height: u32,
+		queued_contribution: Option<&FundingContribution>,
+	) -> SpliceDetails {
+		let negotiation = self.funding_negotiation.as_ref().map(|negotiation| {
+			let status = match negotiation {
+				FundingNegotiation::AwaitingAck { .. } => SpliceNegotiationStatus::AwaitingAck,
+				FundingNegotiation::ConstructingTransaction { .. } => {
+					SpliceNegotiationStatus::ConstructingTransaction
+				},
+				FundingNegotiation::AwaitingSignatures { .. } => {
+					SpliceNegotiationStatus::AwaitingSignatures
+				},
+			};
+			SpliceNegotiationDetails {
+				status,
+				is_initiator: negotiation.is_initiator(),
+				funding_feerate_sat_per_1000_weight: negotiation
+					.funding_feerate_sat_per_1000_weight(),
+				new_channel_value_satoshis: negotiation
+					.as_funding()
+					.map(|funding| funding.get_value_satoshis()),
+				txid: negotiation.as_funding().and_then(|funding| funding.get_funding_txid()),
+				contribution: self.negotiation_contribution.clone(),
+			}
+		});
+		let candidates = self
+			.negotiated_candidates
+			.iter()
+			.map(|candidate| SpliceCandidateDetails {
+				txid: candidate
+					.funding
+					.get_funding_txid()
+					.expect("negotiated candidates should have a funding txid"),
+				new_channel_value_satoshis: candidate.funding.get_value_satoshis(),
+				contribution: candidate.contribution.clone(),
+			})
+			.collect();
+		// At most one candidate can confirm, as they all double-spend the same input. A zero-conf
+		// splice is locked (we send `splice_locked`) before it has any confirmations, so also report
+		// a candidate we have locked even at zero confirmations.
+		let confirmed_candidate = self.negotiated_candidates.iter().find_map(|candidate| {
+			let confirmations = candidate.funding.get_funding_tx_confirmations(best_block_height);
+			let txid = candidate
+				.funding
+				.get_funding_txid()
+				.expect("negotiated candidates should have a funding txid");
+			// The `splice_locked` we sent always refers to the confirmed candidate, as it is
+			// cleared if that candidate is ever unconfirmed by a reorg.
+			let splice_locked_sent = self.sent_funding_txid == Some(txid);
+			if confirmations == 0 && !splice_locked_sent {
+				return None;
+			}
+			Some(ConfirmedSpliceCandidate {
+				txid,
+				confirmations,
+				confirmations_required: context
+					.minimum_depth(&candidate.funding)
+					.expect("set for a ready channel"),
+				splice_locked_sent,
+			})
+		});
+		SpliceDetails {
+			negotiation,
+			queued_contribution: queued_contribution.cloned(),
+			candidates,
+			confirmed_candidate,
+			received_splice_locked_txid: self.received_funding_txid,
+		}
 	}
 
 	fn check_get_splice_locked<SP: SignerProvider>(
@@ -7461,6 +7533,35 @@ where
 				.iter_mut()
 				.map(|candidate| &mut candidate.funding),
 		)
+	}
+
+	/// Returns details about any pending splice attempts for inclusion in
+	/// [`crate::ln::channel_state::ChannelDetails`].
+	pub fn pending_splice_details(&self, best_block_height: u32) -> Option<SpliceDetails> {
+		// A contribution committed via `funding_contributed` sits in `quiescent_action` until
+		// quiescence is reached and it becomes a negotiation; surface it as the queued contribution.
+		let queued_contribution = match &self.quiescent_action {
+			Some(QuiescentAction::Splice { contribution, .. }) => Some(contribution),
+			#[cfg(any(test, fuzzing, feature = "_test_utils"))]
+			Some(QuiescentAction::DoNothing) => None,
+			None => None,
+		};
+		self.pending_splice
+			.as_ref()
+			.map(|pending_splice| {
+				pending_splice.to_details(&self.context, best_block_height, queued_contribution)
+			})
+			// No `PendingFunding` yet (e.g. a first splice still awaiting quiescence), but a queued
+			// contribution is still worth surfacing on its own.
+			.or_else(|| {
+				queued_contribution.map(|contribution| SpliceDetails {
+					negotiation: None,
+					queued_contribution: Some(contribution.clone()),
+					candidates: Vec::new(),
+					confirmed_candidate: None,
+					received_splice_locked_txid: None,
+				})
+			})
 	}
 
 	fn has_pending_splice_awaiting_signatures(&self) -> bool {
@@ -13084,6 +13185,18 @@ where
 		} else {
 			contribution
 		};
+
+		// A queued splice never coexists with a negotiation we initiated: we return early above if
+		// one is already in flight, and a queued action is cleared the moment it becomes our
+		// negotiation at quiescence. It may coexist with a counterparty-initiated negotiation (e.g.
+		// queuing our own contribution while accepting their splice), so we only rule out our own.
+		debug_assert!(
+			self.pending_splice
+				.as_ref()
+				.and_then(|pending_splice| pending_splice.funding_negotiation.as_ref())
+				.map_or(true, |funding_negotiation| !funding_negotiation.is_initiator()),
+			"A queued splice must not coexist with a funding negotiation we initiated",
+		);
 
 		self.propose_quiescence(logger, QuiescentAction::Splice { contribution, locktime })
 	}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -12936,11 +12936,21 @@ where
 						.as_ref()
 						.map(|n| n.funding_feerate_sat_per_1000_weight())
 				});
-			debug_assert!(
-				prev_feerate.is_some(),
-				"pending_splice should have last_funding_feerate or funding_negotiation",
-			);
-			let min_rbf_feerate = prev_feerate.map(min_rbf_feerate);
+			let prev_feerate = match prev_feerate {
+				Some(prev_feerate) => prev_feerate,
+				None => {
+					// The feerate and our contribution are only persisted by LDK 0.3+, so their
+					// absence means this splice was last written by an older version (negotiated
+					// there, or round-tripped 0.3 -> 0.2 -> 0.3) and cannot be RBF'd.
+					return Err(APIError::APIMisuseError {
+						err: format!(
+							"Channel {} has a pending splice from a prior LDK version and cannot be spliced again",
+							self.context.channel_id(),
+						),
+					});
+				},
+			};
+			let min_rbf_feerate = Some(min_rbf_feerate(prev_feerate));
 			let prior = if pending_splice.last_funding_feerate_sat_per_1000_weight.is_some() {
 				pending_splice.latest_contribution().cloned()
 			} else {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -84,7 +84,7 @@ use crate::util::config::{
 use crate::util::errors::APIError;
 use crate::util::logger::{Level as LoggerLevel, Logger, Record, WithContext};
 use crate::util::scid_utils::{block_from_scid, scid_from_parts};
-use crate::util::ser::{Readable, ReadableArgs, RequiredWrapper, Writeable, Writer};
+use crate::util::ser::{Iterable, Readable, ReadableArgs, RequiredWrapper, Writeable, Writer};
 use crate::util::wallet_utils::{ConfirmedUtxo, Input};
 use crate::{impl_readable_for_vec, impl_writeable_for_vec};
 
@@ -2964,9 +2964,20 @@ impl FundingScope {
 struct PendingFunding {
 	funding_negotiation: Option<FundingNegotiation>,
 
+	/// Our contribution to the funding negotiation round currently in progress, if we are
+	/// contributing to it. Set when the round starts, moved into the [`NegotiatedCandidate`]
+	/// when negotiation completes, and dropped in
+	/// [`FundedChannel::reset_pending_splice_state`] if the round is abandoned.
+	///
+	/// When the counterparty initiates an RBF and a prior round included our contribution, this
+	/// is set to that contribution adjusted to the new feerate (or the RBF is rejected if the
+	/// adjustment fails, in which case no round starts). This ensures a splice we contributed to
+	/// never loses our contribution in subsequent rounds.
+	negotiation_contribution: Option<FundingContribution>,
+
 	/// Funding candidates that have been negotiated but have not reached enough confirmations
 	/// by both counterparties to have exchanged `splice_locked` and be promoted.
-	negotiated_candidates: Vec<FundingScope>,
+	negotiated_candidates: Vec<NegotiatedCandidate>,
 
 	/// The funding txid used in the `splice_locked` sent to the counterparty.
 	sent_funding_txid: Option<Txid>,
@@ -2977,20 +2988,25 @@ struct PendingFunding {
 	/// The feerate used in the last successfully negotiated funding transaction.
 	/// Used for validating the minimum feerate increase rule on RBF attempts.
 	last_funding_feerate_sat_per_1000_weight: Option<u32>,
-
-	/// The funding contributions from splice/RBF rounds where we contributed.
-	///
-	/// A new entry is appended when we contribute to a negotiation round (either as initiator
-	/// or acceptor). Rounds where we don't contribute (e.g., counterparty-only splice) do not
-	/// add an entry. Once non-empty, every subsequent round appends: when the counterparty
-	/// initiates an RBF, the last entry is adjusted to the new feerate and appended as a new
-	/// entry (or the RBF is rejected if the adjustment fails, in which case no round starts).
-	///
-	/// If the round aborts, the last entry is popped in
-	/// [`FundedChannel::reset_pending_splice_state`], restoring the prior round's contribution
-	/// as the most recent entry.
-	contributions: Vec<FundingContribution>,
 }
+
+/// A funding candidate that has been negotiated, together with our contribution, if any, to the
+/// negotiation round that produced it.
+#[derive(Debug)]
+struct NegotiatedCandidate {
+	funding: FundingScope,
+
+	/// Our contribution to the negotiation round that produced this candidate, or `None` if only
+	/// the counterparty contributed. Once a candidate includes our contribution, every later
+	/// candidate does as well: RBF rounds carry the contribution forward (possibly adjusted to a
+	/// new feerate) rather than dropping it, preserving the splice intention.
+	contribution: Option<FundingContribution>,
+}
+
+impl_ser_tlv_based!(NegotiatedCandidate, {
+	(1, funding, required),
+	(3, contribution, option),
+});
 
 #[derive(Debug)]
 enum FundingNegotiation {
@@ -3050,20 +3066,44 @@ impl Writeable for PendingFundingWriteable<'_> {
 					Some(FundingNegotiation::AwaitingSignatures { .. })
 				)
 		);
-		let contributions_len = if self.reset_funding_negotiation
-			&& self.pending_funding.funding_negotiation.is_some()
-		{
-			self.pending_funding.contributions.len().saturating_sub(1)
-		} else {
-			self.pending_funding.contributions.len()
-		};
+		// The in-flight round's contribution is only written if its negotiation survives
+		// serialization round trips. It goes in an odd TLV that LDK 0.2 skips (0.2 never tracked
+		// contributions), so a single in-flight splice we contributed to stays loadable there.
+		let negotiation_contribution = funding_negotiation
+			.is_some()
+			.then(|| self.pending_funding.negotiation_contribution.as_ref())
+			.flatten();
+		let candidates = &self.pending_funding.negotiated_candidates;
+		debug_assert!(
+			self.pending_funding.contributions_form_suffix(),
+			"contributions must form a suffix of the negotiated candidates",
+		);
+		// TLV 3 exposes only the first candidate's funding: the single-splice view LDK 0.2
+		// understands. The authoritative candidate list -- each funding bundled with its
+		// contribution -- goes in the odd TLV 11, which current reads and 0.2 skips. A single
+		// non-contributory splice is fully captured by TLV 3 alone, so the bundle is then omitted.
+		// When a single splice does carry a contribution, 0.2 skips it (and operates the splice
+		// without it), so it need not block 0.2 from loading.
+		//
+		// The even TLV 14 is the only thing that makes 0.2 refuse, and it's written exactly when
+		// there is more than one negotiation round (RBF) -- the one thing 0.2 cannot operate. The
+		// odd contribution fields are safe despite being load-bearing for RBF: this gate makes 0.2
+		// refuse the whole channel in that case, so no reader ever skips them when they matter.
+		let first_funding = Iterable(candidates.iter().take(1).map(|candidate| &candidate.funding));
+		let any_contribution = candidates.iter().any(|candidate| candidate.contribution.is_some());
+		let negotiated_candidates =
+			(candidates.len() > 1 || any_contribution).then(|| Iterable(candidates.iter()));
+		let is_rbf = candidates.len() + usize::from(funding_negotiation.is_some()) > 1;
+		let rbf_gate = is_rbf.then_some(());
 		write_tlv_fields!(writer, {
 			(1, funding_negotiation, upgradable_option),
-			(3, self.pending_funding.negotiated_candidates, required_vec),
+			(3, first_funding, required),
 			(5, self.pending_funding.sent_funding_txid, option),
 			(7, self.pending_funding.received_funding_txid, option),
-			(8, self.pending_funding.last_funding_feerate_sat_per_1000_weight, option),
-			(10, self.pending_funding.contributions[..contributions_len], optional_vec),
+			(9, self.pending_funding.last_funding_feerate_sat_per_1000_weight, option),
+			(11, negotiated_candidates, option),
+			(13, negotiation_contribution, option),
+			(14, rbf_gate, option),
 		});
 		Ok(())
 	}
@@ -3071,14 +3111,58 @@ impl Writeable for PendingFundingWriteable<'_> {
 
 impl Readable for PendingFunding {
 	fn read<R: io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
-		Ok(_decode_and_build!(reader, Self, {
+		let mut funding_negotiation = None;
+		let mut legacy_negotiated_candidates: Option<Vec<FundingScope>> = None;
+		let mut sent_funding_txid = None;
+		let mut received_funding_txid = None;
+		let mut last_funding_feerate_sat_per_1000_weight = None;
+		let mut negotiated_candidates: Option<Vec<NegotiatedCandidate>> = None;
+		let mut negotiation_contribution: Option<FundingContribution> = None;
+		let mut rbf_gate: Option<()> = None;
+
+		read_tlv_fields!(reader, {
 			(1, funding_negotiation, upgradable_option),
-			(3, negotiated_candidates, required_vec),
+			(3, legacy_negotiated_candidates, optional_vec),
 			(5, sent_funding_txid, option),
 			(7, received_funding_txid, option),
-			(8, last_funding_feerate_sat_per_1000_weight, option),
-			(10, contributions, optional_vec),
-		}))
+			(9, last_funding_feerate_sat_per_1000_weight, option),
+			(11, negotiated_candidates, optional_vec),
+			(13, negotiation_contribution, option),
+			(14, rbf_gate, option),
+		});
+
+		// TLV 11 (the candidate list, each funding bundled with its contribution) is authoritative
+		// when present. It is omitted for a single non-contributory splice (TLV 3 holds its
+		// funding) and for data written by LDK 0.2 (which only ever wrote TLV 3 and tracked no
+		// contributions); in both cases the candidates carry no contribution.
+		let negotiated_candidates = negotiated_candidates.unwrap_or_else(|| {
+			legacy_negotiated_candidates
+				.unwrap_or_default()
+				.into_iter()
+				.map(|funding| NegotiatedCandidate { funding, contribution: None })
+				.collect()
+		});
+		// An in-flight contribution is only written alongside a surviving negotiation round, so a
+		// contribution without one is invalid.
+		if funding_negotiation.is_none() && negotiation_contribution.is_some() {
+			return Err(DecodeError::InvalidValue);
+		}
+		// TLV 14 (the RBF gate) is written exactly when there is more than one negotiation round, so
+		// pre-RBF readers (LDK 0.2) refuse an RBF they cannot operate. Current reconstructs RBF state
+		// from the candidate list, but a gate inconsistent with that state is invalid.
+		let is_rbf = negotiated_candidates.len() + usize::from(funding_negotiation.is_some()) > 1;
+		if rbf_gate.is_some() != is_rbf {
+			return Err(DecodeError::InvalidValue);
+		}
+
+		Ok(PendingFunding {
+			funding_negotiation,
+			negotiation_contribution,
+			negotiated_candidates,
+			sent_funding_txid,
+			received_funding_txid,
+			last_funding_feerate_sat_per_1000_weight,
+		})
 	}
 }
 
@@ -3175,6 +3259,16 @@ impl FundingNegotiation {
 }
 
 impl PendingFunding {
+	/// Whether our contributions form a suffix of the negotiated candidates: once a round includes
+	/// our contribution, every later round carries it forward (so the splice intention is never
+	/// lost).
+	fn contributions_form_suffix(&self) -> bool {
+		self.negotiated_candidates
+			.iter()
+			.skip_while(|candidate| candidate.contribution.is_none())
+			.all(|candidate| candidate.contribution.is_some())
+	}
+
 	fn awaiting_ack_context(
 		&self, msg_name: &str,
 	) -> Result<(&FundingNegotiationContext, &PublicKey), ChannelError> {
@@ -3228,22 +3322,42 @@ impl PendingFunding {
 		feerate_sat_per_kw >= min_feerate
 	}
 
+	/// All stored contributions: those of the negotiated candidates followed by the in-flight
+	/// negotiation round's, if any.
+	fn contributions(&self) -> impl Iterator<Item = &FundingContribution> + '_ {
+		self.negotiated_candidates
+			.iter()
+			.filter_map(|candidate| candidate.contribution.as_ref())
+			.chain(self.negotiation_contribution.as_ref())
+	}
+
 	fn contributed_inputs(&self) -> impl Iterator<Item = bitcoin::OutPoint> + '_ {
-		self.contributions.iter().flat_map(|c| c.contributed_inputs())
+		self.contributions().flat_map(|c| c.contributed_inputs())
 	}
 
 	fn contributed_outputs(&self) -> impl Iterator<Item = &bitcoin::Script> + '_ {
-		self.contributions.iter().flat_map(|c| c.contributed_outputs())
+		self.contributions().flat_map(|c| c.contributed_outputs())
 	}
 
 	fn prior_contributed_inputs(&self) -> impl Iterator<Item = bitcoin::OutPoint> + '_ {
-		let len = self.contributions.len();
-		self.contributions[..len.saturating_sub(1)].iter().flat_map(|c| c.contributed_inputs())
+		self.negotiated_candidates
+			.iter()
+			.filter_map(|candidate| candidate.contribution.as_ref())
+			.flat_map(|c| c.contributed_inputs())
 	}
 
 	fn prior_contributed_outputs(&self) -> impl Iterator<Item = &bitcoin::Script> + '_ {
-		let len = self.contributions.len();
-		self.contributions[..len.saturating_sub(1)].iter().flat_map(|c| c.contributed_outputs())
+		self.negotiated_candidates
+			.iter()
+			.filter_map(|candidate| candidate.contribution.as_ref())
+			.flat_map(|c| c.contributed_outputs())
+	}
+
+	/// Our most recent contribution across rounds, including any round still under negotiation.
+	fn latest_contribution(&self) -> Option<&FundingContribution> {
+		self.negotiation_contribution.as_ref().or_else(|| {
+			self.negotiated_candidates.last().and_then(|candidate| candidate.contribution.as_ref())
+		})
 	}
 
 	fn check_get_splice_locked<SP: SignerProvider>(
@@ -3251,7 +3365,7 @@ impl PendingFunding {
 	) -> Option<msgs::SpliceLocked> {
 		debug_assert!(confirmed_funding_index < self.negotiated_candidates.len());
 
-		let funding = &self.negotiated_candidates[confirmed_funding_index];
+		let funding = &self.negotiated_candidates[confirmed_funding_index].funding;
 		if !context.check_funding_meets_minimum_depth(funding, height) {
 			return None;
 		}
@@ -7275,8 +7389,9 @@ where
 	/// Builds a [`SpliceFundingFailed`] from a contribution, filtering out inputs/outputs
 	/// that are still committed to a prior splice round.
 	fn splice_funding_failed_for(&self, contribution: FundingContribution) -> SpliceFundingFailed {
-		// The contribution was never pushed to `contributions`, so `contributed_inputs()` and
-		// `contributed_outputs()` return only prior rounds' entries for filtering.
+		// The contribution was never stored in the pending splice state, so
+		// `contributed_inputs()` and `contributed_outputs()` return only prior rounds' entries
+		// for filtering.
 		splice_funding_failed_for!(
 			self,
 			true,
@@ -7326,12 +7441,15 @@ where
 			})
 	}
 
-	fn pending_funding(&self) -> &[FundingScope] {
-		if let Some(pending_splice) = &self.pending_splice {
-			pending_splice.negotiated_candidates.as_slice()
-		} else {
-			&[]
-		}
+	fn negotiated_candidates(&self) -> &[NegotiatedCandidate] {
+		self.pending_splice
+			.as_ref()
+			.map(|pending_splice| pending_splice.negotiated_candidates.as_slice())
+			.unwrap_or(&[])
+	}
+
+	fn pending_funding(&self) -> impl ExactSizeIterator<Item = &FundingScope> + '_ {
+		self.negotiated_candidates().iter().map(|candidate| &candidate.funding)
 	}
 
 	fn funding_and_pending_funding_iter_mut(&mut self) -> impl Iterator<Item = &mut FundingScope> {
@@ -7340,7 +7458,8 @@ where
 				.as_mut()
 				.map(|pending_splice| pending_splice.negotiated_candidates.as_mut_slice())
 				.unwrap_or(&mut [])
-				.iter_mut(),
+				.iter_mut()
+				.map(|candidate| &mut candidate.funding),
 		)
 	}
 
@@ -7431,7 +7550,7 @@ where
 			.take()
 			.map(|negotiation| negotiation.is_initiator())
 			.unwrap_or(false);
-		let contribution = pending_splice.contributions.pop();
+		let contribution = pending_splice.negotiation_contribution.take();
 		if let Some(ref contribution) = contribution {
 			debug_assert!(
 				pending_splice
@@ -7442,8 +7561,8 @@ where
 			);
 		}
 
-		// After pop, `contributed_inputs()` / `contributed_outputs()` return only prior
-		// rounds for filtering.
+		// With the in-flight contribution taken, `contributed_inputs()` /
+		// `contributed_outputs()` return only prior rounds' entries for filtering.
 		let splice_funding_failed = contribution.and_then(|contribution| {
 			splice_funding_failed_for!(
 				self,
@@ -7454,7 +7573,7 @@ where
 			)
 		});
 
-		if self.pending_funding().is_empty() {
+		if self.negotiated_candidates().is_empty() {
 			self.pending_splice.take();
 		}
 
@@ -7481,7 +7600,7 @@ where
 			.as_ref()
 			.map(|negotiation| negotiation.is_initiator())
 			.unwrap_or(false);
-		let contribution = pending_splice.contributions.last().cloned()?;
+		let contribution = pending_splice.negotiation_contribution.clone()?;
 		splice_funding_failed_for!(
 			self,
 			is_initiator,
@@ -8114,7 +8233,7 @@ where
 		}
 
 		core::iter::once(&self.funding)
-			.chain(self.pending_funding().iter())
+			.chain(self.pending_funding())
 			.try_for_each(|funding| self.context.validate_update_add_htlc(funding, msg, fee_estimator))?;
 
 		// Now update local state:
@@ -8546,7 +8665,7 @@ where
 		let funding_contribution = self
 			.pending_splice
 			.as_ref()
-			.and_then(|pending_splice| pending_splice.contributions.last())
+			.and_then(|pending_splice| pending_splice.negotiation_contribution.as_ref())
 			.cloned();
 
 		log_info!(
@@ -8609,7 +8728,7 @@ where
 	) -> Result<Option<ChannelMonitorUpdate>, ChannelError> {
 		self.commitment_signed_check_state()?;
 
-		if !self.pending_funding().is_empty() {
+		if !self.negotiated_candidates().is_empty() {
 			return Err(ChannelError::close(
 				"Got a single commitment_signed message when expecting a batch".to_owned(),
 			));
@@ -8677,7 +8796,7 @@ where
 		// pending splice transaction has confirmed since receiving the batch.
 		let mut commitment_txs = Vec::with_capacity(self.pending_funding().len() + 1);
 		let mut htlc_data = None;
-		for funding in core::iter::once(&self.funding).chain(self.pending_funding().iter()) {
+		for funding in core::iter::once(&self.funding).chain(self.pending_funding()) {
 			let funding_txid =
 				funding.get_funding_txid().expect("Funding txid must be known for pending scope");
 			let msg = messages.get(&funding_txid).ok_or_else(|| {
@@ -9549,7 +9668,14 @@ where
 				let channel_type = funding.get_channel_type().clone();
 				let funding_redeem_script = funding.get_funding_redeemscript();
 
-				pending_splice.negotiated_candidates.push(funding);
+				let contribution = pending_splice.negotiation_contribution.take();
+				pending_splice
+					.negotiated_candidates
+					.push(NegotiatedCandidate { funding, contribution });
+				debug_assert!(
+					pending_splice.contributions_form_suffix(),
+					"a round following one we contributed to must carry our contribution",
+				);
 
 				let splice_negotiated = SpliceFundingNegotiated {
 					funding_txo: funding_txo.into_bitcoin_outpoint(),
@@ -9572,29 +9698,21 @@ where
 					);
 				}
 
-				let contrib_offset = pending_splice
-					.negotiated_candidates
-					.len()
-					.saturating_sub(pending_splice.contributions.len());
 				let candidates = pending_splice
 					.negotiated_candidates
 					.iter()
-					.enumerate()
-					.map(|(i, funding)| {
-						let txid = funding
+					.map(|candidate| {
+						let txid = candidate
+							.funding
 							.get_funding_txid()
 							.expect("negotiated candidates should have a funding txid");
-						let contribution = i
-							.checked_sub(contrib_offset)
-							.and_then(|j| pending_splice.contributions.get(j))
-							.cloned();
 						FundingCandidate {
 							txid,
 							channels: vec![ChannelFunding {
 								counterparty_node_id: self.context.counterparty_node_id,
 								channel_id: self.context.channel_id,
 								purpose: FundingPurpose::Splice,
-								contribution,
+								contribution: candidate.contribution.clone(),
 							}],
 						}
 					})
@@ -9755,7 +9873,7 @@ where
 		debug_assert!(!self.funding.get_channel_type().supports_anchor_zero_fee_commitments());
 
 		let can_send_update_fee = core::iter::once(&self.funding)
-			.chain(self.pending_funding().iter())
+			.chain(self.pending_funding())
 			.all(|funding| self.context.can_send_update_fee(funding, feerate_per_kw, fee_estimator, logger));
 		if !can_send_update_fee {
 			return None;
@@ -10106,7 +10224,7 @@ where
 		}
 
 		core::iter::once(&self.funding)
-			.chain(self.pending_funding().iter())
+			.chain(self.pending_funding())
 			.try_for_each(|funding| FundedChannel::<SP>::check_remote_fee(funding.get_channel_type(), fee_estimator, msg.feerate_per_kw, Some(self.context.feerate_per_kw), logger))?;
 
 		self.context.pending_update_fee = Some((msg.feerate_per_kw, FeeUpdateState::RemoteAnnounced));
@@ -10818,7 +10936,6 @@ where
 		//       for this `txid`.
 		let inferred_splice_locked = msg.my_current_funding_locked.as_ref().and_then(|funding_locked| {
 			self.pending_funding()
-				.iter()
 				.find(|funding| funding.get_funding_txid() == Some(funding_locked.txid))
 				.and_then(|_| {
 					self.pending_splice.as_ref().and_then(|pending_splice| {
@@ -11615,7 +11732,7 @@ where
 		);
 
 		core::iter::once(&self.funding)
-			.chain(self.pending_funding().iter())
+			.chain(self.pending_funding())
 			.try_for_each(|funding| self.context.can_accept_incoming_htlc(funding, dust_exposure_limiting_feerate, &logger))
 	}
 
@@ -11933,6 +12050,7 @@ where
 			let funding = pending_splice
 				.negotiated_candidates
 				.iter_mut()
+				.map(|candidate| &mut candidate.funding)
 				.find(|funding| funding.get_funding_txid() == Some(splice_txid))
 				.unwrap();
 
@@ -11947,9 +12065,12 @@ where
 				.funding_transaction
 				.as_ref()
 				.expect("Promoted splice funding should have a funding transaction");
-			let contributions = core::mem::take(&mut pending_splice.contributions);
-			contributions
+			let candidates = core::mem::take(&mut pending_splice.negotiated_candidates);
+			let negotiation_contribution = pending_splice.negotiation_contribution.take();
+			candidates
 				.into_iter()
+				.filter_map(|candidate| candidate.contribution)
+				.chain(negotiation_contribution)
 				.filter_map(|contribution| {
 					contribution.into_unique_contributions(
 						promoted_tx.input.iter().map(|i| i.previous_output),
@@ -12038,7 +12159,9 @@ where
 				let mut confirmed_funding_index = None;
 				let mut funding_already_confirmed = false;
 
-				for (index, funding) in pending_splice.negotiated_candidates.iter_mut().enumerate() {
+				let candidates =
+					pending_splice.negotiated_candidates.iter_mut().map(|candidate| &mut candidate.funding);
+				for (index, funding) in candidates.enumerate() {
 					if self.context.check_for_funding_tx_confirmed(
 						funding, block_hash, height, index_in_block, &mut confirmed_tx, logger,
 					)? {
@@ -12198,7 +12321,8 @@ where
 		if let Some(pending_splice) = &mut self.pending_splice {
 			let mut confirmed_funding_index = None;
 
-			for (index, funding) in pending_splice.negotiated_candidates.iter().enumerate() {
+			let candidates = pending_splice.negotiated_candidates.iter().map(|candidate| &candidate.funding);
+			for (index, funding) in candidates.enumerate() {
 				if funding.funding_tx_confirmation_height != 0 {
 					if confirmed_funding_index.is_some() {
 						let err_reason = "splice tx of another pending funding already confirmed";
@@ -12210,7 +12334,8 @@ where
 			}
 
 			if let Some(confirmed_funding_index) = confirmed_funding_index {
-				let funding = &mut pending_splice.negotiated_candidates[confirmed_funding_index];
+				let funding =
+					&mut pending_splice.negotiated_candidates[confirmed_funding_index].funding;
 
 				// Check if the splice funding transaction was unconfirmed
 				if funding.get_funding_tx_confirmations(height) == 0 {
@@ -12266,7 +12391,7 @@ where
 
 	pub fn get_relevant_txids(&self) -> impl Iterator<Item = (Txid, u32, Option<BlockHash>)> + '_ {
 		core::iter::once(&self.funding)
-			.chain(self.pending_funding().iter())
+			.chain(self.pending_funding())
 			.map(|funding| {
 				(
 					funding.get_funding_txid(),
@@ -12716,15 +12841,7 @@ where
 			);
 			let min_rbf_feerate = prev_feerate.map(min_rbf_feerate);
 			let prior = if pending_splice.last_funding_feerate_sat_per_1000_weight.is_some() {
-				if let Some(prior) = self
-					.pending_splice
-					.as_ref()
-					.and_then(|pending_splice| pending_splice.contributions.last())
-				{
-					Some(prior.clone())
-				} else {
-					None
-				}
+				pending_splice.latest_contribution().cloned()
 			} else {
 				None
 			};
@@ -13014,11 +13131,11 @@ where
 			FundingNegotiation::AwaitingAck { context, new_holder_funding_key: funding_pubkey };
 		self.pending_splice = Some(PendingFunding {
 			funding_negotiation: Some(funding_negotiation),
+			negotiation_contribution: None,
 			negotiated_candidates: vec![],
 			sent_funding_txid: None,
 			received_funding_txid: None,
 			last_funding_feerate_sat_per_1000_weight: None,
-			contributions: vec![],
 		});
 
 		msgs::SpliceInit {
@@ -13040,6 +13157,7 @@ where
 			.negotiated_candidates
 			.first()
 			.unwrap()
+			.funding
 			.get_holder_pubkeys()
 			.funding_pubkey;
 
@@ -13388,11 +13506,11 @@ where
 		);
 		self.pending_splice = Some(PendingFunding {
 			funding_negotiation: Some(funding_negotiation),
+			negotiation_contribution: adjusted_contribution,
 			negotiated_candidates: Vec::new(),
 			received_funding_txid: None,
 			sent_funding_txid: None,
 			last_funding_feerate_sat_per_1000_weight: None,
-			contributions: adjusted_contribution.into_iter().collect(),
 		});
 
 		Ok(msgs::SpliceAck {
@@ -13475,8 +13593,8 @@ where
 		// Reuse funding pubkeys from the last negotiated candidate since all RBF candidates
 		// for the same splice share the same funding output script.
 		Ok((
-			last_candidate.get_holder_pubkeys().clone(),
-			*last_candidate.counterparty_funding_pubkey(),
+			last_candidate.funding.get_holder_pubkeys().clone(),
+			*last_candidate.funding.counterparty_funding_pubkey(),
 		))
 	}
 
@@ -13500,7 +13618,7 @@ where
 		} else if let Some(prior) = self
 			.pending_splice
 			.as_ref()
-			.and_then(|pending_splice| pending_splice.contributions.last())
+			.and_then(|pending_splice| pending_splice.latest_contribution())
 		{
 			let net_value = holder_balance
 				.ok_or_else(|| ChannelError::Abort(AbortReason::InsufficientRbfFeerate))
@@ -13543,16 +13661,14 @@ where
 			self.pending_splice
 				.as_mut()
 				.expect("pending_splice is Some")
-				.contributions
-				.push(adjusted_contribution.clone());
+				.negotiation_contribution = Some(adjusted_contribution.clone());
 			adjusted_contribution.into_tx_parts()
 		} else if prior_net_value.is_some() {
 			let prior_contribution = self
 				.pending_splice
 				.as_ref()
 				.expect("pending_splice is Some")
-				.contributions
-				.last()
+				.latest_contribution()
 				.expect("prior_net_value was Some")
 				.clone();
 			let adjusted_contribution = prior_contribution
@@ -13561,8 +13677,7 @@ where
 			self.pending_splice
 				.as_mut()
 				.expect("pending_splice is Some")
-				.contributions
-				.push(adjusted_contribution.clone());
+				.negotiation_contribution = Some(adjusted_contribution.clone());
 			adjusted_contribution.into_tx_parts()
 		} else {
 			Default::default()
@@ -13620,8 +13735,8 @@ where
 		let last_candidate = pending_splice.negotiated_candidates.last().ok_or_else(|| {
 			ChannelError::WarnAndDisconnect("No negotiated splice candidates for RBF".to_owned())
 		})?;
-		let holder_pubkeys = last_candidate.get_holder_pubkeys().clone();
-		let counterparty_funding_pubkey = *last_candidate.counterparty_funding_pubkey();
+		let holder_pubkeys = last_candidate.funding.get_holder_pubkeys().clone();
+		let counterparty_funding_pubkey = *last_candidate.funding.counterparty_funding_pubkey();
 
 		let new_funding = self
 			.validate_splice_contributions(
@@ -13886,7 +14001,7 @@ where
 		if !pending_splice
 			.negotiated_candidates
 			.iter()
-			.any(|funding| funding.get_funding_txid() == Some(msg.splice_txid))
+			.any(|candidate| candidate.funding.get_funding_txid() == Some(msg.splice_txid))
 		{
 			let err = "unknown splice funding txid";
 			return Err(ChannelError::close(err.to_string()));
@@ -14084,7 +14199,7 @@ where
 		&self, fee_estimator: &LowerBoundedFeeEstimator<F>,
 	) -> Result<AvailableBalances, ()> {
 		let init = self.context.get_available_balances_for_scope(&self.funding, fee_estimator)?;
-		self.pending_funding().iter().try_fold(init, |acc, funding| {
+		self.pending_funding().try_fold(init, |acc, funding| {
 			let e = self.context.get_available_balances_for_scope(funding, fee_estimator)?;
 			Ok(AvailableBalances {
 				inbound_capacity_msat: acc.inbound_capacity_msat.min(e.inbound_capacity_msat),
@@ -14146,7 +14261,7 @@ where
 		}
 		self.context.resend_order = RAACommitmentOrder::RevokeAndACKFirst;
 
-		let update = if self.pending_funding().is_empty() {
+		let update = if self.negotiated_candidates().is_empty() {
 			let (htlcs_ref, counterparty_commitment_tx) =
 				self.build_commitment_no_state_update(&self.funding, logger);
 			let htlc_outputs = htlcs_ref
@@ -14177,7 +14292,7 @@ where
 		} else {
 			let mut htlc_data = None;
 			let commitment_txs = core::iter::once(&self.funding)
-				.chain(self.pending_funding().iter())
+				.chain(self.pending_funding())
 				.map(|funding| {
 					let (htlcs_ref, counterparty_commitment_tx) =
 						self.build_commitment_no_state_update(funding, logger);
@@ -14239,7 +14354,7 @@ where
 		&self, logger: &L,
 	) -> Result<Vec<msgs::CommitmentSigned>, ChannelError> {
 		core::iter::once(&self.funding)
-			.chain(self.pending_funding().iter())
+			.chain(self.pending_funding())
 			.map(|funding| self.send_commitment_no_state_update_for_funding(funding, logger))
 			.collect::<Result<Vec<_>, ChannelError>>()
 	}
@@ -14710,14 +14825,14 @@ where
 						}
 						let tx_init_rbf = self.send_tx_init_rbf(context);
 						self.pending_splice.as_mut().unwrap()
-							.contributions.push(prior_contribution);
+							.negotiation_contribution = Some(prior_contribution);
 						return Ok(Some(StfuResponse::TxInitRbf(tx_init_rbf)));
 					}
 
 					let splice_init = self.send_splice_init(context);
 					debug_assert!(self.pending_splice.is_some());
 					self.pending_splice.as_mut().unwrap()
-						.contributions.push(prior_contribution);
+						.negotiation_contribution = Some(prior_contribution);
 					return Ok(Some(StfuResponse::SpliceInit(splice_init)));
 				},
 				#[cfg(any(test, fuzzing, feature = "_test_utils"))]
@@ -16380,7 +16495,7 @@ impl<SP: SignerProvider> Writeable for FundedChannel<SP> {
 		// resumed on reestablishment, but keep any already-negotiated candidates.
 		let reset_funding_negotiation = self.should_reset_pending_splice_state(true);
 		let should_persist_pending_splice =
-			!reset_funding_negotiation || !self.pending_funding().is_empty();
+			!reset_funding_negotiation || !self.negotiated_candidates().is_empty();
 		let pending_splice = should_persist_pending_splice
 			.then(|| ())
 			.and_then(|_| self.pending_splice.as_ref())

--- a/lightning/src/ln/channel_state.rs
+++ b/lightning/src/ln/channel_state.rs
@@ -12,10 +12,12 @@
 use alloc::vec::Vec;
 
 use bitcoin::secp256k1::PublicKey;
+use bitcoin::Txid;
 
 use crate::chain::chaininterface::{FeeEstimator, LowerBoundedFeeEstimator};
 use crate::chain::transaction::OutPoint;
 use crate::ln::channel::Channel;
+use crate::ln::funding::FundingContribution;
 use crate::ln::types::ChannelId;
 use crate::sign::SignerProvider;
 use crate::types::features::{ChannelTypeFeatures, InitFeatures};
@@ -494,6 +496,11 @@ pub struct ChannelDetails {
 	///
 	/// [`ChannelConfig::max_dust_htlc_exposure`]: crate::util::config::ChannelConfig::max_dust_htlc_exposure
 	pub current_dust_exposure_msat: Option<u64>,
+	/// Details of any pending splice attempts on this channel, or `None` if no splice is pending.
+	///
+	/// See [`SpliceDetails`] for what is included. This will be `None` for objects serialized with
+	/// LDK versions prior to 0.3.
+	pub splice_details: Option<SpliceDetails>,
 }
 
 impl ChannelDetails {
@@ -619,6 +626,9 @@ impl ChannelDetails {
 			pending_inbound_htlcs: context.get_pending_inbound_htlc_details(funding),
 			pending_outbound_htlcs: context.get_pending_outbound_htlc_details(funding),
 			current_dust_exposure_msat: Some(balance.dust_exposure_msat),
+			splice_details: channel
+				.as_funded()
+				.and_then(|chan| chan.pending_splice_details(best_block_height)),
 		}
 	}
 }
@@ -661,9 +671,174 @@ impl_ser_tlv_based!(ChannelDetails, {
 	(45, pending_outbound_htlcs, optional_vec),
 	(47, funding_redeem_script, option),
 	(49, current_dust_exposure_msat, option),
+	(51, splice_details, option),
 	(_unused, user_channel_id, (static_value,
 		_user_channel_id_low.unwrap_or(0) as u128 | ((_user_channel_id_high.unwrap_or(0) as u128) << 64)
 	)),
+});
+
+/// Details of pending splice attempts on a channel, as returned in
+/// [`ChannelDetails::splice_details`].
+///
+/// This includes a contribution we have committed but not yet begun negotiating, any splice
+/// currently under negotiation with the counterparty, and any negotiated splice or RBF attempts
+/// waiting on sufficient on-chain confirmations.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SpliceDetails {
+	/// A splice or RBF attempt currently being negotiated with the counterparty, if any.
+	///
+	/// Note that a negotiation which has not yet reached
+	/// [`SpliceNegotiationStatus::AwaitingSignatures`] does not survive a restart, so this only
+	/// reflects in-memory negotiation state.
+	pub negotiation: Option<SpliceNegotiationDetails>,
+	/// Our contribution committed via [`ChannelManager::funding_contributed`] that has not yet begun
+	/// negotiating (it is awaiting quiescence with the counterparty), if any.
+	///
+	/// Like the in-flight [`negotiation`] state, this does not survive a restart.
+	///
+	/// [`ChannelManager::funding_contributed`]: crate::ln::channelmanager::ChannelManager::funding_contributed
+	/// [`negotiation`]: Self::negotiation
+	pub queued_contribution: Option<FundingContribution>,
+	/// Negotiated splice transactions that have not yet reached sufficient confirmations by both
+	/// counterparties to have exchanged `splice_locked`, in order: the original negotiation
+	/// followed by any RBF replacements.
+	///
+	/// More than one entry indicates the use of RBF; at most one of these candidates will
+	/// ultimately confirm.
+	pub candidates: Vec<SpliceCandidateDetails>,
+	/// The negotiated candidate that has confirmed on-chain (or, on a zero-conf channel, that we
+	/// have locked at zero confirmations), if any, along with its confirmation progress.
+	///
+	/// At most one candidate can confirm, as the candidates all double-spend the same input, so
+	/// this identifies the single confirming candidate rather than tracking confirmations on each.
+	pub confirmed_candidate: Option<ConfirmedSpliceCandidate>,
+	/// The txid announced in the `splice_locked` received from the counterparty, i.e., the
+	/// candidate that they consider to have sufficient confirmations.
+	///
+	/// Unlike the `splice_locked` we sent (see [`ConfirmedSpliceCandidate::splice_locked_sent`]),
+	/// this need not match [`confirmed_candidate`]: during a reorg, our counterparty may observe a
+	/// different candidate confirm.
+	///
+	/// [`confirmed_candidate`]: Self::confirmed_candidate
+	pub received_splice_locked_txid: Option<Txid>,
+}
+
+impl_ser_tlv_based!(SpliceDetails, {
+	(1, negotiation, option),
+	(3, queued_contribution, option),
+	(5, candidates, required_vec),
+	(7, confirmed_candidate, option),
+	(9, received_splice_locked_txid, option),
+});
+
+/// Details of a splice or RBF attempt currently being negotiated with the counterparty.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SpliceNegotiationDetails {
+	/// How far the negotiation has progressed.
+	pub status: SpliceNegotiationStatus,
+	/// Whether we initiated the negotiation.
+	pub is_initiator: bool,
+	/// The feerate of the splice transaction under negotiation, denominated in satoshi per 1000
+	/// weight units.
+	pub funding_feerate_sat_per_1000_weight: u32,
+	/// The value, in satoshis, of the channel once the splice transaction under negotiation
+	/// confirms and is promoted.
+	///
+	/// This will be `None` while [`SpliceNegotiationStatus::AwaitingAck`], as the value is not
+	/// known until both counterparties' contributions have been exchanged.
+	pub new_channel_value_satoshis: Option<u64>,
+	/// The txid of the splice transaction under negotiation.
+	///
+	/// This will be `None` until [`SpliceNegotiationStatus::AwaitingSignatures`], as the txid is
+	/// not known until the transaction has been fully constructed.
+	pub txid: Option<Txid>,
+	/// Our contribution to the splice under negotiation, or `None` if we are not contributing.
+	///
+	/// Note that for a counterparty-initiated RBF attempt, this is the prior round's contribution
+	/// adjusted to the new feerate.
+	pub contribution: Option<FundingContribution>,
+}
+
+impl_ser_tlv_based!(SpliceNegotiationDetails, {
+	(1, status, required),
+	(3, is_initiator, required),
+	(5, funding_feerate_sat_per_1000_weight, required),
+	(7, new_channel_value_satoshis, option),
+	(9, txid, option),
+	(11, contribution, option),
+});
+
+/// The status of a splice or RBF negotiation in progress with the counterparty.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpliceNegotiationStatus {
+	/// We sent `splice_init` or `tx_init_rbf` and are awaiting the counterparty's acknowledgement.
+	AwaitingAck,
+	/// The splice transaction is being interactively constructed.
+	ConstructingTransaction,
+	/// The splice transaction has been negotiated and is awaiting signatures from both
+	/// counterparties.
+	AwaitingSignatures,
+}
+
+impl_ser_tlv_based_enum!(SpliceNegotiationStatus,
+	(0, AwaitingAck) => {},
+	(2, ConstructingTransaction) => {},
+	(4, AwaitingSignatures) => {},
+);
+
+/// Details of a negotiated splice transaction that has not yet reached sufficient confirmations
+/// by both counterparties to have exchanged `splice_locked`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SpliceCandidateDetails {
+	/// The txid of the splice transaction.
+	pub txid: Txid,
+	/// The value, in satoshis, of the channel once this candidate confirms and is promoted.
+	pub new_channel_value_satoshis: u64,
+	/// Our contribution to this candidate, or `None` if we did not contribute.
+	///
+	/// Once a candidate includes our contribution, every later candidate does as well: RBF
+	/// attempts carry the contribution forward (possibly adjusted to a new feerate) rather than
+	/// dropping it, preserving the splice intention.
+	///
+	/// Note that [`FundingContribution::feerate`] is the feerate used when selecting the
+	/// contribution's inputs, which is not necessarily the exact feerate of the negotiated
+	/// transaction.
+	pub contribution: Option<FundingContribution>,
+}
+
+impl_ser_tlv_based!(SpliceCandidateDetails, {
+	(1, txid, required),
+	(3, new_channel_value_satoshis, required),
+	(5, contribution, option),
+});
+
+/// The confirmation progress of the negotiated splice candidate that has confirmed on-chain, as
+/// exposed in [`SpliceDetails::confirmed_candidate`].
+///
+/// At most one candidate can confirm, as the candidates all double-spend the same input, so this
+/// identifies the single confirming candidate by its txid.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConfirmedSpliceCandidate {
+	/// The txid of the candidate that has confirmed on-chain. This matches the [`txid`] of one of
+	/// the [`SpliceDetails::candidates`].
+	///
+	/// [`txid`]: SpliceCandidateDetails::txid
+	pub txid: Txid,
+	/// The current number of confirmations of the candidate's transaction.
+	pub confirmations: u32,
+	/// The number of confirmations required before `splice_locked` can be sent for the candidate.
+	pub confirmations_required: u32,
+	/// Whether we have sent `splice_locked` for this candidate, i.e., we consider it to have
+	/// sufficient confirmations. The `splice_locked` we sent always refers to this confirmed
+	/// candidate, so it is tracked here rather than as a separate txid.
+	pub splice_locked_sent: bool,
+}
+
+impl_ser_tlv_based!(ConfirmedSpliceCandidate, {
+	(1, txid, required),
+	(3, confirmations, required),
+	(5, confirmations_required, required),
+	(7, splice_locked_sent, required),
 });
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -718,7 +893,10 @@ mod tests {
 		},
 	};
 
-	use super::{ChannelCounterparty, ChannelDetails, ChannelShutdownState};
+	use super::{
+		ChannelCounterparty, ChannelDetails, ChannelShutdownState, ConfirmedSpliceCandidate,
+		SpliceCandidateDetails, SpliceDetails, SpliceNegotiationDetails, SpliceNegotiationStatus,
+	};
 
 	#[test]
 	fn test_channel_details_serialization() {
@@ -783,6 +961,29 @@ mod tests {
 				is_dust: false,
 			}],
 			current_dust_exposure_msat: Some(150_000),
+			splice_details: Some(SpliceDetails {
+				negotiation: Some(SpliceNegotiationDetails {
+					status: SpliceNegotiationStatus::ConstructingTransaction,
+					is_initiator: true,
+					funding_feerate_sat_per_1000_weight: 1000,
+					new_channel_value_satoshis: Some(70_000),
+					txid: None,
+					contribution: None,
+				}),
+				queued_contribution: None,
+				candidates: vec![SpliceCandidateDetails {
+					txid: bitcoin::Txid::from_slice(&[7; 32]).unwrap(),
+					new_channel_value_satoshis: 60_000,
+					contribution: None,
+				}],
+				confirmed_candidate: Some(ConfirmedSpliceCandidate {
+					txid: bitcoin::Txid::from_slice(&[7; 32]).unwrap(),
+					confirmations: 3,
+					confirmations_required: 6,
+					splice_locked_sent: false,
+				}),
+				received_splice_locked_txid: Some(bitcoin::Txid::from_slice(&[7; 32]).unwrap()),
+			}),
 		};
 		let mut buffer = Vec::new();
 		channel_details.write(&mut buffer).unwrap();

--- a/lightning/src/ln/splicing_tests.rs
+++ b/lightning/src/ln/splicing_tests.rs
@@ -552,26 +552,59 @@ pub fn complete_interactive_funding_negotiation_for_both<'a, 'b, 'c, 'd>(
 	assert!(expected_acceptor_scripts.is_empty(), "Not all acceptor outputs were sent");
 }
 
-pub fn sign_interactive_funding_tx<'a, 'b, 'c, 'd>(
-	initiator: &'a Node<'b, 'c, 'd>, acceptor: &'a Node<'b, 'c, 'd>, is_0conf: bool,
+/// Arguments for [`sign_interactive_funding_tx`]. [`SignInteractiveFundingTxArgs::new`] defaults to a
+/// first-attempt splice on a confirmed channel where only the initiator contributes; augment with the
+/// builder methods as the scenario requires.
+pub struct SignInteractiveFundingTxArgs<'a, 'b, 'c, 'd> {
+	initiator: &'a Node<'b, 'c, 'd>,
+	acceptor: &'a Node<'b, 'c, 'd>,
+	is_0conf: bool,
+	acceptor_has_contribution: bool,
 	expected_replaced_txid: Option<Txid>,
+}
+
+impl<'a, 'b, 'c, 'd> SignInteractiveFundingTxArgs<'a, 'b, 'c, 'd> {
+	pub fn new(initiator: &'a Node<'b, 'c, 'd>, acceptor: &'a Node<'b, 'c, 'd>) -> Self {
+		Self {
+			initiator,
+			acceptor,
+			is_0conf: false,
+			acceptor_has_contribution: false,
+			expected_replaced_txid: None,
+		}
+	}
+
+	/// The channel is zero-conf, so `splice_locked` is exchanged at signing and the initiator's
+	/// `splice_locked` is returned.
+	pub fn zero_conf(mut self) -> Self {
+		self.is_0conf = true;
+		self
+	}
+
+	/// The acceptor contributed inputs and so must also sign the funding transaction.
+	pub fn with_acceptor_contribution(mut self) -> Self {
+		self.acceptor_has_contribution = true;
+		self
+	}
+
+	/// This is an RBF replacing the negotiated candidate `prior_txid`, expected as the prior candidate
+	/// in the `TransactionType::InteractiveFunding` broadcast.
+	pub fn replacing(mut self, prior_txid: Txid) -> Self {
+		self.expected_replaced_txid = Some(prior_txid);
+		self
+	}
+}
+
+pub fn sign_interactive_funding_tx<'a, 'b, 'c, 'd>(
+	args: SignInteractiveFundingTxArgs<'a, 'b, 'c, 'd>,
 ) -> (Transaction, Option<(msgs::SpliceLocked, PublicKey)>) {
-	sign_interactive_funding_tx_with_acceptor_contribution(
+	let SignInteractiveFundingTxArgs {
 		initiator,
 		acceptor,
 		is_0conf,
-		false,
+		acceptor_has_contribution,
 		expected_replaced_txid,
-	)
-}
-
-/// `expected_replaced_txid` is the expected txid of the prior negotiated candidate in the
-/// `TransactionType::InteractiveFunding` broadcast: `None` for a first splice attempt; `Some(txid)`
-/// for an RBF replacing that prior negotiated candidate.
-pub fn sign_interactive_funding_tx_with_acceptor_contribution<'a, 'b, 'c, 'd>(
-	initiator: &'a Node<'b, 'c, 'd>, acceptor: &'a Node<'b, 'c, 'd>, is_0conf: bool,
-	acceptor_has_contribution: bool, expected_replaced_txid: Option<Txid>,
-) -> (Transaction, Option<(msgs::SpliceLocked, PublicKey)>) {
+	} = args;
 	let node_id_initiator = initiator.node.get_our_node_id();
 	let node_id_acceptor = acceptor.node.get_our_node_id();
 
@@ -714,7 +747,8 @@ pub fn splice_channel<'a, 'b, 'c, 'd>(
 		funding_contribution,
 		new_funding_script.clone(),
 	);
-	let (splice_tx, splice_locked) = sign_interactive_funding_tx(initiator, acceptor, false, None);
+	let (splice_tx, splice_locked) =
+		sign_interactive_funding_tx(SignInteractiveFundingTxArgs::new(initiator, acceptor));
 	assert!(splice_locked.is_none());
 
 	expect_splice_pending_event(initiator, &node_id_acceptor);
@@ -1745,7 +1779,8 @@ fn fails_initiating_concurrent_splices(reconnect: bool) {
 		}),
 	);
 
-	let (splice_tx, splice_locked) = sign_interactive_funding_tx(&nodes[0], &nodes[1], false, None);
+	let (splice_tx, splice_locked) =
+		sign_interactive_funding_tx(SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]));
 	assert!(splice_locked.is_none());
 
 	expect_splice_pending_event(&nodes[0], &node_1_id);
@@ -1949,8 +1984,8 @@ fn do_test_splice_tiebreak(
 		);
 
 		// Sign (acceptor has contribution) and broadcast.
-		let (tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-			&nodes[0], &nodes[1], false, true, None,
+		let (tx, splice_locked) = sign_interactive_funding_tx(
+			SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).with_acceptor_contribution(),
 		);
 		assert!(splice_locked.is_none());
 
@@ -2017,9 +2052,8 @@ fn do_test_splice_tiebreak(
 		);
 
 		// Sign (no acceptor contribution) and broadcast.
-		let (tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-			&nodes[0], &nodes[1], false, false, None,
-		);
+		let (tx, splice_locked) =
+			sign_interactive_funding_tx(SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]));
 		assert!(splice_locked.is_none());
 
 		expect_splice_pending_event(&nodes[0], &node_id_1);
@@ -2066,7 +2100,7 @@ fn do_test_splice_tiebreak(
 		);
 
 		let (new_splice_tx, splice_locked) =
-			sign_interactive_funding_tx(&nodes[1], &nodes[0], false, None);
+			sign_interactive_funding_tx(SignInteractiveFundingTxArgs::new(&nodes[1], &nodes[0]));
 		assert!(splice_locked.is_none());
 
 		expect_splice_pending_event(&nodes[1], &node_id_0);
@@ -3582,9 +3616,12 @@ fn do_test_propose_splice_while_disconnected(use_0conf: bool) {
 		splice_ack.funding_contribution_satoshis,
 		new_funding_script,
 	);
-	let (splice_tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-		&nodes[0], &nodes[1], use_0conf, true, None,
-	);
+	let mut args =
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).with_acceptor_contribution();
+	if use_0conf {
+		args = args.zero_conf();
+	}
+	let (splice_tx, splice_locked) = sign_interactive_funding_tx(args);
 	expect_splice_pending_event(&nodes[0], &node_id_1);
 	expect_splice_pending_event(&nodes[1], &node_id_0);
 
@@ -4020,7 +4057,8 @@ fn acceptor_can_cancel_queued_funding_contributed_during_counterparty_splice() {
 		new_funding_script,
 	);
 
-	let (splice_tx, splice_locked) = sign_interactive_funding_tx(initiator, acceptor, false, None);
+	let (splice_tx, splice_locked) =
+		sign_interactive_funding_tx(SignInteractiveFundingTxArgs::new(initiator, acceptor));
 	assert!(splice_locked.is_none());
 	expect_splice_pending_event(initiator, &node_id_acceptor);
 	expect_splice_pending_event(acceptor, &node_id_initiator);
@@ -6108,10 +6146,8 @@ fn test_splice_rbf_acceptor_basic() {
 	// Step 10: Sign and broadcast. The prior candidate in the broadcast's
 	// `TransactionType::InteractiveFunding` must point at the first splice tx it is replacing.
 	let (rbf_tx, splice_locked) = sign_interactive_funding_tx(
-		&nodes[0],
-		&nodes[1],
-		false,
-		Some(first_splice_tx.compute_txid()),
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+			.replacing(first_splice_tx.compute_txid()),
 	);
 	assert!(splice_locked.is_none());
 
@@ -6209,10 +6245,8 @@ fn test_splice_rbf_discard_unique_contribution() {
 	);
 
 	let (rbf_tx, splice_locked) = sign_interactive_funding_tx(
-		&nodes[0],
-		&nodes[1],
-		false,
-		Some(first_splice_tx.compute_txid()),
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+			.replacing(first_splice_tx.compute_txid()),
 	);
 	assert!(splice_locked.is_none());
 
@@ -6277,10 +6311,8 @@ fn test_splice_rbf_at_high_feerate() {
 		new_funding_script.clone(),
 	);
 	let (rbf_tx_1, splice_locked) = sign_interactive_funding_tx(
-		&nodes[0],
-		&nodes[1],
-		false,
-		Some(first_splice_tx.compute_txid()),
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+			.replacing(first_splice_tx.compute_txid()),
 	);
 	assert!(splice_locked.is_none());
 	expect_splice_pending_event(&nodes[0], &node_id_1);
@@ -6301,8 +6333,9 @@ fn test_splice_rbf_at_high_feerate() {
 		contribution,
 		new_funding_script,
 	);
-	let (_, splice_locked) =
-		sign_interactive_funding_tx(&nodes[0], &nodes[1], false, Some(rbf_tx_1.compute_txid()));
+	let (_, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).replacing(rbf_tx_1.compute_txid()),
+	);
 	assert!(splice_locked.is_none());
 	expect_splice_pending_event(&nodes[0], &node_id_1);
 	expect_splice_pending_event(&nodes[1], &node_id_0);
@@ -6502,8 +6535,9 @@ fn test_splice_rbf_insufficient_feerate_high() {
 		contribution,
 		new_funding_script,
 	);
-	let (_, splice_locked) =
-		sign_interactive_funding_tx(&nodes[0], &nodes[1], false, Some(splice_tx.compute_txid()));
+	let (_, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).replacing(splice_tx.compute_txid()),
+	);
 	assert!(splice_locked.is_none());
 	expect_splice_pending_event(&nodes[0], &node_id_1);
 	expect_splice_pending_event(&nodes[1], &node_id_0);
@@ -7127,12 +7161,10 @@ pub fn do_test_splice_rbf_tiebreak(
 		);
 
 		// Sign (acceptor has contribution) and broadcast.
-		let (rbf_tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-			&nodes[0],
-			&nodes[1],
-			false,
-			true,
-			Some(first_splice_tx.compute_txid()),
+		let (rbf_tx, splice_locked) = sign_interactive_funding_tx(
+			SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+				.with_acceptor_contribution()
+				.replacing(first_splice_tx.compute_txid()),
 		);
 		assert!(splice_locked.is_none());
 
@@ -7208,12 +7240,9 @@ pub fn do_test_splice_rbf_tiebreak(
 		);
 
 		// Sign (acceptor has no contribution) and broadcast.
-		let (rbf_tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-			&nodes[0],
-			&nodes[1],
-			false,
-			false,
-			Some(first_splice_tx.compute_txid()),
+		let (rbf_tx, splice_locked) = sign_interactive_funding_tx(
+			SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+				.replacing(first_splice_tx.compute_txid()),
 		);
 		assert!(splice_locked.is_none());
 
@@ -7277,7 +7306,7 @@ pub fn do_test_splice_rbf_tiebreak(
 
 		// Sign (no acceptor contribution) and broadcast.
 		let (new_splice_tx, splice_locked) =
-			sign_interactive_funding_tx(&nodes[1], &nodes[0], false, None);
+			sign_interactive_funding_tx(SignInteractiveFundingTxArgs::new(&nodes[1], &nodes[0]));
 		assert!(splice_locked.is_none());
 
 		expect_splice_pending_event(&nodes[1], &node_id_0);
@@ -7459,8 +7488,8 @@ fn test_splice_rbf_acceptor_recontributes() {
 		new_funding_script.clone(),
 	);
 
-	let (first_splice_tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-		&nodes[0], &nodes[1], false, true, None,
+	let (first_splice_tx, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).with_acceptor_contribution(),
 	);
 	assert!(splice_locked.is_none());
 
@@ -7497,12 +7526,10 @@ fn test_splice_rbf_acceptor_recontributes() {
 	);
 
 	// Step 11: Sign (acceptor has contribution) and broadcast.
-	let (rbf_tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-		&nodes[0],
-		&nodes[1],
-		false,
-		true,
-		Some(first_splice_tx.compute_txid()),
+	let (rbf_tx, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+			.with_acceptor_contribution()
+			.replacing(first_splice_tx.compute_txid()),
 	);
 	assert!(splice_locked.is_none());
 
@@ -7594,8 +7621,8 @@ fn test_splice_rbf_after_counterparty_rbf_aborted() {
 		new_funding_script,
 	);
 
-	let (_first_splice_tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-		&nodes[0], &nodes[1], false, true, None,
+	let (_first_splice_tx, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).with_acceptor_contribution(),
 	);
 	assert!(splice_locked.is_none());
 
@@ -7727,8 +7754,8 @@ fn test_splice_rbf_recontributes_feerate_too_high() {
 		new_funding_script.clone(),
 	);
 
-	let (_first_splice_tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-		&nodes[0], &nodes[1], false, true, None,
+	let (_first_splice_tx, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).with_acceptor_contribution(),
 	);
 	assert!(splice_locked.is_none());
 
@@ -7814,8 +7841,10 @@ fn test_splice_rbf_sequential() {
 		funding_contribution_1,
 		new_funding_script.clone(),
 	);
-	let (splice_tx_1, splice_locked) =
-		sign_interactive_funding_tx(&nodes[0], &nodes[1], false, Some(splice_tx_0.compute_txid()));
+	let (splice_tx_1, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+			.replacing(splice_tx_0.compute_txid()),
+	);
 	assert!(splice_locked.is_none());
 	expect_splice_pending_event(&nodes[0], &node_id_1);
 	expect_splice_pending_event(&nodes[1], &node_id_0);
@@ -7835,8 +7864,10 @@ fn test_splice_rbf_sequential() {
 		funding_contribution_2,
 		new_funding_script.clone(),
 	);
-	let (rbf_tx_final, splice_locked) =
-		sign_interactive_funding_tx(&nodes[0], &nodes[1], false, Some(splice_tx_1.compute_txid()));
+	let (rbf_tx_final, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+			.replacing(splice_tx_1.compute_txid()),
+	);
 	assert!(splice_locked.is_none());
 	expect_splice_pending_event(&nodes[0], &node_id_1);
 	expect_splice_pending_event(&nodes[1], &node_id_0);
@@ -7904,8 +7935,9 @@ fn test_splice_rbf_amends_prior_net_positive_contribution_request() {
 			contribution,
 			new_funding_script.clone(),
 		);
-		let (tx, splice_locked) =
-			sign_interactive_funding_tx(&nodes[0], &nodes[1], false, Some(replaced_txid));
+		let (tx, splice_locked) = sign_interactive_funding_tx(
+			SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).replacing(replaced_txid),
+		);
 		assert!(splice_locked.is_none());
 		expect_splice_pending_event(&nodes[0], &node_id_1);
 		expect_splice_pending_event(&nodes[1], &node_id_0);
@@ -8038,8 +8070,9 @@ fn test_splice_rbf_amends_prior_net_negative_contribution_request() {
 			contribution,
 			new_funding_script.clone(),
 		);
-		let (tx, splice_locked) =
-			sign_interactive_funding_tx(&nodes[0], &nodes[1], false, Some(replaced_txid));
+		let (tx, splice_locked) = sign_interactive_funding_tx(
+			SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).replacing(replaced_txid),
+		);
 		assert!(splice_locked.is_none());
 		expect_splice_pending_event(&nodes[0], &node_id_1);
 		expect_splice_pending_event(&nodes[1], &node_id_0);
@@ -8200,8 +8233,8 @@ fn test_splice_rbf_acceptor_contributes_then_disconnects() {
 		new_funding_script.clone(),
 	);
 
-	let (_first_splice_tx, splice_locked) = sign_interactive_funding_tx_with_acceptor_contribution(
-		&nodes[0], &nodes[1], false, true, None,
+	let (_first_splice_tx, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).with_acceptor_contribution(),
 	);
 	assert!(splice_locked.is_none());
 
@@ -9081,10 +9114,8 @@ fn test_splice_rbf_rejects_low_feerate_after_several_attempts() {
 			new_funding_script.clone(),
 		);
 		let (rbf_tx, splice_locked) = sign_interactive_funding_tx(
-			&nodes[0],
-			&nodes[1],
-			false,
-			Some(prev_splice_tx.compute_txid()),
+			SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+				.replacing(prev_splice_tx.compute_txid()),
 		);
 		assert!(splice_locked.is_none());
 		expect_splice_pending_event(&nodes[0], &node_id_1);
@@ -9156,10 +9187,8 @@ fn test_splice_rbf_rejects_own_low_feerate_after_several_attempts() {
 			new_funding_script.clone(),
 		);
 		let (rbf_tx, splice_locked) = sign_interactive_funding_tx(
-			&nodes[0],
-			&nodes[1],
-			false,
-			Some(prev_splice_tx.compute_txid()),
+			SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+				.replacing(prev_splice_tx.compute_txid()),
 		);
 		assert!(splice_locked.is_none());
 		expect_splice_pending_event(&nodes[0], &node_id_1);
@@ -9230,7 +9259,8 @@ fn test_no_disconnect_after_splice_completes() {
 		funding_contribution,
 		new_funding_script,
 	);
-	let (_, splice_locked) = sign_interactive_funding_tx(&nodes[0], &nodes[1], false, None);
+	let (_, splice_locked) =
+		sign_interactive_funding_tx(SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]));
 	assert!(splice_locked.is_none());
 
 	let node_id_0 = nodes[0].node.get_our_node_id();

--- a/lightning/src/ln/splicing_tests.rs
+++ b/lightning/src/ln/splicing_tests.rs
@@ -22,6 +22,7 @@ use crate::ln::channel::{
 	DISCONNECT_PEER_AWAITING_RESPONSE_TICKS, FEE_SPIKE_BUFFER_FEE_INCREASE_MULTIPLE,
 	MIN_CHANNEL_VALUE_SATOSHIS,
 };
+use crate::ln::channel_state::{SpliceDetails, SpliceNegotiationStatus};
 use crate::ln::channelmanager::{provided_init_features, PaymentId, BREAKDOWN_TIMEOUT};
 use crate::ln::functional_test_utils::*;
 use crate::ln::funding::{FundingContribution, FundingContributionError, FundingTemplate};
@@ -561,6 +562,7 @@ pub struct SignInteractiveFundingTxArgs<'a, 'b, 'c, 'd> {
 	is_0conf: bool,
 	acceptor_has_contribution: bool,
 	expected_replaced_txid: Option<Txid>,
+	unconfirmed_funding_txid: Option<Txid>,
 }
 
 impl<'a, 'b, 'c, 'd> SignInteractiveFundingTxArgs<'a, 'b, 'c, 'd> {
@@ -571,6 +573,7 @@ impl<'a, 'b, 'c, 'd> SignInteractiveFundingTxArgs<'a, 'b, 'c, 'd> {
 			is_0conf: false,
 			acceptor_has_contribution: false,
 			expected_replaced_txid: None,
+			unconfirmed_funding_txid: None,
 		}
 	}
 
@@ -593,6 +596,14 @@ impl<'a, 'b, 'c, 'd> SignInteractiveFundingTxArgs<'a, 'b, 'c, 'd> {
 		self.expected_replaced_txid = Some(prior_txid);
 		self
 	}
+
+	/// The channel's funding transaction, identified by `unconfirmed_funding_txid`, is still
+	/// unconfirmed, so signing also (re-)broadcasts it; the helper asserts it is broadcast alongside
+	/// the splice.
+	pub fn with_unconfirmed_funding(mut self, unconfirmed_funding_txid: Txid) -> Self {
+		self.unconfirmed_funding_txid = Some(unconfirmed_funding_txid);
+		self
+	}
 }
 
 pub fn sign_interactive_funding_tx<'a, 'b, 'c, 'd>(
@@ -604,6 +615,7 @@ pub fn sign_interactive_funding_tx<'a, 'b, 'c, 'd>(
 		is_0conf,
 		acceptor_has_contribution,
 		expected_replaced_txid,
+		unconfirmed_funding_txid,
 	} = args;
 	let node_id_initiator = initiator.node.get_our_node_id();
 	let node_id_acceptor = acceptor.node.get_our_node_id();
@@ -696,6 +708,19 @@ pub fn sign_interactive_funding_tx<'a, 'b, 'c, 'd>(
 
 	let tx = {
 		let mut initiator_txn = initiator.tx_broadcaster.txn_broadcast_with_types();
+		if let Some(unconfirmed_funding_txid) = unconfirmed_funding_txid {
+			// The initiator (re-)broadcasts its still-unconfirmed funding alongside the splice;
+			// remove it so only the splice (InteractiveFunding) remains to compare against the acceptor.
+			assert_eq!(initiator_txn.len(), 2);
+			let pos = initiator_txn
+				.iter()
+				.position(|(tx, tx_type)| {
+					tx.compute_txid() == unconfirmed_funding_txid
+						&& matches!(tx_type, TransactionType::Funding { .. })
+				})
+				.expect("the unconfirmed funding should be (re-)broadcast");
+			initiator_txn.remove(pos);
+		}
 		assert_eq!(initiator_txn.len(), 1);
 		let mut acceptor_txn = acceptor.tx_broadcaster.txn_broadcast_with_types();
 		assert_eq!(acceptor_txn.len(), 1);
@@ -2495,6 +2520,23 @@ fn do_test_splice_reestablish(reload: bool, async_monitor_update: bool) {
 		);
 		// We should have another signing event generated upon reload as they're not persisted.
 		let _ = get_event!(nodes[0], Event::FundingTransactionReadyForSigning);
+
+		// The negotiation is awaiting signatures, so it has no negotiated candidate yet, only our
+		// in-flight contribution. That contribution (written under its own TLV) survives the reload.
+		let details = nodes[0]
+			.node
+			.list_channels()
+			.iter()
+			.find(|channel| channel.channel_id == channel_id)
+			.unwrap()
+			.splice_details
+			.clone()
+			.unwrap();
+		let negotiation = details.negotiation.expect("an in-flight splice negotiation");
+		assert_eq!(negotiation.status, SpliceNegotiationStatus::AwaitingSignatures);
+		assert!(negotiation.contribution.is_some());
+		assert!(details.candidates.is_empty());
+
 		if async_monitor_update {
 			persister_0a.set_update_ret(ChannelMonitorUpdateStatus::InProgress);
 			persister_1a.set_update_ret(ChannelMonitorUpdateStatus::InProgress);
@@ -4037,6 +4079,21 @@ fn acceptor_can_cancel_queued_funding_contributed_during_counterparty_splice() {
 		.funding_contributed(&channel_id, &node_id_initiator, queued_contribution.clone(), None)
 		.unwrap();
 	assert!(acceptor.node.get_and_clear_pending_msg_events().is_empty());
+
+	// The acceptor is mid-negotiation on the counterparty's splice and has its own contribution
+	// queued behind it; both surface at once.
+	let details = acceptor
+		.node
+		.list_channels()
+		.into_iter()
+		.find(|channel| channel.channel_id == channel_id)
+		.unwrap()
+		.splice_details
+		.unwrap();
+	assert_eq!(details.queued_contribution, Some(queued_contribution.clone()));
+	let negotiation = details.negotiation.unwrap();
+	assert_eq!(negotiation.status, SpliceNegotiationStatus::ConstructingTransaction);
+	assert!(!negotiation.is_initiator);
 
 	acceptor.node.cancel_funding_contributed(&channel_id, &node_id_initiator).unwrap();
 	let reason = NegotiationFailureReason::LocallyCanceled;
@@ -10277,4 +10334,562 @@ fn test_splice_out_maximum_includes_pending_claimed_inbound_htlc() {
 	assert_eq!(node_1_details.next_splice_out_maximum_sat, expected_splice_out_max);
 
 	assert!(nodes[1].node.splice_channel(&channel_id, &node_id_0).is_ok());
+}
+
+#[test]
+fn test_channel_details_pending_splice() {
+	// Test that `ChannelDetails::splice_details` reflects pending splice state throughout
+	// negotiation, signing, RBF, restarts, and locking.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let (persister_0, persister_1);
+	let (chain_monitor_0, chain_monitor_1);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let (node_0, node_1);
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let node_id_0 = nodes[0].node.get_our_node_id();
+	let node_id_1 = nodes[1].node.get_our_node_id();
+
+	let initial_channel_value_sat = 100_000;
+	let (_, _, channel_id, _) =
+		create_announced_chan_between_nodes_with_value(&nodes, 0, 1, initial_channel_value_sat, 0);
+
+	let splice_details = |node: &Node<'_, '_, '_>| {
+		node.node
+			.list_channels()
+			.iter()
+			.find(|channel| channel.channel_id == channel_id)
+			.unwrap()
+			.splice_details
+			.clone()
+	};
+
+	// No splice is pending yet.
+	assert_eq!(splice_details(&nodes[0]), None);
+	assert_eq!(splice_details(&nodes[1]), None);
+
+	let added_value = Amount::from_sat(50_000);
+	provide_utxo_reserves(&nodes, 2, added_value * 2);
+
+	// Contributing funds queues the contribution but does not start the negotiation; that begins
+	// once the channel becomes quiescent and splice_init is sent. Until then it surfaces as a
+	// queued contribution with no negotiation.
+	let contribution = do_initiate_splice_in(&nodes[0], &nodes[1], channel_id, added_value);
+	assert_eq!(
+		splice_details(&nodes[0]),
+		Some(SpliceDetails {
+			negotiation: None,
+			queued_contribution: Some(contribution.clone()),
+			candidates: vec![],
+			confirmed_candidate: None,
+			received_splice_locked_txid: None,
+		}),
+	);
+	assert_eq!(splice_details(&nodes[1]), None);
+
+	let new_channel_value_sat =
+		(initial_channel_value_sat as i64 + contribution.net_value().to_sat()) as u64;
+
+	let stfu_init = get_event_msg!(nodes[0], MessageSendEvent::SendStfu, node_id_1);
+	nodes[1].node.handle_stfu(node_id_0, &stfu_init);
+	let stfu_ack = get_event_msg!(nodes[1], MessageSendEvent::SendStfu, node_id_0);
+	nodes[0].node.handle_stfu(node_id_1, &stfu_ack);
+
+	// Once quiescent, the initiator sends splice_init and awaits the counterparty's splice_ack.
+	// The new channel value is not yet known as it depends on the counterparty's contribution.
+	let details = splice_details(&nodes[0]).unwrap();
+	let negotiation = details.negotiation.unwrap();
+	assert_eq!(negotiation.status, SpliceNegotiationStatus::AwaitingAck);
+	assert!(negotiation.is_initiator);
+	assert_eq!(negotiation.funding_feerate_sat_per_1000_weight, FEERATE_FLOOR_SATS_PER_KW);
+	assert_eq!(negotiation.new_channel_value_satoshis, None);
+	assert_eq!(negotiation.txid, None);
+	assert_eq!(negotiation.contribution, Some(contribution.clone()));
+	assert!(details.candidates.is_empty());
+	assert_eq!(splice_details(&nodes[1]), None);
+
+	let splice_init = get_event_msg!(nodes[0], MessageSendEvent::SendSpliceInit, node_id_1);
+	nodes[1].node.handle_splice_init(node_id_0, &splice_init);
+
+	// The acceptor starts constructing the transaction upon receiving splice_init, at which
+	// point both contributions are known.
+	let details = splice_details(&nodes[1]).unwrap();
+	let negotiation = details.negotiation.unwrap();
+	assert_eq!(negotiation.status, SpliceNegotiationStatus::ConstructingTransaction);
+	assert!(!negotiation.is_initiator);
+	assert_eq!(negotiation.funding_feerate_sat_per_1000_weight, FEERATE_FLOOR_SATS_PER_KW);
+	assert_eq!(negotiation.new_channel_value_satoshis, Some(new_channel_value_sat));
+	assert_eq!(negotiation.txid, None);
+	assert_eq!(negotiation.contribution, None);
+	assert!(details.candidates.is_empty());
+
+	let splice_ack = get_event_msg!(nodes[1], MessageSendEvent::SendSpliceAck, node_id_0);
+	nodes[0].node.handle_splice_ack(node_id_1, &splice_ack);
+
+	let negotiation = splice_details(&nodes[0]).unwrap().negotiation.unwrap();
+	assert_eq!(negotiation.status, SpliceNegotiationStatus::ConstructingTransaction);
+	assert!(negotiation.is_initiator);
+	assert_eq!(negotiation.new_channel_value_satoshis, Some(new_channel_value_sat));
+	assert_eq!(negotiation.txid, None);
+
+	let new_funding_script = chan_utils::make_funding_redeemscript(
+		&splice_init.funding_pubkey,
+		&splice_ack.funding_pubkey,
+	)
+	.to_p2wsh();
+
+	complete_interactive_funding_negotiation(
+		&nodes[0],
+		&nodes[1],
+		channel_id,
+		contribution.clone(),
+		new_funding_script.clone(),
+	);
+
+	// Once construction completes, the negotiation awaits signatures and the txid is known.
+	let negotiation_0 = splice_details(&nodes[0]).unwrap().negotiation.unwrap();
+	let negotiation_1 = splice_details(&nodes[1]).unwrap().negotiation.unwrap();
+	assert_eq!(negotiation_0.status, SpliceNegotiationStatus::AwaitingSignatures);
+	assert_eq!(negotiation_1.status, SpliceNegotiationStatus::AwaitingSignatures);
+	assert!(negotiation_0.txid.is_some());
+	assert_eq!(negotiation_0.txid, negotiation_1.txid);
+	assert_eq!(negotiation_0.new_channel_value_satoshis, Some(new_channel_value_sat));
+	assert_eq!(negotiation_0.contribution, Some(contribution.clone()));
+	assert_eq!(negotiation_1.contribution, None);
+
+	let (splice_tx, splice_locked) =
+		sign_interactive_funding_tx(SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]));
+	assert!(splice_locked.is_none());
+	assert_eq!(negotiation_0.txid, Some(splice_tx.compute_txid()));
+
+	expect_splice_pending_event(&nodes[0], &node_id_1);
+	expect_splice_pending_event(&nodes[1], &node_id_0);
+
+	// With signatures exchanged, the negotiated splice is a candidate awaiting confirmations.
+	let details = splice_details(&nodes[0]).unwrap();
+	assert_eq!(details.negotiation, None);
+	assert_eq!(details.candidates.len(), 1);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+	assert_eq!(details.candidates[0].new_channel_value_satoshis, new_channel_value_sat);
+	assert_eq!(details.candidates[0].contribution, Some(contribution.clone()));
+	assert_eq!(details.confirmed_candidate, None);
+	assert_eq!(details.received_splice_locked_txid, None);
+
+	// The acceptor did not contribute to the splice.
+	let details = splice_details(&nodes[1]).unwrap();
+	assert_eq!(details.negotiation, None);
+	assert_eq!(details.candidates.len(), 1);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+	assert_eq!(details.candidates[0].contribution, None);
+
+	// Initiate an RBF attempt at a higher feerate.
+	provide_utxo_reserves(&nodes, 2, added_value * 2);
+	let rbf_feerate_sat_per_kwu = FEERATE_FLOOR_SATS_PER_KW as u64 + 25;
+	let rbf_feerate = FeeRate::from_sat_per_kwu(rbf_feerate_sat_per_kwu);
+	let rbf_contribution = do_initiate_rbf_splice_in(&nodes[0], &nodes[1], channel_id, rbf_feerate);
+
+	// The RBF contribution is queued behind the still-pending original candidate until quiescence
+	// is re-reached; until then it surfaces as a queued contribution with no negotiation.
+	let details = splice_details(&nodes[0]).unwrap();
+	assert_eq!(details.queued_contribution, Some(rbf_contribution.clone()));
+	assert_eq!(details.negotiation, None);
+	assert_eq!(details.candidates.len(), 1);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+
+	// Reaching quiescence turns the queued RBF contribution into a negotiation. The initiator sends
+	// tx_init_rbf and awaits tx_ack_rbf, so the RBF round is reported as AwaitingAck alongside the
+	// still-pending original candidate.
+	let stfu_init = get_event_msg!(nodes[0], MessageSendEvent::SendStfu, node_id_1);
+	nodes[1].node.handle_stfu(node_id_0, &stfu_init);
+	let stfu_ack = get_event_msg!(nodes[1], MessageSendEvent::SendStfu, node_id_0);
+	nodes[0].node.handle_stfu(node_id_1, &stfu_ack);
+
+	let details = splice_details(&nodes[0]).unwrap();
+	let negotiation = details.negotiation.unwrap();
+	assert_eq!(negotiation.status, SpliceNegotiationStatus::AwaitingAck);
+	assert_eq!(negotiation.funding_feerate_sat_per_1000_weight, rbf_feerate_sat_per_kwu as u32);
+	assert_eq!(negotiation.contribution, Some(rbf_contribution.clone()));
+	assert_eq!(details.candidates.len(), 1);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+
+	let tx_init_rbf = get_event_msg!(nodes[0], MessageSendEvent::SendTxInitRbf, node_id_1);
+	nodes[1].node.handle_tx_init_rbf(node_id_0, &tx_init_rbf);
+	let tx_ack_rbf = get_event_msg!(nodes[1], MessageSendEvent::SendTxAckRbf, node_id_0);
+	nodes[0].node.handle_tx_ack_rbf(node_id_1, &tx_ack_rbf);
+
+	// The RBF negotiation then moves to constructing the transaction, still alongside the original
+	// candidate.
+	let details = splice_details(&nodes[0]).unwrap();
+	let negotiation = details.negotiation.unwrap();
+	assert_eq!(negotiation.status, SpliceNegotiationStatus::ConstructingTransaction);
+	assert_eq!(negotiation.funding_feerate_sat_per_1000_weight, rbf_feerate_sat_per_kwu as u32);
+	assert_eq!(negotiation.contribution, Some(rbf_contribution.clone()));
+	assert_eq!(details.candidates.len(), 1);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+	assert_eq!(details.candidates[0].contribution, Some(contribution.clone()));
+
+	let rbf_channel_value_sat =
+		(initial_channel_value_sat as i64 + rbf_contribution.net_value().to_sat()) as u64;
+
+	complete_interactive_funding_negotiation(
+		&nodes[0],
+		&nodes[1],
+		channel_id,
+		rbf_contribution.clone(),
+		new_funding_script,
+	);
+	let (rbf_tx, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1]).replacing(splice_tx.compute_txid()),
+	);
+	assert!(splice_locked.is_none());
+
+	expect_splice_pending_event(&nodes[0], &node_id_1);
+	expect_splice_pending_event(&nodes[1], &node_id_0);
+
+	// Both the original splice and its RBF replacement are candidates, in negotiation order.
+	let details = splice_details(&nodes[0]).unwrap();
+	assert_eq!(details.negotiation, None);
+	assert_eq!(details.candidates.len(), 2);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+	assert_eq!(details.candidates[0].contribution, Some(contribution.clone()));
+	assert_eq!(details.candidates[1].txid, rbf_tx.compute_txid());
+	assert_eq!(details.candidates[1].new_channel_value_satoshis, rbf_channel_value_sat);
+	assert_eq!(details.candidates[1].contribution, Some(rbf_contribution.clone()));
+
+	let details = splice_details(&nodes[1]).unwrap();
+	assert_eq!(details.candidates.len(), 2);
+	assert_eq!(details.candidates[1].contribution, None);
+
+	// Pending splice state, including per-candidate contributions, survives a restart.
+	let encoded_monitor_0 = get_monitor!(nodes[0], channel_id).encode();
+	reload_node!(
+		nodes[0],
+		&nodes[0].node.encode(),
+		&[&encoded_monitor_0],
+		persister_0,
+		chain_monitor_0,
+		node_0
+	);
+	let encoded_monitor_1 = get_monitor!(nodes[1], channel_id).encode();
+	reload_node!(
+		nodes[1],
+		&nodes[1].node.encode(),
+		&[&encoded_monitor_1],
+		persister_1,
+		chain_monitor_1,
+		node_1
+	);
+
+	let details = splice_details(&nodes[0]).unwrap();
+	assert_eq!(details.negotiation, None);
+	assert_eq!(details.candidates.len(), 2);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+	assert_eq!(details.candidates[0].contribution, Some(contribution));
+	assert_eq!(details.candidates[1].txid, rbf_tx.compute_txid());
+	assert_eq!(details.candidates[1].contribution, Some(rbf_contribution));
+
+	let details = splice_details(&nodes[1]).unwrap();
+	assert_eq!(details.candidates.len(), 2);
+	assert!(details.candidates.iter().all(|candidate| candidate.contribution.is_none()));
+
+	let mut reconnect_args = ReconnectArgs::new(&nodes[0], &nodes[1]);
+	reconnect_args.send_announcement_sigs = (true, true);
+	reconnect_nodes(reconnect_args);
+
+	// Mine the RBF transaction; only its candidate confirms, identified by its index.
+	mine_transaction(&nodes[0], &rbf_tx);
+	mine_transaction(&nodes[1], &rbf_tx);
+
+	let details = splice_details(&nodes[0]).unwrap();
+	let confirmed = details.confirmed_candidate.unwrap();
+	assert_eq!(confirmed.txid, rbf_tx.compute_txid());
+	assert_eq!(confirmed.confirmations, 1);
+	assert_eq!(confirmed.confirmations_required, 6);
+
+	connect_blocks(&nodes[0], ANTI_REORG_DELAY - 1);
+	connect_blocks(&nodes[1], ANTI_REORG_DELAY - 1);
+
+	// Once sufficiently confirmed, the splice_locked we sent is reflected in the details until
+	// the counterparty's splice_locked is received and the splice is promoted.
+	let splice_locked = get_event_msg!(nodes[0], MessageSendEvent::SendSpliceLocked, node_id_1);
+	let details = splice_details(&nodes[0]).unwrap();
+	assert_eq!(details.received_splice_locked_txid, None);
+	let confirmed = details.confirmed_candidate.unwrap();
+	assert_eq!(confirmed.txid, rbf_tx.compute_txid());
+	assert!(confirmed.splice_locked_sent);
+	assert_eq!(confirmed.confirmations, ANTI_REORG_DELAY);
+
+	lock_splice(&nodes[0], &nodes[1], &splice_locked, false, &[splice_tx.compute_txid()]);
+
+	// The splice is no longer pending once promoted.
+	assert_eq!(splice_details(&nodes[0]), None);
+	assert_eq!(splice_details(&nodes[1]), None);
+}
+
+#[test]
+fn test_channel_details_first_contribution_on_rbf() {
+	// When the counterparty's splice did not include a contribution from us and our first
+	// contribution comes in an RBF round we initiate, the in-flight contribution must not be
+	// attributed to the negotiated counterparty-only candidate.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let node_id_0 = nodes[0].node.get_our_node_id();
+	let node_id_1 = nodes[1].node.get_our_node_id();
+
+	let initial_channel_value_sat = 100_000;
+	let (_, _, channel_id, _) =
+		create_announced_chan_between_nodes_with_value(&nodes, 0, 1, initial_channel_value_sat, 0);
+
+	let added_value = Amount::from_sat(50_000);
+	provide_utxo_reserves(&nodes, 2, added_value * 2);
+
+	// Splice initiated by node 1; node 0 does not contribute.
+	let contribution = do_initiate_splice_in(&nodes[1], &nodes[0], channel_id, added_value);
+	let (splice_tx, _) = splice_channel(&nodes[1], &nodes[0], channel_id, contribution);
+
+	// Node 0 initiates an RBF, contributing for the first time.
+	let rbf_feerate = FeeRate::from_sat_per_kwu(FEERATE_FLOOR_SATS_PER_KW as u64 + 25);
+	let funding_template = nodes[0].node.splice_channel(&channel_id, &node_id_1).unwrap();
+	let wallet = WalletSync::new(Arc::clone(&nodes[0].wallet_source), nodes[0].logger);
+	let rbf_contribution = funding_template
+		.without_prior_contribution(rbf_feerate, FeeRate::MAX)
+		.with_coin_selection_source_sync(&wallet)
+		.add_value(added_value)
+		.unwrap()
+		.build()
+		.unwrap();
+	nodes[0]
+		.node
+		.funding_contributed(&channel_id, &node_id_1, rbf_contribution.clone(), None)
+		.unwrap();
+	complete_rbf_handshake(&nodes[0], &nodes[1]);
+	let _ = get_event_msg!(nodes[0], MessageSendEvent::SendTxAddInput, node_id_1);
+
+	// While the RBF is being negotiated, node 0's contribution belongs to the negotiation, not
+	// to the negotiated counterparty-only candidate.
+	let channels = nodes[0].node.list_channels();
+	let details = channels[0].splice_details.as_ref().unwrap();
+	assert_eq!(details.negotiation.as_ref().unwrap().contribution, Some(rbf_contribution.clone()));
+	assert_eq!(details.candidates.len(), 1);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+	assert_eq!(details.candidates[0].contribution, None);
+
+	// Node 1 adjusted its prior contribution for the RBF round; the negotiated candidate keeps
+	// its original contribution.
+	let channels = nodes[1].node.list_channels();
+	let details = channels[0].splice_details.as_ref().unwrap();
+	assert!(details.negotiation.as_ref().unwrap().contribution.is_some());
+	assert!(details.candidates[0].contribution.is_some());
+
+	// Abort the negotiation via disconnect.
+	nodes[0].node.peer_disconnected(node_id_1);
+	nodes[1].node.peer_disconnected(node_id_0);
+
+	expect_splice_failed_events(
+		&nodes[0],
+		&channel_id,
+		rbf_contribution,
+		NegotiationFailureReason::PeerDisconnected,
+	);
+	// Node 1 did not initiate the RBF round and its contribution to it (the prior round's
+	// contribution adjusted to the new feerate) has no inputs or outputs unique from the prior
+	// round, so no events are emitted.
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+
+	// After the reset, the contribution alignment is restored on both nodes.
+	let channels = nodes[0].node.list_channels();
+	let details = channels[0].splice_details.as_ref().unwrap();
+	assert_eq!(details.negotiation, None);
+	assert_eq!(details.candidates[0].contribution, None);
+	let channels = nodes[1].node.list_channels();
+	let details = channels[0].splice_details.as_ref().unwrap();
+	assert_eq!(details.negotiation, None);
+	assert!(details.candidates[0].contribution.is_some());
+}
+
+#[test]
+fn test_channel_details_zero_conf_splice() {
+	// On a zero-conf channel the splice is locked (we send `splice_locked`) before it has any
+	// confirmations, so `ChannelDetails::splice_details` must still report the locked candidate as
+	// the confirmed candidate at zero confirmations. Once both sides exchange `splice_locked` the
+	// splice is promoted to the channel funding and is no longer reported as pending.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let mut config = test_default_channel_config();
+	config.channel_handshake_limits.trust_own_funding_0conf = true;
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[Some(config.clone()), Some(config)]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let node_id_0 = nodes[0].node.get_our_node_id();
+	let node_id_1 = nodes[1].node.get_our_node_id();
+
+	let initial_channel_value_sat = 100_000;
+	// Leave the original funding unconfirmed -- a zero-conf channel is usable without it -- so the
+	// test stays focused on the zero-conf splice.
+	let (funding_tx, channel_id) =
+		open_zero_conf_channel_with_value(&nodes[0], &nodes[1], None, initial_channel_value_sat, 0);
+
+	let added_value = Amount::from_sat(50_000);
+	provide_utxo_reserves(&nodes, 1, added_value * 2);
+
+	let contribution = do_initiate_splice_in(&nodes[0], &nodes[1], channel_id, added_value);
+	let new_funding_script = complete_splice_handshake(&nodes[0], &nodes[1]);
+	complete_interactive_funding_negotiation(
+		&nodes[0],
+		&nodes[1],
+		channel_id,
+		contribution,
+		new_funding_script,
+	);
+
+	// Sign the splice. The original funding is still unconfirmed, so signing also (re-)broadcasts it
+	// alongside the splice; the helper asserts that and returns the splice transaction. We leave node 0
+	// without the counterparty's `splice_locked`, so the splice stays pending on node 0.
+	let (splice_tx, splice_locked) = sign_interactive_funding_tx(
+		SignInteractiveFundingTxArgs::new(&nodes[0], &nodes[1])
+			.zero_conf()
+			.with_unconfirmed_funding(funding_tx.compute_txid()),
+	);
+
+	expect_splice_pending_event(&nodes[0], &node_id_1);
+	expect_splice_pending_event(&nodes[1], &node_id_0);
+
+	// Node 0 has sent `splice_locked` but has not yet received the counterparty's, so the splice is
+	// still pending. The candidate we locked is reported as the confirmed candidate even though it
+	// has zero confirmations.
+	let details = nodes[0]
+		.node
+		.list_channels()
+		.iter()
+		.find(|channel| channel.channel_id == channel_id)
+		.unwrap()
+		.splice_details
+		.clone()
+		.unwrap();
+	let confirmed =
+		details.confirmed_candidate.expect("the locked zero-conf candidate should be reported");
+	assert_eq!(confirmed.txid, splice_tx.compute_txid());
+	assert_eq!(confirmed.confirmations, 0);
+	assert_eq!(confirmed.confirmations_required, 0);
+	assert!(confirmed.splice_locked_sent);
+	assert_eq!(details.received_splice_locked_txid, None);
+
+	// Exchange both sides' `splice_locked` to lock the splice in. Node 0 sent its at signing (above);
+	// `lock_splice` delivers it to node 1 and brings node 1's back, promoting the splice to the
+	// channel funding on both sides.
+	let (splice_locked_for_node_1, _) =
+		splice_locked.expect("a zero-conf splice sends splice_locked at signing");
+	lock_splice(&nodes[0], &nodes[1], &splice_locked_for_node_1, true, &[]);
+
+	// With the splice promoted, it is no longer reported as a pending splice.
+	let splice_details = |node: &Node<'_, '_, '_>| {
+		node.node
+			.list_channels()
+			.iter()
+			.find(|channel| channel.channel_id == channel_id)
+			.unwrap()
+			.splice_details
+			.clone()
+	};
+	assert_eq!(splice_details(&nodes[0]), None);
+	assert_eq!(splice_details(&nodes[1]), None);
+}
+
+#[test]
+fn test_channel_details_received_splice_locked() {
+	// `received_splice_locked_txid` reports the candidate the counterparty considers locked. Confirm
+	// the splice on only one node so it sends `splice_locked` while the other has not confirmed: the
+	// recipient records the received txid while the splice is still pending and unconfirmed for it.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let node_id_0 = nodes[0].node.get_our_node_id();
+	let node_id_1 = nodes[1].node.get_our_node_id();
+
+	let initial_channel_value_sat = 100_000;
+	let (_, _, channel_id, _) =
+		create_announced_chan_between_nodes_with_value(&nodes, 0, 1, initial_channel_value_sat, 0);
+
+	let added_value = Amount::from_sat(50_000);
+	provide_utxo_reserves(&nodes, 2, added_value * 2);
+	let contribution = do_initiate_splice_in(&nodes[0], &nodes[1], channel_id, added_value);
+	let (splice_tx, _) = splice_channel(&nodes[0], &nodes[1], channel_id, contribution);
+
+	// Confirm the splice on node 0 only, so it sends `splice_locked` while node 1 has not confirmed.
+	mine_transaction(&nodes[0], &splice_tx);
+	connect_blocks(&nodes[0], ANTI_REORG_DELAY - 1);
+	let splice_locked = get_event_msg!(nodes[0], MessageSendEvent::SendSpliceLocked, node_id_1);
+
+	nodes[1].node.handle_splice_locked(node_id_0, &splice_locked);
+
+	// Node 1 records the counterparty's locked candidate, but has not confirmed it itself, so it has
+	// no confirmed candidate of its own and the splice remains pending.
+	let details = nodes[1]
+		.node
+		.list_channels()
+		.iter()
+		.find(|channel| channel.channel_id == channel_id)
+		.unwrap()
+		.splice_details
+		.clone()
+		.unwrap();
+	assert_eq!(details.received_splice_locked_txid, Some(splice_tx.compute_txid()));
+	assert_eq!(details.confirmed_candidate, None);
+	assert_eq!(details.candidates.len(), 1);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
+}
+
+#[test]
+fn test_channel_details_splice_reorg_clears_confirmed_candidate() {
+	// A confirmed splice candidate we have locked is reported as the confirmed candidate; a reorg
+	// that unconfirms it clears the confirmed candidate, including the splice_locked we sent.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let node_id_1 = nodes[1].node.get_our_node_id();
+
+	let initial_channel_value_sat = 100_000;
+	let (_, _, channel_id, _) =
+		create_announced_chan_between_nodes_with_value(&nodes, 0, 1, initial_channel_value_sat, 0);
+
+	let added_value = Amount::from_sat(50_000);
+	provide_utxo_reserves(&nodes, 2, added_value * 2);
+	let contribution = do_initiate_splice_in(&nodes[0], &nodes[1], channel_id, added_value);
+	let (splice_tx, _) = splice_channel(&nodes[0], &nodes[1], channel_id, contribution);
+
+	let splice_details = |node: &Node<'_, '_, '_>| {
+		node.node
+			.list_channels()
+			.iter()
+			.find(|channel| channel.channel_id == channel_id)
+			.unwrap()
+			.splice_details
+			.clone()
+	};
+
+	// Confirm the splice on node 0 so it sends splice_locked and reports the confirmed candidate.
+	mine_transaction(&nodes[0], &splice_tx);
+	connect_blocks(&nodes[0], ANTI_REORG_DELAY - 1);
+	let _ = get_event_msg!(nodes[0], MessageSendEvent::SendSpliceLocked, node_id_1);
+
+	let confirmed = splice_details(&nodes[0]).unwrap().confirmed_candidate.unwrap();
+	assert_eq!(confirmed.txid, splice_tx.compute_txid());
+	assert!(confirmed.splice_locked_sent);
+
+	// Reorg out the blocks that confirmed the splice. The confirmed candidate is cleared, along with
+	// the splice_locked we sent for it; the candidate itself remains pending.
+	disconnect_blocks(&nodes[0], ANTI_REORG_DELAY);
+
+	let details = splice_details(&nodes[0]).unwrap();
+	assert_eq!(details.confirmed_candidate, None);
+	assert_eq!(details.candidates.len(), 1);
+	assert_eq!(details.candidates[0].txid, splice_tx.compute_txid());
 }

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -4249,6 +4249,7 @@ mod tests {
 			pending_inbound_htlcs: Vec::new(),
 			pending_outbound_htlcs: Vec::new(),
 			current_dust_exposure_msat: None,
+			splice_details: None,
 		}
 	}
 
@@ -9813,6 +9814,7 @@ pub(crate) mod bench_utils {
 			pending_inbound_htlcs: Vec::new(),
 			pending_outbound_htlcs: Vec::new(),
 			current_dust_exposure_msat: None,
+			splice_details: None,
 		}
 	}
 

--- a/pending_changelog/4687-pending-splice-details.txt
+++ b/pending_changelog/4687-pending-splice-details.txt
@@ -1,0 +1,19 @@
+# API Updates
+
+ * `ChannelDetails` now has a `splice_details` field
+   (`Option<SpliceDetails>`) reporting any pending splice attempts on a channel:
+   a contribution committed via `ChannelManager::funding_contributed` but not yet
+   negotiating, the in-flight negotiation (`SpliceNegotiationDetails`, with
+   progress given by `SpliceNegotiationStatus`), the negotiated candidates
+   awaiting confirmation (`SpliceCandidateDetails`), the confirmed candidate's
+   progress (`ConfirmedSpliceCandidate`), and the txid of any `splice_locked`
+   received from the counterparty.
+
+# Backwards Compatibility
+
+ * A channel with a pending splice negotiated before upgrading from a prior LDK
+   version (e.g. 0.2) can no longer be spliced: `ChannelManager::splice_channel`
+   now returns an `APIError::APIMisuseError`. Older versions persisted neither the
+   prior feerate (needed to derive the minimum RBF feerate floor) nor our prior
+   contribution (needed to build the RBF transaction), so an RBF attempt cannot
+   proceed.


### PR DESCRIPTION
Wallets like LDK Node need to show a channel's pending splice state (e.g., when displaying channel details), but it is currently only observable by tracking events or the broadcaster's `TransactionType::InteractiveFunding`, neither of which can be queried on demand.

This adds an optional `splice_details` field to `ChannelDetails` exposing that state: any splice/RBF round under negotiation (status, feerate, our contribution, txid and post-splice value once known) and any negotiated candidates awaiting confirmations, along with the `splice_locked` txids exchanged.

The first commit refactors `PendingFunding` to store each round's contribution with its negotiated candidate instead of in a tail-aligned parallel list, which every consumer had to realign (and which this API initially got wrong). The on-disk format is unchanged and remains readable by LDK 0.2.