### PR TITLE
Remove unnecessary (and incorrect) `&mut` cast in net-tokio

### DIFF
--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -663,7 +663,7 @@ fn clone_socket_waker(orig_ptr: *const ()) -> task::RawWaker {
 // sending thread may have already gone away due to a socket close, in which case there's nothing
 // to wake up anyway.
 fn wake_socket_waker(orig_ptr: *const ()) {
-	let sender = unsafe { &mut *(orig_ptr as *mut mpsc::Sender<()>) };
+	let sender = unsafe { &*(orig_ptr as *mut mpsc::Sender<()>) };
 	let _ = sender.try_send(());
 	drop_socket_waker(orig_ptr);
 }


### PR DESCRIPTION
The owned `Waker` wake method assumed it had the only reference to the sender as the `Waker` is owned at that point, however our `Waker`s can be `clone`d, leaving multiple references to the inner `Sender` (held in an `Arc`).

Thus, the `&mut` cast is technically undefined behavior. However, as this patch demonstrates, its only use is in calling an `&self` method which derefs an internal `Arc` in tokio, so its highly unlikely to lead to miscompilation.

Reported by Project Loupe.