### PR TITLE
(Actually) remove incorrect `*mut` cast in net-tokio

### DIFF
--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -663,8 +663,7 @@ fn clone_socket_waker(orig_ptr: *const ()) -> task::RawWaker {
 // sending thread may have already gone away due to a socket close, in which case there's nothing
 // to wake up anyway.
 fn wake_socket_waker(orig_ptr: *const ()) {
-	let sender = unsafe { &*(orig_ptr as *mut mpsc::Sender<()>) };
-	let _ = sender.try_send(());
+	wake_socket_waker_by_ref(orig_ptr);
 	drop_socket_waker(orig_ptr);
 }
 fn wake_socket_waker_by_ref(orig_ptr: *const ()) {


### PR DESCRIPTION
In ae62fa377a0a139d937ce2c7d87d3eb1612732af we removed an incorrect `&mut`, but failed to actually resolve the mut aliasing bug - there remained a deref of a `*mut` which is similarly invalid. Here we actually fix the bug and also DRY up code marginally.

Reported by Project Loupe.