### PR TITLE
Fix: reject fake scids with invalid vout

### DIFF
--- a/lightning/src/util/scid_utils.rs
+++ b/lightning/src/util/scid_utils.rs
@@ -180,7 +180,7 @@ pub(crate) mod fake_scid {
 		let namespace = Namespace::Phantom;
 		let valid_vout = namespace.get_encrypted_vout(block_height, tx_index, fake_scid_rand_bytes);
 		block_height >= segwit_activation_height(chain_hash)
-			&& valid_vout == scid_utils::vout_from_scid(scid) as u8
+			&& valid_vout as u16 == scid_utils::vout_from_scid(scid)
 	}
 
 	/// Returns whether the given fake scid falls into the intercept namespace.
@@ -192,7 +192,7 @@ pub(crate) mod fake_scid {
 		let namespace = Namespace::Intercept;
 		let valid_vout = namespace.get_encrypted_vout(block_height, tx_index, fake_scid_rand_bytes);
 		block_height >= segwit_activation_height(chain_hash)
-			&& valid_vout == scid_utils::vout_from_scid(scid) as u8
+			&& valid_vout as u16 == scid_utils::vout_from_scid(scid)
 	}
 
 	#[cfg(test)]
@@ -248,6 +248,15 @@ pub(crate) mod fake_scid {
 			assert!(is_valid_phantom(&fake_scid_rand_bytes, valid_fake_scid, &testnet_genesis));
 			let invalid_fake_scid = scid_utils::scid_from_parts(1, 0, 12).unwrap();
 			assert!(!is_valid_phantom(&fake_scid_rand_bytes, invalid_fake_scid, &testnet_genesis));
+			// A scid whose low byte matches the namespace value but whose high byte is set must be
+			// rejected (this was previously broken).
+			let high_byte_fake_scid =
+				scid_utils::scid_from_parts(1, 0, valid_encrypted_vout as u64 | 0x0100).unwrap();
+			assert!(!is_valid_phantom(
+				&fake_scid_rand_bytes,
+				high_byte_fake_scid,
+				&testnet_genesis
+			));
 		}
 
 		#[test]
@@ -263,6 +272,15 @@ pub(crate) mod fake_scid {
 			assert!(!is_valid_intercept(
 				&fake_scid_rand_bytes,
 				invalid_fake_scid,
+				&testnet_genesis
+			));
+			// A scid whose low byte matches the namespace value but whose high byte is set must be
+			// rejected (this was previously broken).
+			let high_byte_fake_scid =
+				scid_utils::scid_from_parts(1, 0, valid_encrypted_vout as u64 | 0x0100).unwrap();
+			assert!(!is_valid_intercept(
+				&fake_scid_rand_bytes,
+				high_byte_fake_scid,
 				&testnet_genesis
 			));
 		}


### PR DESCRIPTION
Previously, we would spuriously allow fake scids that had a vout with the high byte set to pass our `is_valid_{phantom,intercept,etc}_scid` checks, even though our fake vouts only ever set the lowest 3 bits of the 2-byte vout.

This can't really be exploited since HTLCs that pass this check would still fail later on in the pipeline, and attackers that want to craft fake scids to pass our checks can still do so after this fix, either via brute force or by reusing a valid fake scid from a previously issued invoice. But at least this makes it harder for them to do so, and makes the check more correct than it was before. Plus invalid fake crafted scids like this could theoretically cause us to generate a spurious `HTLCIntercepted` event, which wouldn't be ideal.

Reported by Project Loupe.