### PR TITLE
Reject case-varied LSPS5 replay signatures

### DIFF
--- a/lightning-liquidity/src/lsps5/validator.rs
+++ b/lightning-liquidity/src/lsps5/validator.rs
@@ -11,7 +11,6 @@
 
 use super::msgs::LSPS5ClientError;
 
-use crate::alloc::string::ToString;
 use crate::lsps0::ser::LSPSDateTime;
 use crate::lsps5::msgs::WebhookNotification;
 use crate::sync::Mutex;
@@ -91,14 +90,17 @@ impl LSPS5Validator {
 	}
 
 	fn check_for_replay_attack(&self, signature: &str) -> Result<(), LSPS5ClientError> {
+		// zbase32 decoding accepts case aliases, so canonicalize the cache key
+		// to match verification semantics without decoding the signature again.
+		let signature = signature.to_ascii_lowercase();
 		let mut signatures = self.recent_signatures.lock().unwrap();
-		if signatures.contains(&signature.to_string()) {
+		if signatures.contains(&signature) {
 			return Err(LSPS5ClientError::ReplayAttack);
 		}
 		if signatures.len() == MAX_RECENT_SIGNATURES {
 			signatures.pop_back();
 		}
-		signatures.push_front(signature.to_string());
+		signatures.push_front(signature);
 		Ok(())
 	}
 }

--- a/lightning-liquidity/tests/lsps5_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps5_integration_tests.rs
@@ -988,6 +988,16 @@ fn replay_prevention_test() {
 	assert!(replay_result.is_err(), "Immediate replay attack should be detected");
 	assert_eq!(replay_result.unwrap_err(), LSPS5ClientError::ReplayAttack);
 
+	let case_modified_signature = signature.to_ascii_uppercase();
+	assert_ne!(case_modified_signature, signature);
+	let case_modified_replay_result =
+		validator.validate(service_node_id, &timestamp, &case_modified_signature, &body);
+	assert!(
+		case_modified_replay_result.is_err(),
+		"Immediate replay attack should be detected when the signature case changes"
+	);
+	assert_eq!(case_modified_replay_result.unwrap_err(), LSPS5ClientError::ReplayAttack);
+
 	// Fill up the validator's signature cache to push out the original signature.
 	for i in 0..MAX_RECENT_SIGNATURES {
 		// Advance time, allowing for another notification


### PR DESCRIPTION
LSPS5 webhook signatures are zbase32 strings, and the verifier accepts case aliases when decoding them. The replay cache compared raw header strings, so a case-only change could bypass immediate replay detection even though it represented the same signature bytes.

Canonicalize the verified signature text before cache lookup and storage. Keying the replay cache on decoded signature bytes would be the semantic ideal, but doing that locally would decode once in the validator and again inside message_signing::verify. This keeps the fix local while matching the verifier's identity semantics. Add regression coverage for the case-varied replay.