### PR TITLE
Refuse to build feature objects larger than `u16::MAX` bytes

### DIFF
--- a/lightning-types/src/features.rs
+++ b/lightning-types/src/features.rs
@@ -1268,6 +1268,9 @@ impl<T: sealed::Context> Features<T> {
 	fn set_bit(&mut self, bit: usize, custom: bool) -> Result<(), ()> {
 		let byte_offset = bit / 8;
 		let mask = 1 << (bit - 8 * byte_offset);
+		if byte_offset >= u16::MAX as usize {
+			return Err(());
+		}
 		if byte_offset < T::KNOWN_FEATURE_MASK.len() && custom {
 			if (T::KNOWN_FEATURE_MASK[byte_offset] & mask) != 0 {
 				return Err(());

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -40,7 +40,10 @@ macro_rules! impl_feature_len_prefixed_write {
 		}
 		impl Readable for $features {
 			fn read<R: io::Read>(r: &mut R) -> Result<Self, DecodeError> {
-				Ok(Self::from_be_bytes(Vec::<u8>::read(r)?))
+				let len: u16 = Readable::read(r)?;
+				let mut bytes = vec![0u8; len as usize];
+				r.read_exact(&mut bytes[..])?;
+				Ok(Self::from_be_bytes(bytes))
 			}
 		}
 	};


### PR DESCRIPTION
These aren't serialize-able and clearly bogus.

Reported by Project Loupe

Not gonna bother with backports here this is trivial