### PR TITLE
[0.2] Another round of backports + initial release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,89 @@
+# 0.2.3 - Jun 18, 2026 - "Through the Loupe"
+
+## API Updates
+ * `DefaultMessageRouter` will now always generate blinded message paths that
+   provide no privacy (where our node is the introduction node) for nodes with
+   public channels. This works around an issue which will appear for any nodes
+   with LND peers that enable onion messaging - such peers will refuse to
+   forward BOLT 12 messages from unknown third parties, which most BOLT 12
+   payers rely on today (#4647).
+ * Explicit `amount_msats` of 0 is rejected in BOLT 12 `Offer`s; `OfferBuilder`
+   now maps 0-amounts to an amount of `None` (#4324).
+
+## Bug Fixes
+ * `Features::supports_zero_conf` no longer clears the `ZeroConf` features and
+   `Features::requires_zero_conf` now correctly reports required, rather than
+   supported, status (#4517).
+ * If an MPP payment is claimed but `ChannelMonitorUpdate`s for some parts are
+   still being completed asynchronously, further channel updates (e.g.
+   forwarding another payment) are pending and the node restarts, the channel
+   could have become stuck (#4520).
+ * The presence of unconfirmed transactions actually no longer causes
+   `ElectrumSyncClient` to spuriously fail to sync (#4590).
+ * LSPS1, LSPS2, and LSPS5 persistence will no longer get stuck and refuse to
+   persist again after a single failure from the KVStore (#4597, #4282).
+ * Dropping the future returned by
+   `OutputSweeper::regenerate_and_broadcast_spend_if_necessary` no longer
+   results in future calls to the same method being spuriously ignored (#4598).
+ * Used async-receive offers are no longer refreshed on every timer tick once
+   their refresh time is reached (#4672).
+ * `FilesystemStore::list_all_keys` will no longer fail if there are stale
+   intermediate files lying around from a previous unclean shutdown (#4618).
+ * When forwarding an HTLC while in a blinded path with proportional fees over
+   200%, LDK will no longer spuriously allow a forward that pays us 1 msat too
+   little in fees (#4697).
+ * Fixed a rare case where a channel could get stuck on reconnect when using
+   both async `ChannelMonitorUpdate` persistence and async signing (#4684).
+ * If we had exactly zero balance in a zero-fee-commitment channel, the
+   counterparty was able to splice all of their balance out, violating the
+   reserve requirements they'd otherwise be forced to keep (#4580).
+ * Providing an `Event::HTLCIntercepted` to the `LSPS2ServiceHandler` twice no
+   longer results in spuriously opening a channel early (#4656).
+ * `Event::PaymentSent::fee_paid_msat` is no longer `None` in cases where
+   `ChannelManager::abandon_payment` was called before the payment ultimately
+   completes anyway (#4651).
+ * `AnchorDescriptor::previous_utxo` now provides the correct `script_pubkey`
+   for non-zero-commitment-fee anchor channels (#4669).
+ * Syncing a `ChainMonitor` using the `Confirm` trait will no longer write some
+   full `ChannelMonitor`s to disk several times per block (#4544).
+ * `OMDomainResolver` now correctly accounts for failed queries when rate
+   limiting, ensuring we continue to respond to queries after failures (#4591).
+ * Calling `ChannelManager::send_payment_with_route` without a `route_params`
+   and with an invalid `Route` will no longer panic (#4707).
+ * `LSPS2ServiceHandler::channel_open_failed` now correctly fails intercepted
+   HTLCs rather than allowing them to fail just before expiry (#4677).
+ * `StaticInvoice::is_offer_expired` was corrected to check offer, rather than
+   static invoice, expiry (#4594).
+ * `lightning-custom-message`'s handling of `peer_connected` events now ensures
+   that sub-handlers will see a `peer_disconnected` event if a different
+   sub-handler refused the connection by `Err`ing `peer_connected` (#4595).
+ * Replay protection for LSPS5 signatures now detects replays which are only
+   different in the encoded signature's case (#4701).
+ * When `lightning-liquidity` is configured in the background processor, there
+   is no longer a stream of `Persisting LiquidityManager...` log spam (#4246).
+ * Incomplete MPP keysend payments will no longer see their HTLCs held until
+   expiry (#4558).
+ * `InvoiceRequestBuilder` will no longer accept a `quantity` of `0` for a
+   BOLT 12 `Offer`, allowing any quantity up to a bound (#4667).
+ * `lightning-custom-message` handlers that return `Ok(None)` when asked to
+   deserialize a message in their defined range no longer cause panics (#4709).
+ * Several spurious debug assertions were fixed (#4537, #4618, #4026)
+
+## Security
+0.2.3 fixes several underestimates of the anchor reserves required to ensure we
+can reliably close channels and a sanitization issue.
+ * When using the `anchor_channel_reserves` module to calculate reserves
+   required to pay for fees when closing anchor channels, zero-fee-commitment
+   channels were not considered. This could allow a counterparty to open many
+   channels, leaving us unable to properly force-close (#4592).
+ * The `anchor_channel_reserves` module overestimated the value of `Utxo`s in
+   the wallet by ignoring the `TxIn` cost to spend them (#4670).
+ * `PrintableString` did not properly sanitize unicode format characters,
+   allowing an attacker to corrupt the rendering of logs or UI (#4593, #4605).
+
+Thanks to Project Loupe for reporting most of the issues fixed in this release.
+
+
 # 0.2.2 - Feb 6, 2025 - "An Async Splicing Production"
 
 ## API Updates

--- a/lightning-custom-message/src/lib.rs
+++ b/lightning-custom-message/src/lib.rs
@@ -358,7 +358,12 @@ macro_rules! composite_custom_message_handler {
 				match message_type {
 					$(
 						$pattern => match <$type>::read(&self.$field, message_type, buffer)? {
-							None => unreachable!(),
+							// A sub-handler returns `None` for a `message_type` it doesn't
+							// recognize. The composite's pattern can be broader than the types
+							// the sub-handler decodes (e.g. a range), and `message_type` is
+							// peer-provided, so report the message as unknown rather than
+							// treating this as unreachable and panicking.
+							None => Ok(None),
 							Some(message) => Ok(Some($message::$variant(message))),
 						},
 					)*
@@ -500,6 +505,71 @@ mod tests {
 			Bar(32769),
 		}
 	);
+
+	struct ReservedBlockHandler;
+	impl CustomMessageReader for ReservedBlockHandler {
+		type CustomMessage = Foo;
+		fn read<R: LengthLimitedRead>(
+			&self, message_type: u16, _b: &mut R,
+		) -> Result<Option<Foo>, DecodeError> {
+			// This build defines only the message at 32768; the rest of the block its
+			// protocol reserved (32768..=32777) is for types future versions may add.
+			// A not-yet-defined type is unknown to this build, so per the
+			// `CustomMessageReader` contract it returns `Ok(None)` -- a newer peer can
+			// send one and this older node will treat it as an unknown message.
+			match message_type {
+				32768 => Ok(Some(Foo)),
+				_ => Ok(None),
+			}
+		}
+	}
+	impl CustomMessageHandler for ReservedBlockHandler {
+		fn handle_custom_message(&self, _msg: Foo, _: PublicKey) -> Result<(), LightningError> {
+			Ok(())
+		}
+		fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, Foo)> {
+			vec![]
+		}
+		fn peer_disconnected(&self, _: PublicKey) {}
+		fn peer_connected(&self, _: PublicKey, _: &Init, _: bool) -> Result<(), ()> {
+			Ok(())
+		}
+		fn provided_node_features(&self) -> NodeFeatures {
+			NodeFeatures::empty()
+		}
+		fn provided_init_features(&self, _: PublicKey) -> InitFeatures {
+			InitFeatures::empty()
+		}
+	}
+
+	composite_custom_message_handler!(
+		struct ReservedBlockComposite {
+			proto: ReservedBlockHandler,
+		}
+
+		enum ReservedBlockMessage {
+			Proto(32768..=32777),
+		}
+	);
+
+	#[test]
+	fn read_treats_a_reserved_in_range_type_as_unknown() {
+		// A sub-handler may own a block of type ids (declared here as a range) yet only
+		// decode the subset its build defines, returning `Ok(None)` for reserved or
+		// not-yet-defined types in the block -- exactly what a node does on receiving a
+		// newer peer's message. `read` must surface that as an unknown message, not
+		// panic.
+		let composite = ReservedBlockComposite { proto: ReservedBlockHandler };
+		let mut buffer: &[u8] = &[];
+		// The message this build defines decodes to its variant.
+		assert!(matches!(
+			composite.read(32768, &mut buffer),
+			Ok(Some(ReservedBlockMessage::Proto(_)))
+		));
+		// A reserved type from the same block is reported unknown, not panicked
+		// (pre-fix the matched arm hit `unreachable!()`).
+		assert!(matches!(composite.read(32770, &mut buffer), Ok(None)));
+	}
 
 	#[test]
 	fn peer_connected_failure_does_not_leak_subhandler_state() {

--- a/lightning-liquidity/src/lsps2/payment_queue.rs
+++ b/lightning-liquidity/src/lsps2/payment_queue.rs
@@ -26,21 +26,29 @@ impl PaymentQueue {
 		PaymentQueue { payments: Vec::new() }
 	}
 
+	fn payment_status(entry: &PaymentQueueEntry) -> (u64, usize) {
+		let total_expected_outbound_amount_msat =
+			entry.htlcs.iter().map(|htlc| htlc.expected_outbound_amount_msat).sum();
+		(total_expected_outbound_amount_msat, entry.htlcs.len())
+	}
+
 	pub(crate) fn add_htlc(&mut self, new_htlc: InterceptedHTLC) -> (u64, usize) {
+		if let Some(entry) = self
+			.payments
+			.iter()
+			.find(|entry| entry.htlcs.iter().any(|htlc| htlc.intercept_id == new_htlc.intercept_id))
+		{
+			debug_assert_eq!(entry.payment_hash, new_htlc.payment_hash);
+			return Self::payment_status(entry);
+		}
+
 		let payment =
 			self.payments.iter_mut().find(|entry| entry.payment_hash == new_htlc.payment_hash);
 		if let Some(entry) = payment {
 			// HTLCs within a payment should have the same payment hash.
 			debug_assert!(entry.htlcs.iter().all(|htlc| htlc.payment_hash == entry.payment_hash));
-			// The given HTLC should not already be present.
-			debug_assert!(entry
-				.htlcs
-				.iter()
-				.all(|htlc| htlc.intercept_id != new_htlc.intercept_id));
 			entry.htlcs.push(new_htlc);
-			let total_expected_outbound_amount_msat =
-				entry.htlcs.iter().map(|htlc| htlc.expected_outbound_amount_msat).sum();
-			(total_expected_outbound_amount_msat, entry.htlcs.len())
+			Self::payment_status(entry)
 		} else {
 			let expected_outbound_amount_msat = new_htlc.expected_outbound_amount_msat;
 			let entry =
@@ -117,6 +125,15 @@ mod tests {
 			(300_000_000, 1),
 		);
 		assert_eq!(payment_queue.pop_greater_than_msat(500_000_000), None);
+
+		assert_eq!(
+			payment_queue.add_htlc(InterceptedHTLC {
+				intercept_id: InterceptId([2; 32]),
+				expected_outbound_amount_msat: 300_000_000,
+				payment_hash: PaymentHash([100; 32]),
+			}),
+			(500_000_000, 2),
+		);
 
 		assert_eq!(
 			payment_queue.add_htlc(InterceptedHTLC {

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -1257,6 +1257,8 @@ where
 	/// This removes the intercept SCID, any outbound channel state, and associated
 	/// channel‐ID mappings for the specified `user_channel_id`, but only while no payment
 	/// has been forwarded yet and no channel has been opened on-chain.
+	/// Any held HTLCs for the pending flow are failed backwards before the local state
+	/// is removed.
 	///
 	/// Returns an error if:
 	///  - there is no channel matching `user_channel_id`, or
@@ -1292,25 +1294,27 @@ where
 
 			let jit_channel = peer_state
 				.outbound_channels_by_intercept_scid
-				.get(&intercept_scid)
+				.get_mut(&intercept_scid)
 				.ok_or_else(|| APIError::APIMisuseError {
-				err: format!(
-					"Failed to map intercept_scid {} for user_channel_id {} to a channel.",
-					intercept_scid, user_channel_id,
-				),
-			})?;
+					err: format!(
+						"Failed to map intercept_scid {} for user_channel_id {} to a channel.",
+						intercept_scid, user_channel_id,
+					),
+				})?;
 
-			let is_pending = matches!(
-				jit_channel.state,
-				OutboundJITChannelState::PendingInitialPayment { .. }
-					| OutboundJITChannelState::PendingChannelOpen { .. }
-			);
+			let intercepted_htlcs = match &mut jit_channel.state {
+				OutboundJITChannelState::PendingInitialPayment { payment_queue }
+				| OutboundJITChannelState::PendingChannelOpen { payment_queue, .. } => payment_queue.clear(),
+				_ => {
+					return Err(APIError::APIMisuseError {
+						err: "Cannot abandon channel open after channel creation or payment forwarding"
+							.to_string(),
+					});
+				},
+			};
 
-			if !is_pending {
-				return Err(APIError::APIMisuseError {
-					err: "Cannot abandon channel open after channel creation or payment forwarding"
-						.to_string(),
-				});
+			for htlc in intercepted_htlcs {
+				let _ = self.channel_manager.get_cm().fail_intercepted_htlc(htlc.intercept_id);
 			}
 
 			peer_state.intercept_scid_by_user_channel_id.remove(&user_channel_id);

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -2361,6 +2361,8 @@ mod tests {
 
 	use bitcoin::{absolute::LockTime, transaction::Version};
 	use core::str::FromStr;
+	use lightning::io::Cursor;
+	use lightning::util::ser::{Readable, Writeable};
 
 	const MAX_VALUE_MSAT: u64 = 21_000_000_0000_0000_000;
 
@@ -2766,6 +2768,52 @@ mod tests {
 				matches!(action, Some(HTLCInterceptedAction::ForwardHTLC(channel_id)) if channel_id == ChannelId([200; 32]))
 			);
 		}
+	}
+
+	#[test]
+	fn replayed_intercepted_htlc_after_persist_is_idempotent() {
+		let payment_size_msat = Some(500_000_000);
+		let opening_fee_params = LSPS2OpeningFeeParams {
+			min_fee_msat: 10_000_000,
+			proportional: 10_000,
+			valid_until: LSPSDateTime::from_str("2035-05-20T08:30:45Z").unwrap(),
+			min_lifetime: 4032,
+			max_client_to_self_delay: 2016,
+			min_payment_size_msat: 10_000_000,
+			max_payment_size_msat: 1_000_000_000,
+			promise: "ignore".to_string(),
+		};
+		let intercept_scid = 42;
+		let user_channel_id = 43;
+		let htlc = InterceptedHTLC {
+			intercept_id: InterceptId([1; 32]),
+			expected_outbound_amount_msat: 500_000_000,
+			payment_hash: PaymentHash([2; 32]),
+		};
+
+		let mut jit_channel =
+			OutboundJITChannel::new(payment_size_msat, opening_fee_params, user_channel_id, false);
+		assert!(matches!(
+			jit_channel.htlc_intercepted(htlc).unwrap(),
+			Some(HTLCInterceptedAction::OpenChannel(_))
+		));
+
+		let mut peer_state = PeerState::new();
+		peer_state.intercept_scid_by_user_channel_id.insert(user_channel_id, intercept_scid);
+		peer_state.insert_outbound_channel(intercept_scid, jit_channel);
+
+		let encoded_peer_state = peer_state.encode();
+		let mut decoded_peer_state = PeerState::read(&mut Cursor::new(encoded_peer_state)).unwrap();
+		let decoded_jit_channel = decoded_peer_state
+			.outbound_channels_by_intercept_scid
+			.get_mut(&intercept_scid)
+			.unwrap();
+
+		assert!(decoded_jit_channel.htlc_intercepted(htlc).unwrap().is_none());
+
+		let ForwardPaymentAction(_, fee_payment) =
+			decoded_jit_channel.channel_ready(ChannelId([3; 32])).unwrap();
+		assert_eq!(fee_payment.htlcs, vec![htlc]);
 	}
 
 	#[test]

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -1784,13 +1784,21 @@ where
 		// TODO: We should eventually persist in parallel, however, when we do, we probably want to
 		// introduce some batching to upper-bound the number of requests inflight at any given
 		// time.
-		let mut did_persist = false;
 
 		if self.persistence_in_flight.fetch_add(1, Ordering::AcqRel) > 0 {
 			// If we're not the first event processor to get here, just return early, the increment
 			// we just did will be treated as "go around again" at the end.
-			return Ok(did_persist);
+			return Ok(false);
 		}
+
+		let res = self.do_persist().await;
+		debug_assert!(res.is_err() || self.persistence_in_flight.load(Ordering::Acquire) == 0);
+		self.persistence_in_flight.store(0, Ordering::Release);
+		res
+	}
+
+	async fn do_persist(&self) -> Result<bool, lightning::io::Error> {
+		let mut did_persist = false;
 
 		loop {
 			let mut need_remove = Vec::new();

--- a/lightning-liquidity/src/lsps2/service.rs
+++ b/lightning-liquidity/src/lsps2/service.rs
@@ -1861,6 +1861,7 @@ where
 					did_persist = true;
 				} else {
 					self.persist_peer_state(counterparty_node_id).await?;
+					did_persist = true;
 				}
 			}
 

--- a/lightning-liquidity/src/lsps5/service.rs
+++ b/lightning-liquidity/src/lsps5/service.rs
@@ -339,6 +339,7 @@ where
 				did_persist = true;
 			} else {
 				self.persist_peer_state(client_id).await?;
+				did_persist = true;
 			}
 		}
 

--- a/lightning-liquidity/src/lsps5/validator.rs
+++ b/lightning-liquidity/src/lsps5/validator.rs
@@ -11,7 +11,6 @@
 
 use super::msgs::LSPS5ClientError;
 
-use crate::alloc::string::ToString;
 use crate::lsps0::ser::LSPSDateTime;
 use crate::lsps5::msgs::WebhookNotification;
 use crate::sync::Mutex;
@@ -91,14 +90,17 @@ impl LSPS5Validator {
 	}
 
 	fn check_for_replay_attack(&self, signature: &str) -> Result<(), LSPS5ClientError> {
+		// zbase32 decoding accepts case aliases, so canonicalize the cache key
+		// to match verification semantics without decoding the signature again.
+		let signature = signature.to_ascii_lowercase();
 		let mut signatures = self.recent_signatures.lock().unwrap();
-		if signatures.contains(&signature.to_string()) {
+		if signatures.contains(&signature) {
 			return Err(LSPS5ClientError::ReplayAttack);
 		}
 		if signatures.len() == MAX_RECENT_SIGNATURES {
 			signatures.pop_back();
 		}
-		signatures.push_front(signature.to_string());
+		signatures.push_front(signature);
 		Ok(())
 	}
 }

--- a/lightning-liquidity/src/manager.rs
+++ b/lightning-liquidity/src/manager.rs
@@ -673,7 +673,7 @@ where
 	/// Persists the state of the service handlers towards the given [`KVStore`] implementation if
 	/// needed.
 	///
-	/// Returns `true` if it persisted sevice handler data.
+	/// Returns `true` if it persisted service handler data.
 	///
 	/// This will be regularly called by LDK's background processor if necessary and only needs to
 	/// be called manually if it's not utilized.
@@ -1289,7 +1289,7 @@ where
 
 	/// Persists the state of the service handlers towards the given [`KVStoreSync`] implementation.
 	///
-	/// Returns `true` if it persisted sevice handler data.
+	/// Returns `true` if it persisted service handler data.
 	///
 	/// Wraps [`LiquidityManager::persist`].
 	pub fn persist(&self) -> Result<bool, lightning::io::Error> {

--- a/lightning-liquidity/tests/lsps2_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps2_integration_tests.rs
@@ -697,6 +697,126 @@ fn channel_open_abandoned() {
 }
 
 #[test]
+fn channel_open_abandoned_releases_intercepted_htlcs() {
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let mut service_node_config = test_default_channel_config();
+	service_node_config.accept_intercept_htlcs = true;
+
+	let mut client_node_config = test_default_channel_config();
+	client_node_config.channel_config.accept_underpaying_htlcs = true;
+
+	let node_chanmgrs = create_node_chanmgrs(
+		3,
+		&node_cfgs,
+		&[Some(service_node_config), Some(client_node_config), None],
+	);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+	let (lsps_nodes, promise_secret) = setup_test_lsps2_nodes_with_payer(nodes);
+	let LSPSNodesWithPayer { ref service_node, ref client_node, ref payer_node } = lsps_nodes;
+
+	let payer_node_id = payer_node.node.get_our_node_id();
+	let service_node_id = service_node.inner.node.get_our_node_id();
+	let client_node_id = client_node.inner.node.get_our_node_id();
+
+	let service_handler = service_node.liquidity_manager.lsps2_service_handler().unwrap();
+	create_chan_between_nodes_with_value(&payer_node, &service_node.inner, 2_000_000, 100_000);
+
+	let intercept_scid = service_node.node.get_intercept_scid();
+	let user_channel_id = 42u128;
+	let cltv_expiry_delta: u32 = 144;
+	let payment_size_msat = Some(1_000_000);
+	let fee_base_msat: u64 = 1_000;
+
+	execute_lsps2_dance(
+		&lsps_nodes,
+		intercept_scid,
+		user_channel_id,
+		cltv_expiry_delta,
+		promise_secret,
+		payment_size_msat,
+		fee_base_msat,
+	);
+
+	let invoice = create_jit_invoice(
+		&client_node,
+		service_node_id,
+		intercept_scid,
+		cltv_expiry_delta,
+		payment_size_msat,
+		"channel-open-abandoned-cleanup",
+		3600,
+	)
+	.unwrap();
+
+	payer_node
+		.node
+		.pay_for_bolt11_invoice(
+			&invoice,
+			PaymentId(invoice.payment_hash().to_byte_array()),
+			None,
+			Default::default(),
+			Retry::Attempts(0),
+		)
+		.unwrap();
+
+	check_added_monitors!(&payer_node, 1);
+	let events = payer_node.node.get_and_clear_pending_msg_events();
+	let ev = SendEvent::from_event(events[0].clone());
+	service_node.inner.node.handle_update_add_htlc(payer_node_id, &ev.msgs[0]);
+	do_commitment_signed_dance(&service_node.inner, &payer_node, &ev.commitment_msg, false, true);
+	service_node.inner.node.process_pending_htlc_forwards();
+
+	let events = service_node.inner.node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	let intercept_id = match &events[0] {
+		Event::HTLCIntercepted {
+			intercept_id,
+			requested_next_hop_scid,
+			payment_hash,
+			expected_outbound_amount_msat,
+			..
+		} => {
+			assert_eq!(*requested_next_hop_scid, intercept_scid);
+			service_handler
+				.htlc_intercepted(
+					*requested_next_hop_scid,
+					*intercept_id,
+					*expected_outbound_amount_msat,
+					*payment_hash,
+				)
+				.unwrap();
+			*intercept_id
+		},
+		other => panic!("Expected HTLCIntercepted, got {:?}", other),
+	};
+
+	match service_node.liquidity_manager.next_event().unwrap() {
+		LiquidityEvent::LSPS2Service(LSPS2ServiceEvent::OpenChannel { .. }) => {},
+		other => panic!("Unexpected event: {:?}", other),
+	};
+
+	service_handler.channel_open_abandoned(&client_node_id, user_channel_id).unwrap();
+
+	let res = service_node.inner.node.fail_intercepted_htlc(intercept_id);
+	assert!(
+		res.is_err(),
+		"channel_open_abandoned must release the intercepted HTLC via fail_intercepted_htlc, but the entry is still pending: {:?}",
+		res,
+	);
+
+	let events = service_node.inner.node.get_and_clear_pending_events();
+	assert_eq!(events.len(), 1);
+	match &events[0] {
+		Event::HTLCHandlingFailed {
+			failure_type: HTLCHandlingFailureType::InvalidForward { requested_forward_scid },
+			..
+		} => assert_eq!(*requested_forward_scid, intercept_scid),
+		other => panic!("Expected HTLCHandlingFailed, got {:?}", other),
+	}
+}
+
+#[test]
 fn channel_open_abandoned_nonexistent_channel() {
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);

--- a/lightning-liquidity/tests/lsps5_integration_tests.rs
+++ b/lightning-liquidity/tests/lsps5_integration_tests.rs
@@ -994,6 +994,16 @@ fn replay_prevention_test() {
 	assert!(replay_result.is_err(), "Immediate replay attack should be detected");
 	assert_eq!(replay_result.unwrap_err(), LSPS5ClientError::ReplayAttack);
 
+	let case_modified_signature = signature.to_ascii_uppercase();
+	assert_ne!(case_modified_signature, signature);
+	let case_modified_replay_result =
+		validator.validate(service_node_id, &timestamp, &case_modified_signature, &body);
+	assert!(
+		case_modified_replay_result.is_err(),
+		"Immediate replay attack should be detected when the signature case changes"
+	);
+	assert_eq!(case_modified_replay_result.unwrap_err(), LSPS5ClientError::ReplayAttack);
+
 	// Fill up the validator's signature cache to push out the original signature.
 	for i in 0..MAX_RECENT_SIGNATURES {
 		// Advance time, allowing for another notification

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -692,7 +692,7 @@ pub(crate) fn amt_to_forward_msat(
 		(post_base_fee_inbound_amt * 1_000_000 + 1_000_000 + prop - 1) / (prop + 1_000_000);
 
 	let fee = ((amt_to_forward * prop) / 1_000_000) + base;
-	if inbound_amt - fee < amt_to_forward {
+	if inbound_amt.checked_sub(fee)? < amt_to_forward {
 		// Rounding up the forwarded amount resulted in underpaying this node, so take an extra 1 msat
 		// in fee to compensate.
 		amt_to_forward -= 1;
@@ -1124,5 +1124,20 @@ mod tests {
 		)
 		.unwrap();
 		assert_eq!(blinded_payinfo.htlc_maximum_msat, 3997);
+	}
+
+	#[test]
+	fn amt_to_forward_msat_underflow() {
+		// `amt_to_forward_msat` is documented to return `None` if underflow occurs, but the
+		// `inbound_amt - fee` subtraction was previously unguarded. With a high proportional fee
+		// and a small inbound amount, rounding the forwarded amount up leaves `fee` larger than
+		// `inbound_amt`, so the subtraction underflows (panicking in debug builds and returning a
+		// nonsensical result in release). Ensure we instead return `None`.
+		let payment_relay = PaymentRelay {
+			cltv_expiry_delta: 0,
+			fee_proportional_millionths: u32::MAX,
+			fee_base_msat: 1,
+		};
+		assert!(super::amt_to_forward_msat(2, &payment_relay).is_none());
 	}
 }

--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -2334,6 +2334,25 @@ fn refresh_static_invoices_for_used_offers() {
 		.handle_onion_message(server.node.get_our_node_id(), &invoice_persisted_om);
 	assert_eq!(recipient.node.flow.test_get_async_receive_offers().len(), 1);
 
+	// The invoice was just refreshed and persisted. A later timer tick must wait until the next
+	// refresh threshold before generating another invoice for the same offer.
+	recipient.node.timer_tick_occurred();
+	let pending_oms_after = recipient.onion_messenger.release_pending_msgs();
+	let mut extra_serve_invoices = 0;
+	if let Some(msgs) = pending_oms_after.get(&server.node.get_our_node_id()) {
+		for msg in msgs {
+			if let PeeledOnion::AsyncPayments(AsyncPaymentsMessage::ServeStaticInvoice(_), _, _) =
+				server.onion_messenger.peel_onion_message(&msg).unwrap()
+			{
+				extra_serve_invoices += 1;
+			}
+		}
+	}
+	assert_eq!(
+		extra_serve_invoices, 0,
+		"used offer invoice was refreshed again immediately after a successful refresh"
+	);
+
 	// Remove the peer restriction added above.
 	server.message_router.peers_override.lock().unwrap().clear();
 	recipient.message_router.peers_override.lock().unwrap().clear();

--- a/lightning/src/ln/async_signer_tests.rs
+++ b/lightning/src/ln/async_signer_tests.rs
@@ -15,7 +15,7 @@ use bitcoin::secp256k1::Secp256k1;
 
 use crate::chain::channelmonitor::LATENCY_GRACE_PERIOD_BLOCKS;
 use crate::chain::ChannelMonitorUpdateStatus;
-use crate::events::{ClosureReason, Event};
+use crate::events::{ClosureReason, Event, HTLCHandlingFailureType};
 use crate::ln::chan_utils::ClosingTransaction;
 use crate::ln::channel::DISCONNECT_PEER_AWAITING_RESPONSE_TICKS;
 use crate::ln::channel_state::{ChannelDetails, ChannelShutdownState};
@@ -496,6 +496,211 @@ fn test_async_raa_peer_disconnect() {
 	);
 	do_test_async_raa_peer_disconnect(UnblockSignerAcrossDisconnectCase::BeforeReestablish, true);
 	do_test_async_raa_peer_disconnect(UnblockSignerAcrossDisconnectCase::BeforeReestablish, false);
+}
+
+#[test]
+fn test_signer_unblocked_clears_monitor_pending_raa_after_reestablish() {
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
+	let mut nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+
+	let node_a_id = nodes[0].node.get_our_node_id();
+	let node_b_id = nodes[1].node.get_our_node_id();
+	let node_c_id = nodes[2].node.get_our_node_id();
+
+	create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_bc = create_announced_chan_between_nodes(&nodes, 1, 2);
+
+	// Rebalance so that node C can send a payment back through node B later in the test.
+	send_payment(&nodes[0], &[&nodes[1], &nodes[2]], 5_000_000);
+
+	// Put the B-C channel into AwaitingRAA by having C fail a payment backwards and retaining C's
+	// final RAA instead of delivering it to B immediately.
+	let (_, payment_hash_1, ..) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], 1_000_000);
+	nodes[2].node.fail_htlc_backwards(&payment_hash_1);
+	expect_and_process_pending_htlcs_and_htlc_handling_failed(
+		&nodes[2],
+		&[HTLCHandlingFailureType::Receive { payment_hash: payment_hash_1 }],
+	);
+	check_added_monitors(&nodes[2], 1);
+
+	let updates = get_htlc_update_msgs(&nodes[2], &node_b_id);
+	assert!(updates.update_add_htlcs.is_empty());
+	assert_eq!(updates.update_fail_htlcs.len(), 1);
+	assert!(updates.update_fail_malformed_htlcs.is_empty());
+	assert!(updates.update_fee.is_none());
+	nodes[1].node.handle_update_fail_htlc(node_c_id, &updates.update_fail_htlcs[0]);
+
+	let pending_c_raa =
+		commitment_signed_dance!(&nodes[1], &nodes[2], &updates.commitment_signed, false, true, false, true);
+	check_added_monitors(&nodes[0], 0);
+
+	// While B is waiting for C's RAA, forward another A-to-C payment. B accepts it on the A-B
+	// channel, but cannot forward it over B-C yet, so it is held in B's holding cell.
+	let (route, payment_hash_2, _payment_preimage_2, payment_secret_2) =
+		get_route_and_payment_hash!(nodes[0], nodes[2], 1_000_000);
+	let onion_2 = RecipientOnionFields::secret_only(payment_secret_2);
+	let id_2 = PaymentId(payment_hash_2.0);
+	nodes[0].node.send_payment_with_route(route, payment_hash_2, onion_2, id_2).unwrap();
+	check_added_monitors(&nodes[0], 1);
+
+	let send_event = SendEvent::from_node(&nodes[0]);
+	assert_eq!(send_event.node_id, node_b_id);
+	assert_eq!(send_event.msgs.len(), 1);
+	nodes[1].node.handle_update_add_htlc(node_a_id, &send_event.msgs[0]);
+	do_commitment_signed_dance(&nodes[1], &nodes[0], &send_event.commitment_msg, false, false);
+
+	expect_and_process_pending_htlcs(&nodes[1], false);
+	check_added_monitors(&nodes[1], 0);
+	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
+
+	// Now make B owe C an RAA whose monitor update has already completed, but whose RAA cannot be
+	// constructed because B's signer is unavailable.
+	let (route, payment_hash_3, _payment_preimage_3, payment_secret_3) =
+		get_route_and_payment_hash!(nodes[2], nodes[0], 1_000_000);
+	let onion_3 = RecipientOnionFields::secret_only(payment_secret_3);
+	let id_3 = PaymentId(payment_hash_3.0);
+	nodes[2].node.send_payment_with_route(route, payment_hash_3, onion_3, id_3).unwrap();
+	check_added_monitors(&nodes[2], 1);
+
+	let send_event = SendEvent::from_node(&nodes[2]);
+	assert_eq!(send_event.node_id, node_b_id);
+	assert_eq!(send_event.msgs.len(), 1);
+	nodes[1].node.handle_update_add_htlc(node_c_id, &send_event.msgs[0]);
+	nodes[1].disable_channel_signer_op(&node_c_id, &chan_bc.2, SignerOp::ReleaseCommitmentSecret);
+	nodes[1].node.handle_commitment_signed_batch_test(node_c_id, &send_event.commitment_msg);
+	check_added_monitors(&nodes[1], 1);
+	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
+
+	// Deliver C's earlier RAA to B while monitor updating is blocked. This frees B's holding-cell
+	// HTLC and leaves a monitor update in flight.
+	chanmon_cfgs[1].persister.set_update_ret(ChannelMonitorUpdateStatus::InProgress);
+	nodes[1].node.handle_revoke_and_ack(node_c_id, &pending_c_raa);
+	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
+	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
+	check_added_monitors(&nodes[1], 1);
+
+	nodes[1].node.peer_disconnected(node_c_id);
+	nodes[2].node.peer_disconnected(node_b_id);
+
+	let init_msg = msgs::Init {
+		features: nodes[2].node.init_features(),
+		networks: None,
+		remote_network_address: None,
+	};
+	nodes[1].node.peer_connected(node_c_id, &init_msg, true).unwrap();
+	let bs_reestablish = get_chan_reestablish_msgs!(nodes[1], nodes[2]);
+	assert_eq!(bs_reestablish.len(), 1);
+	let init_msg = msgs::Init {
+		features: nodes[1].node.init_features(),
+		networks: None,
+		remote_network_address: None,
+	};
+	nodes[2].node.peer_connected(node_b_id, &init_msg, false).unwrap();
+	let cs_reestablish = get_chan_reestablish_msgs!(nodes[2], nodes[1]);
+	assert_eq!(cs_reestablish.len(), 1);
+
+	nodes[1].node.handle_channel_reestablish(node_c_id, &cs_reestablish[0]);
+
+	// The signer-pending path now generates the owed RAA before the held monitor update
+	// completes.
+	nodes[1].enable_channel_signer_op(&node_c_id, &chan_bc.2, SignerOp::ReleaseCommitmentSecret);
+	nodes[1].node.signer_unblocked(Some((node_c_id, chan_bc.2)));
+	let (_, signer_revoke_and_ack, signer_commitment_update, _, _, _, _, _) =
+		handle_chan_reestablish_msgs!(nodes[1], nodes[2]);
+	assert!(signer_revoke_and_ack.is_some());
+
+	// Once the held monitor update completes, B must not generate the same RAA a second time via
+	// the monitor-pending path.
+	chanmon_cfgs[1].persister.set_update_ret(ChannelMonitorUpdateStatus::Completed);
+	let (latest_update, _) = nodes[1].chain_monitor.get_latest_mon_update_id(chan_bc.2);
+	nodes[1].chain_monitor.chain_monitor.force_channel_monitor_updated(chan_bc.2, latest_update);
+	check_added_monitors(&nodes[1], 0);
+	let (_, duplicate_revoke_and_ack, monitor_commitment_update, _, _, _, _, _) =
+		handle_chan_reestablish_msgs!(nodes[1], nodes[2]);
+	assert!(duplicate_revoke_and_ack.is_none());
+
+	nodes[2].node.handle_channel_reestablish(node_b_id, &bs_reestablish[0]);
+	let (_, c_revoke_and_ack, c_commitment_update, _, _, _, _, _) =
+		handle_chan_reestablish_msgs!(nodes[2], nodes[1]);
+	assert!(c_revoke_and_ack.is_none());
+	assert!(c_commitment_update.is_none());
+
+	nodes[2].node.handle_revoke_and_ack(node_b_id, &signer_revoke_and_ack.unwrap());
+	check_added_monitors(&nodes[2], 1);
+
+	let commitment_update = signer_commitment_update.or(monitor_commitment_update);
+	if let Some(commitment_update) = commitment_update {
+		let send_event = SendEvent::from_commitment_update(node_c_id, chan_bc.2, commitment_update);
+		assert_eq!(send_event.node_id, node_c_id);
+		for update_add in send_event.msgs {
+			nodes[2].node.handle_update_add_htlc(node_b_id, &update_add);
+		}
+		nodes[2].node.handle_commitment_signed_batch_test(node_b_id, &send_event.commitment_msg);
+		check_added_monitors(&nodes[2], 1);
+		let (c_raa, c_commitment_signed) = get_revoke_commit_msgs(&nodes[2], &node_b_id);
+		nodes[1].node.handle_revoke_and_ack(node_c_id, &c_raa);
+		check_added_monitors(&nodes[1], 1);
+		nodes[1].node.handle_commitment_signed_batch_test(node_c_id, &c_commitment_signed);
+		check_added_monitors(&nodes[1], 1);
+		let b_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, node_c_id);
+		nodes[2].node.handle_revoke_and_ack(node_b_id, &b_raa);
+		check_added_monitors(&nodes[2], 1);
+	}
+
+	let (route, final_payment_hash, _final_payment_preimage, final_payment_secret) =
+		get_route_and_payment_hash!(nodes[1], nodes[2], 100_000);
+	let final_payment_id = PaymentId(final_payment_hash.0);
+	nodes[1]
+		.node
+		.send_payment_with_route(
+			route,
+			final_payment_hash,
+			RecipientOnionFields::secret_only(final_payment_secret),
+			final_payment_id,
+		)
+		.unwrap();
+	check_added_monitors(&nodes[1], 1);
+	let final_payment_event = nodes[1].node.get_and_clear_pending_msg_events().remove(0);
+	match &final_payment_event {
+		MessageSendEvent::UpdateHTLCs { node_id, .. } => assert_eq!(*node_id, node_c_id),
+		_ => panic!("Unexpected event"),
+	}
+	do_pass_along_path(
+		PassAlongPathArgs::new(
+			&nodes[1],
+			&[&nodes[2]],
+			100_000,
+			final_payment_hash,
+			final_payment_event,
+		)
+		.with_payment_secret(final_payment_secret)
+		.without_clearing_recipient_events(),
+	);
+
+	let claimable_events = nodes[2].node.get_and_clear_pending_events();
+	let final_claimable = claimable_events
+		.iter()
+		.find(|event| {
+			matches!(
+				event,
+				Event::PaymentClaimable { payment_hash, .. } if *payment_hash == final_payment_hash
+			)
+		})
+		.unwrap();
+	check_payment_claimable(
+		final_claimable,
+		final_payment_hash,
+		final_payment_secret,
+		100_000,
+		None,
+		node_c_id,
+	);
+	expect_htlc_failure_conditions(
+		nodes[1].node.get_and_clear_pending_events(),
+		&[HTLCHandlingFailureType::Forward { node_id: Some(node_c_id), channel_id: chan_bc.2 }],
+	);
 }
 
 fn do_test_async_raa_peer_disconnect(

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -9587,6 +9587,13 @@ where
 			self.context.signer_pending_commitment_update = true;
 			commitment_update = None;
 		}
+		if revoke_and_ack.is_some() {
+			// If signer-pending state regenerated an RAA, the monitor update for that RAA was
+			// already persisted before we set `signer_pending_revoke_and_ack`. Thus, if reconnect
+			// also marked the same RAA monitor-pending while another monitor update was in flight,
+			// the RAA we're returning here satisfies that monitor-pending resend.
+			self.context.monitor_pending_revoke_and_ack = false;
+		}
 
 		let (closing_signed, signed_closing_tx, shutdown_result) = if self.context.signer_pending_closing {
 			debug_assert!(self.context.last_sent_closing_fee.is_some());

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5402,7 +5402,7 @@ where
 			// Create a dummy route params since they're a required parameter but unused in this case
 			let (payee_node_id, cltv_delta) = route.paths.first()
 				.and_then(|path| path.hops.last().map(|hop| (hop.pubkey, hop.cltv_expiry_delta as u32)))
-				.unwrap_or_else(|| (PublicKey::from_slice(&[2; 32]).unwrap(), MIN_FINAL_CLTV_EXPIRY_DELTA as u32));
+				.unwrap_or_else(|| (PublicKey::from_slice(&[2; 33]).unwrap(), MIN_FINAL_CLTV_EXPIRY_DELTA as u32));
 			let dummy_payment_params = PaymentParameters::from_node_id(payee_node_id, cltv_delta);
 			RouteParameters::from_payment_params_and_value(dummy_payment_params, route.get_total_amount())
 		});

--- a/lightning/src/offers/async_receive_offer_cache.rs
+++ b/lightning/src/offers/async_receive_offer_cache.rs
@@ -491,7 +491,7 @@ impl AsyncReceiveOfferCache {
 			match offer.status {
 				OfferStatus::Used { invoice_created_at: ref mut inv_created_at }
 				| OfferStatus::Ready { invoice_created_at: ref mut inv_created_at } => {
-					*inv_created_at = core::cmp::min(invoice_created_at, *inv_created_at);
+					*inv_created_at = core::cmp::max(invoice_created_at, *inv_created_at);
 				},
 				OfferStatus::Pending => offer.status = OfferStatus::Ready { invoice_created_at },
 			}


### PR DESCRIPTION
Backport of 47e5c04f64492ade647652463dd6e3435f1aa815 (#4282), #4672, #4684, and #4701. Also added draft release notes for 0.2.3. There's still a few things open but this should get us ready to cut a release this week.