### PR TITLE
Fix string slicing in TXT record validation

### DIFF
--- a/lightning/src/onion_message/dns_resolution.rs
+++ b/lightning/src/onion_message/dns_resolution.rs
@@ -537,7 +537,8 @@ impl OMNameResolver {
 					.filter_map(|data| String::from_utf8(data).ok())
 					.filter(|data_string| data_string.len() > URI_PREFIX.len())
 					.filter(|data_string| {
-						data_string[..URI_PREFIX.len()].eq_ignore_ascii_case(URI_PREFIX)
+						let pfx = &data_string.as_bytes()[..URI_PREFIX.len()];
+						pfx.eq_ignore_ascii_case(URI_PREFIX.as_bytes())
 					});
 				// Check that there is exactly one TXT record that begins with
 				// bitcoin: as required by BIP 353 (and is valid UTF-8).


### PR DESCRIPTION
Rust's panicy string slicing behavior has always been a sharp edge and here it finally caught up with us. Ensure we don't slice into a string provided in an onion message until we're sure the index is a character boundary.

Reported by Jordan Mecom of Block's Security Team