### PR TITLE
Get real rand in `possiblyrandom` on supported platforms w/o feat

### DIFF
--- a/possiblyrandom/src/lib.rs
+++ b/possiblyrandom/src/lib.rs
@@ -20,16 +20,19 @@
 
 #![no_std]
 
-#[cfg(feature = "getrandom")]
+#[cfg(any(
+	feature = "getrandom",
+	not(any(target_os = "unknown", target_os = "none"))
+))]
 extern crate getrandom;
 
 /// Possibly fills `dest` with random data. May fill it with zeros.
 #[inline]
 pub fn getpossiblyrandom(dest: &mut [u8]) {
-	#[cfg(feature = "getrandom")]
-	if getrandom::getrandom(dest).is_err() {
-		dest.fill(0);
-	}
-	#[cfg(not(feature = "getrandom"))]
 	dest.fill(0);
+	#[cfg(any(
+		feature = "getrandom",
+		not(any(target_os = "unknown", target_os = "none"))
+	))]
+	let _ = getrandom::getrandom(dest);
 }


### PR DESCRIPTION
It turns out that conditionally-enabling a dependency via `target` in `Cargo.toml` does not enable the corresponding dependency `feature` when compiling the code. As a result, only when building `possiblyrandom` with an explicit `getrandom` feature did we ever actually return random values.

This fixes this by matching the `target` cfg in `Cargo.toml` to the cfg in `lib.rs`.

Reported by Project Loupe