### PR TITLE
Simplify ChannelUnavailable APIError handling with let-else

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -19829,7 +19829,7 @@ impl<
 		#[cfg(test)]
 		let reconstruct_manager_from_monitors =
 			args.reconstruct_manager_from_monitors.unwrap_or_else(|| {
-				use core::hash::{BuildHasher, Hasher};
+				use core::hash::BuildHasher;
 
 				match std::env::var("LDK_TEST_REBUILD_MGR_FROM_MONITORS") {
 					Ok(val) => match val.as_str() {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -11465,26 +11465,11 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 			},
 		};
 
-		// We have to match below instead of map_err on the above as in the map_err closure the borrow checker
-		// would consider peer_state moved even though we would bail out with the `?` operator.
-		let (channel_id, mut channel, message_send_event) = match res {
-			Ok(res) => res,
-			Err(err) => {
-				mem::drop(peer_state_lock);
-				mem::drop(per_peer_state);
-				// TODO(dunxen): Find/make less icky way to do this.
-				match self.handle_error(
-					Result::<(), MsgHandleErrInternal>::Err(err),
-					*counterparty_node_id,
-				) {
-					Ok(_) => {
-						unreachable!("`handle_error` only returns Err as we've passed in an Err")
-					},
-					Err(e) => {
-						return Err(APIError::ChannelUnavailable { err: e.err });
-					},
-				}
-			},
+		let Ok((channel_id, mut channel, message_send_event)) = res else {
+			mem::drop(peer_state_lock);
+			mem::drop(per_peer_state);
+			let e = self.handle_error::<()>(res.map(|_| ()), *counterparty_node_id).unwrap_err();
+			return Err(APIError::ChannelUnavailable { err: e.err });
 		};
 
 		if trusted_channel_features.is_some_and(|f| f.is_0conf()) {


### PR DESCRIPTION
e9e3060b596f3be2cdbb26d42ebbf952d901f7fa Fixes the TODO for the error handling.
3d6a879efb1a78916cbbc7dcc84557bd4433ada8 Fixes the triggered `manual_str_repeat` lint.