### PR TITLE
[0.2] Fix MSRV compatibility + cut 0.2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,9 +266,15 @@ jobs:
           cd fuzz && cargo update -p regex --precise "1.9.6" && cargo update -p syn --precise "2.0.106" && cargo update -p quote --precise "1.0.41"
           cargo update -p proc-macro2 --precise "1.0.103" --verbose && cargo update -p serde_json --precise "1.0.145" --verbose
           cargo update -p itoa --precise "1.0.15" --verbose && cargo update -p ryu --precise "1.0.20" --verbose
+          cargo update -p libc --precise 0.2.183
+          cargo update -p unicode-ident --precise 1.0.22
+          cargo update -p honggfuzz --precise 0.5.59
+          cargo update -p semver --precise 1.0.27
           cd write-seeds && cargo update -p regex --precise "1.9.6" && cargo update -p syn --precise "2.0.106" && cargo update -p quote --precise "1.0.41"
           cargo update -p proc-macro2 --precise "1.0.103" --verbose && cargo update -p serde_json --precise "1.0.145" --verbose
           cargo update -p itoa --precise "1.0.15" --verbose && cargo update -p ryu --precise "1.0.20" --verbose
+          cargo update -p libc --precise 0.2.183
+          cargo update -p unicode-ident --precise 1.0.22
       - name: Sanity check fuzz targets on Rust ${{ env.TOOLCHAIN }}
         run: |
           cd fuzz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.4 - Jun 25, 2026 - "Release the CI"
+
+## Bug Fixes
+ * 0.2.3 broke the MSRV of the `lightning` crate, which now again compiles on
+   `rustc` 1.63 (#4737).
+
+
 # 0.2.3 - Jun 18, 2026 - "Through the Loupe"
 
 ## API Updates

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -29,6 +29,12 @@ function PIN_RELEASE_DEPS {
 	# Starting with version 1.0.21, the `ryu` crate has an MSRV of rustc 1.68
 	[ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p ryu --precise "1.0.20" --verbose
 
+	# Starting with version 1.0.23, the `unicode-ident` crate has an MSRV of rustc 1.71
+	[ "$RUSTC_MINOR_VERSION" -lt 71 ] && cargo update -p unicode-ident --precise 1.0.22
+
+	# Starting with version 0.2.184, the `libc` crate has an MSRV of rustc 1.65
+	[ "$RUSTC_MINOR_VERSION" -lt 65 ] && cargo update -p libc --precise 0.2.183 --verbose
+
 	return 0 # Don't fail the script if our rustc is higher than the last check
 }
 
@@ -55,6 +61,13 @@ PIN_RELEASE_DEPS # pin the release dependencies in our main workspace
 # lock_api 0.4.13 requires rustc 1.64.0
 [ "$RUSTC_MINOR_VERSION" -lt 64 ] && cargo update -p lock_api --precise "0.4.12" --verbose
 
+# inventory 0.3.22 requires rustc 1.68.0
+[ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p inventory --precise "0.3.21" --verbose
+
+# Starting with version 0.4.0, the `getrandom` crate has an MSRV of rustc 1.85
+GETRANDOM_VERSION="$(cargo tree 2>&1 | grep -o 'getrandom v0.4.*' | tr -d ' `' | tr 'v' '@' || echo -n)"
+[ "$RUSTC_MINOR_VERSION" -lt 85 ] && cargo update -p "$GETRANDOM_VERSION" --precise 0.3.4 --verbose
+
 export RUST_BACKTRACE=1
 
 echo -e "\n\nChecking the workspace, except lightning-transaction-sync."
@@ -71,6 +84,8 @@ pushd lightning-tests
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p syn --precise "2.0.106" --verbose
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p quote --precise "1.0.41" --verbose
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p proc-macro2 --precise "1.0.103" --verbose
+[ "$RUSTC_MINOR_VERSION" -lt 71 ] && cargo update -p unicode-ident --precise 1.0.22
+[ "$RUSTC_MINOR_VERSION" -lt 65 ] && cargo update -p libc --precise 0.2.183 --verbose
 cargo test
 popd
 
@@ -147,6 +162,8 @@ pushd no-std-check
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p serde_json --precise "1.0.145" --verbose
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p itoa --precise "1.0.15" --verbose
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p ryu --precise "1.0.20" --verbose
+[ "$RUSTC_MINOR_VERSION" -lt 71 ] && cargo update -p unicode-ident --precise "1.0.22" --verbose
+[ "$RUSTC_MINOR_VERSION" -lt 65 ] && cargo update -p libc --precise "0.2.183" --verbose
 cargo check --verbose --color always
 [ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 popd
@@ -160,6 +177,7 @@ popd
 
 if [ -f "$(which arm-none-eabi-gcc)" ]; then
 	pushd no-std-check
+	[ "$RUSTC_MINOR_VERSION" -lt 71 ] && cargo update -p unicode-ident --precise "1.0.22" --verbose
 	cargo build --target=thumbv7m-none-eabi
 	[ "$CI_MINIMIZE_DISK_USAGE" != "" ] && cargo clean
 	popd

--- a/ci/ci-tx-sync-tests.sh
+++ b/ci/ci-tx-sync-tests.sh
@@ -20,6 +20,12 @@ PIN_RELEASE_DEPS # pin the release dependencies
 # Starting with version 1.2.0, the `idna_adapter` crate has an MSRV of rustc 1.81.0.
 [ "$RUSTC_MINOR_VERSION" -lt 81 ] && cargo update -p idna_adapter --precise "1.1.0" --verbose
 
+# Starting with version 1.9.0, the `zeroize` crate has an MSRV of rustc 1.85.
+[ "$RUSTC_MINOR_VERSION" -lt 85 ] && cargo update -p zeroize --precise "1.8.2" --verbose
+
+# Starting with version 0.27.8, the `hyper-rustls` crate has an MSRV of rustc 1.85.
+[ "$RUSTC_MINOR_VERSION" -lt 85 ] && cargo update -p hyper-rustls --precise "0.27.7" --verbose
+
 export RUST_BACKTRACE=1
 
 echo -e "\n\nChecking Transaction Sync Clients with features."

--- a/fuzz/ci-fuzz.sh
+++ b/fuzz/ci-fuzz.sh
@@ -21,7 +21,7 @@ RUSTFLAGS="$RUSTFLAGS --cfg=fuzzing" cargo run ../hfuzz_workspace/full_stack_tar
 cargo clean
 popd
 
-cargo install --color always --force honggfuzz --no-default-features
+cargo install --color always --force honggfuzz --no-default-features --version "=0.5.59" --locked
 
 # Because we're fuzzing relatively few iterations, the maximum possible
 # compiler optimizations aren't necessary, so we turn off LTO

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Matt Corallo"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lightningdevkit/rust-lightning/"

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -579,7 +579,7 @@ where
 		};
 
 		let has_pending_claims = monitor_state.monitor.has_pending_claims();
-		if has_pending_claims || get_partition_key(channel_id).is_some_and(|key| key % partition_factor == 0) {
+		if has_pending_claims || get_partition_key(channel_id).map(|key| key % partition_factor == 0).unwrap_or(false) {
 			log_trace!(
 				logger,
 				"Syncing Channel Monitor for channel {}",

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -62,9 +62,8 @@ use crate::offers::nonce::Nonce;
 use crate::offers::parse::Bolt12SemanticError;
 use crate::onion_message::messenger::{DefaultMessageRouter, Destination, MessageSendInstructions, NodeIdMessageRouter, NullMessageRouter, PeeledOnion, PADDED_PATH_LENGTH};
 use crate::onion_message::offers::OffersMessage;
-use crate::routing::gossip::{NodeAlias, NodeId};
 use crate::routing::router::{PaymentParameters, RouteParameters, RouteParametersConfig};
-use crate::sign::{NodeSigner, Recipient};
+use crate::sign::NodeSigner;
 use crate::util::ser::Writeable;
 
 /// This used to determine whether we built a compact path or not, but now its just a random

--- a/lightning/src/ln/splicing_tests.rs
+++ b/lightning/src/ln/splicing_tests.rs
@@ -2358,7 +2358,7 @@ fn do_test_splice_out_initiator_reserve_breach_zero_fee_commitments(
 			// dust limits, but later when we check the balances against those new
 			// dust limits
 			assert_eq!(
-				channel_value_sat.checked_add_signed(funding_contribution_sat).unwrap(),
+				(channel_value_sat as i64 + funding_contribution_sat) as u64,
 				high_dust_limit_satoshis
 			);
 			format!(

--- a/lightning/src/util/sweep.rs
+++ b/lightning/src/util/sweep.rs
@@ -1132,7 +1132,6 @@ mod tests {
 	use bitcoin::{Amount, BlockHash, ScriptBuf, Transaction, TxOut, Txid};
 
 	use core::future as core_future;
-	use core::pin::pin;
 	use core::sync::atomic::Ordering;
 	use core::task::Poll;
 
@@ -1238,7 +1237,7 @@ mod tests {
 		// `write` future is `future::pending()`), then drop the future to mimic
 		// cancellation - the sort of thing a `tokio::time::timeout` wrapper produces.
 		{
-			let mut fut = pin!(sweeper.regenerate_and_broadcast_spend_if_necessary());
+			let mut fut = Box::pin(sweeper.regenerate_and_broadcast_spend_if_necessary());
 			let waker = dummy_waker();
 			let mut ctx = task::Context::from_waker(&waker);
 			assert!(matches!(fut.as_mut().poll(&mut ctx), Poll::Pending));


### PR DESCRIPTION
dbc581419ceabc3e336ec48ca1bea038b634d5c2 broke MSRV for 0.2 which is still 1.63. We fix it here.